### PR TITLE
Support KDoc during import check

### DIFF
--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/UnusedImportsTest.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/UnusedImportsTest.kt
@@ -31,6 +31,49 @@ class UnusedImportsTest : RuleTest {
 	}
 
 	@Test
+	fun shouldTakeIntoAccountDocumentation() {
+		assertThat(rule.lint(
+				"""
+            import tasks.success
+            import tasks.failure
+						import tasks.undefined
+
+						/**
+						*  Reference to [failure]
+						*/
+						class Test{
+							/** Reference to [undefined]*/
+							fun main() {
+								task {
+								} success {
+								}
+							}
+						}
+            """
+		)).isEmpty()
+	}
+
+	@Test
+	internal fun shouldIgnoreLabelForLink() {
+		assertThat(rule.lint(
+				"""
+            import tasks.success
+            import tasks.failure
+						import tasks.undefined
+
+						/**
+						* Reference [undefined][failure]
+						*/
+						fun main() {
+							task {
+							} success {
+							}
+						}
+            """
+		)).hasSize(1)
+	}
+
+	@Test
 	fun testLint() {
 		assertThat(rule.lint(
 				"""
@@ -64,7 +107,9 @@ class UnusedImportsTest : RuleTest {
             import p.C
             import escaped.`when`
             import escaped.`foo`
+            import p.D
 
+						/** reference to [D] */
             fun main() {
                 println(a())
                 C.call()
@@ -78,7 +123,9 @@ class UnusedImportsTest : RuleTest {
             import p2.B as B2
             import p.C
             import escaped.`when`
+            import p.D
 
+						/** reference to [D] */
             fun main() {
                 println(a())
                 C.call()

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/UnusedImportsTest.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/UnusedImportsTest.kt
@@ -36,19 +36,19 @@ class UnusedImportsTest : RuleTest {
 				"""
             import tasks.success
             import tasks.failure
-						import tasks.undefined
+            import tasks.undefined
 
-						/**
-						*  Reference to [failure]
-						*/
-						class Test{
-							/** Reference to [undefined]*/
-							fun main() {
-								task {
-								} success {
-								}
-							}
-						}
+            /**
+            *  Reference to [failure]
+            */
+            class Test{
+              /** Reference to [undefined]*/
+              fun main() {
+                task {
+                } success {
+                }
+              }
+            }
             """
 		)).isEmpty()
 	}
@@ -59,16 +59,16 @@ class UnusedImportsTest : RuleTest {
 				"""
             import tasks.success
             import tasks.failure
-						import tasks.undefined
+            import tasks.undefined
 
-						/**
-						* Reference [undefined][failure]
-						*/
-						fun main() {
-							task {
-							} success {
-							}
-						}
+            /**
+            * Reference [undefined][failure]
+            */
+            fun main() {
+            task {
+            } success {
+            }
+}
             """
 		)).hasSize(1)
 	}
@@ -109,7 +109,7 @@ class UnusedImportsTest : RuleTest {
             import escaped.`foo`
             import p.D
 
-						/** reference to [D] */
+            /** reference to [D] */
             fun main() {
                 println(a())
                 C.call()
@@ -125,7 +125,7 @@ class UnusedImportsTest : RuleTest {
             import escaped.`when`
             import p.D
 
-						/** reference to [D] */
+            /** reference to [D] */
             fun main() {
                 println(a())
                 C.call()


### PR DESCRIPTION
References from KDoc are considered as valid source for import. Previously such imports were qualified as unused.

Please, see tests for examples.