### PR TITLE
Rename detekt-rules Specs to Test

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCallTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCallTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 /**
  * @author Artur Bosch
  */
-class ExplicitGarbageCollectionCallSpec {
+class ExplicitGarbageCollectionCallTest {
 
 	@Test
 	fun systemGC() {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 /**
  * @author Artur Bosch
  */
-class EmptyCodeSpec {
+class EmptyCodeTest {
 
 	val root = load(Case.Empty)
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionsTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionsTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 /**
  * @author Artur Bosch
  */
-class ExceptionsSpec {
+class ExceptionsTest {
 
 	val root = load(Case.Exceptions)
 


### PR DESCRIPTION
As I was copy pasting my tests for my PR #75 in the detekt-rules module yesterday and the Spec/Test name of the Test classes was off for non-Spek tests.

This renames some Test files that were called `Spec` even though they are not using Spek. Took a quick look around the other modules and it seems like now all test files should have the right name.

Is the goal for all tests to use Spek in the end? I could also rewrite some of them to use Spek if you prefer.