### PR TITLE
LateinitUsage: Add ignoreOnClassesPattern property.

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.preprocessor.typeReferenceName
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.psiUtil.containingClass
 
 class LateinitUsage(config: Config = Config.empty) : Rule(config) {
 
@@ -24,6 +25,8 @@ class LateinitUsage(config: Config = Config.empty) : Rule(config) {
 					.map { it.trim() }
 					.filter { it.isNotBlank() }
 					.map { it.removeSuffix("*") }
+
+	private val ignoreOnClassesPattern = Regex(valueOrDefault(IGNORE_ON_CLASSES_PATTERN, ""))
 
 	private var properties = mutableListOf<KtProperty>()
 
@@ -46,7 +49,8 @@ class LateinitUsage(config: Config = Config.empty) : Rule(config) {
 				?.map { Pair(it.split(".").last(), it) }
 				?.toMap()
 
-		properties.filter { !isExcludedByAnnotation(it, resolvedAnnotations) }
+		properties.filterNot { isExcludedByAnnotation(it, resolvedAnnotations) }
+				.filterNot { it.containingClass()?.name?.matches(ignoreOnClassesPattern) ?: false }
 				.forEach {
 					report(CodeSmell(issue, Entity.from(it)))
 				}
@@ -68,5 +72,6 @@ class LateinitUsage(config: Config = Config.empty) : Rule(config) {
 
 	companion object {
 		const val EXCLUDE_ANNOTATED_PROPERTIES = "excludeAnnotatedProperties"
+		const val IGNORE_ON_CLASSES_PATTERN = "ignoreOnClassesPattern"
 	}
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
@@ -15,7 +15,7 @@ class LateinitUsageSpec : Spek({
 
 			import kotlin.jvm.JvmField
 
-			class Test {
+			class SomeRandomTest {
 				@JvmField lateinit var test: Int
 			}
 		"""
@@ -48,6 +48,16 @@ class LateinitUsageSpec : Spek({
 		it("should not exclude lateinit properties not matching the exclude pattern") {
 			val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.EXCLUDE_ANNOTATED_PROPERTIES to "IgnoreThis"))).lint(code)
 			assertThat(findings).hasSize(1)
+		}
+
+		it("should report lateinit properties when ignoreOnClassesPattern does not match") {
+			val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.IGNORE_ON_CLASSES_PATTERN to "[\\w]+Test1234"))).lint(code)
+			assertThat(findings).hasSize(1)
+		}
+
+		it("should not report lateinit properties when ignoreOnClassesPattern does match") {
+			val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.IGNORE_ON_CLASSES_PATTERN to "[\\w]+Test"))).lint(code)
+			assertThat(findings).hasSize(0)
 		}
 	}
 })


### PR DESCRIPTION
Fixes #207 by adding an option to pass a regex to disable this rule temporarily for certain classes.