### PR TITLE
remove unstable load() method in rule tests

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Unstable.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Unstable.kt
@@ -1,8 +1,0 @@
-package io.gitlab.arturbosch.detekt.api
-
-/**
- * Marks an member as experimental feature which may be changed or removed in the future.
- *
- * @author Artur Bosch
- */
-annotation class Unstable(val value: String = "", val removedIn: String = "")

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/CommonSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/CommonSpec.kt
@@ -2,6 +2,8 @@ package io.gitlab.arturbosch.detekt.rules
 
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.rules.style.WildcardImport
+import io.gitlab.arturbosch.detekt.test.compileForTest
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
@@ -12,11 +14,11 @@ import org.jetbrains.spek.subject.SubjectSpek
  */
 class CommonSpec : SubjectSpek<Rule>({
 	subject { WildcardImport() }
-	val root = load(Case.Default)
+	val file = compileForTest(Case.Default.path())
 
 	describe("running specified rule") {
 		it("should detect one finding") {
-			subject.visit(root)
+			subject.lint(file.text)
 			assertThat(subject.findings).hasSize(1)
 		}
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/ComplexMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/ComplexMethodSpec.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.rules
 
 import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
 import io.gitlab.arturbosch.detekt.rules.complexity.ComplexMethod
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.it
@@ -13,8 +14,7 @@ class ComplexMethodSpec : Spek({
 
 	it("finds one complex method") {
 		val subject = ComplexMethod()
-		val root = load(Case.ComplexClass)
-		subject.visit(root)
+		subject.lint(Case.ComplexClass.path())
 		assertThat(subject.findings).hasSize(1)
 		assertThat((subject.findings[0] as ThresholdedCodeSmell).value).isEqualTo(13)
 		assertThat((subject.findings[0] as ThresholdedCodeSmell).threshold).isEqualTo(10)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/KT.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/KT.kt
@@ -1,8 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules
 
-import io.gitlab.arturbosch.detekt.api.Unstable
-import io.gitlab.arturbosch.detekt.core.KtCompiler
-import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -30,12 +27,4 @@ enum class Case(val file: String) {
 		requireNotNull(resource)
 		return Paths.get(resource.path)
 	}
-}
-
-@Unstable
-private val compiler = KtCompiler(Case.CasesFolder.path())
-
-@Unstable
-fun load(case: Case): KtFile {
-	return compiler.compile(case.path())
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/LargeClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/LargeClassSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules
 
 import io.gitlab.arturbosch.detekt.rules.complexity.LargeClass
+import io.gitlab.arturbosch.detekt.test.lint
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
@@ -16,8 +17,7 @@ class LargeClassSpec : SubjectSpek<LargeClass>({
 
 	describe("nested classes are also considered") {
 		it("should detect only the nested large class") {
-			val root = load(Case.NestedClasses)
-			subject.visit(root)
+			subject.lint(Case.NestedClasses.path())
 			assertEquals(subject.findings.size, 1)
 		}
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/LongMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/LongMethodSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules
 
 import io.gitlab.arturbosch.detekt.rules.complexity.LongMethod
+import io.gitlab.arturbosch.detekt.test.lint
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
@@ -14,16 +15,14 @@ class LongMethodSpec : SubjectSpek<LongMethod>({
 
 	describe("nested functions can be long") {
 		it("should find two long methods") {
-			val root = load(Case.NestedLongMethods)
-			subject.visit(root)
+			subject.lint(Case.NestedLongMethods.path())
 			assertEquals(subject.findings.size, 2)
 		}
 	}
 
 	describe("nested classes can contain long methods") {
 		it("should detect one nested long method") {
-			val root = load(Case.NestedClasses)
-			subject.visit(root)
+			subject.lint(Case.NestedClasses.path())
 			assertEquals(subject.findings.size, 1)
 		}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/NamingConventionViolationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/NamingConventionViolationSpec.kt
@@ -15,8 +15,7 @@ class NamingConventionViolationSpec : SubjectSpek<NamingConventionViolation>({
 	subject { NamingConventionViolation() }
 
 	it("should find all wrong namings") {
-		val root = load(Case.NamingConventions)
-		subject.visit(root)
+		subject.lint(Case.NamingConventions.path())
 		assertThat(subject.findings).hasSize(9)
 	}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/NestedBlockDepthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/NestedBlockDepthSpec.kt
@@ -22,8 +22,7 @@ class NestedBlockDepthSpec : SubjectSpek<NestedBlockDepth>({
 
 	describe("nested classes are also considered") {
 		it("should detect only the nested large class") {
-			val root = load(Case.NestedClasses)
-			subject.visit(root)
+			subject.lint(Case.NestedClasses.path())
 			assertEquals(subject.findings.size, 1)
 			assertEquals((subject.findings[0] as ThresholdedCodeSmell).value, 5)
 		}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/NoDocOverPublicClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/NoDocOverPublicClassSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules
 
 import io.gitlab.arturbosch.detekt.rules.documentation.NoDocOverPublicClass
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
@@ -12,8 +13,7 @@ class NoDocOverPublicClassSpec : SubjectSpek<NoDocOverPublicClass>({
 	subject { NoDocOverPublicClass() }
 
 	it("finds two undocumented classes") {
-		val root = load(Case.Comments)
-		subject.visit(root)
+		subject.lint(Case.Comments.path())
 		assertThat(subject.findings).hasSize(2)
 	}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/NoDocOverPublicMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/NoDocOverPublicMethodSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules
 
 import io.gitlab.arturbosch.detekt.rules.documentation.NoDocOverPublicMethod
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
@@ -12,8 +13,7 @@ class NoDocOverPublicMethodSpec : SubjectSpek<NoDocOverPublicMethod>({
 	subject { NoDocOverPublicMethod() }
 
 	it("finds three undocumented functions") {
-		val root = load(Case.Comments)
-		subject.visit(root)
+		subject.lint(Case.Comments.path())
 		assertThat(subject.findings).hasSize(3)
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeTest.kt
@@ -3,7 +3,8 @@ package io.gitlab.arturbosch.detekt.rules.empty
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.rules.Case
-import io.gitlab.arturbosch.detekt.rules.load
+import io.gitlab.arturbosch.detekt.test.compileForTest
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -12,7 +13,7 @@ import org.junit.jupiter.api.Test
  */
 class EmptyCodeTest {
 
-	val root = load(Case.Empty)
+	val file = compileForTest(Case.Empty.path())
 
 	@Test
 	fun findsEmptyCatch() {
@@ -66,7 +67,7 @@ class EmptyCodeTest {
 
 	private fun test(block: () -> Rule) {
 		val rule = block()
-		rule.visit(root)
+		rule.lint(file.text)
 		assertThat(rule.findings).hasSize(1)
 	}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionsTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionsTest.kt
@@ -2,7 +2,8 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.rules.Case
-import io.gitlab.arturbosch.detekt.rules.load
+import io.gitlab.arturbosch.detekt.test.compileForTest
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -11,7 +12,7 @@ import org.junit.jupiter.api.Test
  */
 class ExceptionsTest {
 
-	val root = load(Case.Exceptions)
+	val file = compileForTest(Case.Exceptions.path())
 
 	@Test
 	fun findThrowError() {
@@ -70,7 +71,7 @@ class ExceptionsTest {
 
 	private fun findOne(block: () -> Rule) {
 		val rule = block()
-		rule.visit(root)
+		rule.lint(file.text)
 		assertThat(rule.findings).hasSize(1)
 	}
 


### PR DESCRIPTION
This PR:
- Removes the Unstable annotation
- Removes the `load()` methods from Rule tests
- Migrates all usages of `load()` to use the `.lint()` method

Resolves #77 

