### PR TITLE
change cli parameter --project (-p) to --input (-i)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Usage: detekt [options]
       Enables parallel compilation of source files. Should only be used if the
       analyzing project has more than ~200 kotlin files.
       Default: false
-  * --project, -p
-      Project path to analyze (path/to/project).
+  * --input, -i
+      Input path to analyze (path/to/project).
     --rules, -r
       Extra paths to ruleset jars separated by ';'.
     --useTabs
@@ -110,7 +110,7 @@ Usage: detekt [options]
       Default: false
 ```
 
-`--project` can either be a directory or a single Kotlin file.
+`--input` can either be a directory or a single Kotlin file.
 The currently only supported configuration format is yaml. `--config` should point to one. Generating a default configuration file is as easy as using the `--generate-config` parameter.
 `filters` can be used for example to exclude all test directories.
 With `rules` you can point to additional ruleset.jar's creating by yourself or others. 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -12,9 +12,9 @@ import java.nio.file.Path
  */
 class Main {
 
-	@Parameter(names = arrayOf("--project", "-p"), required = true,
-			converter = ExistingPathConverter::class, description = "Project path to analyze (path/to/project).")
-	private var project: Path? = null
+	@Parameter(names = arrayOf("--input", "-i"), required = true,
+			converter = ExistingPathConverter::class, description = "Input path to analyze (path/to/project).")
+	private var input: Path? = null
 
 	@Parameter(names = arrayOf("--filters", "-f"),
 			description = "Path filters defined through regex with separator ';' (\".*test.*\").")
@@ -73,8 +73,8 @@ class Main {
 	@Parameter(names = arrayOf("--help", "-h"), help = true, description = "Shows the usage.")
 	var help: Boolean = false
 
-	val projectPath: Path
-		get() = project!!
+	val inputPath: Path
+		get() = input!!
 
 	companion object {
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Runner.kt
@@ -40,7 +40,7 @@ class Runner(private val main: Main) : Executable {
 			val rules = createRulePaths()
 			val config = loadConfiguration()
 			val changeListeners = createProcessors()
-			return ProcessingSettings(projectPath, config, pathFilters, parallel,
+			return ProcessingSettings(inputPath, config, pathFilters, parallel,
 					disableDefaultRuleSets, rules, changeListeners) to config
 		}
 	}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/Formatting.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/Formatting.kt
@@ -19,7 +19,7 @@ class Formatting {
 		fun main(args: Array<String>) {
 			with(parseArguments(args)) {
 				val config = loadConfiguration()
-				val settings = ProcessingSettings(projectPath, config, createPathFilters(), parallel, excludeDefaultRuleSets = true)
+				val settings = ProcessingSettings(inputPath, config, createPathFilters(), parallel, excludeDefaultRuleSets = true)
 				val detektor = Detektor(settings, KtTreeCompiler.instance(settings), listOf(FormattingProvider()))
 				val detektion = detektor.run()
 				OutputFacade(this, config, detektion).run {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/Constants.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/Constants.kt
@@ -15,7 +15,7 @@ const val DEFAULT_PATH_EXCLUDES = ".*/test/.*,.*/resources/.*,.*/build/.*,.*/tar
 
 const val CONFIG_RESOURCE_PARAMETER = "--config-resource"
 const val FILTERS_PARAMETER = "--filters"
-const val PROJECT_PARAMETER = "--project"
+const val INPUT_PARAMETER = "--input"
 const val CONFIG_PARAMETER = "--config"
 const val RULES_PARAMETER = "--rules"
 const val OUTPUT_PARAMETER = "--output"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -31,8 +31,8 @@ open class DetektExtension(open var version: String = SUPPORTED_DETEKT_VERSION,
 	fun profileArgumentsOrDefault(project: Project): List<String> {
 		return with(createArgumentsForProfile()) {
 			if (isNotEmpty()) {
-				if (!contains(PROJECT_PARAMETER)) {
-					add(PROJECT_PARAMETER)
+				if (!contains(INPUT_PARAMETER)) {
+					add(INPUT_PARAMETER)
 					add(project.projectDir.toString())
 				}
 				this
@@ -82,6 +82,6 @@ open class DetektExtension(open var version: String = SUPPORTED_DETEKT_VERSION,
 }
 
 internal fun Project.fallbackArguments() = listOf(
-		PROJECT_PARAMETER, projectDir.absolutePath,
+		INPUT_PARAMETER, projectDir.absolutePath,
 		CONFIG_RESOURCE_PARAMETER, DEFAULT_DETEKT_CONFIG_RESOURCE,
 		FILTERS_PARAMETER, DEFAULT_PATH_EXCLUDES)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/ProfileExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/ProfileExtension.kt
@@ -18,7 +18,7 @@ open class ProfileExtension(val name: String,
 
 	fun arguments(debug: Boolean = false): MutableMap<String, String> {
 		return mutableMapOf<String, String>().apply {
-			input?.let { put(PROJECT_PARAMETER, it) }
+			input?.let { put(INPUT_PARAMETER, it) }
 			config?.let { put(CONFIG_PARAMETER, it) }
 			configResource?.let { put(CONFIG_RESOURCE_PARAMETER, it) }
 			filters?.let { put(FILTERS_PARAMETER, it) }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtensionTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtensionTest.kt
@@ -26,7 +26,7 @@ internal class DetektExtensionTest : Spek({
 			val main = Main().apply { JCommander(this).parse(*args.toTypedArray()) }
 			val fallback = Main().apply { JCommander(this).parse(*project.fallbackArguments().toTypedArray()) }
 
-			Assertions.assertThat(main.projectPath).isEqualTo(fallback.projectPath)
+			Assertions.assertThat(main.inputPath).isEqualTo(fallback.inputPath)
 			Assertions.assertThat(main.configResource).isEqualTo(fallback.configResource)
 			Assertions.assertThat(main.config).isEqualTo(fallback.config)
 			Assertions.assertThat(main.baseline).isEqualTo(fallback.baseline)
@@ -39,6 +39,6 @@ internal class DetektExtensionTest : Spek({
 
 // TODO remove after https://youtrack.jetbrains.com/issue/KT-16497
 internal fun Project.fallbackArguments() = listOf(
-		PROJECT_PARAMETER, projectDir.absolutePath,
+		INPUT_PARAMETER, projectDir.absolutePath,
 		CONFIG_RESOURCE_PARAMETER, DEFAULT_DETEKT_CONFIG_RESOURCE,
 		FILTERS_PARAMETER, DEFAULT_PATH_EXCLUDES)

--- a/detekt-migration/src/main/kotlin/io/gitlab/arturbosch/detekt/migration/Migration.kt
+++ b/detekt-migration/src/main/kotlin/io/gitlab/arturbosch/detekt/migration/Migration.kt
@@ -19,7 +19,7 @@ class Migration {
 		fun main(args: Array<String>) {
 			with(parseArguments(args)) {
 				val config = loadConfiguration()
-				val settings = ProcessingSettings(projectPath, config, createPathFilters(), parallel, excludeDefaultRuleSets = true)
+				val settings = ProcessingSettings(inputPath, config, createPathFilters(), parallel, excludeDefaultRuleSets = true)
 				val detektor = Detektor(settings, KtTreeCompiler.instance(settings), listOf(MigrationRuleSetProvider()))
 				val detektion = detektor.run()
 				OutputFacade(this, config, detektion).run {


### PR DESCRIPTION
Changes the CLI parameter `--project/-p` to `--input/-i`. This aligns the Gradle plugin and the CLI version of detekt.

However as we move towards v1.0 we should be sure about how to name these parameters and not change them around too much as these are breaking API changes. Since we're still pre v1.0 this should be okay but definitely noted in the changelog.

Resolves #138