### PR TITLE
Simplify reading resource files

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
@@ -19,7 +19,7 @@ open class KtCompiler(val project: Path) {
 	fun compile(subPath: Path): KtFile {
 		require(subPath.isFile()) { "Given sub path should be a regular file!" }
 		val relativePath = if (project == subPath) subPath else project.relativize(subPath)
-		val content = String(Files.readAllBytes(subPath))
+		val content = subPath.toFile().readText()
 		val lineSeparator = content.determineLineSeparator()
 		val normalizedContent = content.normalize()
 		val ktFile = createKtFile(normalizedContent, relativePath)

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/Resources.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/Resources.kt
@@ -1,8 +1,7 @@
 package io.gitlab.arturbosch.detekt.test
 
+import java.io.File
 import java.net.URI
-import java.nio.file.Files
-import java.nio.file.Paths
 
 internal object Resources
 
@@ -13,4 +12,4 @@ fun resource(name: String): URI {
 	return resource.toURI()
 }
 
-fun resourceAsString(name: String): String = String(Files.readAllBytes(Paths.get(resource(name))))
+fun resourceAsString(name: String): String = File(resource(name)).readText()


### PR DESCRIPTION
This also fixes a bytes-to-string encoding issue on Windows where UTF-8 is not the default.