### PR TITLE
Add package/import statements excludes to MaxLineLength rule 

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,11 @@ style:
     methodPattern: '^[a-z$][a-zA-Z$0-9]*$'
     classPattern: '[A-Z$][a-zA-Z$]*'
     enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
+  MaxLineLength:
+    active: true
+    maxLineLength: 120
+    excludePackageStatements: false
+    excludeImportStatements: false
 
 comments:
   active: true

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -102,6 +102,8 @@ style:
   MaxLineLength:
     active: true
     maxLineLength: 120
+    excludePackageStatements: false
+    excludeImportStatements: false
   NamingConventionViolation:
     active: true
     variablePattern: '^(_)?[a-z$][a-zA-Z$0-9]*$'

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -14,10 +14,14 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 	override val issue = Issue(javaClass.simpleName, Severity.Style, "", Dept.FIVE_MINS)
 
 	private val maxLineLength: Int = valueOrDefault(MAX_LINE_LENGTH, DEFAULT_IDEA_LINE_LENGTH)
+	private val excludePackageStatements: Boolean = valueOrDefault(EXCLUDE_PACKAGE_STATEMENTS, DEFAULT_VALUE_PACKAGE_EXCLUDE)
+	private val excludeImportStatements: Boolean = valueOrDefault(EXCLUDE_IMPORT_STATEMENTS, DEFAULT_VALUE_IMPORTS_EXCLUDE)
 
 	override fun visitKtFile(file: KtFile) {
 		var offset = 0
 		file.text.splitToSequence("\n")
+				.filter { filterPackageStatements(it) }
+				.filter { filterImportStatements(it) }
 				.map { it.length }
 				.forEach {
 					offset += it
@@ -27,9 +31,29 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 				}
 	}
 
+	private fun filterPackageStatements(line: String): Boolean {
+		if (excludePackageStatements) {
+			return !line.startsWith("package ")
+		}
+		return true
+	}
+
+	private fun filterImportStatements(line: String): Boolean {
+		if (excludeImportStatements) {
+			return !line.startsWith("import ")
+		}
+		return true
+	}
+
 	companion object {
-		val MAX_LINE_LENGTH = "maxLineLength"
-		val DEFAULT_IDEA_LINE_LENGTH = 120
+		const val MAX_LINE_LENGTH = "maxLineLength"
+		const val DEFAULT_IDEA_LINE_LENGTH = 120
+
+		const val EXCLUDE_PACKAGE_STATEMENTS = "excludePackageStatements"
+		const val DEFAULT_VALUE_PACKAGE_EXCLUDE = false
+
+		const val EXCLUDE_IMPORT_STATEMENTS = "excludeImportStatements"
+		const val DEFAULT_VALUE_IMPORTS_EXCLUDE = false
 	}
 }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions
@@ -11,9 +12,9 @@ import org.jetbrains.spek.api.dsl.it
 
 class MaxLineLengthSpec : Spek({
 
-	val file = compileForTest(Case.MaxLineLength.path()).text
-
 	given("a kt file with some long lines") {
+		val file = compileForTest(Case.MaxLineLength.path()).text
+
 		it("should report no errors when maxLineLength is set to 200") {
 			val rule = MaxLineLength(TestConfig(mapOf("maxLineLength" to "200")))
 
@@ -26,6 +27,60 @@ class MaxLineLengthSpec : Spek({
 
 			val findings = rule.lint(file)
 			Assertions.assertThat(findings).hasSize(3)
+		}
+	}
+
+	given("a kt file a long package name and long import statements") {
+		val code = """
+			package veeeeeeeeeeeeeerylong.statement.that.is.longer.than.onehundredtwenty.characters.which.detekt.should.report.by.default
+
+			import veeeeeeeeeeeeeerylong.statement.that.is.longer.than.onehundredtwenty.characters.which.detekt.should.report.by.default
+
+			class Test {
+			}
+		"""
+
+		val file = compileContentForTest(code).text
+
+		it("should report the package statement and import statements by default") {
+			val rule = MaxLineLength()
+
+			val findings = rule.lint(file)
+			Assertions.assertThat(findings).hasSize(2)
+		}
+
+		it("should report the package statement and import statements if they're enabled") {
+			val rule = MaxLineLength(TestConfig(mapOf(
+					"excludePackageStatements" to "false",
+					"excludeImportStatements" to "false"
+			)))
+
+			val findings = rule.lint(file)
+			Assertions.assertThat(findings).hasSize(2)
+		}
+
+		it("should not report the package statement if it is disabled") {
+			val rule = MaxLineLength(TestConfig(mapOf("excludePackageStatements" to "true")))
+
+			val findings = rule.lint(file)
+			Assertions.assertThat(findings).hasSize(1)
+		}
+
+		it("should not report the import statements if it is disabled") {
+			val rule = MaxLineLength(TestConfig(mapOf("excludeImportStatements" to "true")))
+
+			val findings = rule.lint(file)
+			Assertions.assertThat(findings).hasSize(1)
+		}
+
+		it("should not report anything if both package and import statements are disabled") {
+			val rule = MaxLineLength(TestConfig(mapOf(
+					"excludePackageStatements" to "true",
+					"excludeImportStatements" to "true"
+			)))
+
+			val findings = rule.lint(file)
+			Assertions.assertThat(findings).hasSize(0)
 		}
 	}
 })


### PR DESCRIPTION
Resolves #111 

Adds options to exclude package and import statements from the `MaxLineLength` rule.

In #111 you mentioned calling the configs `excludePackages` and `excludeImports`. I added `..Statements` as a suffix. Let me know if you're okay with that. I'm happy to change it to the names you mentioned.

I also added the `MaxLineLength` to the config shown in the `README.md`