### PR TITLE
Add severity to Findings

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -7,6 +7,7 @@ package io.gitlab.arturbosch.detekt.api
  * @author Artur Bosch
  */
 open class CodeSmell(override val id: String,
+					 override val severity: Rule.Severity,
 					 override val entity: Entity,
 					 override val description: String = "",
 					 override val metrics: List<Metric> = listOf(),
@@ -26,8 +27,8 @@ open class CodeSmell(override val id: String,
  * for the existence of this rule violation.
  */
 open class CodeSmellWithReferenceAndMetric(
-		id: String, entity: Entity, val reference: Entity, metric: Metric) : ThresholdedCodeSmell(
-		id, entity, metric, references = listOf(reference)) {
+		id: String, severity: Rule.Severity, entity: Entity, val reference: Entity, metric: Metric) : ThresholdedCodeSmell(
+		id, severity, entity, metric, references = listOf(reference)) {
 
 	override fun compact(): String {
 		return "$id - $metric - ref=${reference.name} - ${entity.compact()}"
@@ -39,8 +40,8 @@ open class CodeSmellWithReferenceAndMetric(
  * for the existence of this rule violation.
  */
 open class ThresholdedCodeSmell(
-		id: String, entity: Entity, val metric: Metric, references: List<Entity> = emptyList()) : CodeSmell(
-		id, entity, metrics = listOf(metric), references = references) {
+		id: String, severity: Rule.Severity, entity: Entity, val metric: Metric, references: List<Entity> = emptyList()) : CodeSmell(
+		id, severity, entity, metrics = listOf(metric), references = references) {
 	val value: Int
 		get() = metric.value
 	val threshold: Int

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
@@ -13,6 +13,7 @@ import kotlin.reflect.full.memberProperties
  */
 interface Finding : Compactable, Describable, Reflective, HasEntity, HasMetrics {
 	val id: String
+	val severity: Rule.Severity
 	val references: List<Entity>
 }
 

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/RuleTest.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/RuleTest.kt
@@ -74,13 +74,13 @@ class TestLM : Rule("LongMethod") {
 		val start = Location.startLineAndColumn(function.funKeyword!!).line
 		val end = Location.startLineAndColumn(function.lastBlockStatementOrThis()).line
 		val offset = end - start
-		if (offset > 10) addFindings(CodeSmell(id, Entity.from(function)))
+		if (offset > 10) addFindings(CodeSmell(id, severity, Entity.from(function)))
 	}
 }
 
 class TestLPL : Rule("LongParameterList") {
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		val size = function.valueParameters.size
-		if (size > 5) addFindings(CodeSmell(id, Entity.from(function)))
+		if (size > 5) addFindings(CodeSmell(id, severity, Entity.from(function)))
 	}
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/ConsecutiveBlankLines.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/ConsecutiveBlankLines.kt
@@ -15,7 +15,7 @@ class ConsecutiveBlankLines(config: Config) : TokenRule("ConsecutiveBlankLines",
 	override fun visitSpaces(space: PsiWhiteSpace) {
 		val parts = space.text.split("\n")
 		if (parts.size > 3) {
-			addFindings(CodeSmell(id, Entity.from(space, offset = 2)))
+			addFindings(CodeSmell(id, severity, Entity.from(space, offset = 2)))
 			withAutoCorrect {
 				(space as LeafPsiElement).replaceWithText("${parts.first()}\n\n${parts.last()}")
 			}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/ExpressionBodySyntax.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/ExpressionBodySyntax.kt
@@ -21,7 +21,7 @@ class ExpressionBodySyntax(config: Config = Config.empty) : Rule(
 		if (function.bodyExpression != null) {
 			val body = function.bodyExpression!!
 			body.singleReturnStatement()?.let { returnStmt ->
-				addFindings(CodeSmell(id, Entity.from(body)))
+				addFindings(CodeSmell(id, severity, Entity.from(body)))
 				withAutoCorrect {
 					val equals = FACTORY.createEQ().node
 					val returnedExpression = returnStmt.returnedExpression!!

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/ExpressionBodySyntaxLineBreaks.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/ExpressionBodySyntaxLineBreaks.kt
@@ -31,11 +31,11 @@ class ExpressionBodySyntaxLineBreaks(config: Config = Config.empty) : Rule(
 		val (exprStart, exprEnd) = body.startAndEndLine()
 		if (equalsLine != exprStart) {
 			if (exprStart == exprEnd) {
-				addFindings(CodeSmell(id, Entity.from(equals)))
+				addFindings(CodeSmell(id, severity, Entity.from(equals)))
 				withAutoCorrect { body.alignToEqualsToken(equals) }
 			} else {
 				if (equals.trimSpacesBefore(autoCorrect, ignoreLineBreaks = true)) {
-					addFindings(CodeSmell(id, Entity.from(equals)))
+					addFindings(CodeSmell(id, severity, Entity.from(equals)))
 				}
 			}
 		}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/Indentation.kt
@@ -49,12 +49,12 @@ class Indentation(config: Config) : TokenRule("Indentation", Severity.Style, con
 					if (it.length % indent != 0) {
 						if (node.isPartOf(KtParameterList::class) && firstParameterColumn.value != 0) {
 							if (firstParameterColumn.value - 1 != it.length) {
-								addFindings(CodeSmell(id, Entity.from(node, offset = 1),
+								addFindings(CodeSmell(id, severity, Entity.from(node, offset = 1),
 										"Unexpected indentation (${it.length}) (" +
 												"parameters should be either vertically aligned or indented by the multiple of 4)"))
 							}
 						} else {
-							addFindings(CodeSmell(id, Entity.from(node, offset = 1),
+							addFindings(CodeSmell(id, severity, Entity.from(node, offset = 1),
 									"Unexpected indentation (${it.length}) (it should be multiple of $indent)"))
 						}
 					}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/MultipleSpaces.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/MultipleSpaces.kt
@@ -14,7 +14,7 @@ class MultipleSpaces(config: Config) : TokenRule("MultipleSpaces", Severity.Styl
 
 	override fun visitSpaces(space: PsiWhiteSpace) {
 		if (!space.textContains('\n') && space.textLength > 1) {
-			addFindings(CodeSmell(id, Entity.from(space, offset = 1)))
+			addFindings(CodeSmell(id, severity, Entity.from(space, offset = 1)))
 			withAutoCorrect {
 				(space as LeafPsiElement).replaceWithText(" ")
 			}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/OptionalSemicolon.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/OptionalSemicolon.kt
@@ -18,7 +18,7 @@ class OptionalSemicolon(config: Config = Config.empty) : TokenRule("OptionalSemi
 		if (leaf.isNotPartOfEnum() && leaf.isNotPartOfString()) {
 			val nextLeaf = leaf.nextLeaf()
 			if (nextLeaf.isSemicolonOrEOF() || nextTokenHasSpaces(nextLeaf)) {
-				addFindings(CodeSmell(id, Entity.from(leaf)))
+				addFindings(CodeSmell(id, severity, Entity.from(leaf)))
 				withAutoCorrect { leaf.delete() }
 			}
 		}
@@ -26,7 +26,7 @@ class OptionalSemicolon(config: Config = Config.empty) : TokenRule("OptionalSemi
 
 	override fun visitDoubleSemicolon(leaf: LeafPsiElement) {
 		if (leaf.isNotPartOfEnum() && leaf.isNotPartOfString()) {
-			addFindings(CodeSmell(id, Entity.from(leaf)))
+			addFindings(CodeSmell(id, severity, Entity.from(leaf)))
 			withAutoCorrect {
 				deleteOneOrTwoSemicolons(leaf)
 			}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/OptionalUnit.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/OptionalUnit.kt
@@ -22,7 +22,7 @@ class OptionalUnit(config: Config = Config.empty) : Rule("OptionalUnit", Severit
 			val typeReference = function.typeReference
 			typeReference?.typeElement?.text?.let {
 				if (it == "Unit") {
-					addFindings(CodeSmell(id, Entity.from(typeReference)))
+					addFindings(CodeSmell(id, severity, Entity.from(typeReference)))
 					withAutoCorrect {
 						deleteUnitReturnType(colon, typeReference)
 					}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAfterComma.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAfterComma.kt
@@ -23,7 +23,7 @@ class SpacingAfterComma(config: Config) : TokenRule("SpacingAfterComma", Severit
 
 	private fun checkSpace(leaf: LeafPsiElement) {
 		if (leaf.isSpaceMissing()) {
-			addFindings(CodeSmell(id, Entity.from(leaf, offset = 1)))
+			addFindings(CodeSmell(id, severity, Entity.from(leaf, offset = 1)))
 			withAutoCorrect {
 				leaf.rawInsertAfterMe(PsiWhiteSpaceImpl(" "))
 			}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAfterKeyword.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAfterKeyword.kt
@@ -36,7 +36,7 @@ class SpacingAfterKeyword(config: Config) : TokenRule("SpacingAfterKeyword", Sev
 
 	override fun visitLeaf(leaf: LeafPsiElement) {
 		if (keywords.contains(leaf.elementType) && !leaf.nextLeafIsWhiteSpace()) {
-			addFindings(CodeSmell(id, Entity.from(leaf, offset = leaf.text.length)))
+			addFindings(CodeSmell(id, severity, Entity.from(leaf, offset = leaf.text.length)))
 			withAutoCorrect {
 				handleCatchCase(leaf)
 				leaf.rawInsertAfterMe(PsiWhiteSpaceImpl(" "))
@@ -44,7 +44,7 @@ class SpacingAfterKeyword(config: Config) : TokenRule("SpacingAfterKeyword", Sev
 		} else if (keywordsWithoutSpaces.contains(leaf.elementType) && leaf.nextLeafIsWhiteSpace()) {
 			val parent = leaf.parent // property accessors without body need no check #71
 			if (parent is KtPropertyAccessor && parent.hasBody()) {
-				addFindings(CodeSmell(id, Entity.from(leaf, offset = leaf.text.length)))
+				addFindings(CodeSmell(id, severity, Entity.from(leaf, offset = leaf.text.length)))
 				withAutoCorrect {
 					leaf.nextLeaf()?.delete()
 				}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAroundBraces.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAroundBraces.kt
@@ -41,7 +41,7 @@ class SpacingAroundBraces(config: Config) : TokenRule(
 	private fun PsiElement?.checkForInvalidSpace(brace: LeafPsiElement) {
 		if (this is PsiWhiteSpace && !textContains('\n') &&
 				shouldNotToBeSeparatedBySpace(nextLeaf(skipEmptyElements = true))) {
-			addFindings(CodeSmell(id, Entity.from(brace)))
+			addFindings(CodeSmell(id, severity, Entity.from(brace)))
 			withAutoCorrect { delete() }
 		}
 	}
@@ -61,7 +61,7 @@ class SpacingAroundBraces(config: Config) : TokenRule(
 		}
 
 		if (!spacingBefore || !spacingAfter) {
-			addFindings(CodeSmell(id, Entity.from(this)))
+			addFindings(CodeSmell(id, severity, Entity.from(this)))
 		}
 	}
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAroundColon.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAroundColon.kt
@@ -29,7 +29,7 @@ class SpacingAroundColon(config: Config) : TokenRule("SpacingAroundColon", Sever
 			else -> false
 		}
 		if (modified) {
-			addFindings(CodeSmell(id, Entity.from(colon)))
+			addFindings(CodeSmell(id, severity, Entity.from(colon)))
 		}
 	}
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAroundOperator.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAroundOperator.kt
@@ -58,7 +58,7 @@ class SpacingAroundOperator(config: Config) : TokenRule("SpacingAroundOperator",
 				!node.isPartOf(KtSuperExpression::class) /*super<T>*/) {
 
 			if (node.trimSpacesAround(autoCorrect)) {
-				addFindings(CodeSmell(id, Entity.from(node)))
+				addFindings(CodeSmell(id, severity, Entity.from(node)))
 			}
 
 		}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/TrailingSpaces.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/TrailingSpaces.kt
@@ -29,7 +29,7 @@ class TrailingSpaces(config: Config) : TokenRule("TrailingSpaces", Severity.Styl
 
 	private fun replaceTracingSpaces(node: PsiWhiteSpace, candidates: List<String>, replaceWith: String) {
 		if (candidates.find { !it.isEmpty() } != null) {
-			addFindings(CodeSmell(id, Entity.from(node)))
+			addFindings(CodeSmell(id, severity, Entity.from(node)))
 			withAutoCorrect {
 				(node as LeafPsiElement).replaceWithText(replaceWith)
 			}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/UnusedImports.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/UnusedImports.kt
@@ -27,7 +27,7 @@ class UnusedImports(config: Config) : Rule("UnusedImports", Severity.Style, conf
 		imports.clear()
 		super.visitFile(file)
 		imports.forEach {
-			addFindings(CodeSmell(id, Entity.from(it.second), "Unused import"))
+			addFindings(CodeSmell(id, severity, Entity.from(it.second), "Unused import"))
 			withAutoCorrect {
 				it.second.delete()
 			}

--- a/detekt-migration/src/main/kotlin/io/gitlab/arturbosch/detekt/migration/ImportMigration.kt
+++ b/detekt-migration/src/main/kotlin/io/gitlab/arturbosch/detekt/migration/ImportMigration.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.migration
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Metric
+import io.gitlab.arturbosch.detekt.api.Rule
 
 /**
  * @author Artur Bosch
@@ -11,6 +12,7 @@ data class ImportMigration(private val toReplace: String,
 						   private val replacement: String,
 						   override val entity: Entity) : Finding {
 	override val id: String = "ImportMigration"
+	override val severity: Rule.Severity = Rule.Severity.Minor
 	override val references: List<Entity> = emptyList()
 	override val metrics: List<Metric> = emptyList()
 	override val description: String = "$id - $toReplace migrated to $replacement @ ${entity.location.compact()}"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/FeatureEnvy.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/FeatureEnvy.kt
@@ -71,7 +71,7 @@ class FeatureEnvy(config: Config = Config.empty) : CodeSmellRule("FeatureEnvy", 
 				println(ktElement.text)
 				println("factor: $value")
 				if (threshold < value) {
-					addFindings(CodeSmellWithReferenceAndMetric(id, entityOfFunction,
+					addFindings(CodeSmellWithReferenceAndMetric(id, severity, entityOfFunction,
 							Entity.from(ktElement), Metric("FeatureEnvyFactor", value, threshold, 100)))
 				}
 			}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
@@ -21,7 +21,7 @@ class DuplicateCaseInWhenExpression(config: Config) : Rule("DuplicateCaseInWhenE
 				.distinct().size
 
 		if (numberOfEntries > distinctNumber) {
-			addFindings(CodeSmell(id, Entity.from(expression)))
+			addFindings(CodeSmell(id, severity, Entity.from(expression)))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
@@ -32,7 +32,7 @@ class EqualsWithHashCodeExist(config: Config = Config.empty) : Rule("EqualsWithH
 
 		queue.push(ViolationHolder())
 		super.visitClassOrObject(classOrObject)
-		if (queue.pop().violation()) addFindings(CodeSmell(id, Entity.from(classOrObject)))
+		if (queue.pop().violation()) addFindings(CodeSmell(id, severity, Entity.from(classOrObject)))
 	}
 
 	override fun visitNamedFunction(function: KtNamedFunction) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
@@ -24,7 +24,7 @@ class ExplicitGarbageCollectionCall(config: Config) : Rule("ExplicitGarbageColle
 		if (it.textMatches("gc") || it.textMatches("runFinalization")) {
 			it.getReceiverExpression()?.let {
 				when (it.text) {
-					"System", "Runtime.getRuntime()" -> addFindings(CodeSmell(id, Entity.Companion.from(expression)))
+					"System", "Runtime.getRuntime()" -> addFindings(CodeSmell(id, severity, Entity.Companion.from(expression)))
 				}
 			}
 		}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
@@ -45,7 +45,7 @@ class ComplexCondition(config: Config = Config.empty, threshold: Int = 3) : Code
 			val conditionString = longestBinExpr.text
 			val count = frequency(conditionString, "&&") + frequency(conditionString, "||") + 1
 			if (count > threshold) {
-				addFindings(ThresholdedCodeSmell(id, Entity.from(condition), Metric("SIZE", count, threshold)))
+				addFindings(ThresholdedCodeSmell(id, severity, Entity.from(condition), Metric("SIZE", count, threshold)))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -22,7 +22,7 @@ class ComplexMethod(config: Config = Config.empty, threshold: Int = 10) : CodeSm
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		val mcc = MccVisitor().visit(function)
 		if (mcc > threshold) {
-			addFindings(ThresholdedCodeSmell(id, Entity.Companion.from(function), Metric("MCC", mcc, threshold)))
+			addFindings(ThresholdedCodeSmell(id, severity, Entity.Companion.from(function), Metric("MCC", mcc, threshold)))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -48,7 +48,7 @@ class LargeClass(config: Config = Config.empty, threshold: Int = 70) : CodeSmell
 		super.visitClassOrObject(classOrObject)
 		val loc = locStack.pop()
 		if (loc > threshold) {
-			addFindings(ThresholdedCodeSmell(id, Entity.Companion.from(classOrObject), Metric("SIZE", loc, threshold)))
+			addFindings(ThresholdedCodeSmell(id, severity, Entity.Companion.from(classOrObject), Metric("SIZE", loc, threshold)))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -19,7 +19,7 @@ class LongMethod(config: Config = Config.empty, threshold: Int = 20) : CodeSmell
 		body?.let {
 			val size = body.statements.size
 			if (size > threshold) addFindings(
-					ThresholdedCodeSmell(id, Entity.Companion.from(function), Metric("SIZE", size, threshold)))
+					ThresholdedCodeSmell(id, severity, Entity.Companion.from(function), Metric("SIZE", size, threshold)))
 		}
 		super.visitNamedFunction(function)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -22,7 +22,7 @@ class LongParameterList(config: Config = Config.empty, threshold: Int = 5) : Cod
 	private fun KtParameterList.checkThreshold() {
 		val size = parameters.size
 		if (size > threshold) {
-			addFindings(ThresholdedCodeSmell(id, Entity.Companion.from(this), Metric("SIZE", size, threshold)))
+			addFindings(ThresholdedCodeSmell(id, severity, Entity.Companion.from(this), Metric("SIZE", size, threshold)))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
@@ -25,7 +25,7 @@ class NestedBlockDepth(config: Config = Config.empty, threshold: Int = 3) : Code
 		val visitor = FunctionDepthVisitor(threshold)
 		visitor.visitNamedFunction(function)
 		if (visitor.isTooDeep)
-			addFindings(ThresholdedCodeSmell(id,
+			addFindings(ThresholdedCodeSmell(id, severity,
 					Entity.from(function), Metric("SIZE", visitor.maxDepth, threshold)))
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -19,7 +19,7 @@ class TooManyFunctions(config: Config = Config.empty, threshold: Int = 10) : Cod
 		super.visitFile(file)
 		if (amount > threshold) {
 			addFindings(ThresholdedCodeSmell(
-					id = id, entity = Entity.from(file),
+					id = id, severity = severity, entity = Entity.from(file),
 					metric = Metric(type = "SIZE", value = amount, threshold = 10))
 			)
 		}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethod.kt
@@ -16,7 +16,7 @@ class CommentOverPrivateMethod(config: Config = Config.empty) : CodeSmellRule("C
 		val modifierList = function.modifierList
 		if (modifierList != null && function.docComment != null) {
 			if (modifierList.hasModifier(KtTokens.PRIVATE_KEYWORD)) {
-				addFindings(CodeSmell(id, Entity.Companion.from(function.docComment!!)))
+				addFindings(CodeSmell(id, severity, Entity.Companion.from(function.docComment!!)))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
@@ -16,7 +16,7 @@ class CommentOverPrivateProperty(config: Config = Config.empty) : CodeSmellRule(
 		val modifierList = property.modifierList
 		if (modifierList != null && property.docComment != null) {
 			if (modifierList.hasModifier(KtTokens.PRIVATE_KEYWORD)) {
-				addFindings(CodeSmell(id, Entity.from(property.docComment!!)))
+				addFindings(CodeSmell(id, severity, Entity.from(property.docComment!!)))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/NoDocOverPublicClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/NoDocOverPublicClass.kt
@@ -16,7 +16,7 @@ class NoDocOverPublicClass(config: Config = Config.empty) : Rule("NoDocOverPubli
 	override fun visitClass(klass: KtClass) {
 
 		if (klass.isPublicNotOverriden()) {
-			addFindings(CodeSmell(id, Entity.Companion.from(klass)))
+			addFindings(CodeSmell(id, severity, Entity.Companion.from(klass)))
 		}
 		if (klass.notEnum()) { // Stop considering enum entries
 			super.visitClass(klass)
@@ -30,7 +30,7 @@ class NoDocOverPublicClass(config: Config = Config.empty) : Rule("NoDocOverPubli
 			return
 
 		if (declaration.isPublicNotOverriden()) {
-			addFindings(CodeSmell(id, Entity.Companion.from(declaration)))
+			addFindings(CodeSmell(id, severity, Entity.Companion.from(declaration)))
 		}
 		super.visitObjectDeclaration(declaration)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/NoDocOverPublicMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/NoDocOverPublicMethod.kt
@@ -18,11 +18,11 @@ class NoDocOverPublicMethod(config: Config = Config.empty) : Rule("NoDocOverPubl
 		val modifierList = function.modifierList
 		if (function.docComment == null) {
 			if (modifierList == null) {
-				addFindings(CodeSmell(id, methodHeaderLocation(function)))
+				addFindings(CodeSmell(id, severity, methodHeaderLocation(function)))
 			}
 			if (modifierList != null) {
 				if (function.isPublicNotOverriden()) {
-					addFindings(CodeSmell(id, methodHeaderLocation(function)))
+					addFindings(CodeSmell(id, severity, methodHeaderLocation(function)))
 				}
 			}
 		}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
@@ -12,7 +12,7 @@ class EmptyClassBlock(config: Config) : EmptyRule("EmptyClassBlock", config = co
 
 	override fun visitClassOrObject(classOrObject: KtClassOrObject) {
 		classOrObject.getBody()?.declarations?.let {
-			if (it.isEmpty()) addFindings(CodeSmell(id, Entity.from(classOrObject)))
+			if (it.isEmpty()) addFindings(CodeSmell(id, severity, Entity.from(classOrObject)))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
@@ -14,7 +14,7 @@ open class EmptyRule(id: String, config: Config, severity: Severity = Rule.Sever
 
 	fun KtExpression.addFindingIfBlockExprIsEmpty() {
 		this.asBlockExpression()?.statements?.let {
-			if (it.isEmpty()) addFindings(CodeSmell(id, Entity.from(this)))
+			if (it.isEmpty()) addFindings(CodeSmell(id, severity, Entity.from(this)))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyWhenBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyWhenBlock.kt
@@ -12,7 +12,7 @@ class EmptyWhenBlock(config: Config) : EmptyRule("EmptyWhenBlock", config = conf
 
 	override fun visitWhenExpression(expression: KtWhenExpression) {
 		if (expression.entries.isEmpty()) {
-			addFindings(CodeSmell(id, Entity.from(expression)))
+			addFindings(CodeSmell(id, severity, Entity.from(expression)))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionsRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionsRule.kt
@@ -16,13 +16,13 @@ open class ExceptionsRule(id: String, config: Config, severity: Severity = Rule.
 		this.catchParameter?.let {
 			val text = it.typeReference?.text
 			if (text != null && text == exception())
-				addFindings(CodeSmell(id, Entity.from(it)))
+				addFindings(CodeSmell(id, severity, Entity.from(it)))
 		}
 	}
 
 	fun KtThrowExpression.addFindingIfThrowingClassMatchesExact(exception: () -> String) {
 		thrownExpression?.text?.substringBefore("(")?.let {
-			if (it == exception()) addFindings(CodeSmell(id, Entity.from(this)))
+			if (it == exception()) addFindings(CodeSmell(id, severity, Entity.from(this)))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NamingConventionViolation.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NamingConventionViolation.kt
@@ -64,7 +64,7 @@ class NamingConventionViolation(config: Config = Config.empty) : Rule(RULE_SUB_C
 	}
 
 	private fun add(declaration: KtNamedDeclaration) {
-		addFindings(CodeSmell(id, Entity.Companion.from(declaration)))
+		addFindings(CodeSmell(id, severity, Entity.Companion.from(declaration)))
 	}
 
 	private fun KtVariableDeclaration.isTopLevel(): Boolean = this is KtProperty && this.isTopLevel

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -14,7 +14,7 @@ class WildcardImport(config: Config = Config.empty) : Rule("WildcardImport", Sev
 	override fun visitImportDirective(importDirective: KtImportDirective) {
 		val import = importDirective.importPath?.pathStr
 		if (import != null && import.contains("*")) {
-			addFindings(CodeSmell(id, Entity.Companion.from(importDirective)))
+			addFindings(CodeSmell(id, severity, Entity.Companion.from(importDirective)))
 		}
 	}
 }

--- a/detekt-sample-ruleset/src/main/kotlin/io/gitlab/arturbosch/detekt/sampleruleset/TooManyFunctions.kt
+++ b/detekt-sample-ruleset/src/main/kotlin/io/gitlab/arturbosch/detekt/sampleruleset/TooManyFunctions.kt
@@ -16,7 +16,7 @@ class TooManyFunctions : Rule("TooManyFunctions") {
 	override fun visitFile(file: PsiFile) {
 		super.visitFile(file)
 		if (amount > 10) {
-			addFindings(CodeSmell(id, Entity.from(file)))
+			addFindings(CodeSmell(id, severity, Entity.from(file)))
 		}
 	}
 

--- a/detekt-sample-ruleset/src/main/kotlin/io/gitlab/arturbosch/detekt/sampleruleset/TooManyFunctionsTwo.kt
+++ b/detekt-sample-ruleset/src/main/kotlin/io/gitlab/arturbosch/detekt/sampleruleset/TooManyFunctionsTwo.kt
@@ -19,7 +19,9 @@ class TooManyFunctionsTwo(config: Config) : Rule("TooManyFunctionsTwo", Severity
 		super.visitFile(file)
 		if (amount > 10) {
 			addFindings(CodeSmell(
-					id = id, entity = Entity.from(file),
+					id = id,
+					severity = severity,
+					entity = Entity.from(file),
 					description = "Too many functions can make the maintainability of a file more costly",
 					metrics = listOf(Metric(type = "SIZE", value = amount, threshold = 10)),
 					references = listOf())


### PR DESCRIPTION
This is the first PR of 3 to fix #66 

Since reports should contain the severity of the found issue, I added that field to Findings.
Maybe it would be even nicer at some point to separate the Rule metadata from the Rule itself and report findings through a shared context. This would be similar to Lint Detector/Context/Issue setup.