### PR TITLE
move rule providers to providers package

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CommentSmellProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CommentSmellProvider.kt
@@ -1,8 +1,12 @@
-package io.gitlab.arturbosch.detekt.rules.documentation
+package io.gitlab.arturbosch.detekt.rules.providers
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.rules.documentation.CommentOverPrivateMethod
+import io.gitlab.arturbosch.detekt.rules.documentation.CommentOverPrivateProperty
+import io.gitlab.arturbosch.detekt.rules.documentation.UndocumentedPublicClass
+import io.gitlab.arturbosch.detekt.rules.documentation.UndocumentedPublicFunction
 
 /**
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/ComplexityProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/ComplexityProvider.kt
@@ -1,8 +1,15 @@
-package io.gitlab.arturbosch.detekt.rules.complexity
+package io.gitlab.arturbosch.detekt.rules.providers
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.rules.complexity.ComplexMethod
+import io.gitlab.arturbosch.detekt.rules.complexity.LargeClass
+import io.gitlab.arturbosch.detekt.rules.complexity.LongMethod
+import io.gitlab.arturbosch.detekt.rules.complexity.LongParameterList
+import io.gitlab.arturbosch.detekt.rules.complexity.NestedBlockDepth
+import io.gitlab.arturbosch.detekt.rules.complexity.TooManyFunctions
+import io.gitlab.arturbosch.detekt.rules.complexity.ComplexCondition
 
 /**
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -1,8 +1,11 @@
-package io.gitlab.arturbosch.detekt.rules.style
+package io.gitlab.arturbosch.detekt.rules.providers
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.rules.style.MaxLineLength
+import io.gitlab.arturbosch.detekt.rules.style.NamingConventionViolation
+import io.gitlab.arturbosch.detekt.rules.style.WildcardImport
 
 /**
  * @author Artur Bosch

--- a/detekt-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
+++ b/detekt-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -1,7 +1,7 @@
-io.gitlab.arturbosch.detekt.rules.complexity.ComplexityProvider
+io.gitlab.arturbosch.detekt.rules.providers.ComplexityProvider
 io.gitlab.arturbosch.detekt.rules.providers.CodeSmellProvider
-io.gitlab.arturbosch.detekt.rules.style.StyleGuideProvider
-io.gitlab.arturbosch.detekt.rules.documentation.CommentSmellProvider
+io.gitlab.arturbosch.detekt.rules.providers.StyleGuideProvider
+io.gitlab.arturbosch.detekt.rules.providers.CommentSmellProvider
 io.gitlab.arturbosch.detekt.rules.providers.EmptyCodeProvider
 io.gitlab.arturbosch.detekt.rules.providers.PotentialBugProvider
 io.gitlab.arturbosch.detekt.rules.providers.ExceptionsProvider


### PR DESCRIPTION
As discussed in #131 this moves all rule providers together into the `providers` package.

Resolves #131 