### PR TITLE
Turn off auto correction for sonar analysis

### DIFF
--- a/detekt-sonar-kotlin/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/DetektSensor.kt
+++ b/detekt-sonar-kotlin/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/DetektSensor.kt
@@ -30,7 +30,7 @@ class DetektSensor : Sensor {
 
 		val filters = ".*/test/.*,.*/resources/.*,.*/build/.*".split(",").map { PathFilter(it) }
 		val config = YamlConfig.loadResource(ClasspathResourceConverter().convert("/default-detekt-config.yml"))
-		val settings = ProcessingSettings(baseDir.toPath(), config = config, pathFilters = filters)
+		val settings = ProcessingSettings(baseDir.toPath(), config = NoAutoCorrectConfig(config), pathFilters = filters)
 
 		val detektor = DetektFacade.instance(settings)
 		val detektion = detektor.run()

--- a/detekt-sonar-kotlin/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/NoAutoCorrectConfig.kt
+++ b/detekt-sonar-kotlin/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/NoAutoCorrectConfig.kt
@@ -1,0 +1,20 @@
+package io.gitlab.arturbosch.detekt.sonar
+
+import io.gitlab.arturbosch.detekt.api.Config
+
+/**
+ * Config wrapper for disabling automatic correction
+ */
+@Suppress("UNCHECKED_CAST")
+class NoAutoCorrectConfig(private val config: Config): Config {
+
+    override fun subConfig(key: String): Config = config.subConfig(key)
+
+    override fun <T : Any> valueOrDefault(key: String, default: T): T {
+        if ("autoCorrect".equals(key)) {
+            return false as T
+        }
+        return config.valueOrDefault(key, default)
+    }
+
+}


### PR DESCRIPTION
Now Detekt uses default settings during sonar analysis.
Autocorrection is on by default. As result Sonar shows `corrected` code instead of original (in repos)
I disabled it, but may be it is not the best solution.