### PR TITLE
Fix DetektGenerateConfigTask to use --input instead of --project.

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -26,7 +26,7 @@ open class DetektGenerateConfigTask : DefaultTask() {
 		project.javaexec {
 			it.main = "io.gitlab.arturbosch.detekt.cli.Main"
 			it.classpath = configuration
-			it.args("--project", project.projectDir.absolutePath, "--generate-config")
+			it.args("--input", project.projectDir.absolutePath, "--generate-config")
 		}
 	}
 }


### PR DESCRIPTION
This was left out in #206. Right now the detektCheck is not usable as it'll fail. `Was passed main parameter '--project' but no main parameter was defined in your arg class`