### PR TITLE
Add Excludes to WildcardImport rule reusing logic from LateinitUsage

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Excludes.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Excludes.kt
@@ -1,0 +1,12 @@
+package io.gitlab.arturbosch.detekt.api
+
+class Excludes(excludeParameter: String) {
+    private val excludes = excludeParameter
+            .split(",")
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .map { it.removeSuffix("*") }
+
+    fun contains(value: String) = excludes.filter { value.contains(it) }.isNotEmpty()
+    fun none(value: String) = !contains(value)
+}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Excludes.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Excludes.kt
@@ -1,12 +1,12 @@
 package io.gitlab.arturbosch.detekt.api
 
 class Excludes(excludeParameter: String) {
-    private val excludes = excludeParameter
-            .split(",")
-            .map { it.trim() }
-            .filter { it.isNotBlank() }
-            .map { it.removeSuffix("*") }
+	private val excludes = excludeParameter
+			.split(",")
+			.map { it.trim() }
+			.filter { it.isNotBlank() }
+			.map { it.removeSuffix("*") }
 
-    fun contains(value: String) = excludes.filter { value.contains(it) }.isNotEmpty()
-    fun none(value: String) = !contains(value)
+	fun contains(value: String) = excludes.filter { value.contains(it) }.isNotEmpty()
+	fun none(value: String) = !contains(value)
 }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ExcludesSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ExcludesSpec.kt
@@ -1,0 +1,88 @@
+package io.gitlab.arturbosch.detekt.api
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+
+class ExcludesSpec : Spek({
+
+	given("an excludes rule with a single exclude") {
+		val excludes = Excludes("test")
+
+		it("contains the `test` parameter") {
+			val parameter = "test"
+			assertThat(excludes.contains(parameter)).isTrue()
+			assertThat(excludes.none(parameter)).isFalse()
+		}
+
+		it("contains an extension of the `test` parameter") {
+			val parameter = "test.com"
+			assertThat(excludes.contains(parameter)).isTrue()
+			assertThat(excludes.none(parameter)).isFalse()
+		}
+
+		it("does not contain a different parameter") {
+			val parameter = "detekt"
+			assertThat(excludes.contains(parameter)).isFalse()
+			assertThat(excludes.none(parameter)).isTrue()
+		}
+	}
+
+	given("an excludes rule with multiple excludes") {
+		val excludes = Excludes("here.there.io, test.com")
+
+		it("contains the `test` parameter") {
+			val parameter = "test.com"
+			assertThat(excludes.contains(parameter)).isTrue()
+			assertThat(excludes.none(parameter)).isFalse()
+		}
+
+		it("contains the `here.there.io` parameter") {
+			val parameter = "here.there.io"
+			assertThat(excludes.contains(parameter)).isTrue()
+			assertThat(excludes.none(parameter)).isFalse()
+		}
+
+		it("does not contain a parameter spanning over the excludes") {
+			val parameter = "io.test.com"
+			assertThat(excludes.contains(parameter)).isTrue()
+			assertThat(excludes.none(parameter)).isFalse()
+		}
+
+		it("does not contain a different") {
+			val parameter = "detekt"
+			assertThat(excludes.contains(parameter)).isFalse()
+			assertThat(excludes.none(parameter)).isTrue()
+		}
+	}
+
+	given("an excludes rule with lots of whitespace and an empty parameter") {
+		val excludes = Excludes("    test,  ,       here.there       ")
+
+		it("contains the `test` parameter") {
+			val parameter = "test"
+			assertThat(excludes.contains(parameter)).isTrue()
+			assertThat(excludes.none(parameter)).isFalse()
+		}
+
+		it("contains the `here.there` parameter") {
+			val parameter = "here.there"
+			assertThat(excludes.contains(parameter)).isTrue()
+			assertThat(excludes.none(parameter)).isFalse()
+		}
+
+		it("does not contain a different parameter") {
+			val parameter = "detekt"
+			assertThat(excludes.contains(parameter)).isFalse()
+			assertThat(excludes.none(parameter)).isTrue()
+		}
+
+		it("does not match empty strings") {
+			val parameter = "  "
+			assertThat(excludes.contains(parameter)).isFalse()
+			assertThat(excludes.none(parameter)).isTrue()
+		}
+
+	}
+})

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -1,11 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.preprocessor.typeReferenceName
 import org.jetbrains.kotlin.psi.KtFile
@@ -18,12 +13,7 @@ class LateinitUsage(config: Config = Config.empty) : Rule(config) {
 			"Usage of lateinit. Using lateinit for property initialization " +
 					"is error prone, try using constructor injection or delegation.")
 
-	private val excludeAnnotatedProperties: List<String>
-			= valueOrDefault(EXCLUDE_ANNOTATED_PROPERTIES, "")
-					.split(",")
-					.map { it.trim() }
-					.filter { it.isNotBlank() }
-					.map { it.removeSuffix("*") }
+	private val excludeAnnotatedProperties = Excludes(valueOrDefault(EXCLUDE_ANNOTATED_PROPERTIES, ""))
 
 	private var properties = mutableListOf<KtProperty>()
 
