### PR TITLE
Rule: Find usages of forEach on Ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ Currently there are seven rule sets which are used per default when running the 
 - empty         - finds empty block statements
 - potential-bugs    - code is structured in a way it can lead to bugs like 'only equals but not hashcode is implemented' or explicit garbage
  collection calls
+- performance   - finds potential performance issues
 
 ##### Additional RuleSets 
 
@@ -453,6 +454,11 @@ potential-bugs:
     active: true
   LateinitUsage:
     active: false
+
+performance:
+  active: true
+  ForEachOnRange:
+    active: true
 
 exceptions:
   active: true

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -18,7 +18,7 @@ data class Issue(val id: String,
  * a grade which is most harmful to their projects.
  */
 enum class Severity {
-	CodeSmell, Style, Warning, Defect, Minor, Maintainability, Security
+	CodeSmell, Style, Warning, Defect, Minor, Maintainability, Security, Performance
 
 }
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/format/XmlOutputFormat.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/format/XmlOutputFormat.kt
@@ -48,6 +48,7 @@ class XmlOutputFormat(report: Path) : OutputFormat(report) {
 			Severity.Defect -> MessageType.Error()
 			Severity.Minor -> MessageType.Info()
 			Severity.Security -> MessageType.Fatal()
+			Severity.Performance -> MessageType.Warning()
 		}
 
 	private fun Any.toXmlString() = XmlEscape.escapeXml(toString().trim())

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -20,6 +20,11 @@ potential-bugs:
   LateinitUsage:
     active: false
 
+performance:
+  active: true
+  ForEachOnRange:
+    active: true
+
 exceptions:
   active: true
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/RuleSetLocator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/RuleSetLocator.kt
@@ -39,5 +39,5 @@ class RuleSetLocator(val excludeDefaultRuleSets: Boolean,
 	private fun RuleSetProvider.provided() = ruleSetId in defaultRuleSetIds
 
 	private val defaultRuleSetIds = listOf("code-smell", "comments", "complexity", "empty",
-			"exceptions", "potential-bugs", "style")
+			"exceptions", "potential-bugs", "performance", "style")
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
@@ -1,0 +1,45 @@
+package io.gitlab.arturbosch.detekt.rules.performance
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.kotlin.com.intellij.psi.util.PsiUtil
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtPsiUtil
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+import org.jetbrains.kotlin.psi.psiUtil.containingClass
+import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
+import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
+
+
+class ForEachOnRange(config: Config = Config.empty) : Rule(config) {
+	override val issue = Issue("ForEachOnRange",
+			Severity.Performance,
+			"Using the forEach method on ranges has a heavy performance cost. Prefer using simple for loops")
+	
+	override fun visitCallExpression(expression: KtCallExpression) {
+		super.visitCallExpression(expression)
+
+		expression.getCallNameExpression()?.let {
+			if (!it.textMatches("forEach")) {
+				return
+			}
+
+			it.getReceiverExpression()?.text?.let {
+				if (it matches rangeRegex) {
+					report(CodeSmell(issue, Entity.from(expression)))
+				}
+			}
+		}
+	}
+
+	companion object {
+		val rangeRegex = Regex("\\(.*\\.\\..+\\)")
+	}
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PerformanceProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PerformanceProvider.kt
@@ -1,0 +1,17 @@
+package io.gitlab.arturbosch.detekt.rules.providers
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.rules.performance.ForEachOnRange
+
+class PerformanceProvider : RuleSetProvider {
+
+	override val ruleSetId: String = "performance"
+
+	override fun instance(config: Config): RuleSet {
+		return RuleSet(ruleSetId, listOf(
+				ForEachOnRange(config)
+		))
+	}
+}

--- a/detekt-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
+++ b/detekt-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -3,5 +3,6 @@ io.gitlab.arturbosch.detekt.rules.providers.CodeSmellProvider
 io.gitlab.arturbosch.detekt.rules.providers.StyleGuideProvider
 io.gitlab.arturbosch.detekt.rules.providers.CommentSmellProvider
 io.gitlab.arturbosch.detekt.rules.providers.EmptyCodeProvider
+io.gitlab.arturbosch.detekt.rules.providers.PerformanceProvider
 io.gitlab.arturbosch.detekt.rules.providers.PotentialBugProvider
 io.gitlab.arturbosch.detekt.rules.providers.ExceptionsProvider

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
@@ -1,0 +1,61 @@
+package io.gitlab.arturbosch.detekt.rules.performance
+
+import io.gitlab.arturbosch.detekt.rules.bugs.LateinitUsage
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+
+class ForEachOnRangeSpec : Spek({
+
+	given("a kt file with using a forEach on a range") {
+		val code = """
+			package foo
+
+			fun test() {
+				(1..10).forEach {
+					println(it)
+				}
+			}
+		"""
+
+		it("should report the forEach usage") {
+			val findings = ForEachOnRange().lint(code)
+			Assertions.assertThat(findings).hasSize(1)
+		}
+	}
+
+	given("a kt file with using any other method on a range") {
+		val code = """
+			package foo
+
+			fun test() {
+				(1..10).isEmpty()
+			}
+		"""
+
+		it("should report not report any issues") {
+			val findings = ForEachOnRange().lint(code)
+			Assertions.assertThat(findings).isEmpty()
+		}
+	}
+
+	given("a kt file with using a forEach on a list") {
+		val code = """
+			package foo
+
+			fun test() {
+				listOf<Int>(1, 2, 3).forEach {
+					println(it)
+				}
+			}
+		"""
+
+		it("should report not report any issues") {
+			val findings = ForEachOnRange().lint(code)
+			Assertions.assertThat(findings).isEmpty()
+		}
+	}
+})


### PR DESCRIPTION
Adds a rule as described in #155 to find usages of forEach on ranges.

I'm still confused that the PSI doesn't allow us to fetch the "parent" of a method which would allow us to check if the parent class is in the `kotlin.ranges` package. Now we parse the receiver expression with a RegEx to verify it matches a range.