### PR TITLE
Improve changelog generator

### DIFF
--- a/github-milestone-report.groovy
+++ b/github-milestone-report.groovy
@@ -33,11 +33,11 @@ def mId = args.size() > 2 ? args[2].toInteger() : sortedMilestones.last().number
 def milestone = repository.getMilestone(mId)
 def issues = repository.getIssues(GHIssueState.ALL, milestone)
 
-def section = Report.section(milestone.title) + "\n"
+def section = Report.section(milestone.title.trim()) + "\n"
 def issuesString = issues.collect {
-	(Report.entry(it.title, it.number, it.url))
+	(Report.entry(it.title.trim(), it.number, it.getHtmlUrl()))
 }.join("\n") + "\n"
-def footer = Report.footer(milestone.title, milestone.url)
+def footer = Report.footer(milestone.title.trim(), milestone.getHtmlUrl())
 
 println(section)
 println(issuesString)

--- a/github-milestone-report.groovy
+++ b/github-milestone-report.groovy
@@ -19,11 +19,10 @@ class Report {
 	}
 }
 
-if (args.size() < 3) throw new IllegalArgumentException("Usage: [userId] [repositoryId] [milestoneId]")
+if (args.size() > 3) throw new IllegalArgumentException("Usage: [userId] [repositoryId] [milestoneId]")
 
-def user = args[0] ?: "arturbosch"
-def repo = args[1] ?: "detekt"
-def mId = args[2].toInteger() ?: 8
+def user = args.size() > 0 ? args[0] : "arturbosch"
+def repo = args.size() > 1 ? args[1] : "detekt"
 
 def github = GitHub.connectAnonymously()
 def repository = github.getUser(user).getRepository(repo)

--- a/github-milestone-report.groovy
+++ b/github-milestone-report.groovy
@@ -27,6 +27,10 @@ def mId = args[2].toInteger() ?: 8
 
 def github = GitHub.connectAnonymously()
 def repository = github.getUser(user).getRepository(repo)
+
+def milestones = repository.listMilestones(GHIssueState.OPEN)
+def sortedMilestones = milestones.sort { it.number }
+def mId = args.size() > 2 ? args[2].toInteger() : sortedMilestones.last().number
 def milestone = repository.getMilestone(mId)
 def issues = repository.getIssues(GHIssueState.ALL, milestone)
 


### PR DESCRIPTION
I've tweaked the changelog generator script a bit:

 * **Parameters are now optional**, uses default values pointing to this repo and the latest milestone
    Next improvement would be named arguments so you can override only one of the defaults at a time
 * All **URLs point to human-friendly HTML pages** instead of pointing to API responses
 * Titles are `trim()`med to avoid leading and trailing spaces

### Sample output before (for M12)

#### M12

- Suppress for TooManyFunctions is not considered in detekt - [#108](https://api.github.com/repos/arturbosch/detekt/issues/108)
- Update documentation and migration guide for M12 - [#105](https://api.github.com/repos/arturbosch/detekt/issues/105)
- NoDocOverPublicClass always reported for objects - [#104](https://api.github.com/repos/arturbosch/detekt/issues/104)
...
- Baseline does not work anymore as expected due to inner restructure for the new output formats  - [#83](https://api.github.com/repos/arturbosch/detekt/issues/83)
...

See all issues at: [M12](https://api.github.com/repos/arturbosch/detekt/milestones/8)

### Sample output after (for M12)

#### M12

- Suppress for TooManyFunctions is not considered in detekt - [#108](https://github.com/arturbosch/detekt/issues/108)
- Update documentation and migration guide for M12 - [#105](https://github.com/arturbosch/detekt/issues/105)
- NoDocOverPublicClass always reported for objects - [#104](https://github.com/arturbosch/detekt/issues/104)
...
- Baseline does not work anymore as expected due to inner restructure for the new output formats - [#83](https://github.com/arturbosch/detekt/issues/83)
...

See all issues at: [M12](https://github.com/arturbosch/detekt/milestone/8)