@@ -63,7 +53,7 @@ class LateinitUsage(config: Config = Config.empty) : Rule(config) {
 					}
 					.filterNotNull()
 					.none { annotationFqn ->
-						excludeAnnotatedProperties.none { annotationFqn.contains(it) }
+						excludeAnnotatedProperties.none(annotationFqn)
 					}
 
 	companion object {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -1,6 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
-import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Excludes
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.preprocessor.typeReferenceName
 import org.jetbrains.kotlin.psi.KtFile
@@ -47,14 +53,14 @@ class LateinitUsage(config: Config = Config.empty) : Rule(config) {
 
 	private fun isExcludedByAnnotation(property: KtProperty, resolvedAnnotations: Map<String, String>?)
 			= property.annotationEntries
-					.map {
-						val shortName = it.typeReferenceName
-						resolvedAnnotations?.get(shortName) ?: shortName
-					}
-					.filterNotNull()
-					.none { annotationFqn ->
-						excludeAnnotatedProperties.none(annotationFqn)
-					}
+			.map {
+				val shortName = it.typeReferenceName
+				resolvedAnnotations?.get(shortName) ?: shortName
+			}
+			.filterNotNull()
+			.none { annotationFqn ->
+				excludeAnnotatedProperties.none(annotationFqn)
+			}
 
 	companion object {
 		const val EXCLUDE_ANNOTATED_PROPERTIES = "excludeAnnotatedProperties"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -33,7 +33,7 @@ class WildcardImport(config: Config = Config.empty) : Rule(config) {
 	}
 
 	companion object {
-		const val EXCLUDED_IMPORTS = "excludedImports"
+		const val EXCLUDED_IMPORTS = "excludeImports"
 	}
 }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -1,6 +1,13 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Excludes
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtImportDirective
 
 /**
@@ -13,7 +20,7 @@ class WildcardImport(config: Config = Config.empty) : Rule(config) {
 			"Wildcard imports should be replaced with imports using fully qualified class names. " +
 					"Wildcard imports can lead to naming conflicts. " +
 					"A library update can introduce naming clashes with your classes which " +
-                    "results in compilation errors.",
+					"results in compilation errors.",
 			Debt.FIVE_MINS)
 
 	private val excludedImports = Excludes(valueOrDefault(EXCLUDED_IMPORTS, ""))

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -1,12 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.psi.KtImportDirective
 
 /**
@@ -19,14 +13,27 @@ class WildcardImport(config: Config = Config.empty) : Rule(config) {
 			"Wildcard imports should be replaced with imports using fully qualified class names. " +
 					"Wildcard imports can lead to naming conflicts. " +
 					"A library update can introduce naming clashes with your classes which " +
-					"results in compilation errors.",
+                    "results in compilation errors.",
 			Debt.FIVE_MINS)
+
+	private val excludedImports = Excludes(valueOrDefault(EXCLUDED_IMPORTS, ""))
 
 	override fun visitImportDirective(importDirective: KtImportDirective) {
 		val import = importDirective.importPath?.pathStr
-		if (import != null && import.contains("*")) {
+		import?.let {
+			if (!import.contains("*")) {
+				return
+			}
+
+			if (excludedImports.contains(import)) {
+				return
+			}
 			report(CodeSmell(issue, Entity.from(importDirective)))
 		}
+	}
+
+	companion object {
+		const val EXCLUDED_IMPORTS = "excludedImports"
 	}
 }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
@@ -27,21 +27,35 @@ class WildcardImportSpec : Spek({
 			val rule = WildcardImport(TestConfig(mapOf("active" to "false")))
 
 			val findings = rule.lint(file)
-			Assertions.assertThat(findings).isEmpty()
+			assertThat(findings).isEmpty()
 		}
 
 		it("should report all wildcard imports") {
 			val rule = WildcardImport()
 
 			val findings = rule.lint(file)
-			Assertions.assertThat(findings).hasSize(2)
+			assertThat(findings).hasSize(2)
 		}
 
 		it("should not report excluded wildcard imports") {
-			val rule = WildcardImport(TestConfig(mapOf("excludedImports" to "test.test.*")))
+			val rule = WildcardImport(TestConfig(mapOf("excludeImports" to "test.test.*")))
 
 			val findings = rule.lint(file)
-			Assertions.assertThat(findings).hasSize(1)
+			assertThat(findings).hasSize(1)
+		}
+
+		it("should not report excluded wildcard imports when multiple are excluded") {
+			val rule = WildcardImport(TestConfig(mapOf("excludeImports" to "test.test.*, io.gitlab.arturbosch.detekt")))
+
+			val findings = rule.lint(file)
+			assertThat(findings).isEmpty()
+		}
+
+		it("ignores excludes that are not matching") {
+			val rule = WildcardImport(TestConfig(mapOf("excludeImports" to "other.test.*")))
+
+			val findings = rule.lint(file)
+			assertThat(findings).hasSize(2)
 		}
 	}
 
@@ -57,7 +71,7 @@ class WildcardImportSpec : Spek({
 
 		it("should not report any issues") {
 			val findings = WildcardImport().lint(code)
-			Assertions.assertThat(findings).isEmpty()
+			assertThat(findings).isEmpty()
 		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -15,6 +15,7 @@ class WildcardImportSpec : Spek({
 			package test
 
 			import io.gitlab.arturbosch.detekt.*
+			import test.test.detekt.*
 
 			class Test {
 			}
@@ -31,6 +32,13 @@ class WildcardImportSpec : Spek({
 
 		it("should report all wildcard imports") {
 			val rule = WildcardImport()
+
+			val findings = rule.lint(file)
+			Assertions.assertThat(findings).hasSize(2)
+		}
+
+		it("should not report excluded wildcard imports") {
+			val rule = WildcardImport(TestConfig(mapOf("excludedImports" to "test.test.*")))
 
 			val findings = rule.lint(file)
 			Assertions.assertThat(findings).hasSize(1)


### PR DESCRIPTION
This PR:
- Extracts an `Excludes` class which manages rule parameters containing arguments that should be excluded from the rule.
- Uses `Excludes` in the `LateinitUsage` rule
- Adds `excludedImports` parameter to `WildcardImport` rule

Resolves #223 

What else should go into the `Excludes` class?