### PR TITLE
Add CodeStyle Rule for MaxLineLength

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -96,6 +96,9 @@ style:
   active: true
   WildcardImport:
     active: true
+  MaxLineLength:
+    active: true
+    maxLineLength: 100
   NamingConventionViolation:
     active: true
     variablePattern: '^(_)?[a-z$][a-zA-Z$0-9]*$'

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -98,7 +98,7 @@ style:
     active: true
   MaxLineLength:
     active: true
-    maxLineLength: 100
+    maxLineLength: 120
   NamingConventionViolation:
     active: true
     variablePattern: '^(_)?[a-z$][a-zA-Z$0-9]*$'

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -5,18 +5,14 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Rule
 import org.jetbrains.kotlin.psi.KtFile
-import java.io.BufferedReader
-import java.io.InputStreamReader
 
 class MaxLineLength(config: Config = Config.empty) : Rule("MaxLineLength", Severity.Style, config) {
 
-	private val maxLineLength: Int = withConfig { valueOrDefault(MAX_LINE_LENGTH) { "100" } }.toInt()
+	private val maxLineLength: Int = withConfig { valueOrDefault(MAX_LINE_LENGTH) { "120" } }.toInt()
 
 	override fun visit(root: KtFile) {
-		val bufferedReader = BufferedReader(InputStreamReader(root.text.byteInputStream()))
-
 		var offset = 0
-		bufferedReader.lines()
+		root.text.splitToSequence("\n")
 				.map { it.length }
 				.forEach {
 					offset += it

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -1,0 +1,33 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Rule
+import org.jetbrains.kotlin.psi.KtFile
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+class MaxLineLength(config: Config = Config.empty) : Rule("MaxLineLength", Severity.Style, config) {
+
+	private val maxLineLength: Int = withConfig { valueOrDefault(MAX_LINE_LENGTH) { "100" } }.toInt()
+
+	override fun visit(root: KtFile) {
+		val bufferedReader = BufferedReader(InputStreamReader(root.text.byteInputStream()))
+
+		var offset = 0
+		bufferedReader.lines()
+				.map { it.length }
+				.forEach {
+					offset += it
+					if (it > maxLineLength) {
+						addFindings(CodeSmell(id, Entity.Companion.from(root, offset)))
+					}
+				}
+	}
+
+	companion object {
+		val MAX_LINE_LENGTH = "maxLineLength"
+	}
+}
+

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
@@ -14,6 +14,7 @@ class StyleGuideProvider : RuleSetProvider {
 	override fun instance(config: Config): RuleSet {
 		return RuleSet(ruleSetId, listOf(
 				WildcardImport(config),
+				MaxLineLength(config),
 				NamingConventionViolation(config)
 		))
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/KT.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/KT.kt
@@ -15,6 +15,7 @@ enum class Case(val file: String) {
 	Empty("/cases/Empty.kt"),
 	Exceptions("/cases/Exceptions.kt"),
 	NamingConventions("/cases/NamingConventions.kt"),
+	MaxLineLength("/cases/MaxLineLength.kt"),
 	ComplexClass("/cases/ComplexClass.kt"),
 	Comments("/cases/Comments.kt"),
 	NestedClasses("/cases/NestedClasses.kt"),

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -1,0 +1,30 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.rules.Case
+import io.gitlab.arturbosch.detekt.rules.load
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MaxLineLengthSpec {
+
+	val root = load(Case.MaxLineLength)
+
+	@Test
+	fun findMaxLineLengthViolationsWithDefault() {
+		find(6) { MaxLineLength() }
+	}
+
+	@Test
+	fun findMaxLineLengthViolationsWithConfig() {
+		find(0) { MaxLineLength(TestConfig(mapOf("maxLineLength" to "200"))) }
+	}
+
+	private fun find(expected: Int, block: () -> Rule) {
+		val rule = block()
+		rule.visit(root)
+		assertThat(rule.findings).hasSize(expected)
+	}
+
+}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -1,30 +1,32 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.rules.Case
-import io.gitlab.arturbosch.detekt.rules.load
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
+import io.gitlab.arturbosch.detekt.test.compileForTest
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
 
-class MaxLineLengthSpec {
+class MaxLineLengthSpec : Spek({
 
-	val root = load(Case.MaxLineLength)
+	val file = compileForTest(Case.MaxLineLength.path()).text
 
-	@Test
-	fun findMaxLineLengthViolationsWithDefault() {
-		find(6) { MaxLineLength() }
+	given("a kt file with some long lines") {
+		it("should report no errors when maxLineLength is set to 200") {
+			val rule = MaxLineLength(TestConfig(mapOf("maxLineLength" to "200")))
+
+			val findings = rule.lint(file)
+			Assertions.assertThat(findings).hasSize(0)
+		}
+
+		it("should report all errors with default maxLineLength") {
+			val rule = MaxLineLength()
+
+			val findings = rule.lint(file)
+			Assertions.assertThat(findings).hasSize(3)
+		}
 	}
-
-	@Test
-	fun findMaxLineLengthViolationsWithConfig() {
-		find(0) { MaxLineLength(TestConfig(mapOf("maxLineLength" to "200"))) }
-	}
-
-	private fun find(expected: Int, block: () -> Rule) {
-		val rule = block()
-		rule.visit(root)
-		assertThat(rule.findings).hasSize(expected)
-	}
-
-}
+})

--- a/detekt-rules/src/test/resources/cases/MaxLineLength.kt
+++ b/detekt-rules/src/test/resources/cases/MaxLineLength.kt
@@ -1,0 +1,31 @@
+package cases
+
+class MaxLineLength {
+
+    companion object {
+        val LOREM_IPSUM = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+    }
+
+    val loremIpsumField = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+
+    fun main() {
+        val thisIsAVeryLongValName = "This is a very, very long String that will break the MaxLineLengthRule"
+
+        if (thisIsAVeryLongValName.length > "This is not quite as long of a String".length) {
+            println("It's indeed a very long String")
+        }
+
+        val hello = anIncrediblyLongAndComplexMethodNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot()
+        val loremIpsum = getLoremIpsum()
+
+        println(hello)
+        println(loremIpsum)
+
+    }
+
+    fun anIncrediblyLongAndComplexMethodNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot(): String {
+        return "Hello"
+    }
+
+    fun getLoremIpsum() = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+}


### PR DESCRIPTION
Resolves #56 

This feels like a very basic, stupid implementation walking though each source file line by line.

Happy for suggestions on how to improve the Rule. Was at first trying to walk the PSI Tree, but that would require lots of manual whitespace and codeword counting if I understood it correctly.