### PR TITLE
Add Tests for WildcardImport and NamingConvention rules

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NamingConventionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NamingConventionSpec.kt
@@ -1,0 +1,62 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.compileContentForTest
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+
+class NamingConventionSpec : Spek({
+
+	given("a kt file with crazy naming schemes") {
+		val code = """
+			package test
+
+			class __TEST__ {
+				val TEST = 1
+
+				fun UpperCaseMethod() {
+				}
+
+				companion object {
+					const val constant: String = "test"
+				}
+			}
+
+			enum class __ENUM__ {
+				enumvalue
+			}
+		"""
+
+		val file = compileContentForTest(code).text
+
+		it("should ignore all naming violations if rule is turned off") {
+			val rule = NamingConventionViolation(TestConfig(mapOf("active" to "false")))
+
+			val findings = rule.lint(file)
+			Assertions.assertThat(findings).isEmpty()
+		}
+
+		it("should report all naming violations") {
+			val rule = NamingConventionViolation()
+
+			val findings = rule.lint(file)
+			Assertions.assertThat(findings).hasSize(6)
+		}
+
+		it("should report no violations with custom naming scheme") {
+			val rule = NamingConventionViolation(TestConfig(mapOf(
+					"variablePattern" to "TEST",
+					"constantPattern" to "constant",
+					"methodPattern" to "UpperCaseMethod",
+					"classPattern" to "__([A-Z]+)__",
+					"enumEntryPattern" to "enumvalue"
+			)))
+
+			val findings = rule.lint(file)
+			Assertions.assertThat(findings).isEmpty()
+		}
+	}
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -1,0 +1,55 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.compileContentForTest
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+
+class WildcardImportSpec : Spek({
+
+	given("a kt file with wildcard imports") {
+		val code = """
+			package test
+
+			import io.gitlab.arturbosch.detekt.*
+
+			class Test {
+			}
+		"""
+
+		val file = compileContentForTest(code).text
+
+		it("should not report anything when the rule is turned off") {
+			val rule = WildcardImport(TestConfig(mapOf("active" to "false")))
+
+			val findings = rule.lint(file)
+			Assertions.assertThat(findings).isEmpty()
+		}
+
+		it("should report all wildcard imports") {
+			val rule = WildcardImport()
+
+			val findings = rule.lint(file)
+			Assertions.assertThat(findings).hasSize(1)
+		}
+	}
+
+	given("a kt file with no wildcard imports") {
+		val code = """
+			package test
+
+			import test.Test
+
+			class Test {
+			}
+		"""
+
+		it("should not report any issues") {
+			val findings = WildcardImport().lint(code)
+			Assertions.assertThat(findings).isEmpty()
+		}
+	}
+})


### PR DESCRIPTION
These two rules were missing tests. This PR adds some.