### PR TITLE
Improve SuppressSpec test

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
@@ -19,9 +19,9 @@ class SuppressingSpec : Spek({
 
 	it("all findings are suppressed on element levels") {
 		val ktFile = compileForTest(Case.SuppressedElements.path())
-		val ruleSet = RuleSet("Test", listOf(LongMethod(threshold = 0),
-				LongParameterList(threshold = 0),
-				ComplexCondition(threshold = 0),
+		val ruleSet = RuleSet("Test", listOf(LongMethod(),
+				LongParameterList(),
+				ComplexCondition(),
 				MaxLineLength()))
 		val findings = ruleSet.accept(ktFile)
 		findings.forEach {
@@ -32,9 +32,9 @@ class SuppressingSpec : Spek({
 
 	it("all findings are suppressed on file levels") {
 		val ktFile = compileForTest(Case.SuppressedElementsByFile.path())
-		val ruleSet = RuleSet("Test", listOf(LongMethod(threshold = 0),
-				LongParameterList(threshold = 0),
-				ComplexCondition(threshold = 0),
+		val ruleSet = RuleSet("Test", listOf(LongMethod(),
+				LongParameterList(),
+				ComplexCondition(),
 				MaxLineLength()))
 		val findings = ruleSet.accept(ktFile)
 		findings.forEach {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
@@ -45,9 +45,9 @@ class SuppressingSpec : Spek({
 
 	it("all findings are suppressed on class levels") {
 		val ktFile = compileForTest(Case.SuppressedElementsByClass.path())
-		val ruleSet = RuleSet("Test", listOf(LongMethod(threshold = 0),
-				LongParameterList(threshold = 0),
-				ComplexCondition(threshold = 0),
+		val ruleSet = RuleSet("Test", listOf(LongMethod(),
+				LongParameterList(),
+				ComplexCondition(),
 				MaxLineLength()))
 		val findings = ruleSet.accept(ktFile)
 		findings.forEach {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.rules.complexity.ComplexCondition
 import io.gitlab.arturbosch.detekt.rules.complexity.LongMethod
 import io.gitlab.arturbosch.detekt.rules.complexity.LongParameterList
 import io.gitlab.arturbosch.detekt.rules.complexity.TooManyFunctions
+import io.gitlab.arturbosch.detekt.rules.style.MaxLineLength
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
@@ -18,7 +19,10 @@ class SuppressingSpec : Spek({
 
 	it("all findings are suppressed on element levels") {
 		val ktFile = compileForTest(Case.SuppressedElements.path())
-		val ruleSet = RuleSet("Test", listOf(LongMethod(), LongParameterList(), ComplexCondition()))
+		val ruleSet = RuleSet("Test", listOf(LongMethod(threshold = 0),
+				LongParameterList(threshold = 0),
+				ComplexCondition(threshold = 0),
+				MaxLineLength()))
 		val findings = ruleSet.accept(ktFile)
 		findings.forEach {
 			println(it.compact())
@@ -28,7 +32,10 @@ class SuppressingSpec : Spek({
 
 	it("all findings are suppressed on file levels") {
 		val ktFile = compileForTest(Case.SuppressedElementsByFile.path())
-		val ruleSet = RuleSet("Test", listOf(LongMethod(), LongParameterList(), ComplexCondition()))
+		val ruleSet = RuleSet("Test", listOf(LongMethod(threshold = 0),
+				LongParameterList(threshold = 0),
+				ComplexCondition(threshold = 0),
+				MaxLineLength()))
 		val findings = ruleSet.accept(ktFile)
 		findings.forEach {
 			println(it.compact())
@@ -38,7 +45,10 @@ class SuppressingSpec : Spek({
 
 	it("all findings are suppressed on class levels") {
 		val ktFile = compileForTest(Case.SuppressedElementsByClass.path())
-		val ruleSet = RuleSet("Test", listOf(LongMethod(), LongParameterList(), ComplexCondition()))
+		val ruleSet = RuleSet("Test", listOf(LongMethod(threshold = 0),
+				LongParameterList(threshold = 0),
+				ComplexCondition(threshold = 0),
+				MaxLineLength()))
 		val findings = ruleSet.accept(ktFile)
 		findings.forEach {
 			println(it.compact())

--- a/detekt-rules/src/test/resources/SuppressedByElementAnnotation.kt
+++ b/detekt-rules/src/test/resources/SuppressedByElementAnnotation.kt
@@ -50,4 +50,9 @@ class SuppressedElements {
 		assert(false) { "FAILED TEST" }
 	}
 
+	@SuppressWarnings("MaxLineLength")
+	fun lineLength() {
+		val s = "Lorem ipsum dolor sit amet, wisi nominavi usu ne. Sea in impedit patrioque, vis cu moderatius quaerendum scribentur. Ex cum appareat ocurreret delicatissimi. Usu harum labores te. Natum signiferumque no nam, est id oratio blandit. Temporibus consectetuer consequuntur ei est, his in dolorum vituperata."
+	}
+
 }

--- a/detekt-rules/src/test/resources/SuppressedElementsByClassAnnotation.kt
+++ b/detekt-rules/src/test/resources/SuppressedElementsByClassAnnotation.kt
@@ -1,7 +1,7 @@
 /**
  * @author Artur Bosch
  */
-@Suppress("unused", "LongMethod", "LongParameterList", "ComplexCondition", "TooManyFunctions")
+@Suppress("unused", "LongMethod", "LongParameterList", "ComplexCondition", "TooManyFunctions", "MaxLineLength")
 class SuppressedElements3 {
 
 	fun lpl(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) = (a + b + c + d + e + f).apply {
@@ -39,4 +39,7 @@ class SuppressedElements3 {
 		assert(false) { "FAILED TEST" }
 	}
 
+	fun lineLength() {
+		val s = "Lorem ipsum dolor sit amet, wisi nominavi usu ne. Sea in impedit patrioque, vis cu moderatius quaerendum scribentur. Ex cum appareat ocurreret delicatissimi. Usu harum labores te. Natum signiferumque no nam, est id oratio blandit. Temporibus consectetuer consequuntur ei est, his in dolorum vituperata."
+	}
 }

--- a/detekt-rules/src/test/resources/SuppressedElementsByFileAnnotation.kt
+++ b/detekt-rules/src/test/resources/SuppressedElementsByFileAnnotation.kt
@@ -1,4 +1,4 @@
-@file:Suppress("unused", "LongMethod", "LongParameterList", "ComplexCondition")
+@file:Suppress("unused", "LongMethod", "LongParameterList", "ComplexCondition", "MaxLineLength")
 
 /**
  * @author Artur Bosch
@@ -43,6 +43,10 @@ class SuppressedElements2 {
 		lpl(1, 2, 3, 4, 5, 6)
 		lpl(1, 2, 3, 4, 5, 6)
 		assert(false) { "FAILED TEST" }
+	}
+
+	fun lineLength() {
+		val s = "Lorem ipsum dolor sit amet, wisi nominavi usu ne. Sea in impedit patrioque, vis cu moderatius quaerendum scribentur. Ex cum appareat ocurreret delicatissimi. Usu harum labores te. Natum signiferumque no nam, est id oratio blandit. Temporibus consectetuer consequuntur ei est, his in dolorum vituperata."
 	}
 
 }


### PR DESCRIPTION
 * ~use threshold for rules, otherwise they do not detect error~
 * added MaxLineLength to test

Test are failing now.
For `MaxLineLength`  suppress doesn't work on class and element level
~For `LongMethod` suppress doesn't work on element level~

Unfortunately, I'm not familiar enough with "visitors" to quickly fix it :(