### PR TITLE
Convert Kotlin source code strings to Unix line endings

### DIFF
--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/Utils.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/Utils.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.api
 
+import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.KtFile
@@ -14,7 +15,7 @@ internal object Compiler {
 	private val psiFileFactory: PsiFileFactory = PsiFileFactory.getInstance(PROJECT)
 
 	fun compileFromContent(content: String): KtFile {
-		return psiFileFactory.createFileFromText(KotlinLanguage.INSTANCE, content) as KtFile
+		return psiFileFactory.createFileFromText(KotlinLanguage.INSTANCE, StringUtilRt.convertLineSeparators(content)) as KtFile
 	}
 }
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.PROJECT
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
+import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
 import org.jetbrains.kotlin.com.intellij.testFramework.LightVirtualFile
 import org.jetbrains.kotlin.idea.KotlinLanguage
@@ -21,7 +22,7 @@ open class KtCompiler(val project: Path) {
 		val relativePath = if (project == subPath) subPath else project.relativize(subPath)
 		val content = String(Files.readAllBytes(subPath))
 		val lineSeparator = content.determineLineSeparator()
-		val normalizedContent = content.normalize()
+		val normalizedContent = StringUtilRt.convertLineSeparators(content)
 		val ktFile = createKtFile(normalizedContent, relativePath)
 		ktFile.putExtraInformation(lineSeparator, relativePath)
 		return ktFile
@@ -33,10 +34,8 @@ open class KtCompiler(val project: Path) {
 	}
 
 	private fun createKtFile(content: String, relativePath: Path) = psiFileFactory.createFileFromText(
-			relativePath.fileName.toString(), KotlinLanguage.INSTANCE, content,
+			relativePath.fileName.toString(), KotlinLanguage.INSTANCE, StringUtilRt.convertLineSeparators(content),
 			true, true, false, LightVirtualFile(relativePath.toString())) as KtFile
-
-	private fun String.normalize() = this.replace("\r\n", "\n").replace("\r", "\n")
 
 	private fun String.determineLineSeparator(): String {
 		val i = this.lastIndexOf('\n')

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.test
 
 import io.gitlab.arturbosch.detekt.core.KtCompiler
+import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Paths
@@ -13,6 +14,6 @@ import java.nio.file.Paths
 internal object KtTestCompiler : KtCompiler(Paths.get(resource("/"))) {
 
 	fun compileFromContent(content: String): KtFile
-			= psiFileFactory.createFileFromText(KotlinLanguage.INSTANCE, content) as KtFile
+			= psiFileFactory.createFileFromText(KotlinLanguage.INSTANCE, StringUtilRt.convertLineSeparators(content)) as KtFile
 
 }


### PR DESCRIPTION
On Windows, Git is often configured with core.autocrlf = true, resulting
in test resource files like ConditionalReturns.kt to have DOS line
endings. Passing the content of such files to createFileFromText() fails
because it can only handle Unix line endings. So convert the line
endings beforehand.