### PR TITLE
Remove lateinit usage in Main.kt

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -99,9 +99,6 @@ class Main {
 		private fun validateCli(cli: Main): List<String> {
 			val violations = ArrayList<String>()
 			with(cli) {
-				if (project == null) {
-					violations += "Path to project must be provided via the --project parameter"
-				}
 				output?.let {
 					if (Files.exists(it) && it.isDirectory()) {
 						violations += "Output file must not be a directory."

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -14,7 +14,7 @@ class Main {
 
 	@Parameter(names = arrayOf("--project", "-p"), required = true,
 			converter = ExistingPathConverter::class, description = "Project path to analyze (path/to/project).")
-	lateinit var project: Path
+	private var project: Path? = null
 
 	@Parameter(names = arrayOf("--filters", "-f"),
 			description = "Path filters defined through regex with separator ';' (\".*test.*\").")
@@ -72,6 +72,9 @@ class Main {
 	@Parameter(names = arrayOf("--help", "-h"), help = true, description = "Shows the usage.")
 	var help: Boolean = false
 
+	val projectPath : Path
+		get() = project!!
+
 	companion object {
 
 		@JvmStatic
@@ -96,6 +99,9 @@ class Main {
 		private fun validateCli(cli: Main): List<String> {
 			val violations = ArrayList<String>()
 			with(cli) {
+				if (project == null) {
+					violations += "Path to project must be provided via the --project parameter"
+				}
 				output?.let {
 					if (Files.exists(it) && it.isDirectory()) {
 						violations += "Output file must not be a directory."

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Runner.kt
@@ -40,7 +40,7 @@ class Runner(private val main: Main) : Executable {
 			val rules = createRulePaths()
 			val config = loadConfiguration()
 			val changeListeners = createProcessors()
-			return ProcessingSettings(project, config, pathFilters, parallel,
+			return ProcessingSettings(projectPath, config, pathFilters, parallel,
 					disableDefaultRuleSets, rules, changeListeners) to config
 		}
 	}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/Formatting.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/Formatting.kt
@@ -19,7 +19,7 @@ class Formatting {
 		fun main(args: Array<String>) {
 			with(parseArguments(args)) {
 				val config = loadConfiguration()
-				val settings = ProcessingSettings(project, config, createPathFilters(), parallel, excludeDefaultRuleSets = true)
+				val settings = ProcessingSettings(projectPath, config, createPathFilters(), parallel, excludeDefaultRuleSets = true)
 				val detektor = Detektor(settings, KtTreeCompiler.instance(settings), listOf(FormattingProvider()))
 				val detektion = detektor.run()
 				OutputFacade(this, config, detektion).run {

--- a/detekt-migration/src/main/kotlin/io/gitlab/arturbosch/detekt/migration/Migration.kt
+++ b/detekt-migration/src/main/kotlin/io/gitlab/arturbosch/detekt/migration/Migration.kt
@@ -19,7 +19,7 @@ class Migration {
 		fun main(args: Array<String>) {
 			with(parseArguments(args)) {
 				val config = loadConfiguration()
-				val settings = ProcessingSettings(project, config, createPathFilters(), parallel, excludeDefaultRuleSets = true)
+				val settings = ProcessingSettings(projectPath, config, createPathFilters(), parallel, excludeDefaultRuleSets = true)
 				val detektor = Detektor(settings, KtTreeCompiler.instance(settings), listOf(MigrationRuleSetProvider()))
 				val detektion = detektor.run()
 				OutputFacade(this, config, detektion).run {


### PR DESCRIPTION
Resolves #132 

This follows the recommendation from the issue. But overall I'm not sure if its nicer to have 3 `!!` in the code compared to the `lateinit var`.

Probably also the null check in `validateCli` is not really useful as the project parameter is already `required = true` and thus JCommander will already throw an exception if the parameter is not specified. 