### PR TITLE
[Prototype] Introduce Context and Issue for rules

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -6,15 +6,14 @@ package io.gitlab.arturbosch.detekt.api
  *
  * @author Artur Bosch
  */
-open class CodeSmell(override val id: String,
-					 override val severity: Rule.Severity,
+open class CodeSmell(override val issue: Issue,
 					 override val entity: Entity,
-					 override val description: String = "",
+					 override val message: String = "",
 					 override val metrics: List<Metric> = listOf(),
 					 override val references: List<Entity> = listOf()) : Finding {
 
 	override fun compact(): String {
-		return "$id - ${entity.compact()}"
+		return "${issue.id} - ${entity.compact()}"
 	}
 
 	override fun compactWithSignature(): String {
@@ -27,11 +26,11 @@ open class CodeSmell(override val id: String,
  * for the existence of this rule violation.
  */
 open class CodeSmellWithReferenceAndMetric(
-		id: String, severity: Rule.Severity, entity: Entity, val reference: Entity, metric: Metric) : ThresholdedCodeSmell(
-		id, severity, entity, metric, references = listOf(reference)) {
+		issue: Issue, entity: Entity, val reference: Entity, metric: Metric) : ThresholdedCodeSmell(
+		issue, entity, metric, references = listOf(reference)) {
 
 	override fun compact(): String {
-		return "$id - $metric - ref=${reference.name} - ${entity.compact()}"
+		return "${issue.id} - $metric - ref=${reference.name} - ${entity.compact()}"
 	}
 }
 
@@ -40,14 +39,14 @@ open class CodeSmellWithReferenceAndMetric(
  * for the existence of this rule violation.
  */
 open class ThresholdedCodeSmell(
-		id: String, severity: Rule.Severity, entity: Entity, val metric: Metric, references: List<Entity> = emptyList()) : CodeSmell(
-		id, severity, entity, metrics = listOf(metric), references = references) {
+		issue: Issue, entity: Entity, val metric: Metric, references: List<Entity> = emptyList()) : CodeSmell(
+		issue, entity, metrics = listOf(metric), references = references) {
 	val value: Int
 		get() = metric.value
 	val threshold: Int
 		get() = metric.threshold
 
 	override fun compact(): String {
-		return "$id - $metric - ${entity.compact()}"
+		return "${issue.id} - $metric - ${entity.compact()}"
 	}
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
@@ -1,0 +1,27 @@
+package io.gitlab.arturbosch.detekt.api
+
+class Context {
+
+    /**
+     * Returns a list of violations.
+     */
+    val findings: List<Finding>
+        get() = _findings
+
+    private val _findings: MutableList<Finding> = mutableListOf()
+
+    fun report(finding: Finding) {
+        val ktElement = finding.entity.ktElement
+        if (ktElement == null || !ktElement.isSuppressedBy(finding.issue.id)) {
+            _findings += finding
+        }
+    }
+
+//    fun <K, V> List<Pair<K, List<V>>>.toMergedMap(): Map<K, List<V>> {
+//        val map = HashMap<K, MutableList<V>>()
+//        this.forEach {
+//            map.merge(it.first, it.second.toMutableList(), { l1, l2 -> l1.apply { addAll(l2) } })
+//        }
+//        return map
+//    }
+}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/DetektVisitor.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/DetektVisitor.kt
@@ -1,10 +1,1024 @@
 package io.gitlab.arturbosch.detekt.api
 
-import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
+import org.jetbrains.kotlin.com.intellij.psi.*
+import org.jetbrains.kotlin.com.intellij.psi.templateLanguages.OuterLanguageElement
+import org.jetbrains.kotlin.psi.*
 
 /**
  * Base visitor for detekt rules.
  *
  * @author Artur Bosch
  */
-open class DetektVisitor : KtTreeVisitorVoid()
+open class DetektVisitor : KtTreeVisitor<Context>() {
+    // methods with void return
+
+    open fun visitKtElement(context: Context, element: KtElement) {
+        super.visitKtElement(element, context)
+    }
+
+    open fun visitDeclaration(context: Context, dcl: KtDeclaration) {
+        super.visitDeclaration(dcl, context)
+    }
+
+    open fun visitClass(context: Context, klass: KtClass) {
+        super.visitClass(klass, context)
+    }
+
+    open fun visitClassOrObject(context: Context, classOrObject: KtClassOrObject) {
+        super.visitClassOrObject(classOrObject, context)
+    }
+
+    open fun visitSecondaryConstructor(context: Context, constructor: KtSecondaryConstructor) {
+        super.visitSecondaryConstructor(constructor, context)
+    }
+
+    open fun visitPrimaryConstructor(context: Context, constructor: KtPrimaryConstructor) {
+        super.visitPrimaryConstructor(constructor, context)
+    }
+
+    open fun visitNamedFunction(context: Context, function: KtNamedFunction) {
+        super.visitNamedFunction(function, context)
+    }
+
+    open fun visitProperty(context: Context, property: KtProperty) {
+        super.visitProperty(property, context)
+    }
+
+    open fun visitTypeAlias(context: Context, typeAlias: KtTypeAlias) {
+        super.visitTypeAlias(typeAlias, context)
+    }
+
+    open fun visitDestructuringDeclaration(context: Context,
+                                           destructuringDeclaration: KtDestructuringDeclaration) {
+        super.visitDestructuringDeclaration(destructuringDeclaration, context)
+    }
+
+    open fun visitDestructuringDeclarationEntry(context: Context,
+                                                multiDeclarationEntry: KtDestructuringDeclarationEntry) {
+        super.visitDestructuringDeclarationEntry(multiDeclarationEntry, context)
+    }
+
+    open fun visitKtFile(context: Context, file: KtFile) {
+        super.visitKtFile(file, context)
+    }
+
+    open fun visitScript(context: Context, script: KtScript) {
+        super.visitScript(script, context)
+    }
+
+    open fun visitImportDirective(context: Context, importDirective: KtImportDirective) {
+        super.visitImportDirective(importDirective, context)
+    }
+
+    open fun visitImportList(context: Context, importList: KtImportList) {
+        super.visitImportList(importList, context)
+    }
+
+    open fun visitClassBody(context: Context, classBody: KtClassBody) {
+        super.visitClassBody(classBody, context)
+    }
+
+    open fun visitModifierList(context: Context, list: KtModifierList) {
+        super.visitModifierList(list, context)
+    }
+
+    open fun visitAnnotation(context: Context, annotation: KtAnnotation) {
+        super.visitAnnotation(annotation, context)
+    }
+
+    open fun visitAnnotationEntry(context: Context, annotationEntry: KtAnnotationEntry) {
+        super.visitAnnotationEntry(annotationEntry, context)
+    }
+
+    open fun visitConstructorCalleeExpression(context: Context,
+                                              constructorCalleeExpression: KtConstructorCalleeExpression) {
+        super.visitConstructorCalleeExpression(constructorCalleeExpression, context)
+    }
+
+    open fun visitTypeParameterList(context: Context, list: KtTypeParameterList) {
+        super.visitTypeParameterList(list, context)
+    }
+
+    open fun visitTypeParameter(context: Context, parameter: KtTypeParameter) {
+        super.visitTypeParameter(parameter, context)
+    }
+
+    open fun visitEnumEntry(context: Context, enumEntry: KtEnumEntry) {
+        super.visitEnumEntry(enumEntry, context)
+    }
+
+    open fun visitParameterList(context: Context, list: KtParameterList) {
+        super.visitParameterList(list, context)
+    }
+
+    open fun visitParameter(context: Context, parameter: KtParameter) {
+        super.visitParameter(parameter, context)
+    }
+
+    open fun visitSuperTypeList(context: Context, list: KtSuperTypeList) {
+        super.visitSuperTypeList(list, context)
+    }
+
+    open fun visitSuperTypeListEntry(context: Context, specifier: KtSuperTypeListEntry) {
+        super.visitSuperTypeListEntry(specifier, context)
+    }
+
+    open fun visitDelegatedSuperTypeEntry(context: Context, specifier: KtDelegatedSuperTypeEntry) {
+        super.visitDelegatedSuperTypeEntry(specifier, context)
+    }
+
+    open fun visitSuperTypeCallEntry(context: Context, call: KtSuperTypeCallEntry) {
+        super.visitSuperTypeCallEntry(call, context)
+    }
+
+    open fun visitSuperTypeEntry(context: Context, specifier: KtSuperTypeEntry) {
+        super.visitSuperTypeEntry(specifier, context)
+    }
+
+    open fun visitConstructorDelegationCall(context: Context, call: KtConstructorDelegationCall) {
+        super.visitConstructorDelegationCall(call, context)
+    }
+
+    open fun visitPropertyDelegate(context: Context, delegate: KtPropertyDelegate) {
+        super.visitPropertyDelegate(delegate, context)
+    }
+
+    open fun visitTypeReference(context: Context, typeReference: KtTypeReference) {
+        super.visitTypeReference(typeReference, context)
+    }
+
+    open fun visitValueArgumentList(context: Context, list: KtValueArgumentList) {
+        super.visitValueArgumentList(list, context)
+    }
+
+    open fun visitArgument(context: Context, argument: KtValueArgument) {
+        super.visitArgument(argument, context)
+    }
+
+    open fun visitExpression(context: Context, expression: KtExpression) {
+        super.visitExpression(expression, context)
+    }
+
+    open fun visitLoopExpression(context: Context, loopExpression: KtLoopExpression) {
+        super.visitLoopExpression(loopExpression, context)
+    }
+
+    open fun visitConstantExpression(context: Context, expression: KtConstantExpression) {
+        super.visitConstantExpression(expression, context)
+    }
+
+    open fun visitSimpleNameExpression(context: Context, expression: KtSimpleNameExpression) {
+        super.visitSimpleNameExpression(expression, context)
+    }
+
+    open fun visitReferenceExpression(context: Context, expression: KtReferenceExpression) {
+        super.visitReferenceExpression(expression, context)
+    }
+
+    open fun visitLabeledExpression(context: Context, expression: KtLabeledExpression) {
+        super.visitLabeledExpression(expression, context)
+    }
+
+    open fun visitPrefixExpression(context: Context, expression: KtPrefixExpression) {
+        super.visitPrefixExpression(expression, context)
+    }
+
+    open fun visitPostfixExpression(context: Context, expression: KtPostfixExpression) {
+        super.visitPostfixExpression(expression, context)
+    }
+
+    open fun visitUnaryExpression(context: Context, expression: KtUnaryExpression) {
+        super.visitUnaryExpression(expression, context)
+    }
+
+    open fun visitBinaryExpression(context: Context, expression: KtBinaryExpression) {
+        super.visitBinaryExpression(expression, context)
+    }
+
+    open fun visitReturnExpression(context: Context, expression: KtReturnExpression) {
+        super.visitReturnExpression(expression, context)
+    }
+
+    open fun visitExpressionWithLabel(context: Context, expression: KtExpressionWithLabel) {
+        super.visitExpressionWithLabel(expression, context)
+    }
+
+    open fun visitThrowExpression(context: Context, expression: KtThrowExpression) {
+        super.visitThrowExpression(expression, context)
+    }
+
+    open fun visitBreakExpression(context: Context, expression: KtBreakExpression) {
+        super.visitBreakExpression(expression, context)
+    }
+
+    open fun visitContinueExpression(context: Context, expression: KtContinueExpression) {
+        super.visitContinueExpression(expression, context)
+    }
+
+    open fun visitIfExpression(context: Context, expression: KtIfExpression) {
+        super.visitIfExpression(expression, context)
+    }
+
+    open fun visitWhenExpression(context: Context, expression: KtWhenExpression) {
+        super.visitWhenExpression(expression, context)
+    }
+
+    open fun visitCollectionLiteralExpression(context: Context, expression: KtCollectionLiteralExpression) {
+        super.visitCollectionLiteralExpression(expression, context)
+    }
+
+    open fun visitTryExpression(context: Context, expression: KtTryExpression) {
+        super.visitTryExpression(expression, context)
+    }
+
+    open fun visitForExpression(context: Context, expression: KtForExpression) {
+        super.visitForExpression(expression, context)
+    }
+
+    open fun visitWhileExpression(context: Context, expression: KtWhileExpression) {
+        super.visitWhileExpression(expression, context)
+    }
+
+    open fun visitDoWhileExpression(context: Context, expression: KtDoWhileExpression) {
+        super.visitDoWhileExpression(expression, context)
+    }
+
+    open fun visitLambdaExpression(context: Context, lambdaExpression: KtLambdaExpression) {
+        super.visitLambdaExpression(lambdaExpression, context)
+    }
+
+    open fun visitAnnotatedExpression(context: Context, expression: KtAnnotatedExpression) {
+        super.visitAnnotatedExpression(expression, context)
+    }
+
+    open fun visitCallExpression(context: Context, expression: KtCallExpression) {
+        super.visitCallExpression(expression, context)
+    }
+
+    open fun visitArrayAccessExpression(context: Context, expression: KtArrayAccessExpression) {
+        super.visitArrayAccessExpression(expression, context)
+    }
+
+    open fun visitQualifiedExpression(context: Context, expression: KtQualifiedExpression) {
+        super.visitQualifiedExpression(expression, context)
+    }
+
+    open fun visitDoubleColonExpression(context: Context, expression: KtDoubleColonExpression) {
+        super.visitDoubleColonExpression(expression, context)
+    }
+
+    open fun visitCallableReferenceExpression(context: Context, expression: KtCallableReferenceExpression) {
+        super.visitCallableReferenceExpression(expression, context)
+    }
+
+    open fun visitClassLiteralExpression(context: Context, expression: KtClassLiteralExpression) {
+        super.visitClassLiteralExpression(expression, context)
+    }
+
+    open fun visitDotQualifiedExpression(context: Context, expression: KtDotQualifiedExpression) {
+        super.visitDotQualifiedExpression(expression, context)
+    }
+
+    open fun visitSafeQualifiedExpression(context: Context, expression: KtSafeQualifiedExpression) {
+        super.visitSafeQualifiedExpression(expression, context)
+    }
+
+    open fun visitObjectLiteralExpression(context: Context, expression: KtObjectLiteralExpression) {
+        super.visitObjectLiteralExpression(expression, context)
+    }
+
+    open fun visitBlockExpression(context: Context, expression: KtBlockExpression) {
+        super.visitBlockExpression(expression, context)
+    }
+
+    open fun visitCatchSection(context: Context, catchClause: KtCatchClause) {
+        super.visitCatchSection(catchClause, context)
+    }
+
+    open fun visitFinallySection(context: Context, finallySection: KtFinallySection) {
+        super.visitFinallySection(finallySection, context)
+    }
+
+    open fun visitTypeArgumentList(context: Context, typeArgumentList: KtTypeArgumentList) {
+        super.visitTypeArgumentList(typeArgumentList, context)
+    }
+
+    open fun visitThisExpression(context: Context, expression: KtThisExpression) {
+        super.visitThisExpression(expression, context)
+    }
+
+    open fun visitSuperExpression(context: Context, expression: KtSuperExpression) {
+        super.visitSuperExpression(expression, context)
+    }
+
+    open fun visitParenthesizedExpression(context: Context, expression: KtParenthesizedExpression) {
+        super.visitParenthesizedExpression(expression, context)
+    }
+
+    open fun visitInitializerList(context: Context, list: KtInitializerList) {
+        super.visitInitializerList(list, context)
+    }
+
+    open fun visitAnonymousInitializer(context: Context, initializer: KtAnonymousInitializer) {
+        super.visitAnonymousInitializer(initializer, context)
+    }
+
+    open fun visitScriptInitializer(context: Context, initializer: KtScriptInitializer) {
+        super.visitScriptInitializer(initializer, context)
+    }
+
+    open fun visitClassInitializer(context: Context, initializer: KtClassInitializer) {
+        super.visitClassInitializer(initializer, context)
+    }
+
+    open fun visitPropertyAccessor(context: Context, accessor: KtPropertyAccessor) {
+        super.visitPropertyAccessor(accessor, context)
+    }
+
+    open fun visitTypeConstraintList(context: Context, list: KtTypeConstraintList) {
+        super.visitTypeConstraintList(list, context)
+    }
+
+    open fun visitTypeConstraint(context: Context, constraint: KtTypeConstraint) {
+        super.visitTypeConstraint(constraint, context)
+    }
+
+    open fun visitUserType(context: Context, type: KtUserType) {
+        super.visitUserType(type, context)
+    }
+
+    open fun visitDynamicType(context: Context, type: KtDynamicType) {
+        super.visitDynamicType(type, context)
+    }
+
+    open fun visitFunctionType(context: Context, type: KtFunctionType) {
+        super.visitFunctionType(type, context)
+    }
+
+    open fun visitSelfType(context: Context, type: KtSelfType) {
+        super.visitSelfType(type, context)
+    }
+
+    open fun visitBinaryWithTypeRHSExpression(context: Context, expression: KtBinaryExpressionWithTypeRHS) {
+        super.visitBinaryWithTypeRHSExpression(expression, context)
+    }
+
+    open fun visitStringTemplateExpression(context: Context, expression: KtStringTemplateExpression) {
+        super.visitStringTemplateExpression(expression, context)
+    }
+
+    open fun visitNamedDeclaration(context: Context, declaration: KtNamedDeclaration) {
+        super.visitNamedDeclaration(declaration, context)
+    }
+
+    open fun visitNullableType(context: Context, nullableType: KtNullableType) {
+        super.visitNullableType(nullableType, context)
+    }
+
+    open fun visitTypeProjection(context: Context, typeProjection: KtTypeProjection) {
+        super.visitTypeProjection(typeProjection, context)
+    }
+
+    open fun visitWhenEntry(context: Context, jetWhenEntry: KtWhenEntry) {
+        super.visitWhenEntry(jetWhenEntry, context)
+    }
+
+    open fun visitIsExpression(context: Context, expression: KtIsExpression) {
+        super.visitIsExpression(expression, context)
+    }
+
+    open fun visitWhenConditionIsPattern(context: Context, condition: KtWhenConditionIsPattern) {
+        super.visitWhenConditionIsPattern(condition, context)
+    }
+
+    open fun visitWhenConditionInRange(context: Context, condition: KtWhenConditionInRange) {
+        super.visitWhenConditionInRange(condition, context)
+    }
+
+    open fun visitWhenConditionWithExpression(context: Context, condition: KtWhenConditionWithExpression) {
+        super.visitWhenConditionWithExpression(condition, context)
+    }
+
+    open fun visitObjectDeclaration(context: Context, declaration: KtObjectDeclaration) {
+        super.visitObjectDeclaration(declaration, context)
+    }
+
+    open fun visitStringTemplateEntry(context: Context, entry: KtStringTemplateEntry) {
+        super.visitStringTemplateEntry(entry, context)
+    }
+
+    open fun visitStringTemplateEntryWithExpression(context: Context, entry: KtStringTemplateEntryWithExpression) {
+        super.visitStringTemplateEntryWithExpression(entry, context)
+    }
+
+    open fun visitBlockStringTemplateEntry(context: Context, entry: KtBlockStringTemplateEntry) {
+        super.visitBlockStringTemplateEntry(entry, context)
+    }
+
+    open fun visitSimpleNameStringTemplateEntry(context: Context, entry: KtSimpleNameStringTemplateEntry) {
+        super.visitSimpleNameStringTemplateEntry(entry, context)
+    }
+
+    open fun visitLiteralStringTemplateEntry(context: Context, entry: KtLiteralStringTemplateEntry) {
+        super.visitLiteralStringTemplateEntry(entry, context)
+    }
+
+    open fun visitEscapeStringTemplateEntry(context: Context, entry: KtEscapeStringTemplateEntry) {
+        super.visitEscapeStringTemplateEntry(entry, context)
+    }
+
+    open fun visitPackageDirective(context: Context, directive: KtPackageDirective) {
+        super.visitPackageDirective(directive, context)
+    }
+
+    open fun visitAnnotationUseSiteTarget(context: Context, annotationTarget: KtAnnotationUseSiteTarget) {
+        super.visitAnnotationUseSiteTarget(annotationTarget, context)
+    }
+
+    open fun visitFileAnnotationList(context: Context, fileAnnotationList: KtFileAnnotationList) {
+        super.visitFileAnnotationList(fileAnnotationList, context)
+    }
+
+    // hidden methods
+    override final fun visitKtElement(element: KtElement, context: Context): Void? {
+        visitKtElement(context, element)
+        return null
+    }
+
+    override final fun visitDeclaration(dcl: KtDeclaration, context: Context): Void? {
+        visitDeclaration(context, dcl)
+        return null
+    }
+
+    override final fun visitClass(klass: KtClass, context: Context): Void? {
+        visitClass(context, klass)
+        return null
+    }
+
+    override final fun visitClassOrObject(classOrObject: KtClassOrObject, context: Context): Void? {
+        visitClassOrObject(context, classOrObject)
+        return null
+    }
+
+    override final fun visitSecondaryConstructor(constructor: KtSecondaryConstructor, context: Context): Void? {
+        visitSecondaryConstructor(context, constructor)
+        return null
+    }
+
+    override final fun visitPrimaryConstructor(constructor: KtPrimaryConstructor, context: Context): Void? {
+        visitPrimaryConstructor(context, constructor)
+        return null
+    }
+
+    override final fun visitNamedFunction(function: KtNamedFunction, context: Context): Void? {
+        visitNamedFunction(context, function)
+        return null
+    }
+
+    override final fun visitProperty(property: KtProperty, context: Context): Void? {
+        visitProperty(context, property)
+        return null
+    }
+
+    override final fun visitTypeAlias(typeAlias: KtTypeAlias, context: Context): Void? {
+        visitTypeAlias(context, typeAlias)
+        return null
+    }
+
+    override final fun visitDestructuringDeclaration(multiDeclaration: KtDestructuringDeclaration,
+                                                     context: Context): Void? {
+        visitDestructuringDeclaration(context, multiDeclaration)
+        return null
+    }
+
+    override final fun visitDestructuringDeclarationEntry(multiDeclarationEntry: KtDestructuringDeclarationEntry,
+                                                          context: Context): Void? {
+        visitDestructuringDeclarationEntry(context, multiDeclarationEntry)
+        return null
+    }
+
+    override final fun visitKtFile(file: KtFile, context: Context): Void? {
+        visitKtFile(context, file)
+        return null
+    }
+
+    override final fun visitScript(script: KtScript, context: Context): Void? {
+        visitScript(context, script)
+        return null
+    }
+
+    override final fun visitImportDirective(importDirective: KtImportDirective, context: Context): Void? {
+        visitImportDirective(context, importDirective)
+        return null
+    }
+
+    override final fun visitImportList(importList: KtImportList, context: Context): Void? {
+        visitImportList(context, importList)
+        return null
+    }
+
+    override final fun visitClassBody(classBody: KtClassBody, context: Context): Void? {
+        visitClassBody(context, classBody)
+        return null
+    }
+
+    override final fun visitModifierList(list: KtModifierList, context: Context): Void? {
+        visitModifierList(context, list)
+        return null
+    }
+
+    override final fun visitAnnotation(annotation: KtAnnotation, context: Context): Void? {
+        visitAnnotation(context, annotation)
+        return null
+    }
+
+    override final fun visitAnnotationEntry(annotationEntry: KtAnnotationEntry, context: Context): Void? {
+        visitAnnotationEntry(context, annotationEntry)
+        return null
+    }
+
+    override final fun visitConstructorCalleeExpression(constructorCalleeExpression: KtConstructorCalleeExpression,
+                                                        context: Context): Void? {
+        visitConstructorCalleeExpression(context, constructorCalleeExpression)
+        return null
+    }
+
+    override final fun visitTypeParameterList(list: KtTypeParameterList, context: Context): Void? {
+        visitTypeParameterList(context, list)
+        return null
+    }
+
+    override final fun visitTypeParameter(parameter: KtTypeParameter, context: Context): Void? {
+        visitTypeParameter(context, parameter)
+        return null
+    }
+
+    override final fun visitEnumEntry(enumEntry: KtEnumEntry, context: Context): Void? {
+        visitEnumEntry(context, enumEntry)
+        return null
+    }
+
+    override final fun visitParameterList(list: KtParameterList, context: Context): Void? {
+        visitParameterList(context, list)
+        return null
+    }
+
+    override final fun visitParameter(parameter: KtParameter, context: Context): Void? {
+        visitParameter(context, parameter)
+        return null
+    }
+
+    override final fun visitSuperTypeList(list: KtSuperTypeList, context: Context): Void? {
+        visitSuperTypeList(context, list)
+        return null
+    }
+
+    override final fun visitSuperTypeListEntry(specifier: KtSuperTypeListEntry, context: Context): Void? {
+        visitSuperTypeListEntry(context, specifier)
+        return null
+    }
+
+    override final fun visitDelegatedSuperTypeEntry(specifier: KtDelegatedSuperTypeEntry, context: Context): Void? {
+        visitDelegatedSuperTypeEntry(context, specifier)
+        return null
+    }
+
+    override final fun visitSuperTypeCallEntry(call: KtSuperTypeCallEntry, context: Context): Void? {
+        visitSuperTypeCallEntry(context, call)
+        return null
+    }
+
+    override final fun visitSuperTypeEntry(specifier: KtSuperTypeEntry, context: Context): Void? {
+        visitSuperTypeEntry(context, specifier)
+        return null
+    }
+
+    override final fun visitConstructorDelegationCall(call: KtConstructorDelegationCall, context: Context): Void? {
+        visitConstructorDelegationCall(context, call)
+        return null
+    }
+
+    override final fun visitPropertyDelegate(delegate: KtPropertyDelegate, context: Context): Void? {
+        visitPropertyDelegate(context, delegate)
+        return null
+    }
+
+    override final fun visitTypeReference(typeReference: KtTypeReference, context: Context): Void? {
+        visitTypeReference(context, typeReference)
+        return null
+    }
+
+    override final fun visitValueArgumentList(list: KtValueArgumentList, context: Context): Void? {
+        visitValueArgumentList(context, list)
+        return null
+    }
+
+    override final fun visitArgument(argument: KtValueArgument, context: Context): Void? {
+        visitArgument(context, argument)
+        return null
+    }
+
+    override final fun visitExpression(expression: KtExpression, context: Context): Void? {
+        visitExpression(context, expression)
+        return null
+    }
+
+    override final fun visitLoopExpression(loopExpression: KtLoopExpression, context: Context): Void? {
+        visitLoopExpression(context, loopExpression)
+        return null
+    }
+
+    override final fun visitConstantExpression(expression: KtConstantExpression, context: Context): Void? {
+        visitConstantExpression(context, expression)
+        return null
+    }
+
+    override final fun visitSimpleNameExpression(expression: KtSimpleNameExpression, context: Context): Void? {
+        visitSimpleNameExpression(context, expression)
+        return null
+    }
+
+    override final fun visitReferenceExpression(expression: KtReferenceExpression, context: Context): Void? {
+        visitReferenceExpression(context, expression)
+        return null
+    }
+
+    override final fun visitLabeledExpression(expression: KtLabeledExpression, context: Context): Void? {
+        visitLabeledExpression(context, expression)
+        return null
+    }
+
+    override final fun visitPrefixExpression(expression: KtPrefixExpression, context: Context): Void? {
+        visitPrefixExpression(context, expression)
+        return null
+    }
+
+    override final fun visitPostfixExpression(expression: KtPostfixExpression, context: Context): Void? {
+        visitPostfixExpression(context, expression)
+        return null
+    }
+
+    override final fun visitUnaryExpression(expression: KtUnaryExpression, context: Context): Void? {
+        visitUnaryExpression(context, expression)
+        return null
+    }
+
+    override final fun visitBinaryExpression(expression: KtBinaryExpression, context: Context): Void? {
+        visitBinaryExpression(context, expression)
+        return null
+    }
+
+    override final fun visitReturnExpression(expression: KtReturnExpression, context: Context): Void? {
+        visitReturnExpression(context, expression)
+        return null
+    }
+
+    override final fun visitExpressionWithLabel(expression: KtExpressionWithLabel, context: Context): Void? {
+        visitExpressionWithLabel(context, expression)
+        return null
+    }
+
+    override final fun visitThrowExpression(expression: KtThrowExpression, context: Context): Void? {
+        visitThrowExpression(context, expression)
+        return null
+    }
+
+    override final fun visitBreakExpression(expression: KtBreakExpression, context: Context): Void? {
+        visitBreakExpression(context, expression)
+        return null
+    }
+
+    override final fun visitContinueExpression(expression: KtContinueExpression, context: Context): Void? {
+        visitContinueExpression(context, expression)
+        return null
+    }
+
+    override final fun visitIfExpression(expression: KtIfExpression, context: Context): Void? {
+        visitIfExpression(context, expression)
+        return null
+    }
+
+    override final fun visitWhenExpression(expression: KtWhenExpression, context: Context): Void? {
+        visitWhenExpression(context, expression)
+        return null
+    }
+
+    override final fun visitTryExpression(expression: KtTryExpression, context: Context): Void? {
+        visitTryExpression(context, expression)
+        return null
+    }
+
+    override final fun visitForExpression(expression: KtForExpression, context: Context): Void? {
+        visitForExpression(context, expression)
+        return null
+    }
+
+    override final fun visitWhileExpression(expression: KtWhileExpression, context: Context): Void? {
+        visitWhileExpression(context, expression)
+        return null
+    }
+
+    override final fun visitDoWhileExpression(expression: KtDoWhileExpression, context: Context): Void? {
+        visitDoWhileExpression(context, expression)
+        return null
+    }
+
+    override final fun visitLambdaExpression(expression: KtLambdaExpression, context: Context): Void? {
+        visitLambdaExpression(context, expression)
+        return null
+    }
+
+    override final fun visitAnnotatedExpression(expression: KtAnnotatedExpression, context: Context): Void? {
+        visitAnnotatedExpression(context, expression)
+        return null
+    }
+
+    override final fun visitCallExpression(expression: KtCallExpression, context: Context): Void? {
+        visitCallExpression(context, expression)
+        return null
+    }
+
+    override final fun visitArrayAccessExpression(expression: KtArrayAccessExpression, context: Context): Void? {
+        visitArrayAccessExpression(context, expression)
+        return null
+    }
+
+    override final fun visitQualifiedExpression(expression: KtQualifiedExpression, context: Context): Void? {
+        visitQualifiedExpression(context, expression)
+        return null
+    }
+
+    override final fun visitDoubleColonExpression(expression: KtDoubleColonExpression, context: Context): Void? {
+        visitDoubleColonExpression(context, expression)
+        return null
+    }
+
+    override final fun visitCallableReferenceExpression(expression: KtCallableReferenceExpression,
+                                                        context: Context): Void? {
+        visitCallableReferenceExpression(context, expression)
+        return null
+    }
+
+    override final fun visitClassLiteralExpression(expression: KtClassLiteralExpression, context: Context): Void? {
+        visitClassLiteralExpression(context, expression)
+        return null
+    }
+
+    override final fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression, context: Context): Void? {
+        visitDotQualifiedExpression(context, expression)
+        return null
+    }
+
+    override final fun visitSafeQualifiedExpression(expression: KtSafeQualifiedExpression, context: Context): Void? {
+        visitSafeQualifiedExpression(context, expression)
+        return null
+    }
+
+    override final fun visitObjectLiteralExpression(expression: KtObjectLiteralExpression, context: Context): Void? {
+        visitObjectLiteralExpression(context, expression)
+        return null
+    }
+
+    override final fun visitBlockExpression(expression: KtBlockExpression, context: Context): Void? {
+        visitBlockExpression(context, expression)
+        return null
+    }
+
+    override final fun visitCatchSection(catchClause: KtCatchClause, context: Context): Void? {
+        visitCatchSection(context, catchClause)
+        return null
+    }
+
+    override final fun visitFinallySection(finallySection: KtFinallySection, context: Context): Void? {
+        visitFinallySection(context, finallySection)
+        return null
+    }
+
+    override final fun visitTypeArgumentList(typeArgumentList: KtTypeArgumentList, context: Context): Void? {
+        visitTypeArgumentList(context, typeArgumentList)
+        return null
+    }
+
+    override final fun visitThisExpression(expression: KtThisExpression, context: Context): Void? {
+        visitThisExpression(context, expression)
+        return null
+    }
+
+    override final fun visitSuperExpression(expression: KtSuperExpression, context: Context): Void? {
+        visitSuperExpression(context, expression)
+        return null
+    }
+
+    override final fun visitParenthesizedExpression(expression: KtParenthesizedExpression, context: Context): Void? {
+        visitParenthesizedExpression(context, expression)
+        return null
+    }
+
+    override final fun visitInitializerList(list: KtInitializerList, context: Context): Void? {
+        visitInitializerList(context, list)
+        return null
+    }
+
+    override final fun visitAnonymousInitializer(initializer: KtAnonymousInitializer, context: Context): Void? {
+        visitAnonymousInitializer(context, initializer)
+        return null
+    }
+
+    override final fun visitPropertyAccessor(accessor: KtPropertyAccessor, context: Context): Void? {
+        visitPropertyAccessor(context, accessor)
+        return null
+    }
+
+    override final fun visitTypeConstraintList(list: KtTypeConstraintList, context: Context): Void? {
+        visitTypeConstraintList(context, list)
+        return null
+    }
+
+    override final fun visitTypeConstraint(constraint: KtTypeConstraint, context: Context): Void? {
+        visitTypeConstraint(context, constraint)
+        return null
+    }
+
+    override final fun visitUserType(type: KtUserType, context: Context): Void? {
+        visitUserType(context, type)
+        return null
+    }
+
+    override final fun visitDynamicType(type: KtDynamicType, context: Context): Void? {
+        visitDynamicType(context, type)
+        return null
+    }
+
+    override final fun visitFunctionType(type: KtFunctionType, context: Context): Void? {
+        visitFunctionType(context, type)
+        return null
+    }
+
+    override final fun visitSelfType(type: KtSelfType, context: Context): Void? {
+        visitSelfType(context, type)
+        return null
+    }
+
+    override final fun visitBinaryWithTypeRHSExpression(expression: KtBinaryExpressionWithTypeRHS,
+                                                        context: Context): Void? {
+        visitBinaryWithTypeRHSExpression(context, expression)
+        return null
+    }
+
+    override final fun visitStringTemplateExpression(expression: KtStringTemplateExpression, context: Context): Void? {
+        visitStringTemplateExpression(context, expression)
+        return null
+    }
+
+    override final fun visitNamedDeclaration(declaration: KtNamedDeclaration, context: Context): Void? {
+        visitNamedDeclaration(context, declaration)
+        return null
+    }
+
+    override final fun visitNullableType(nullableType: KtNullableType, context: Context): Void? {
+        visitNullableType(context, nullableType)
+        return null
+    }
+
+    override final fun visitTypeProjection(typeProjection: KtTypeProjection, context: Context): Void? {
+        visitTypeProjection(context, typeProjection)
+        return null
+    }
+
+    override final fun visitWhenEntry(jetWhenEntry: KtWhenEntry, context: Context): Void? {
+        visitWhenEntry(context, jetWhenEntry)
+        return null
+    }
+
+    override final fun visitIsExpression(expression: KtIsExpression, context: Context): Void? {
+        visitIsExpression(context, expression)
+        return null
+    }
+
+    override final fun visitWhenConditionIsPattern(condition: KtWhenConditionIsPattern, context: Context): Void? {
+        visitWhenConditionIsPattern(context, condition)
+        return null
+    }
+
+    override final fun visitWhenConditionInRange(condition: KtWhenConditionInRange, context: Context): Void? {
+        visitWhenConditionInRange(context, condition)
+        return null
+    }
+
+    override final fun visitWhenConditionWithExpression(condition: KtWhenConditionWithExpression,
+                                                        context: Context): Void? {
+        visitWhenConditionWithExpression(context, condition)
+        return null
+    }
+
+    override final fun visitObjectDeclaration(declaration: KtObjectDeclaration, context: Context): Void? {
+        visitObjectDeclaration(context, declaration)
+        return null
+    }
+
+    override final fun visitStringTemplateEntry(entry: KtStringTemplateEntry, context: Context): Void? {
+        visitStringTemplateEntry(context, entry)
+        return null
+    }
+
+    override final fun visitStringTemplateEntryWithExpression(entry: KtStringTemplateEntryWithExpression,
+                                                              context: Context): Void? {
+        visitStringTemplateEntryWithExpression(context, entry)
+        return null
+    }
+
+    override final fun visitBlockStringTemplateEntry(entry: KtBlockStringTemplateEntry, context: Context): Void? {
+        visitBlockStringTemplateEntry(context, entry)
+        return null
+    }
+
+    override final fun visitSimpleNameStringTemplateEntry(entry: KtSimpleNameStringTemplateEntry,
+                                                          context: Context): Void? {
+        visitSimpleNameStringTemplateEntry(context, entry)
+        return null
+    }
+
+    override final fun visitLiteralStringTemplateEntry(entry: KtLiteralStringTemplateEntry, context: Context): Void? {
+        visitLiteralStringTemplateEntry(context, entry)
+        return null
+    }
+
+    override final fun visitEscapeStringTemplateEntry(entry: KtEscapeStringTemplateEntry, context: Context): Void? {
+        visitEscapeStringTemplateEntry(context, entry)
+        return null
+    }
+
+    override final fun visitPackageDirective(directive: KtPackageDirective, context: Context): Void? {
+        visitPackageDirective(context, directive)
+        return null
+    }
+
+    override final fun visitScriptInitializer(initializer: KtScriptInitializer, context: Context): Void? {
+        visitScriptInitializer(context, initializer)
+        return null
+    }
+
+    override final fun visitClassInitializer(initializer: KtClassInitializer, context: Context): Void? {
+        visitClassInitializer(context, initializer)
+        return null
+    }
+
+    override final fun visitCollectionLiteralExpression(expression: KtCollectionLiteralExpression,
+                                                        context: Context): Void? {
+        visitCollectionLiteralExpression(context, expression)
+        return null
+    }
+
+    override final fun visitAnnotationUseSiteTarget(annotationTarget: KtAnnotationUseSiteTarget,
+                                                    context: Context): Void? {
+        visitAnnotationUseSiteTarget(context, annotationTarget)
+        return null
+    }
+
+    override final fun visitFileAnnotationList(fileAnnotationList: KtFileAnnotationList, context: Context): Void? {
+        visitFileAnnotationList(context, fileAnnotationList)
+        return null
+    }
+
+    // Prevent override
+
+    override final fun visitFile(file: PsiFile?) {
+        super.visitFile(file)
+    }
+
+    override final fun visitErrorElement(element: PsiErrorElement?) {
+        super.visitErrorElement(element)
+    }
+
+    override final fun visitComment(comment: PsiComment?) {
+        super.visitComment(comment)
+    }
+
+    override final fun visitPlainTextFile(file: PsiPlainTextFile?) {
+        super.visitPlainTextFile(file)
+    }
+
+    override final fun visitElement(element: PsiElement?) {
+        super.visitElement(element)
+    }
+
+    override final fun visitOuterLanguageElement(element: OuterLanguageElement?) {
+        super.visitOuterLanguageElement(element)
+    }
+
+    override final fun visitWhiteSpace(space: PsiWhiteSpace?) {
+        super.visitWhiteSpace(space)
+    }
+
+    override final fun visitDirectory(dir: PsiDirectory?) {
+        super.visitDirectory(dir)
+    }
+
+    override final fun visitBinaryFile(file: PsiBinaryFile?) {
+        super.visitBinaryFile(file)
+    }
+
+    override final fun visitPlainText(content: PsiPlainText?) {
+        super.visitPlainText(content)
+    }
+}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
@@ -12,8 +12,7 @@ import kotlin.reflect.full.memberProperties
  * @author Artur Bosch
  */
 interface Finding : Compactable, Describable, Reflective, HasEntity, HasMetrics {
-	val id: String
-	val severity: Rule.Severity
+	val issue: Issue
 	val references: List<Entity>
 }
 
@@ -64,8 +63,8 @@ interface Compactable {
 }
 
 /**
- * Provides a description attribute.
+ * Provides a message attribute to explain the specific finding.
  */
 interface Describable {
-	val description: String
+	val message: String
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
@@ -16,21 +16,15 @@ class RuleSet(val id: String, val rules: List<Rule>) {
 	/**
 	 * Iterates over the given kotlin file list and calling the accept method.
 	 */
-	fun acceptAll(files: List<KtFile>): Pair<String, List<Finding>> {
-		return id to files.flatMap { accept(it) }
+	fun acceptAll(context: Context, files: List<KtFile>) {
+		return files.forEach { accept(context, it) }
 	}
 
 	/**
 	 * Visits given file with all rules of this rule set, returning a list
 	 * of all code smell findings.
 	 */
-	fun accept(file: KtFile): List<Finding> {
-		val findings: MutableList<Finding> = mutableListOf()
-		rules.forEach {
-			it.visit(file)
-			findings += it.findings
-		}
-		return findings
+	fun accept(context: Context, file: KtFile) {
+		rules.forEach { it.visit(context, file) }
 	}
-
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SpecificRules.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SpecificRules.kt
@@ -1,16 +1,10 @@
 package io.gitlab.arturbosch.detekt.api
 
 /**
- * Basic extension of a rule by specifying the severity as a code smell.
- * @author Artur Bosch
- */
-abstract class CodeSmellRule(id: String, config: Config) : Rule(id, Rule.Severity.CodeSmell, config)
-
-/**
  * Provides a threshold attribute for this rule, which is specified manually for default values
  * but can be also obtained from within a configuration object.
  */
-abstract class CodeSmellThresholdRule(id: String, config: Config, threshold: Int) : CodeSmellRule(id, config) {
+abstract class ThresholdRule(id: String, config: Config, threshold: Int) : Rule(id, config) {
 	/**
 	 * The used threshold for this rule is loaded from the configuration or used from the constructor value.
 	 */

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/TokenRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/TokenRule.kt
@@ -16,60 +16,58 @@ import org.jetbrains.kotlin.psi.KtFile
  */
 @Suppress("EmptyFunctionBlock")
 abstract class TokenRule(id: String,
-						 severity: Severity = Rule.Severity.Minor,
-						 config: Config = Config.empty) : Rule(id, severity, config) {
+						 config: Config = Config.empty) : Rule(id, config) {
 
-	override fun visit(root: KtFile) {
+	override fun visit(context: Context, root: KtFile) {
 		ifRuleActive {
-			clearFindings()
-			preVisit(root)
-			root.node.visitTokens { procedure(it) }
-			postVisit(root)
+			preVisit(context, root)
+			root.node.visitTokens { procedure(context, it) }
+			postVisit(context, root)
 		}
 	}
 
 	/**
 	 * Every ASTNode is considered in isolation. Use 'is' operator to search for wished elements.
 	 */
-	open fun procedure(node: ASTNode) {
+	open fun procedure(context: Context, node: ASTNode) {
 		when (node) {
-			is PsiWhiteSpace -> visitSpaces(node)
-			is LeafPsiElement -> visitLeaf(node)
+			is PsiWhiteSpace -> visitSpaces(context, node)
+			is LeafPsiElement -> visitLeaf(context, node)
 
 		}
 	}
 
-	open fun visitLeaf(leaf: LeafPsiElement) {
+	open fun visitLeaf(context: Context, leaf: LeafPsiElement) {
 		if (!leaf.isPartOfString()) {
 			when (leaf.text) {
-				"}" -> visitRightBrace(leaf)
-				"{" -> visitLeftBrace(leaf)
-				":" -> visitColon(leaf)
-				";" -> visitSemicolon(leaf)
-				";;" -> visitDoubleSemicolon(leaf)
-				"," -> visitComma(leaf)
+				"}" -> visitRightBrace(context, leaf)
+				"{" -> visitLeftBrace(context, leaf)
+				":" -> visitColon(context, leaf)
+				";" -> visitSemicolon(context, leaf)
+				";;" -> visitDoubleSemicolon(context, leaf)
+				"," -> visitComma(context, leaf)
 			}
 		}
 	}
 
-	protected open fun visitSemicolon(leaf: LeafPsiElement) {
+	protected open fun visitSemicolon(context: Context, leaf: LeafPsiElement) {
 	}
 
-	protected open fun visitDoubleSemicolon(leaf: LeafPsiElement) {
+	protected open fun visitDoubleSemicolon(context: Context, leaf: LeafPsiElement) {
 	}
 
-	protected open fun visitComma(leaf: LeafPsiElement) {
+	protected open fun visitComma(context: Context, leaf: LeafPsiElement) {
 	}
 
-	protected open fun visitColon(colon: LeafPsiElement) {
+	protected open fun visitColon(context: Context, colon: LeafPsiElement) {
 	}
 
-	protected open fun visitLeftBrace(brace: LeafPsiElement) {
+	protected open fun visitLeftBrace(context: Context, brace: LeafPsiElement) {
 	}
 
-	protected open fun visitRightBrace(brace: LeafPsiElement) {
+	protected open fun visitRightBrace(context: Context, brace: LeafPsiElement) {
 	}
 
-	protected open fun visitSpaces(space: PsiWhiteSpace) {
+	protected open fun visitSpaces(context: Context, space: PsiWhiteSpace) {
 	}
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/DetektProgressListener.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/DetektProgressListener.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.cli
 
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.core.Detektion
 import io.gitlab.arturbosch.detekt.core.FileProcessListener
 import org.jetbrains.kotlin.psi.KtFile
@@ -12,7 +13,7 @@ class DetektProgressListener : FileProcessListener {
 		kotlin.io.print("Analyzing ${files.size} kotlin files: ")
 	}
 
-	override fun onProcess(file: KtFile) {
+	override fun onProcess(context: Context, file: KtFile) {
 		kotlin.io.print(".")
 	}
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Junk.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Junk.kt
@@ -7,4 +7,4 @@ fun Any?.print(prefix: String = "", suffix: String = "") {
 }
 
 val Finding.baselineId: String
-	get() = this.id + ":" + this.signature
+	get() = this.issue.id + ":" + this.signature

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -12,6 +12,7 @@ import java.nio.file.Path
 /**
  * @author Artur Bosch
  */
+@Suppress("MaxLineLength")
 class Main {
 
 	@Parameter(names = arrayOf("--project", "-p"), required = true,

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/OutputFacade.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/OutputFacade.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.cli
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.cli.out.DetektBaselineFormat
 import io.gitlab.arturbosch.detekt.cli.out.SmellThreshold
 import io.gitlab.arturbosch.detekt.cli.out.format.OutputFormat
@@ -18,7 +19,7 @@ class OutputFacade(args: Main,
 				   private val detektion: Detektion) {
 
 	private val outputFormatter: OutputFormat.Formatter = args.outputFormatter
-	private val findings: Map<String, List<Finding>> = detektion.findings
+	private val findings: Map<Issue, List<Finding>> = detektion.findings
 	private val notifications: List<Notification> = detektion.notifications
 	private val baselineFormat = args.baseline?.let { DetektBaselineFormat(it) }
 	private val createBaseline = args.createBaseline

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/PathConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/PathConverters.kt
@@ -31,7 +31,8 @@ class PathConverter : IStringConverter<Path> {
 class ClasspathResourceConverter : IStringConverter<URL> {
 	override fun convert(resource: String): URL {
 		val relativeResource = if (resource.startsWith("/")) resource else "/" + resource
-		val url = javaClass.getResource(relativeResource) ?: throw ParameterException("Classpath resource '$resource' does not exist!")
+		val url = javaClass.getResource(relativeResource) ?:
+				throw ParameterException("Classpath resource '$resource' does not exist!")
 		return url
 	}
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineHandler.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineHandler.kt
@@ -16,7 +16,8 @@ class BaselineHandler : DefaultHandler() {
 	private val whiteIds = mutableListOf<String>()
 	private val blackIds = mutableListOf<String>()
 
-	internal fun createBaseline() = Baseline(Blacklist(blackIds, blackstamp ?: now()), Whitelist(whiteIds, whitestamp ?: now()))
+	internal fun createBaseline() =
+			Baseline(Blacklist(blackIds, blackstamp ?: now()), Whitelist(whiteIds, whitestamp ?: now()))
 	private fun now() = Instant.now().toEpochMilli().toString()
 
 	override fun startElement(uri: String, localName: String, qName: String, attributes: Attributes) {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/debug/Debugger.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/debug/Debugger.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.cli.debug
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.cli.Executable
 import io.gitlab.arturbosch.detekt.cli.Main
 import io.gitlab.arturbosch.detekt.core.KtCompiler
@@ -12,9 +13,10 @@ class Debugger(val main: Main) : Executable {
 
 	override fun execute() {
 		val ktFile = KtCompiler(main.project).compile(main.project)
+		val context = Context()
 		DebugRuleSetProvider.buildRuleset(Config.empty)?.rules?.forEach {
 			println("Rule: ${it.id}\n")
-			it.visit(ktFile)
+			it.visit(context, ktFile)
 			println()
 		}
 	}

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/debug/ElementPrinter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/debug/ElementPrinter.kt
@@ -1,15 +1,16 @@
 package io.gitlab.arturbosch.detekt.cli.debug
 
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.cli.print
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.psi.KtElement
 
 /**
  * @author Artur Bosch
  */
 class ElementPrinter : Rule("ElementPrinter") {
 
-	override fun visitElement(element: PsiElement) {
+	override fun visitKtElement(context: Context, element: KtElement) {
 		element.print()
 	}
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/debug/TokenPrinter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/debug/TokenPrinter.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.cli.debug
 
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.api.TokenRule
 import io.gitlab.arturbosch.detekt.cli.print
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -9,7 +10,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
  */
 class TokenPrinter : TokenRule("TokenPrinter") {
 
-	override fun procedure(node: ASTNode) {
+	override fun procedure(context: Context, node: ASTNode) {
 		node.print()
 	}
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/SmellThreshold.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/SmellThreshold.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.cli.out
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.core.Detektion
 import java.util.HashMap
 
@@ -34,18 +35,18 @@ class SmellThreshold(config: Config,
 
 	}
 
-	private fun extractRuleToRulesetIdMap(detektion: Detektion): HashMap<String, String> {
-		return detektion.findings.mapValues { it.value.map { it.id }.toSet() }
+	private fun extractRuleToRulesetIdMap(detektion: Detektion): HashMap<String, Issue> {
+		return detektion.findings.mapValues { it.value.map { it.issue.id }.toSet() }
 				.map { map -> map.value.map { it to map.key }.toMap() }
-				.fold(HashMap<String, String>()) { result, map -> result.putAll(map); result }
+				.fold(HashMap<String, Issue>()) { result, map -> result.putAll(map); result }
 	}
 
 	private fun Int.reached(amount: Int): Boolean = this != -1 && this <= amount
 
-	private fun Finding.weighted(ids: Map<String, String>): Int {
-		val key = ids[id] // entry of ID > entry of RulesetID > default weight 1
-		return weightsConfig.valueOrDefault(id,
-				if (key != null) weightsConfig.valueOrDefault(key, 1) else 1)
+	private fun Finding.weighted(ids: Map<String, Issue>): Int {
+		val key = ids[issue.id] // entry of ID > entry of RulesetID > default weight 1
+		return weightsConfig.valueOrDefault(issue.id,
+				if (key != null) weightsConfig.valueOrDefault(key.id, 1) else 1)
 	}
 
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/format/XmlOutputFormat.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/format/XmlOutputFormat.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.cli.out.format
 
 import io.gitlab.arturbosch.detekt.api.Finding
-import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Issue
 import java.nio.file.Path
 
 /**
@@ -28,8 +28,8 @@ class XmlOutputFormat(report: Path) : OutputFormat(report) {
                         "\t<error line=\"${it.location.source.line.toXmlString()}\"",
                         "column=\"${it.location.source.column.toXmlString()}\"",
                         "severity=\"${it.messageType.label.toXmlString()}\"",
-                        "message=\"${(it.description + "(${it.id})").toXmlString()}\"",
-                        "source=\"${"detekt.${it.id.toXmlString()}"}\" />"
+                        "message=\"${(it.message + "(${it.issue.id})").toXmlString()}\"",
+                        "source=\"${"detekt.${it.issue.id.toXmlString()}"}\" />"
                 ).joinToString(separator = " ")
             }
             lines += "</file>"
@@ -40,14 +40,14 @@ class XmlOutputFormat(report: Path) : OutputFormat(report) {
     }
 
     private val Finding.messageType: MessageType
-        get() = when (severity) {
-            Rule.Severity.CodeSmell -> MessageType.Warning()
-            Rule.Severity.Style -> MessageType.Warning()
-            Rule.Severity.Warning -> MessageType.Warning()
-            Rule.Severity.Maintainability -> MessageType.Warning()
-            Rule.Severity.Defect -> MessageType.Error()
-            Rule.Severity.Minor -> MessageType.Info()
-            Rule.Severity.Security -> MessageType.Fatal()
+        get() = when (issue.severity) {
+            Issue.Severity.CodeSmell -> MessageType.Warning()
+            Issue.Severity.Style -> MessageType.Warning()
+            Issue.Severity.Warning -> MessageType.Warning()
+            Issue.Severity.Maintainability -> MessageType.Warning()
+            Issue.Severity.Defect -> MessageType.Error()
+            Issue.Severity.Minor -> MessageType.Info()
+            Issue.Severity.Security -> MessageType.Fatal()
         }
 
     private fun Any.toXmlString() = XmlEscape.escapeXml(toString().trim())

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/format/XmlOutputFormatTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/format/XmlOutputFormatTest.kt
@@ -12,6 +12,9 @@ internal class XmlOutputFormatTest {
     private val entity1 = Entity("Sample1", "com.sample.Sample1", "", Location(SourceLocation(11, 1), TextLocation(0, 10), "abcd", "src/main/com/sample/Sample1.kt"))
     private val entity2 = Entity("Sample2", "com.sample.Sample2", "", Location(SourceLocation(22, 2), TextLocation(0, 20), "efgh", "src/main/com/sample/Sample2.kt"))
 
+    private val issue1 = Issue("id-a", Issue.Severity.CodeSmell)
+    private val issue2 = Issue("id-b", Issue.Severity.CodeSmell)
+
     private val path = Files.createTempDirectory("reports")
     private val file = path.resolve("report.xml")
     private lateinit var outputFormat: XmlOutputFormat
@@ -31,46 +34,46 @@ internal class XmlOutputFormatTest {
 
     @Test
     fun renderOneForSingleFile() {
-        val smell = CodeSmell("id_1", Rule.Severity.CodeSmell, entity1)
+        val smell = CodeSmell(issue1, entity1)
 
         val result = outputFormat.render(listOf(smell))
 
         //language=XML
-        assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"(id_1)\" source=\"detekt.id_1\" />\n</file>\n</checkstyle>")
+        assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"(id-a)\" source=\"detekt.id-a\" />\n</file>\n</checkstyle>")
     }
 
     @Test
     fun renderTwoForSingleFile() {
-        val smell1 = CodeSmell("id_1", Rule.Severity.CodeSmell, entity1)
-        val smell2 = CodeSmell("id_2", Rule.Severity.CodeSmell, entity1)
+        val smell1 = CodeSmell(issue1, entity1)
+        val smell2 = CodeSmell(issue2, entity1)
 
         val result = outputFormat.render(listOf(smell1, smell2))
 
         //language=XML
-        assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"(id_1)\" source=\"detekt.id_1\" />\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"(id_2)\" source=\"detekt.id_2\" />\n</file>\n</checkstyle>")
+        assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"(id-a)\" source=\"detekt.id-a\" />\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"(id-b)\" source=\"detekt.id-b\" />\n</file>\n</checkstyle>")
     }
 
     @Test
     fun renderOneForMultipleFiles() {
-        val smell1 = CodeSmell("id_1", Rule.Severity.CodeSmell, entity1)
-        val smell2 = CodeSmell("id_1", Rule.Severity.CodeSmell, entity2)
+        val smell1 = CodeSmell(issue1, entity1)
+        val smell2 = CodeSmell(issue1, entity2)
 
         val result = outputFormat.render(listOf(smell1, smell2))
 
         //language=XML
-        assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"(id_1)\" source=\"detekt.id_1\" />\n</file>\n<file name=\"src/main/com/sample/Sample2.kt\">\n\t<error line=\"22\" column=\"2\" severity=\"warning\" message=\"(id_1)\" source=\"detekt.id_1\" />\n</file>\n</checkstyle>")
+        assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"(id-a)\" source=\"detekt.id-a\" />\n</file>\n<file name=\"src/main/com/sample/Sample2.kt\">\n\t<error line=\"22\" column=\"2\" severity=\"warning\" message=\"(id-a)\" source=\"detekt.id-a\" />\n</file>\n</checkstyle>")
     }
 
     @Test
     fun renderTwoForMultipleFiles() {
-        val smell1 = CodeSmell("id_1", Rule.Severity.CodeSmell, entity1)
-        val smell2 = CodeSmell("id_2", Rule.Severity.CodeSmell, entity1)
-        val smell3 = CodeSmell("id_1", Rule.Severity.CodeSmell, entity2)
-        val smell4 = CodeSmell("id_2", Rule.Severity.CodeSmell, entity2)
+        val smell1 = CodeSmell(issue1, entity1)
+        val smell2 = CodeSmell(issue2, entity1)
+        val smell3 = CodeSmell(issue1, entity2)
+        val smell4 = CodeSmell(issue2, entity2)
 
         val result = outputFormat.render(listOf(smell1, smell2, smell3, smell4))
 
         //language=XML
-        assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"(id_1)\" source=\"detekt.id_1\" />\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"(id_2)\" source=\"detekt.id_2\" />\n</file>\n<file name=\"src/main/com/sample/Sample2.kt\">\n\t<error line=\"22\" column=\"2\" severity=\"warning\" message=\"(id_1)\" source=\"detekt.id_1\" />\n\t<error line=\"22\" column=\"2\" severity=\"warning\" message=\"(id_2)\" source=\"detekt.id_2\" />\n</file>\n</checkstyle>")
+        assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"(id-a)\" source=\"detekt.id-a\" />\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"(id-b)\" source=\"detekt.id-b\" />\n</file>\n<file name=\"src/main/com/sample/Sample2.kt\">\n\t<error line=\"22\" column=\"2\" severity=\"warning\" message=\"(id-a)\" source=\"detekt.id-a\" />\n\t<error line=\"22\" column=\"2\" severity=\"warning\" message=\"(id-b)\" source=\"detekt.id-b\" />\n</file>\n</checkstyle>")
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektion.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektion.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.util.keyFMap.KeyFMap
 
@@ -8,14 +9,14 @@ import org.jetbrains.kotlin.com.intellij.util.keyFMap.KeyFMap
  * @author Artur Bosch
  */
 interface Detektion {
-	val findings: Map<String, List<Finding>>
+	val findings: Map<Issue, List<Finding>>
 	val notifications: List<Notification>
 
 	fun <V> getData(key: Key<V>): V?
 	fun <V> addData(key: Key<V>, value: V)
 }
 
-data class DetektResult(override val findings: Map<String, List<Finding>>,
+data class DetektResult(override val findings: Map<Issue, List<Finding>>,
 						override val notifications: List<Notification>) : Detektion {
 
 	private var userData = KeyFMap.EMPTY_MAP

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/FileProcessListeners.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/FileProcessListeners.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.core
 
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.core.visitors.ComplexityVisitor
 import io.gitlab.arturbosch.detekt.core.visitors.LLOCVisitor
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
@@ -11,7 +12,7 @@ import org.jetbrains.kotlin.psi.KtFile
 @Suppress("EmptyFunctionBlock")
 interface FileProcessListener {
 	fun onStart(files: List<KtFile>) {}
-	fun onProcess(file: KtFile) {}
+	fun onProcess(context: Context, file: KtFile) {}
 	fun onFinish(files: List<KtFile>, result: Detektion) {}
 }
 
@@ -19,8 +20,8 @@ class ProjectComplexityProcessor : FileProcessListener {
 
 	private val complexityVisitor = ComplexityVisitor()
 
-	override fun onProcess(file: KtFile) {
-		val value = complexityVisitor.visitAndReturn(file)
+	override fun onProcess(context: Context, file: KtFile) {
+		val value = complexityVisitor.visitAndReturn(context, file)
 		file.putUserData(COMPLEXITY_KEY, value)
 	}
 
@@ -38,8 +39,8 @@ class ProjectLLOCProcessor : FileProcessListener {
 
 	private val llocVisitor = LLOCVisitor()
 
-	override fun onProcess(file: KtFile) {
-		val value = llocVisitor.visitAndReturn(file)
+	override fun onProcess(context: Context, file: KtFile) {
+		val value = llocVisitor.visitAndReturn(context, file)
 		file.putUserData(LLOC_KEY, value)
 	}
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Junk.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Junk.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.core
 
 import java.nio.file.Files
 import java.nio.file.Path
-import java.util.HashMap
 import java.util.stream.Collectors
 import java.util.stream.Stream
 
@@ -11,14 +10,6 @@ import java.util.stream.Stream
  */
 
 fun <T> Stream<T>.toList(): List<T> = collect(Collectors.toList<T>())
-
-fun <K, V> List<Pair<K, List<V>>>.toMergedMap(): Map<K, List<V>> {
-	val map = HashMap<K, MutableList<V>>()
-	this.forEach {
-		map.merge(it.first, it.second.toMutableList(), { l1, l2 -> l1.apply { addAll(l2) } })
-	}
-	return map
-}
 
 fun Path.exists(): Boolean = Files.exists(this)
 fun Path.isFile(): Boolean = Files.isRegularFile(this)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/visitors/ComplexityVisitor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/visitors/ComplexityVisitor.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.visitors
 
+import io.gitlab.arturbosch.detekt.api.Context
 import org.jetbrains.kotlin.psi.KtFile
 
 /**
@@ -9,9 +10,9 @@ class ComplexityVisitor : ReturningVisitor<Int>() {
 
 	override var value: Int = 0
 
-	override fun visitKtFile(file: KtFile) {
+	override fun visitKtFile(context: Context, file: KtFile) {
 		with(McCabeVisitor()) {
-			file.accept(this)
+			file.accept(this, context)
 			value = mcc
 		}
 	}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/visitors/LLOCVisitor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/visitors/LLOCVisitor.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.visitors
 
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.core.visitors.util.LLOC
 import org.jetbrains.kotlin.psi.KtFile
 
@@ -10,7 +11,7 @@ class LLOCVisitor : ReturningVisitor<Int>() {
 
 	override var value: Int = 0
 
-	override fun visitKtFile(file: KtFile) {
+	override fun visitKtFile(context: Context, file: KtFile) {
 		val lines = file.text.split("\n")
 		value = LLOC.analyze(lines)
 	}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/visitors/McCabeVisitor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/visitors/McCabeVisitor.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.visitors
 
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtIfExpression
@@ -20,38 +21,38 @@ class McCabeVisitor : DetektVisitor() {
 		mcc++
 	}
 
-	fun visit(function: KtNamedFunction): Int {
+	fun visit(context: Context, function: KtNamedFunction): Int {
 		mcc = 0
-		super.visitNamedFunction(function)
+		super.visitNamedFunction(context, function)
 		return mcc
 	}
 
-	override fun visitNamedFunction(function: KtNamedFunction) {
+	override fun visitNamedFunction(context: Context, function: KtNamedFunction) {
 		inc()
-		super.visitNamedFunction(function)
+		super.visitNamedFunction(context, function)
 	}
 
-	override fun visitIfExpression(expression: KtIfExpression) {
+	override fun visitIfExpression(context: Context, expression: KtIfExpression) {
 		inc()
-		super.visitIfExpression(expression)
+		super.visitIfExpression(context, expression)
 	}
 
-	override fun visitLoopExpression(loopExpression: KtLoopExpression) {
+	override fun visitLoopExpression(context: Context, loopExpression: KtLoopExpression) {
 		inc()
-		super.visitLoopExpression(loopExpression)
+		super.visitLoopExpression(context, loopExpression)
 	}
 
-	override fun visitWhenExpression(expression: KtWhenExpression) {
+	override fun visitWhenExpression(context: Context, expression: KtWhenExpression) {
 		inc()
-		super.visitWhenExpression(expression)
+		super.visitWhenExpression(context, expression)
 	}
 
-	override fun visitTryExpression(expression: KtTryExpression) {
+	override fun visitTryExpression(context: Context, expression: KtTryExpression) {
 		inc()
-		super.visitTryExpression(expression)
+		super.visitTryExpression(context, expression)
 	}
 
-	override fun visitCallExpression(expression: KtCallExpression) {
+	override fun visitCallExpression(context: Context, expression: KtCallExpression) {
 		if (expression.isUsedForNesting()) {
 			val lambdaArguments = expression.lambdaArguments
 			if (lambdaArguments.size > 0) {
@@ -61,7 +62,7 @@ class McCabeVisitor : DetektVisitor() {
 				}
 			}
 		}
-		super.visitCallExpression(expression)
+		super.visitCallExpression(context, expression)
 	}
 
 	fun KtCallExpression.isUsedForNesting(): Boolean = when (getCallNameExpression()?.text) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/visitors/ReturningVisitor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/visitors/ReturningVisitor.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.visitors
 
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import org.jetbrains.kotlin.psi.KtFile
 
@@ -10,8 +11,8 @@ abstract class ReturningVisitor<T> : DetektVisitor() {
 
 	protected abstract var value: T
 
-	fun visitAndReturn(file: KtFile): T {
-		file.accept(this)
+	fun visitAndReturn(context: Context, file: KtFile): T {
+		file.accept(this, context)
 		val result = value
 		reset()
 		return result

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/visitors/ComplexityVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/visitors/ComplexityVisitorTest.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.visitors
 
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.core.path
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.assertj.core.api.Assertions.assertThat
@@ -13,7 +14,8 @@ internal class ComplexityVisitorTest {
 	@Test
 	fun complexityOfDefaultCaseIsOne() {
 		val file = compileForTest(path.resolve("Default.kt"))
-		val mcc = ComplexityVisitor().visitAndReturn(file)
+		val context = Context()
+		val mcc = ComplexityVisitor().visitAndReturn(context, file)
 
 		assertThat(mcc).isEqualTo(0)
 	}
@@ -21,7 +23,8 @@ internal class ComplexityVisitorTest {
 	@Test
 	fun complexityOfComplexAndNestedClass() {
 		val file = compileForTest(path.resolve("ComplexClass.kt"))
-		val mcc = ComplexityVisitor().visitAndReturn(file)
+		val context = Context()
+		val mcc = ComplexityVisitor().visitAndReturn(context, file)
 
 		assertThat(mcc).isEqualTo(42)
 	}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/visitors/LLOCVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/visitors/LLOCVisitorTest.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.visitors
 
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.core.path
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.assertj.core.api.Assertions.assertThat
@@ -13,7 +14,8 @@ internal class LLOCVisitorTest {
 	@Test
 	fun defaultCaseHasOneClassAndAnnotationLine() {
 		val file = compileForTest(path.resolve("Default.kt"))
-		val lloc = LLOCVisitor().visitAndReturn(file)
+		val context = Context()
+		val lloc = LLOCVisitor().visitAndReturn(context, file)
 
 		assertThat(lloc).isEqualTo(2)
 	}
@@ -21,7 +23,8 @@ internal class LLOCVisitorTest {
 	@Test
 	fun llocOfComplexClass() {
 		val file = compileForTest(path.resolve("ComplexClass.kt"))
-		val lloc = LLOCVisitor().visitAndReturn(file)
+		val context = Context()
+		val lloc = LLOCVisitor().visitAndReturn(context, file)
 
 		assertThat(lloc).isEqualTo(85)
 	}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/ConsecutiveBlankLines.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/ConsecutiveBlankLines.kt
@@ -1,25 +1,25 @@
 package io.gitlab.arturbosch.detekt.formatting
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.TokenRule
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
 /**
  * @author Artur Bosch
  */
-class ConsecutiveBlankLines(config: Config) : TokenRule("ConsecutiveBlankLines", Severity.Style, config) {
+class ConsecutiveBlankLines(config: Config) : TokenRule("ConsecutiveBlankLines", config) {
 
-	override fun visitSpaces(space: PsiWhiteSpace) {
+	override fun visitSpaces(context: Context, space: PsiWhiteSpace) {
 		val parts = space.text.split("\n")
 		if (parts.size > 3) {
-			addFindings(CodeSmell(id, severity, Entity.from(space, offset = 2)))
+			context.report(CodeSmell(ISSUE, Entity.from(space, offset = 2)))
 			withAutoCorrect {
 				(space as LeafPsiElement).replaceWithText("${parts.first()}\n\n${parts.last()}")
 			}
 		}
 	}
 
+	companion object {
+		val ISSUE = Issue("ConsecutiveBlankLines", Issue.Severity.Style)
+	}
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/ExpressionBodySyntax.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/ExpressionBodySyntax.kt
@@ -1,10 +1,6 @@
 package io.gitlab.arturbosch.detekt.formatting
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.FACTORY
-import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtExpression
@@ -15,13 +11,13 @@ import org.jetbrains.kotlin.psi.KtReturnExpression
  * @author Artur Bosch
  */
 class ExpressionBodySyntax(config: Config = Config.empty) : Rule(
-		"ExpressionBodySyntax", Severity.Style, config) {
+		"ExpressionBodySyntax", config) {
 
-	override fun visitNamedFunction(function: KtNamedFunction) {
+	override fun visitNamedFunction(context: Context, function: KtNamedFunction) {
 		if (function.bodyExpression != null) {
 			val body = function.bodyExpression!!
 			body.singleReturnStatement()?.let { returnStmt ->
-				addFindings(CodeSmell(id, severity, Entity.from(body)))
+				context.report(CodeSmell(ISSUE, Entity.from(body)))
 				withAutoCorrect {
 					val equals = FACTORY.createEQ().node
 					val returnedExpression = returnStmt.returnedExpression!!
@@ -44,4 +40,7 @@ class ExpressionBodySyntax(config: Config = Config.empty) : Rule(
 		}
 	}
 
+	companion object {
+		val ISSUE = Issue("ExpressionBodySyntax", Issue.Severity.Style)
+	}
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/MultipleSpaces.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/MultipleSpaces.kt
@@ -1,24 +1,24 @@
 package io.gitlab.arturbosch.detekt.formatting
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.TokenRule
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 
 /**
  * @author Artur Bosch
  */
-class MultipleSpaces(config: Config) : TokenRule("MultipleSpaces", Severity.Style, config) {
+class MultipleSpaces(config: Config) : TokenRule("MultipleSpaces", config) {
 
-	override fun visitSpaces(space: PsiWhiteSpace) {
+	override fun visitSpaces(context: Context, space: PsiWhiteSpace) {
 		if (!space.textContains('\n') && space.textLength > 1) {
-			addFindings(CodeSmell(id, severity, Entity.from(space, offset = 1)))
+			context.report(CodeSmell(ISSUE, Entity.from(space, offset = 1)))
 			withAutoCorrect {
 				(space as LeafPsiElement).replaceWithText(" ")
 			}
 		}
 	}
 
+	companion object {
+		val ISSUE = Issue("MultipleSpaces", Issue.Severity.Style)
+	}
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/OptionalSemicolon.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/OptionalSemicolon.kt
@@ -1,9 +1,6 @@
 package io.gitlab.arturbosch.detekt.formatting
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.TokenRule
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
@@ -12,21 +9,21 @@ import org.jetbrains.kotlin.psi.psiUtil.nextLeaf
 /**
  * @author Artur Bosch
  */
-class OptionalSemicolon(config: Config = Config.empty) : TokenRule("OptionalSemicolon", Severity.Style, config) {
+class OptionalSemicolon(config: Config = Config.empty) : TokenRule("OptionalSemicolon", config) {
 
-	override fun visitSemicolon(leaf: LeafPsiElement) {
+	override fun visitSemicolon(context: Context, leaf: LeafPsiElement) {
 		if (leaf.isNotPartOfEnum() && leaf.isNotPartOfString()) {
 			val nextLeaf = leaf.nextLeaf()
 			if (nextLeaf.isSemicolonOrEOF() || nextTokenHasSpaces(nextLeaf)) {
-				addFindings(CodeSmell(id, severity, Entity.from(leaf)))
+				context.report(CodeSmell(ISSUE, Entity.from(leaf)))
 				withAutoCorrect { leaf.delete() }
 			}
 		}
 	}
 
-	override fun visitDoubleSemicolon(leaf: LeafPsiElement) {
+	override fun visitDoubleSemicolon(context: Context, leaf: LeafPsiElement) {
 		if (leaf.isNotPartOfEnum() && leaf.isNotPartOfString()) {
-			addFindings(CodeSmell(id, severity, Entity.from(leaf)))
+			context.report(CodeSmell(ISSUE, Entity.from(leaf)))
 			withAutoCorrect {
 				deleteOneOrTwoSemicolons(leaf)
 			}
@@ -47,5 +44,8 @@ class OptionalSemicolon(config: Config = Config.empty) : TokenRule("OptionalSemi
 
 	private fun PsiElement?.isSemicolonOrEOF() = this == null || isSemicolon() || isDoubleSemicolon()
 
+	companion object {
+		val ISSUE = Issue("OptionalSemicolon", Issue.Severity.Style)
+	}
 }
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/OptionalUnit.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/OptionalUnit.kt
@@ -1,9 +1,6 @@
 package io.gitlab.arturbosch.detekt.formatting
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
@@ -13,23 +10,23 @@ import org.jetbrains.kotlin.psi.KtTypeReference
 /**
  * @author Artur Bosch
  */
-class OptionalUnit(config: Config = Config.empty) : Rule("OptionalUnit", Severity.Style, config) {
+class OptionalUnit(config: Config = Config.empty) : Rule("OptionalUnit", config) {
 
-	override fun visitNamedFunction(function: KtNamedFunction) {
+	override fun visitNamedFunction(context: Context, function: KtNamedFunction) {
 		if (function.funKeyword == null) return
 		val colon = function.colon
 		if (function.hasDeclaredReturnType() && colon != null) {
 			val typeReference = function.typeReference
 			typeReference?.typeElement?.text?.let {
 				if (it == "Unit") {
-					addFindings(CodeSmell(id, severity, Entity.from(typeReference)))
+					context.report(CodeSmell(ISSUE, Entity.from(typeReference)))
 					withAutoCorrect {
 						deleteUnitReturnType(colon, typeReference)
 					}
 				}
 			}
 		}
-		super.visitNamedFunction(function)
+		super.visitNamedFunction(context, function)
 	}
 
 	private fun deleteUnitReturnType(colon: PsiElement, typeReference: KtTypeReference) {
@@ -42,5 +39,9 @@ class OptionalUnit(config: Config = Config.empty) : Rule("OptionalUnit", Severit
 			}
 		}
 		colon.delete()
+	}
+
+	companion object {
+		val ISSUE = Issue("OptionalUnit", Issue.Severity.Style)
 	}
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAfterComma.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAfterComma.kt
@@ -1,29 +1,25 @@
 package io.gitlab.arturbosch.detekt.formatting
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.TokenRule
-import io.gitlab.arturbosch.detekt.api.isPartOfString
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 
 /**
  * @author Artur Bosch
  */
-class SpacingAfterComma(config: Config) : TokenRule("SpacingAfterComma", Severity.Style, config) {
+class SpacingAfterComma(config: Config) : TokenRule("SpacingAfterComma", config) {
 
-	override fun visitComma(leaf: LeafPsiElement) {
-		checkSpace(leaf)
+	override fun visitComma(context: Context, leaf: LeafPsiElement) {
+		checkSpace(context, leaf)
 	}
 
-	override fun visitSemicolon(leaf: LeafPsiElement) {
-		checkSpace(leaf)
+	override fun visitSemicolon(context: Context, leaf: LeafPsiElement) {
+		checkSpace(context, leaf)
 	}
 
-	private fun checkSpace(leaf: LeafPsiElement) {
+	private fun checkSpace(context: Context, leaf: LeafPsiElement) {
 		if (leaf.isSpaceMissing()) {
-			addFindings(CodeSmell(id, severity, Entity.from(leaf, offset = 1)))
+			context.report(CodeSmell(ISSUE, Entity.from(leaf, offset = 1)))
 			withAutoCorrect {
 				leaf.rawInsertAfterMe(PsiWhiteSpaceImpl(" "))
 			}
@@ -32,4 +28,7 @@ class SpacingAfterComma(config: Config) : TokenRule("SpacingAfterComma", Severit
 
 	private fun LeafPsiElement.isSpaceMissing() = !isPartOfString() && !nextLeafIsWhiteSpace()
 
+	companion object {
+		val ISSUE = Issue("SpacingAfterComma", Issue.Severity.Style)
+	}
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAroundColon.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAroundColon.kt
@@ -1,9 +1,6 @@
 package io.gitlab.arturbosch.detekt.formatting
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.TokenRule
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.psi.KtAnnotatedExpression
 import org.jetbrains.kotlin.psi.KtClass
@@ -15,9 +12,9 @@ import org.jetbrains.kotlin.psi.KtVariableDeclaration
 /**
  * @author Artur Bosch
  */
-class SpacingAroundColon(config: Config) : TokenRule("SpacingAroundColon", Severity.Style, config) {
+class SpacingAroundColon(config: Config) : TokenRule("SpacingAroundColon", config) {
 
-	override fun visitColon(colon: LeafPsiElement) {
+	override fun visitColon(context: Context, colon: LeafPsiElement) {
 		val parent = colon.parent
 		val modified = when {
 			parent is KtAnnotatedExpression -> false
@@ -29,8 +26,11 @@ class SpacingAroundColon(config: Config) : TokenRule("SpacingAroundColon", Sever
 			else -> false
 		}
 		if (modified) {
-			addFindings(CodeSmell(id, severity, Entity.from(colon)))
+			context.report(CodeSmell(ISSUE, Entity.from(colon)))
 		}
 	}
 
+	companion object {
+		val ISSUE = Issue("SpacingAroundColon", Issue.Severity.Style)
+	}
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAroundOperator.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAroundOperator.kt
@@ -1,10 +1,6 @@
 package io.gitlab.arturbosch.detekt.formatting
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.TokenRule
-import io.gitlab.arturbosch.detekt.api.isPartOf
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
@@ -43,12 +39,12 @@ import org.jetbrains.kotlin.psi.KtValueArgument
  *
  * @author Artur Bosch
  */
-class SpacingAroundOperator(config: Config) : TokenRule("SpacingAroundOperator", Severity.Style, config) {
+class SpacingAroundOperator(config: Config) : TokenRule("SpacingAroundOperator", config) {
 
 	private val tokenSet = TokenSet.create(MUL, PLUS, MINUS, DIV, PERC, LT, GT, LTEQ, GTEQ, EQEQEQ, EXCLEQEQEQ, EQEQ,
 			EXCLEQ, ANDAND, OROR, ELVIS, EQ, MULTEQ, DIVEQ, PERCEQ, PLUSEQ, MINUSEQ, ARROW)
 
-	override fun procedure(node: ASTNode) {
+	override fun procedure(context: Context, node: ASTNode) {
 		if (tokenSet.contains(node.elementType) && node is LeafPsiElement &&
 				!node.isPartOf(KtPrefixExpression::class) && // not unary
 				!node.isPartOf(KtTypeParameterList::class) && // fun <T>fn(): T {}
@@ -58,10 +54,12 @@ class SpacingAroundOperator(config: Config) : TokenRule("SpacingAroundOperator",
 				!node.isPartOf(KtSuperExpression::class) /*super<T>*/) {
 
 			if (node.trimSpacesAround(autoCorrect)) {
-				addFindings(CodeSmell(id, severity, Entity.from(node)))
+				context.report(CodeSmell(ISSUE, Entity.from(node)))
 			}
-
 		}
 	}
 
+	companion object {
+		val ISSUE = Issue("SpacingAroundOperator", Issue.Severity.Style)
+	}
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/TrailingSpaces.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/TrailingSpaces.kt
@@ -1,9 +1,6 @@
 package io.gitlab.arturbosch.detekt.formatting
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.TokenRule
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
@@ -12,28 +9,34 @@ import org.jetbrains.kotlin.psi.psiUtil.nextLeaf
 /**
  * @author Artur Bosch
  */
-class TrailingSpaces(config: Config) : TokenRule("TrailingSpaces", Severity.Style, config) {
+class TrailingSpaces(config: Config) : TokenRule("TrailingSpaces", config) {
 
-	override fun visitSpaces(space: PsiWhiteSpace) {
+	override fun visitSpaces(context: Context, space: PsiWhiteSpace) {
 		val candidates = space.text.split("\n")
 		if (candidates.size > 1) {
-			replaceTracingSpaces(space, candidates.dropLast(),
+			replaceTracingSpaces(context, space, candidates.dropLast(),
 					replaceWith = "\n".repeat(candidates.size - 1) + candidates.last())
 		} else if (space.nextIsEOF()) {
-			replaceTracingSpaces(space, candidates,
+			replaceTracingSpaces(context, space, candidates,
 					replaceWith = "\n".repeat(candidates.size - 1))
 		}
 	}
 
 	private fun PsiElement.nextIsEOF() = nextLeaf() == null
 
-	private fun replaceTracingSpaces(node: PsiWhiteSpace, candidates: List<String>, replaceWith: String) {
+	private fun replaceTracingSpaces(context: Context,
+									 node: PsiWhiteSpace,
+									 candidates: List<String>,
+									 replaceWith: String) {
 		if (candidates.find { !it.isEmpty() } != null) {
-			addFindings(CodeSmell(id, severity, Entity.from(node)))
+			context.report(CodeSmell(ISSUE, Entity.from(node)))
 			withAutoCorrect {
 				(node as LeafPsiElement).replaceWithText(replaceWith)
 			}
 		}
 	}
 
+	companion object {
+		val ISSUE = Issue("TrailingSpaces", Issue.Severity.Style)
+	}
 }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProviderTest.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProviderTest.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.formatting
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -17,7 +18,10 @@ class FormattingProviderTest {
 	@Test
 	fun test() {
 		val ruleSet = FormattingProvider().instance(Config.empty)
-		val (_, findings) = ruleSet.acceptAll(listOf(compileForTest(path)))
-		assertThat(findings.groupBy { it.id }.values.size).isGreaterThanOrEqualTo(8)
+		val context = Context()
+
+		ruleSet.acceptAll(context, listOf(compileForTest(path)))
+
+		assertThat(context.findings.values.size).isGreaterThanOrEqualTo(8)
 	}
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/IdeaExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/IdeaExtension.kt
@@ -28,7 +28,10 @@ open class IdeaExtension(open var path: String? = null,
 	}
 
 	override fun toString(): String {
-		return "IdeaExtension(path=$path, codeStyleScheme=$codeStyleScheme, inspectionsProfile=$inspectionsProfile, mask='$mask')"
+		return "IdeaExtension(" +
+				"path=$path, " +
+				"codeStyleScheme=$codeStyleScheme, " +
+				"inspectionsProfile=$inspectionsProfile, mask='$mask')"
 	}
 }
 

--- a/detekt-migration/src/main/kotlin/io/gitlab/arturbosch/detekt/migration/ImportMigration.kt
+++ b/detekt-migration/src/main/kotlin/io/gitlab/arturbosch/detekt/migration/ImportMigration.kt
@@ -2,8 +2,8 @@ package io.gitlab.arturbosch.detekt.migration
 
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Metric
-import io.gitlab.arturbosch.detekt.api.Rule
 
 /**
  * @author Artur Bosch
@@ -11,10 +11,9 @@ import io.gitlab.arturbosch.detekt.api.Rule
 data class ImportMigration(private val toReplace: String,
 						   private val replacement: String,
 						   override val entity: Entity) : Finding {
-	override val id: String = "ImportMigration"
-	override val severity: Rule.Severity = Rule.Severity.Minor
 	override val references: List<Entity> = emptyList()
 	override val metrics: List<Metric> = emptyList()
-	override val description: String = "$id - $toReplace migrated to $replacement @ ${entity.location.compact()}"
-	override fun compact(): String = description
+	override val issue: Issue = Issue("ImportMigration", Issue.Severity.Defect)
+	override val message = "${issue.id} - $toReplace migrated to $replacement @ ${entity.location.compact()}"
+	override fun compact(): String = issue.description
 }

--- a/detekt-migration/src/main/kotlin/io/gitlab/arturbosch/detekt/migration/MigrateImportsRule.kt
+++ b/detekt-migration/src/main/kotlin/io/gitlab/arturbosch/detekt/migration/MigrateImportsRule.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.migration
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.PROJECT
 import io.gitlab.arturbosch.detekt.api.Rule
@@ -13,14 +14,14 @@ import org.jetbrains.kotlin.resolve.ImportPath
 /**
  * @author Artur Bosch
  */
-class MigrateImportsRule(config: Config) : Rule("MigrateImports", Severity.Defect) {
+class MigrateImportsRule(config: Config) : Rule("MigrateImports") {
 
 	private val replacements: HashMap<String, String> = config.valueOrDefault("imports", HashMap<String, String>())
 	private val toReplaces = replacements.keys
 
 	private val factory = KtImportsFactory(PROJECT)
 
-	override fun visitImportList(importList: KtImportList) {
+	override fun visitImportList(context: Context, importList: KtImportList) {
 
 		importList.imports
 				.filter { it.importedFqName?.toString() in toReplaces }
@@ -31,9 +32,8 @@ class MigrateImportsRule(config: Config) : Rule("MigrateImports", Severity.Defec
 						CodeEditUtil.removeChildren(node, node.firstChildNode, node.lastChildNode)
 						val newImport = factory.createImportDirective(ImportPath.fromString(it))
 						node.addChild(newImport.importedReference?.node!!)
-						addFindings(ImportMigration(key!!, it, Entity.from(import)))
+						context.report(ImportMigration(key!!, it, Entity.from(import)))
 					}
 				}
 	}
-
 }

--- a/detekt-migration/src/test/kotlin/io/gitlab/arturbosch/detekt/migration/MigrateImportsTest.kt
+++ b/detekt-migration/src/test/kotlin/io/gitlab/arturbosch/detekt/migration/MigrateImportsTest.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.migration
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -31,8 +32,9 @@ import bye.bye
 
 fun main(args: Array<String>) {}
 				"""
+		val context = Context()
 
-		MigrateImportsRule(MigrationTestConfig).visit(ktFile)
+		MigrateImportsRule(MigrationTestConfig).visit(context, ktFile)
 
 		assertThat(ktFile.text).isEqualTo(expected)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules
 
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBlockExpression
@@ -24,15 +25,15 @@ fun KtCallExpression.isUsedForNesting(): Boolean = when (getCallNameExpression()
 	else -> false
 }
 
-inline fun <reified T : KtElement> KtElement.collectByType(): List<T> {
+inline fun <reified T : KtElement> KtElement.collectByType(context: Context): List<T> {
 	val list = mutableListOf<T>()
 	this.accept(object : DetektVisitor() {
-		override fun visitKtElement(element: KtElement) {
+		override fun visitKtElement(context: Context, element: KtElement) {
 			if (element is T) {
 				list.add(element)
 			}
-			element.children.forEach { it.accept(this) }
+			element.children.forEach { if (it is KtElement) it.accept(this, context) }
 		}
-	})
+	}, context)
 	return list
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
@@ -1,17 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.psi.KtWhenExpression
 
 /**
  * @author Artur Bosch
  */
-class DuplicateCaseInWhenExpression(config: Config) : Rule("DuplicateCaseInWhenExpression", Severity.Defect, config) {
+class DuplicateCaseInWhenExpression(config: Config) : Rule("DuplicateCaseInWhenExpression", config) {
 
-	override fun visitWhenExpression(expression: KtWhenExpression) {
+	override fun visitWhenExpression(context: Context, expression: KtWhenExpression) {
 		val numberOfEntries = expression.entries.size
 		val distinctNumber = expression.entries
 				.map { it.conditions }
@@ -21,7 +18,11 @@ class DuplicateCaseInWhenExpression(config: Config) : Rule("DuplicateCaseInWhenE
 				.distinct().size
 
 		if (numberOfEntries > distinctNumber) {
-			addFindings(CodeSmell(id, severity, Entity.from(expression)))
+			context.report(CodeSmell(ISSUE, Entity.from(expression)))
 		}
+	}
+
+	companion object {
+		val ISSUE = Issue("DuplicateCaseInWhenExpression", Issue.Severity.Defect)
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -1,28 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
-import io.gitlab.arturbosch.detekt.api.CodeSmellThresholdRule
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Metric
-import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
+import io.gitlab.arturbosch.detekt.api.*
 import io.gitlab.arturbosch.detekt.rules.asBlockExpression
-import org.jetbrains.kotlin.com.intellij.psi.PsiFile
-import org.jetbrains.kotlin.psi.KtBlockExpression
-import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtClassOrObject
-import org.jetbrains.kotlin.psi.KtIfExpression
-import org.jetbrains.kotlin.psi.KtLoopExpression
-import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.psi.KtTryExpression
-import org.jetbrains.kotlin.psi.KtWhenEntry
-import org.jetbrains.kotlin.psi.KtWhenExpression
+import org.jetbrains.kotlin.psi.*
 import java.util.ArrayDeque
 
 /**
  * @author Artur Bosch
  */
-class LargeClass(config: Config = Config.empty, threshold: Int = 70) : CodeSmellThresholdRule("LargeClass", config, threshold) {
+class LargeClass(config: Config = Config.empty, threshold: Int = 70) : ThresholdRule("LargeClass", config, threshold) {
 
 	private val locStack = ArrayDeque<Int>()
 
@@ -34,64 +20,63 @@ class LargeClass(config: Config = Config.empty, threshold: Int = 70) : CodeSmell
 		locStack.push(locStack.pop() + amount)
 	}
 
-	override fun visitFile(file: PsiFile?) { //TODO
+	override fun preVisit(context: Context, root: KtFile) {
 		locStack.clear()
-		super.visitFile(file)
 	}
 
-	override fun visitClassOrObject(classOrObject: KtClassOrObject) {
+	override fun visitClassOrObject(context: Context, classOrObject: KtClassOrObject) {
 		locStack.push(0)
 		classOrObject.getBody()?.let {
 			addToHead(it.declarations.size)
 		}
 		incHead() // for class body
-		super.visitClassOrObject(classOrObject)
+		super.visitClassOrObject(context, classOrObject)
 		val loc = locStack.pop()
 		if (loc > threshold) {
-			addFindings(ThresholdedCodeSmell(id, severity, Entity.Companion.from(classOrObject), Metric("SIZE", loc, threshold)))
+			context.report(ThresholdedCodeSmell(ISSUE, Entity.Companion.from(classOrObject), Metric("SIZE", loc, threshold)))
 		}
 	}
 
 	/**
 	 * Top level members must be skipped as loc stack can be empty - #64
 	 */
-	override fun visitProperty(property: KtProperty) {
+	override fun visitProperty(context: Context, property: KtProperty) {
 		if (property.isTopLevel) return
-		super.visitProperty(property)
+		super.visitProperty(context, property)
 	}
 
-	override fun visitNamedFunction(function: KtNamedFunction) {
+	override fun visitNamedFunction(context: Context, function: KtNamedFunction) {
 		if (function.isTopLevel) return
 		val body: KtBlockExpression? = function.bodyExpression.asBlockExpression()
 		body?.let { addToHead(body.statements.size) }
-		super.visitNamedFunction(function)
+		super.visitNamedFunction(context, function)
 	}
 
-	override fun visitIfExpression(expression: KtIfExpression) {
+	override fun visitIfExpression(context: Context, expression: KtIfExpression) {
 		expression.then?.let { addToHead(it.children.size) }
 		expression.`else`?.let { addToHead(it.children.size) }
-		super.visitIfExpression(expression)
+		super.visitIfExpression(context, expression)
 	}
 
-	override fun visitLoopExpression(loopExpression: KtLoopExpression) {
+	override fun visitLoopExpression(context: Context, loopExpression: KtLoopExpression) {
 		loopExpression.body?.let { addToHead(it.children.size) }
-		super.visitLoopExpression(loopExpression)
+		super.visitLoopExpression(context, loopExpression)
 	}
 
-	override fun visitWhenExpression(expression: KtWhenExpression) {
+	override fun visitWhenExpression(context: Context, expression: KtWhenExpression) {
 		addToHead(expression.children.filter { it is KtWhenEntry }.size)
-		super.visitWhenExpression(expression)
+		super.visitWhenExpression(context, expression)
 	}
 
-	override fun visitTryExpression(expression: KtTryExpression) {
+	override fun visitTryExpression(context: Context, expression: KtTryExpression) {
 		addToHead(expression.tryBlock.statements.size)
 		addToHead(expression.catchClauses.size)
 		expression.catchClauses.map { it.catchBody?.children?.size }.forEach { addToHead(it ?: 0) }
 		expression.finallyBlock?.finalExpression?.statements?.size?.let { addToHead(it) }
-		super.visitTryExpression(expression)
+		super.visitTryExpression(context, expression)
 	}
 
-	override fun visitCallExpression(expression: KtCallExpression) {
+	override fun visitCallExpression(context: Context, expression: KtCallExpression) {
 		val lambdaArguments = expression.lambdaArguments
 		if (lambdaArguments.size > 0) {
 			val lambdaArgument = lambdaArguments[0]
@@ -99,6 +84,10 @@ class LargeClass(config: Config = Config.empty, threshold: Int = 70) : CodeSmell
 				addToHead(it.statements.size)
 			}
 		}
-		super.visitCallExpression(expression)
+		super.visitCallExpression(context, expression)
+	}
+
+	companion object {
+		val ISSUE = Issue("LargeClass", Issue.Severity.CodeSmell)
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -1,10 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
-import io.gitlab.arturbosch.detekt.api.CodeSmellThresholdRule
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Metric
-import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
+import io.gitlab.arturbosch.detekt.api.*
 import io.gitlab.arturbosch.detekt.rules.asBlockExpression
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -12,15 +8,19 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 /**
  * @author Artur Bosch
  */
-class LongMethod(config: Config = Config.empty, threshold: Int = 20) : CodeSmellThresholdRule("LongMethod", config, threshold) {
+class LongMethod(config: Config = Config.empty, threshold: Int = 20) : ThresholdRule("LongMethod", config, threshold) {
 
-	override fun visitNamedFunction(function: KtNamedFunction) {
+	override fun visitNamedFunction(context: Context, function: KtNamedFunction) {
 		val body: KtBlockExpression? = function.bodyExpression.asBlockExpression()
 		body?.let {
 			val size = body.statements.size
-			if (size > threshold) addFindings(
-					ThresholdedCodeSmell(id, severity, Entity.Companion.from(function), Metric("SIZE", size, threshold)))
+			if (size > threshold) context.report(
+					ThresholdedCodeSmell(ISSUE, Entity.Companion.from(function), Metric("SIZE", size, threshold)))
 		}
-		super.visitNamedFunction(function)
+		super.visitNamedFunction(context, function)
+	}
+
+	companion object {
+		val ISSUE = Issue("LongMethod", Issue.Severity.CodeSmell)
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -1,10 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
-import io.gitlab.arturbosch.detekt.api.CodeSmellThresholdRule
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Metric
-import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameterList
@@ -12,17 +8,22 @@ import org.jetbrains.kotlin.psi.KtParameterList
 /**
  * @author Artur Bosch
  */
-class LongParameterList(config: Config = Config.empty, threshold: Int = 5) : CodeSmellThresholdRule("LongParameterList", config, threshold) {
+class LongParameterList(config: Config = Config.empty, threshold: Int = 5) :
+		ThresholdRule("LongParameterList", config, threshold) {
 
-	override fun visitNamedFunction(function: KtNamedFunction) {
+	override fun visitNamedFunction(context: Context, function: KtNamedFunction) {
 		if (function.hasModifier(KtTokens.OVERRIDE_KEYWORD)) return
-		function.valueParameterList?.checkThreshold()
+		function.valueParameterList?.checkThreshold(context)
 	}
 
-	private fun KtParameterList.checkThreshold() {
+	private fun KtParameterList.checkThreshold(context: Context) {
 		val size = parameters.size
 		if (size > threshold) {
-			addFindings(ThresholdedCodeSmell(id, severity, Entity.Companion.from(this), Metric("SIZE", size, threshold)))
+			context.report(ThresholdedCodeSmell(ISSUE, Entity.Companion.from(this), Metric("SIZE", size, threshold)))
 		}
+	}
+
+	companion object {
+		val ISSUE = Issue("LongParameterList", Issue.Severity.CodeSmell)
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -1,32 +1,31 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
-import io.gitlab.arturbosch.detekt.api.CodeSmellThresholdRule
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Metric
-import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
-import org.jetbrains.kotlin.com.intellij.psi.PsiFile
+import io.gitlab.arturbosch.detekt.api.*
+import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
  * @author Artur Bosch
  */
-class TooManyFunctions(config: Config = Config.empty, threshold: Int = 10) : CodeSmellThresholdRule("TooManyFunctions", config, threshold) {
+class TooManyFunctions(config: Config = Config.empty, threshold: Int = 10) :
+		ThresholdRule("TooManyFunctions", config, threshold) {
 
 	private var amount: Int = 0
 
-	override fun visitFile(file: PsiFile) {// TODO
-		super.visitFile(file)
+	override fun postVisit(context: Context, root: KtFile) {
 		if (amount > threshold) {
-			addFindings(ThresholdedCodeSmell(
-					id = id, severity = severity, entity = Entity.from(file),
+			context.report(ThresholdedCodeSmell(
+					issue = ISSUE, entity = Entity.from(root),
 					metric = Metric(type = "SIZE", value = amount, threshold = 10))
 			)
 		}
 	}
 
-	override fun visitNamedFunction(function: KtNamedFunction) {
+	override fun visitNamedFunction(context: Context, function: KtNamedFunction) {
 		amount++
 	}
 
+	companion object {
+		val ISSUE = Issue("TooManyFunctions", Issue.Severity.CodeSmell)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethod.kt
@@ -1,23 +1,24 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.CodeSmellRule
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
  * @author Artur Bosch
  */
-class CommentOverPrivateMethod(config: Config = Config.empty) : CodeSmellRule("CommentOverPrivateMethod", config) {
+class CommentOverPrivateMethod(config: Config = Config.empty) : Rule("CommentOverPrivateMethod", config) {
 
-	override fun visitNamedFunction(function: KtNamedFunction) {
+	override fun visitNamedFunction(context: Context, function: KtNamedFunction) {
 		val modifierList = function.modifierList
 		if (modifierList != null && function.docComment != null) {
 			if (modifierList.hasModifier(KtTokens.PRIVATE_KEYWORD)) {
-				addFindings(CodeSmell(id, severity, Entity.Companion.from(function.docComment!!)))
+				context.report(CodeSmell(ISSUE, Entity.Companion.from(function.docComment!!)))
 			}
 		}
+	}
+
+	companion object {
+		val ISSUE = Issue("CommentOverPrivateMethod", Issue.Severity.CodeSmell)
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
@@ -1,24 +1,24 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.CodeSmellRule
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtProperty
 
 /**
  * @author Artur Bosch
  */
-class CommentOverPrivateProperty(config: Config = Config.empty) : CodeSmellRule("CommentOverPrivateProperty", config) {
+class CommentOverPrivateProperty(config: Config = Config.empty) : Rule("CommentOverPrivateProperty", config) {
 
-	override fun visitProperty(property: KtProperty) {
+	override fun visitProperty(context: Context, property: KtProperty) {
 		val modifierList = property.modifierList
 		if (modifierList != null && property.docComment != null) {
 			if (modifierList.hasModifier(KtTokens.PRIVATE_KEYWORD)) {
-				addFindings(CodeSmell(id, severity, Entity.from(property.docComment!!)))
+				context.report(CodeSmell(ISSUE, Entity.from(property.docComment!!)))
 			}
 		}
 	}
 
+	companion object {
+		val ISSUE = Issue("CommentOverPrivateProperty", Issue.Severity.CodeSmell)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/NoDocOverPublicClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/NoDocOverPublicClass.kt
@@ -1,9 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.*
 import io.gitlab.arturbosch.detekt.rules.isPublicNotOverriden
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
@@ -11,31 +8,34 @@ import org.jetbrains.kotlin.psi.KtObjectDeclaration
 /**
  * @author Artur Bosch
  */
-class NoDocOverPublicClass(config: Config = Config.empty) : Rule("NoDocOverPublicClass", Severity.Maintainability, config) {
+class NoDocOverPublicClass(config: Config = Config.empty) : Rule("NoDocOverPublicClass", config) {
 
-	override fun visitClass(klass: KtClass) {
+	override fun visitClass(context: Context, klass: KtClass) {
 
 		if (klass.isPublicNotOverriden()) {
-			addFindings(CodeSmell(id, severity, Entity.Companion.from(klass)))
+			context.report(CodeSmell(ISSUE, Entity.Companion.from(klass)))
 		}
 		if (klass.notEnum()) { // Stop considering enum entries
-			super.visitClass(klass)
+			super.visitClass(context, klass)
 		}
 	}
 
 	private fun KtClass.notEnum() = !this.isEnum()
 
-	override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {
+	override fun visitObjectDeclaration(context: Context, declaration: KtObjectDeclaration) {
 		if (declaration.isCompanionWithoutName())
 			return
 
 		if (declaration.isPublicNotOverriden()) {
-			addFindings(CodeSmell(id, severity, Entity.Companion.from(declaration)))
+			context.report(CodeSmell(ISSUE, Entity.Companion.from(declaration)))
 		}
-		super.visitObjectDeclaration(declaration)
+		super.visitObjectDeclaration(context, declaration)
 	}
 
 	private fun KtObjectDeclaration.isCompanionWithoutName() =
 			this.isCompanion() && this.nameAsSafeName.asString() == "Companion"
 
+	companion object {
+		val ISSUE = Issue("NoDocOverPublicClass", Issue.Severity.Maintainability)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/NoDocOverPublicMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/NoDocOverPublicMethod.kt
@@ -1,28 +1,25 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.*
 import io.gitlab.arturbosch.detekt.rules.isPublicNotOverriden
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
  * @author Artur Bosch
  */
-class NoDocOverPublicMethod(config: Config = Config.empty) : Rule("NoDocOverPublicMethod", Severity.Maintainability, config) {
+class NoDocOverPublicMethod(config: Config = Config.empty) : Rule("NoDocOverPublicMethod", config) {
 
-	override fun visitNamedFunction(function: KtNamedFunction) {
+	override fun visitNamedFunction(context: Context, function: KtNamedFunction) {
 		if (function.funKeyword == null && function.isLocal) return
 
 		val modifierList = function.modifierList
 		if (function.docComment == null) {
 			if (modifierList == null) {
-				addFindings(CodeSmell(id, severity, methodHeaderLocation(function)))
+				context.report(CodeSmell(ISSUE, methodHeaderLocation(function)))
 			}
 			if (modifierList != null) {
 				if (function.isPublicNotOverriden()) {
-					addFindings(CodeSmell(id, severity, methodHeaderLocation(function)))
+					context.report(CodeSmell(ISSUE, methodHeaderLocation(function)))
 				}
 			}
 		}
@@ -30,4 +27,7 @@ class NoDocOverPublicMethod(config: Config = Config.empty) : Rule("NoDocOverPubl
 
 	private fun methodHeaderLocation(function: KtNamedFunction) = Entity.from(function)
 
+	companion object {
+		val ISSUE = Issue("NoDocOverPublicMethod", Issue.Severity.Maintainability)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtCatchClause
 
 /**
@@ -8,8 +10,11 @@ import org.jetbrains.kotlin.psi.KtCatchClause
  */
 class EmptyCatchBlock(config: Config) : EmptyRule("EmptyCatchBlock", config = config) {
 
-	override fun visitCatchSection(catchClause: KtCatchClause) {
-		catchClause.catchBody?.addFindingIfBlockExprIsEmpty()
+	override fun visitCatchSection(context: Context, catchClause: KtCatchClause) {
+		catchClause.catchBody?.addFindingIfBlockExprIsEmpty(context, ISSUE)
 	}
 
+	companion object {
+		val ISSUE = Issue("EmptyCatchBlock", Issue.Severity.Minor)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
@@ -1,8 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
 /**
@@ -10,10 +8,13 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
  */
 class EmptyClassBlock(config: Config) : EmptyRule("EmptyClassBlock", config = config) {
 
-	override fun visitClassOrObject(classOrObject: KtClassOrObject) {
+	override fun visitClassOrObject(context: Context, classOrObject: KtClassOrObject) {
 		classOrObject.getBody()?.declarations?.let {
-			if (it.isEmpty()) addFindings(CodeSmell(id, severity, Entity.from(classOrObject)))
+			if (it.isEmpty()) context.report(CodeSmell(ISSUE, Entity.from(classOrObject)))
 		}
 	}
 
+	companion object {
+		val ISSUE = Issue("EmptyClassBlock", Issue.Severity.Minor)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDoWhileBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDoWhileBlock.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtDoWhileExpression
 
 /**
@@ -8,8 +10,11 @@ import org.jetbrains.kotlin.psi.KtDoWhileExpression
  */
 class EmptyDoWhileBlock(config: Config) : EmptyRule("EmptyDoWhileBlock", config = config) {
 
-	override fun visitDoWhileExpression(expression: KtDoWhileExpression) {
-		expression.body?.addFindingIfBlockExprIsEmpty()
+	override fun visitDoWhileExpression(context: Context, expression: KtDoWhileExpression) {
+		expression.body?.addFindingIfBlockExprIsEmpty(context, ISSUE)
 	}
 
+	companion object {
+		val ISSUE = Issue("EmptyDoWhileBlock", Issue.Severity.Minor)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyElseBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyElseBlock.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtIfExpression
 
 /**
@@ -8,8 +10,11 @@ import org.jetbrains.kotlin.psi.KtIfExpression
  */
 class EmptyElseBlock(config: Config) : EmptyRule("EmptyElseBlock", config = config) {
 
-	override fun visitIfExpression(expression: KtIfExpression) {
-		expression.`else`?.addFindingIfBlockExprIsEmpty()
+	override fun visitIfExpression(context: Context, expression: KtIfExpression) {
+		expression.`else`?.addFindingIfBlockExprIsEmpty(context, ISSUE)
 	}
 
+	companion object {
+		val ISSUE = Issue("EmptyElseBlock", Issue.Severity.Minor)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFinallyBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFinallyBlock.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtFinallySection
 
 /**
@@ -8,8 +10,12 @@ import org.jetbrains.kotlin.psi.KtFinallySection
  */
 class EmptyFinallyBlock(config: Config) : EmptyRule("EmptyFinallyBlock", config = config) {
 
-	override fun visitFinallySection(finallySection: KtFinallySection) {
-		finallySection.finalExpression?.addFindingIfBlockExprIsEmpty()
+	override fun visitFinallySection(context: Context, finallySection: KtFinallySection) {
+		finallySection.finalExpression?.addFindingIfBlockExprIsEmpty(context, ISSUE)
+	}
+
+	companion object {
+		val ISSUE = Issue("EmptyFinallyBlock", Issue.Severity.Minor)
 	}
 
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyForBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyForBlock.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtForExpression
 
 /**
@@ -8,7 +10,11 @@ import org.jetbrains.kotlin.psi.KtForExpression
  */
 class EmptyForBlock(config: Config) : EmptyRule("EmptyForBlock", config = config) {
 
-	override fun visitForExpression(expression: KtForExpression) {
-		expression.body?.addFindingIfBlockExprIsEmpty()
+	override fun visitForExpression(context: Context, expression: KtForExpression) {
+		expression.body?.addFindingIfBlockExprIsEmpty(context, ISSUE)
+	}
+
+	companion object {
+		val ISSUE = Issue("EmptyForBlock", Issue.Severity.Minor)
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
@@ -8,8 +10,12 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  */
 class EmptyFunctionBlock(config: Config) : EmptyRule("EmptyFunctionBlock", config = config) {
 
-	override fun visitNamedFunction(function: KtNamedFunction) {
-		function.bodyExpression?.addFindingIfBlockExprIsEmpty()
+	override fun visitNamedFunction(context: Context, function: KtNamedFunction) {
+		function.bodyExpression?.addFindingIfBlockExprIsEmpty(context, ISSUE)
+	}
+
+	companion object {
+		val ISSUE = Issue("EmptyFunctionBlock", Issue.Severity.Minor)
 	}
 
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlock.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtIfExpression
 
 /**
@@ -8,8 +10,11 @@ import org.jetbrains.kotlin.psi.KtIfExpression
  */
 class EmptyIfBlock(config: Config) : EmptyRule("EmptyIfBlock", config = config) {
 
-	override fun visitIfExpression(expression: KtIfExpression) {
-		expression.then?.addFindingIfBlockExprIsEmpty()
+	override fun visitIfExpression(context: Context, expression: KtIfExpression) {
+		expression.then?.addFindingIfBlockExprIsEmpty(context, ISSUE)
 	}
 
+	companion object {
+		val ISSUE = Issue("EmptyIfBlock", Issue.Severity.Minor)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
@@ -1,20 +1,17 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.*
 import io.gitlab.arturbosch.detekt.rules.asBlockExpression
 import org.jetbrains.kotlin.psi.KtExpression
 
 /**
  * @author Artur Bosch
  */
-open class EmptyRule(id: String, config: Config, severity: Severity = Rule.Severity.Minor) : Rule(id, severity, config) {
+open class EmptyRule(id: String, config: Config) : Rule(id, config) {
 
-	fun KtExpression.addFindingIfBlockExprIsEmpty() {
+	fun KtExpression.addFindingIfBlockExprIsEmpty(context: Context, issue: Issue) {
 		this.asBlockExpression()?.statements?.let {
-			if (it.isEmpty()) addFindings(CodeSmell(id, severity, Entity.from(this)))
+			if (it.isEmpty()) context.report(CodeSmell(issue, Entity.from(this)))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyWhenBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyWhenBlock.kt
@@ -1,8 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.psi.KtWhenExpression
 
 /**
@@ -10,10 +8,14 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  */
 class EmptyWhenBlock(config: Config) : EmptyRule("EmptyWhenBlock", config = config) {
 
-	override fun visitWhenExpression(expression: KtWhenExpression) {
+	override fun visitWhenExpression(context: Context, expression: KtWhenExpression) {
 		if (expression.entries.isEmpty()) {
-			addFindings(CodeSmell(id, severity, Entity.from(expression)))
+			context.report(CodeSmell(ISSUE, Entity.from(expression)))
 		}
+	}
+
+	companion object {
+		val ISSUE = Issue("EmptyWhenBlock", Issue.Severity.Minor)
 	}
 
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyWhileBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyWhileBlock.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtWhileExpression
 
 /**
@@ -8,8 +10,12 @@ import org.jetbrains.kotlin.psi.KtWhileExpression
  */
 class EmptyWhileBlock(config: Config) : EmptyRule("EmptyWhileBlock", config = config) {
 
-	override fun visitWhileExpression(expression: KtWhileExpression) {
-		expression.body?.addFindingIfBlockExprIsEmpty()
+	override fun visitWhileExpression(context: Context, expression: KtWhileExpression) {
+		expression.body?.addFindingIfBlockExprIsEmpty(context, ISSUE)
+	}
+
+	companion object {
+		val ISSUE = Issue("EmptyWhileBlock", Issue.Severity.Minor)
 	}
 
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/CatchArrayIndexOutOfBoundsException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/CatchArrayIndexOutOfBoundsException.kt
@@ -1,15 +1,21 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtCatchClause
 
 /**
  * @author Artur Bosch
  */
-class CatchArrayIndexOutOfBoundsException(config: Config = Config.empty) : ExceptionsRule("CatchArrayIndexOutOfBoundsException", config) {
+class CatchArrayIndexOutOfBoundsException(config: Config = Config.empty) :
+		ExceptionsRule("CatchArrayIndexOutOfBoundsException", config) {
 
-	override fun visitCatchSection(catchClause: KtCatchClause) {
-		catchClause.addFindingIfExceptionClassMatchesExact { "ArrayIndexOutOfBoundsException" }
+	override fun visitCatchSection(context: Context, catchClause: KtCatchClause) {
+		catchClause.addFindingIfExceptionClassMatchesExact(context, ISSUE) { "ArrayIndexOutOfBoundsException" }
 	}
 
+	companion object {
+		val ISSUE = Issue("CatchArrayIndexOutOfBoundsException", Issue.Severity.Maintainability)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/CatchError.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/CatchError.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtCatchClause
 
 /**
@@ -8,8 +10,11 @@ import org.jetbrains.kotlin.psi.KtCatchClause
  */
 class CatchError(config: Config = Config.empty) : ExceptionsRule("CatchError", config) {
 
-	override fun visitCatchSection(catchClause: KtCatchClause) {
-		catchClause.addFindingIfExceptionClassMatchesExact { "Error" }
+	override fun visitCatchSection(context: Context, catchClause: KtCatchClause) {
+		catchClause.addFindingIfExceptionClassMatchesExact(context, ISSUE) { "Error" }
 	}
 
+	companion object {
+		val ISSUE = Issue("CatchError", Issue.Severity.Maintainability)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/CatchException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/CatchException.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtCatchClause
 
 /**
@@ -8,8 +10,11 @@ import org.jetbrains.kotlin.psi.KtCatchClause
  */
 class CatchException(config: Config = Config.empty) : ExceptionsRule("CatchException", config) {
 
-	override fun visitCatchSection(catchClause: KtCatchClause) {
-		catchClause.addFindingIfExceptionClassMatchesExact { "Exception" }
+	override fun visitCatchSection(context: Context, catchClause: KtCatchClause) {
+		catchClause.addFindingIfExceptionClassMatchesExact(context, ISSUE) { "Exception" }
 	}
 
+	companion object {
+		val ISSUE = Issue("CatchException", Issue.Severity.Maintainability)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/CatchIndexOutOfBoundsException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/CatchIndexOutOfBoundsException.kt
@@ -1,15 +1,21 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtCatchClause
 
 /**
  * @author Artur Bosch
  */
-class CatchIndexOutOfBoundsException(config: Config = Config.empty) : ExceptionsRule("CatchIndexOutOfBoundsException", config) {
+class CatchIndexOutOfBoundsException(config: Config = Config.empty) :
+		ExceptionsRule("CatchIndexOutOfBoundsException", config) {
 
-	override fun visitCatchSection(catchClause: KtCatchClause) {
-		catchClause.addFindingIfExceptionClassMatchesExact { "IndexOutOfBoundsException" }
+	override fun visitCatchSection(context: Context, catchClause: KtCatchClause) {
+		catchClause.addFindingIfExceptionClassMatchesExact(context, ISSUE) { "IndexOutOfBoundsException" }
 	}
 
+	companion object {
+		val ISSUE = Issue("CatchIndexOutOfBoundsException", Issue.Severity.Maintainability)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/CatchNullPointerException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/CatchNullPointerException.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtCatchClause
 
 /**
@@ -8,8 +10,12 @@ import org.jetbrains.kotlin.psi.KtCatchClause
  */
 class CatchNullPointerException(config: Config = Config.empty) : ExceptionsRule("CatchNullPointerException", config) {
 
-	override fun visitCatchSection(catchClause: KtCatchClause) {
-		catchClause.addFindingIfExceptionClassMatchesExact { "NullPointerException" }
+	override fun visitCatchSection(context: Context, catchClause: KtCatchClause) {
+		catchClause.addFindingIfExceptionClassMatchesExact(context, ISSUE) { "NullPointerException" }
+	}
+
+	companion object {
+		val ISSUE = Issue("CatchNullPointerException", Issue.Severity.Maintainability)
 	}
 
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/CatchRuntimeException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/CatchRuntimeException.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtCatchClause
 
 /**
@@ -8,8 +10,11 @@ import org.jetbrains.kotlin.psi.KtCatchClause
  */
 class CatchRuntimeException(config: Config = Config.empty) : ExceptionsRule("CatchRuntimeException", config) {
 
-	override fun visitCatchSection(catchClause: KtCatchClause) {
-		catchClause.addFindingIfExceptionClassMatchesExact { "RuntimeException" }
+	override fun visitCatchSection(context: Context, catchClause: KtCatchClause) {
+		catchClause.addFindingIfExceptionClassMatchesExact(context, ISSUE) { "RuntimeException" }
 	}
 
+	companion object {
+		val ISSUE = Issue("CatchRuntimeException", Issue.Severity.Maintainability)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionsRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionsRule.kt
@@ -1,28 +1,25 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.psi.KtCatchClause
 import org.jetbrains.kotlin.psi.KtThrowExpression
 
 /**
  * @author Artur Bosch
  */
-open class ExceptionsRule(id: String, config: Config, severity: Severity = Rule.Severity.Maintainability) : Rule(id, severity, config) {
+open class ExceptionsRule(id: String, config: Config) : Rule(id, config) {
 
-	fun KtCatchClause.addFindingIfExceptionClassMatchesExact(exception: () -> String) {
+	fun KtCatchClause.addFindingIfExceptionClassMatchesExact(context: Context, issue: Issue, exception: () -> String) {
 		this.catchParameter?.let {
 			val text = it.typeReference?.text
 			if (text != null && text == exception())
-				addFindings(CodeSmell(id, severity, Entity.from(it)))
+				context.report(CodeSmell(issue, Entity.from(it)))
 		}
 	}
 
-	fun KtThrowExpression.addFindingIfThrowingClassMatchesExact(exception: () -> String) {
+	fun KtThrowExpression.addFindingIfThrowingClassMatchesExact(context: Context, issue: Issue, exception: () -> String) {
 		thrownExpression?.text?.substringBefore("(")?.let {
-			if (it == exception()) addFindings(CodeSmell(id, severity, Entity.from(this)))
+			if (it == exception()) context.report(CodeSmell(issue, Entity.from(this)))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowError.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowError.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtThrowExpression
 
 /**
@@ -8,8 +10,11 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  */
 class ThrowError(config: Config = Config.empty) : ExceptionsRule("ThrowError", config) {
 
-	override fun visitThrowExpression(expression: KtThrowExpression) {
-		expression.addFindingIfThrowingClassMatchesExact { "Error" }
+	override fun visitThrowExpression(context: Context, expression: KtThrowExpression) {
+		expression.addFindingIfThrowingClassMatchesExact(context, ISSUE) { "Error" }
 	}
 
+	companion object {
+		val ISSUE = Issue("ThrowError", Issue.Severity.Maintainability)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowException.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtThrowExpression
 
 /**
@@ -8,8 +10,11 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  */
 class ThrowException(config: Config = Config.empty) : ExceptionsRule("ThrowException", config) {
 
-	override fun visitThrowExpression(expression: KtThrowExpression) {
-		expression.addFindingIfThrowingClassMatchesExact { "Exception" }
+	override fun visitThrowExpression(context: Context, expression: KtThrowExpression) {
+		expression.addFindingIfThrowingClassMatchesExact(context, ISSUE) { "Exception" }
 	}
 
+	companion object {
+		val ISSUE = Issue("ThrowException", Issue.Severity.Maintainability)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowNullPointerException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowNullPointerException.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtThrowExpression
 
 /**
@@ -8,8 +10,11 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  */
 class ThrowNullPointerException(config: Config = Config.empty) : ExceptionsRule("ThrowNullPointerException", config) {
 
-	override fun visitThrowExpression(expression: KtThrowExpression) {
-		expression.addFindingIfThrowingClassMatchesExact { "NullPointerException" }
+	override fun visitThrowExpression(context: Context, expression: KtThrowExpression) {
+		expression.addFindingIfThrowingClassMatchesExact(context, ISSUE) { "NullPointerException" }
 	}
 
+	companion object {
+		val ISSUE = Issue("ThrowNullPointerException", Issue.Severity.Maintainability)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowRuntimeException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowRuntimeException.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtThrowExpression
 
 /**
@@ -8,8 +10,11 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  */
 class ThrowRuntimeException(config: Config = Config.empty) : ExceptionsRule("ThrowRuntimeException", config) {
 
-	override fun visitThrowExpression(expression: KtThrowExpression) {
-		expression.addFindingIfThrowingClassMatchesExact { "RuntimeException" }
+	override fun visitThrowExpression(context: Context, expression: KtThrowExpression) {
+		expression.addFindingIfThrowingClassMatchesExact(context, ISSUE) { "RuntimeException" }
 	}
 
+	companion object {
+		val ISSUE = Issue("ThrowRuntimeException", Issue.Severity.Maintainability)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowThrowable.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowThrowable.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Issue
 import org.jetbrains.kotlin.psi.KtThrowExpression
 
 /**
@@ -8,8 +10,11 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  */
 class ThrowThrowable(config: Config = Config.empty) : ExceptionsRule("ThrowThrowable", config) {
 
-	override fun visitThrowExpression(expression: KtThrowExpression) {
-		expression.addFindingIfThrowingClassMatchesExact { "Throwable" }
+	override fun visitThrowExpression(context: Context, expression: KtThrowExpression) {
+		expression.addFindingIfThrowingClassMatchesExact(context, ISSUE) { "Throwable" }
 	}
 
+	companion object {
+		val ISSUE = Issue("ThrowThrowable", Issue.Severity.Maintainability)
+	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CommentSmellProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CommentSmellProvider.kt
@@ -1,8 +1,12 @@
-package io.gitlab.arturbosch.detekt.rules.documentation
+package io.gitlab.arturbosch.detekt.rules.providers
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.rules.documentation.CommentOverPrivateMethod
+import io.gitlab.arturbosch.detekt.rules.documentation.CommentOverPrivateProperty
+import io.gitlab.arturbosch.detekt.rules.documentation.NoDocOverPublicClass
+import io.gitlab.arturbosch.detekt.rules.documentation.NoDocOverPublicMethod
 
 /**
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/ComplexityProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/ComplexityProvider.kt
@@ -1,8 +1,9 @@
-package io.gitlab.arturbosch.detekt.rules.complexity
+package io.gitlab.arturbosch.detekt.rules.providers
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.rules.complexity.*
 
 /**
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -1,8 +1,11 @@
-package io.gitlab.arturbosch.detekt.rules.style
+package io.gitlab.arturbosch.detekt.rules.providers
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.rules.style.MaxLineLength
+import io.gitlab.arturbosch.detekt.rules.style.NamingConventionViolation
+import io.gitlab.arturbosch.detekt.rules.style.WildcardImport
 
 /**
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -1,29 +1,27 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.psi.KtFile
 
-class MaxLineLength(config: Config = Config.empty) : Rule("MaxLineLength", Severity.Style, config) {
+class MaxLineLength(config: Config = Config.empty) : Rule("MaxLineLength", config) {
 
 	private val maxLineLength: Int = withConfig { valueOrDefault(MAX_LINE_LENGTH, 120) }
 
-	override fun visit(root: KtFile) {
+	override fun visitKtFile(context: Context, file: KtFile) {
 		var offset = 0
-		root.text.splitToSequence("\n")
+		file.text.splitToSequence("\n")
 				.map { it.length }
 				.forEach {
 					offset += it
 					if (it > maxLineLength) {
-						addFindings(CodeSmell(id, severity, Entity.Companion.from(root, offset)))
+						context.report(CodeSmell(ISSUE, Entity.Companion.from(file.findElementAt(offset) ?: file)))
 					}
 				}
 	}
 
 	companion object {
 		val MAX_LINE_LENGTH = "maxLineLength"
+		val ISSUE = Issue("MaxLineLength", Issue.Severity.Style)
 	}
 }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -1,21 +1,22 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.psi.KtImportDirective
 
 /**
  * @author Artur Bosch
  */
-class WildcardImport(config: Config = Config.empty) : Rule("WildcardImport", Severity.Style, config) {
+class WildcardImport(config: Config = Config.empty) : Rule("WildcardImport", config) {
 
-	override fun visitImportDirective(importDirective: KtImportDirective) {
+	override fun visitImportDirective(context: Context, importDirective: KtImportDirective) {
 		val import = importDirective.importPath?.pathStr
 		if (import != null && import.contains("*")) {
-			addFindings(CodeSmell(id, severity, Entity.Companion.from(importDirective)))
+			context.report(CodeSmell(ISSUE, Entity.Companion.from(importDirective)))
 		}
+	}
+
+	companion object {
+		val ISSUE = Issue("WildcardImport", Issue.Severity.Style)
 	}
 }
 

--- a/detekt-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
+++ b/detekt-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -1,7 +1,7 @@
-io.gitlab.arturbosch.detekt.rules.complexity.ComplexityProvider
+io.gitlab.arturbosch.detekt.rules.providers.ComplexityProvider
 io.gitlab.arturbosch.detekt.rules.providers.CodeSmellProvider
-io.gitlab.arturbosch.detekt.rules.style.StyleGuideProvider
-io.gitlab.arturbosch.detekt.rules.documentation.CommentSmellProvider
+io.gitlab.arturbosch.detekt.rules.providers.StyleGuideProvider
+io.gitlab.arturbosch.detekt.rules.providers.CommentSmellProvider
 io.gitlab.arturbosch.detekt.rules.providers.EmptyCodeProvider
 io.gitlab.arturbosch.detekt.rules.providers.PotentialBugProvider
 io.gitlab.arturbosch.detekt.rules.providers.ExceptionsProvider

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/CommonSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/CommonSpec.kt
@@ -18,8 +18,8 @@ class CommonSpec : SubjectSpek<Rule>({
 
 	describe("running specified rule") {
 		it("should detect one finding") {
-			subject.lint(file.text)
-			assertThat(subject.findings).hasSize(1)
+			val findings = subject.lint(file.text)
+			assertThat(findings).hasSize(1)
 		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/ComplexMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/ComplexMethodSpec.kt
@@ -14,9 +14,9 @@ class ComplexMethodSpec : Spek({
 
 	it("finds one complex method") {
 		val subject = ComplexMethod()
-		subject.lint(Case.ComplexClass.path())
-		assertThat(subject.findings).hasSize(1)
-		assertThat((subject.findings[0] as ThresholdedCodeSmell).value).isEqualTo(13)
-		assertThat((subject.findings[0] as ThresholdedCodeSmell).threshold).isEqualTo(10)
+		val findings = subject.lint(Case.ComplexClass.path())
+		assertThat(findings).hasSize(1)
+		assertThat((findings[0] as ThresholdedCodeSmell).value).isEqualTo(13)
+		assertThat((findings[0] as ThresholdedCodeSmell).threshold).isEqualTo(10)
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/LargeClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/LargeClassSpec.kt
@@ -2,11 +2,11 @@ package io.gitlab.arturbosch.detekt.rules
 
 import io.gitlab.arturbosch.detekt.rules.complexity.LargeClass
 import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
 import org.jetbrains.spek.subject.itBehavesLike
-import kotlin.test.assertEquals
 
 /**
  * @author Artur Bosch
@@ -17,8 +17,8 @@ class LargeClassSpec : SubjectSpek<LargeClass>({
 
 	describe("nested classes are also considered") {
 		it("should detect only the nested large class") {
-			subject.lint(Case.NestedClasses.path())
-			assertEquals(subject.findings.size, 1)
+            val findings = subject.lint(Case.NestedClasses.path())
+            assertThat(findings).hasSize(1)
 		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/LongMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/LongMethodSpec.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.test.lint
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
-import kotlin.test.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 
 /**
  * @author Artur Bosch
@@ -15,15 +15,15 @@ class LongMethodSpec : SubjectSpek<LongMethod>({
 
 	describe("nested functions can be long") {
 		it("should find two long methods") {
-			subject.lint(Case.NestedLongMethods.path())
-			assertEquals(subject.findings.size, 2)
+            val findings = subject.lint(Case.NestedLongMethods.path())
+            assertThat(findings).hasSize(2)
 		}
 	}
 
 	describe("nested classes can contain long methods") {
 		it("should detect one nested long method") {
-			subject.lint(Case.NestedClasses.path())
-			assertEquals(subject.findings.size, 1)
+            val findings = subject.lint(Case.NestedClasses.path())
+            assertThat(findings).hasSize(1)
 		}
 
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/NamingConventionViolationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/NamingConventionViolationSpec.kt
@@ -15,8 +15,8 @@ class NamingConventionViolationSpec : SubjectSpek<NamingConventionViolation>({
 	subject { NamingConventionViolation() }
 
 	it("should find all wrong namings") {
-		subject.lint(Case.NamingConventions.path())
-		assertThat(subject.findings).hasSize(9)
+        val findings = subject.lint(Case.NamingConventions.path())
+		assertThat(findings).hasSize(9)
 	}
 
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/NestedBlockDepthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/NestedBlockDepthSpec.kt
@@ -11,7 +11,6 @@ import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
 import org.jetbrains.spek.subject.itBehavesLike
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
 /**
  * @author Artur Bosch
@@ -22,9 +21,9 @@ class NestedBlockDepthSpec : SubjectSpek<NestedBlockDepth>({
 
 	describe("nested classes are also considered") {
 		it("should detect only the nested large class") {
-			subject.lint(Case.NestedClasses.path())
-			assertEquals(subject.findings.size, 1)
-			assertEquals((subject.findings[0] as ThresholdedCodeSmell).value, 5)
+            val findings = subject.lint(Case.NestedClasses.path())
+            assertThat(findings).hasSize(1)
+            assertThat((findings[0] as ThresholdedCodeSmell).value).isEqualTo(5)
 		}
 	}
 
@@ -41,14 +40,14 @@ class NestedBlockDepthTest : RuleTest {
 		val psi = node.psi
 		if (psi.isNotPartOfEnum() && psi.isNotPartOfString()) {
 			if (psi.isDoubleSemicolon()) {
-				addFindings(CodeSmell(id, Entity.from(psi)))
+				context.report(CodeSmell(id, Entity.from(psi)))
 				withAutoCorrect {
 					deleteOneOrTwoSemicolons(node as LeafPsiElement)
 				}
 			} else if (psi.isSemicolon()) {
 				val nextLeaf = psi.nextLeaf()
 				if (nextLeaf.isSemicolonOrEOF() || nextTokenHasSpaces(nextLeaf)) {
-					addFindings(CodeSmell(id, Entity.from(psi)))
+					context.report(CodeSmell(id, Entity.from(psi)))
 					withAutoCorrect { psi.delete() }
 				}
 			}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/NoDocOverPublicClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/NoDocOverPublicClassSpec.kt
@@ -13,8 +13,8 @@ class NoDocOverPublicClassSpec : SubjectSpek<NoDocOverPublicClass>({
 	subject { NoDocOverPublicClass() }
 
 	it("finds two undocumented classes") {
-		subject.lint(Case.Comments.path())
-		assertThat(subject.findings).hasSize(2)
+        val findings = subject.lint(Case.Comments.path())
+		assertThat(findings).hasSize(2)
 	}
 
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/NoDocOverPublicMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/NoDocOverPublicMethodSpec.kt
@@ -13,7 +13,7 @@ class NoDocOverPublicMethodSpec : SubjectSpek<NoDocOverPublicMethod>({
 	subject { NoDocOverPublicMethod() }
 
 	it("finds three undocumented functions") {
-		subject.lint(Case.Comments.path())
-		assertThat(subject.findings).hasSize(3)
+        val findings = subject.lint(Case.Comments.path())
+		assertThat(findings).hasSize(3)
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules
 
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.rules.complexity.ComplexCondition
 import io.gitlab.arturbosch.detekt.rules.complexity.LongMethod
@@ -17,7 +18,9 @@ class SuppressingSpec : Spek({
 	it("all findings are suppressed on element levels") {
 		val ktFile = compileForTest(Case.SuppressedElements.path())
 		val ruleSet = RuleSet("Test", listOf(LongMethod(), LongParameterList(), ComplexCondition()))
-		val findings = ruleSet.accept(ktFile)
+		val context = Context()
+		ruleSet.accept(context, ktFile)
+		val findings = context.findings.flatMap { it.value }
 		findings.forEach {
 			println(it.compact())
 		}
@@ -27,7 +30,9 @@ class SuppressingSpec : Spek({
 	it("all findings are suppressed on file levels") {
 		val ktFile = compileForTest(Case.SuppressedElementsByFile.path())
 		val ruleSet = RuleSet("Test", listOf(LongMethod(), LongParameterList(), ComplexCondition()))
-		val findings = ruleSet.accept(ktFile)
+		val context = Context()
+		ruleSet.accept(context, ktFile)
+		val findings = context.findings.flatMap { it.value }
 		findings.forEach {
 			println(it.compact())
 		}
@@ -37,7 +42,9 @@ class SuppressingSpec : Spek({
 	it("all findings are suppressed on class levels") {
 		val ktFile = compileForTest(Case.SuppressedElementsByClass.path())
 		val ruleSet = RuleSet("Test", listOf(LongMethod(), LongParameterList(), ComplexCondition()))
-		val findings = ruleSet.accept(ktFile)
+		val context = Context()
+		ruleSet.accept(context, ktFile)
+		val findings = context.findings.flatMap { it.value }
 		findings.forEach {
 			println(it.compact())
 		}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.rules.CommonSpec
 import io.gitlab.arturbosch.detekt.test.compileForTest
@@ -23,9 +24,10 @@ class EqualsWithHashCodeExistTest {
 	fun nestedClasses() {
 		val subject = EqualsWithHashCodeExist(Config.empty)
 		val file = compileForTest(Case.NestedClasses.path())
+		val context = Context()
 
-		subject.visit(file)
+		subject.visit(context, file)
 
-		assertThat(subject.findings).hasSize(2)
+		assertThat(context.findings).hasSize(2)
 	}
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCallTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCallTest.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.assertj.core.api.Assertions.assertThat
@@ -15,10 +16,11 @@ class ExplicitGarbageCollectionCallTest {
 	fun systemGC() {
 		val subject = ExplicitGarbageCollectionCall(Config.empty)
 		val file = compileForTest(Case.Default.path())
+		val context = Context()
 
-		subject.visit(file)
+		subject.visit(context, file)
 
-		assertThat(subject.findings).hasSize(3)
+		assertThat(context.findings).hasSize(3)
 	}
 
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeTest.kt
@@ -67,8 +67,8 @@ class EmptyCodeTest {
 
 	private fun test(block: () -> Rule) {
 		val rule = block()
-		rule.lint(file.text)
-		assertThat(rule.findings).hasSize(1)
+		val findings = rule.lint(file.text)
+		assertThat(findings).hasSize(1)
 	}
 
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionsTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionsTest.kt
@@ -71,8 +71,8 @@ class ExceptionsTest {
 
 	private fun findOne(block: () -> Rule) {
 		val rule = block()
-		rule.lint(file.text)
-		assertThat(rule.findings).hasSize(1)
+		val findings = rule.lint(file.text)
+		assertThat(findings).hasSize(1)
 	}
 
 }

--- a/detekt-sample-ruleset/src/main/kotlin/io/gitlab/arturbosch/detekt/sampleruleset/TooManyFunctions.kt
+++ b/detekt-sample-ruleset/src/main/kotlin/io/gitlab/arturbosch/detekt/sampleruleset/TooManyFunctions.kt
@@ -1,9 +1,7 @@
 package io.gitlab.arturbosch.detekt.sampleruleset
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Rule
-import org.jetbrains.kotlin.com.intellij.psi.PsiFile
+import io.gitlab.arturbosch.detekt.api.*
+import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
@@ -13,15 +11,18 @@ class TooManyFunctions : Rule("TooManyFunctions") {
 
 	private var amount: Int = 0
 
-	override fun visitFile(file: PsiFile) {
-		super.visitFile(file)
-		if (amount > 10) {
-			addFindings(CodeSmell(id, severity, Entity.from(file)))
-		}
-	}
-
-	override fun visitNamedFunction(function: KtNamedFunction) {
+	override fun visitNamedFunction(context: Context, function: KtNamedFunction) {
 		amount++
 	}
 
+	override fun postVisit(context: Context, root: KtFile) {
+		super.postVisit(context, root)
+		if (amount > 10) {
+			context.report(CodeSmell(ISSUE, Entity.from(root)))
+		}
+	}
+
+	companion object {
+		val ISSUE = Issue("TooManyFunctions")
+	}
 }

--- a/detekt-sample-ruleset/src/main/kotlin/io/gitlab/arturbosch/detekt/sampleruleset/TooManyFunctionsTwo.kt
+++ b/detekt-sample-ruleset/src/main/kotlin/io/gitlab/arturbosch/detekt/sampleruleset/TooManyFunctionsTwo.kt
@@ -1,36 +1,35 @@
 package io.gitlab.arturbosch.detekt.sampleruleset
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Metric
-import io.gitlab.arturbosch.detekt.api.Rule
-import org.jetbrains.kotlin.com.intellij.psi.PsiFile
+import io.gitlab.arturbosch.detekt.api.*
+import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
  * @author Artur Bosch
  */
-class TooManyFunctionsTwo(config: Config) : Rule("TooManyFunctionsTwo", Severity.Maintainability, config) {
+class TooManyFunctionsTwo(config: Config) : Rule("TooManyFunctionsTwo", config) {
 
 	private var amount: Int = 0
 
-	override fun visitFile(file: PsiFile) {
-		super.visitFile(file)
+	override fun postVisit(context: Context, root: KtFile) {
+		super.postVisit(context, root)
 		if (amount > 10) {
-			addFindings(CodeSmell(
-					id = id,
-					severity = severity,
-					entity = Entity.from(file),
-					description = "Too many functions can make the maintainability of a file more costly",
+			context.report(CodeSmell(
+					issue = ISSUE,
+					entity = Entity.from(root),
 					metrics = listOf(Metric(type = "SIZE", value = amount, threshold = 10)),
 					references = listOf())
 			)
 		}
 	}
 
-	override fun visitNamedFunction(function: KtNamedFunction) {
+	override fun visitNamedFunction(context: Context, function: KtNamedFunction) {
 		amount++
 	}
 
+	companion object {
+		val ISSUE = Issue("TooManyFunctionsTwo",
+				Issue.Severity.Maintainability,
+				"Too many functions can make the maintainability of a file more costly")
+	}
 }

--- a/detekt-sample-ruleset/src/test/kotlin/io/gitlab/arturbosch/detekt/sampleruleset/TooManyFunctionsSpec.kt
+++ b/detekt-sample-ruleset/src/test/kotlin/io/gitlab/arturbosch/detekt/sampleruleset/TooManyFunctionsSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.sampleruleset
 
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
@@ -14,9 +15,10 @@ class TooManyFunctionsSpec : SubjectSpek<TooManyFunctions>({
 
 	describe("a simple test") {
 		it("should find one file with too many functions") {
+			val context = Context()
 			val ktFile = compileContentForTest(code)
-			subject.visit(ktFile)
-			assertThat(subject.findings).hasSize(1)
+			subject.visit(context, ktFile)
+			assertThat(context.findings).hasSize(1)
 		}
 	}
 

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.test
 
+import io.gitlab.arturbosch.detekt.api.Context
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Rule
 import org.jetbrains.kotlin.psi.KtFile
@@ -16,8 +17,9 @@ fun Rule.lint(path: Path): List<Finding> {
 }
 
 private fun Rule.findingsAfterVisit(ktFile: KtFile): List<Finding> {
-	this.visit(ktFile)
-	return this.findings
+	val context = Context()
+	this.visit(context, ktFile)
+	return context.findings
 }
 
 fun Rule.format(content: String): String {
@@ -31,6 +33,7 @@ fun Rule.format(path: Path): String {
 }
 
 private fun Rule.contentAfterVisit(ktFile: KtFile): String {
-	this.visit(ktFile)
+	val context = Context()
+	this.visit(context, ktFile)
 	return ktFile.text
 }


### PR DESCRIPTION
As mentioned in PR #74, this is a proposal to extract the finding collection and rule metadata responsibility from the rule itself. 

It should be now for example pretty straightforward to convert all the `EmptyRule`s and `ExceptionRule`s to one single rule each which has several issues. That should also increase the performance since multiple issues will be found in one run.

Since you mentioned threading concerns, I decided that the context won't be singleton, just that every rule has its own context.