### PR TITLE
Rule: ModifierOrder

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,8 @@ style:
   active: true
   WildcardImport:
     active: true
+  ModifierOrder:
+    active: true
   NamingConventionViolation:
     active: true
     variablePattern: '^(_)?[a-z$][a-zA-Z$0-9]*$'

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -25,7 +25,7 @@ enum class Severity {
 /**
  * Debt describes the estimated amount of work needed to fix a given issue.
  */
-data class Debt(val days: Int, val hours: Int, val mins: Int) {
+data class Debt(val days: Int = 0, val hours: Int = 0, val mins: Int = 0) {
 
 	init {
 		require(days >= 0 && hours >= 0 && mins >= 0)

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -118,6 +118,8 @@ style:
   ForbiddenComment:
     active: true
     values: 'TODO:,FIXME:,STOPSHIP:'
+  ModifierOrder:
+    active: true
   WildcardImport:
     active: true
   MaxLineLength:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenComment
 import io.gitlab.arturbosch.detekt.rules.style.FileParsingRule
+import io.gitlab.arturbosch.detekt.rules.style.ModifierOrder
 import io.gitlab.arturbosch.detekt.rules.style.NamingConventionViolation
 import io.gitlab.arturbosch.detekt.rules.style.NewLineAtEndOfFile
 import io.gitlab.arturbosch.detekt.rules.style.SafeCast
@@ -24,7 +25,8 @@ class StyleGuideProvider : RuleSetProvider {
 				FileParsingRule(config),
 				ForbiddenComment(config),
 				NamingConventionViolation(config),
-				SafeCast(config)
+				SafeCast(config),
+				ModifierOrder(config)
 		))
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
@@ -1,0 +1,82 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.lexer.KtTokens.ABSTRACT_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.ANNOTATION_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.COMPANION_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.CONST_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.DATA_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.ENUM_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.EXTERNAL_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.FINAL_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.INFIX_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.INLINE_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.INNER_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.INTERNAL_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.LATEINIT_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.OPEN_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.OPERATOR_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.OVERRIDE_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.PRIVATE_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.PROTECTED_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.PUBLIC_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.SEALED_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.SUSPEND_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.TAILREC_KEYWORD
+import org.jetbrains.kotlin.psi.KtModifierList
+import org.jetbrains.kotlin.psi.psiUtil.allChildren
+import java.util.Arrays
+
+class ModifierOrder(config: Config = Config.empty) : Rule(config) {
+
+	override val issue = Issue(javaClass.simpleName,
+			Severity.Style,
+			"Line detected that is longer than the defined maximum line length in the code style.",
+			Debt(mins = 1))
+
+	// subset of KtTokens.MODIFIER_KEYWORDS_ARRAY
+	private val order = arrayOf(
+			PUBLIC_KEYWORD, PROTECTED_KEYWORD, PRIVATE_KEYWORD, INTERNAL_KEYWORD,
+			FINAL_KEYWORD, OPEN_KEYWORD, ABSTRACT_KEYWORD,
+			SUSPEND_KEYWORD, TAILREC_KEYWORD,
+			OVERRIDE_KEYWORD,
+			CONST_KEYWORD, LATEINIT_KEYWORD,
+			INNER_KEYWORD, EXTERNAL_KEYWORD,
+			ENUM_KEYWORD, ANNOTATION_KEYWORD, SEALED_KEYWORD, DATA_KEYWORD,
+			COMPANION_KEYWORD,
+			INLINE_KEYWORD,
+			// NOINLINE_KEYWORD, CROSSINLINE_KEYWORD, OUT_KEYWORD, IN_KEYWORD, VARARG_KEYWORD, REIFIED_KEYWORD
+			INFIX_KEYWORD,
+			OPERATOR_KEYWORD
+			// HEADER_KEYWORD, IMPL_KEYWORD
+	)
+
+	override fun visitModifierList(list: KtModifierList) {
+		super.visitModifierList(list)
+
+		val modifiers = list.allChildren
+				.toList()
+				.filter { it !is PsiWhiteSpace }
+				.toTypedArray()
+
+		val sortedModifiers = modifiers.copyOf()
+				.apply { sortWith(compareBy { order.indexOf(it.node.elementType) }) }
+
+		if (!Arrays.equals(modifiers, sortedModifiers)) {
+			val modifierString = sortedModifiers.map { it.text }
+					.joinToString(" ")
+
+			report(CodeSmell(Issue(javaClass.simpleName, Severity.Style, "Modifier order should be: " +
+					"$modifierString", Debt(mins = 1)), Entity.from(list)))
+		}
+	}
+}
+
+data class Test(val test: String)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
@@ -81,5 +81,3 @@ class ModifierOrder(config: Config = Config.empty) : Rule(config) {
 		}
 	}
 }
-
-data class Test(val test: String)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
@@ -34,6 +34,9 @@ import org.jetbrains.kotlin.psi.KtModifierList
 import org.jetbrains.kotlin.psi.psiUtil.allChildren
 import java.util.Arrays
 
+/**
+ * Modifier order array taken from ktlint: https://github.com/shyiko/ktlint
+ */
 class ModifierOrder(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/KT.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/KT.kt
@@ -15,6 +15,7 @@ enum class Case(val file: String) {
 	NamingConventions("/cases/NamingConventions.kt"),
 	NewLineAtEndOfFile("/cases/NewLineAtEndOfFile.kt"),
 	MaxLineLength("/cases/MaxLineLength.kt"),
+	ModifierOrder("/cases/ModifierOrder.kt"),
 	ComplexClass("/cases/ComplexClass.kt"),
 	Comments("/cases/Comments.kt"),
 	NestedClasses("/cases/NestedClasses.kt"),

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
@@ -82,7 +82,7 @@ class ModifierOrderSpec : Spek({
 			val rule = ModifierOrder()
 
 			val findings = rule.lint(file.text)
-			Assertions.assertThat(findings).hasSize(2)
+			Assertions.assertThat(findings).hasSize(3)
 		}
 	}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
@@ -1,0 +1,89 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.rules.Case
+import io.gitlab.arturbosch.detekt.rules.complexity.code
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.compileContentForTest
+import io.gitlab.arturbosch.detekt.test.compileForTest
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+
+class ModifierOrderSpec : Spek({
+
+	given("a kt class with wrongly ordered modifiers") {
+		val file = "data internal class Test(val test: String)"
+
+		it("should report modifiers") {
+			val rule = ModifierOrder()
+
+			val findings = rule.lint(file)
+			Assertions.assertThat(findings).hasSize(1)
+		}
+
+		it("should not report issues if inactive") {
+			val rule = ModifierOrder(TestConfig(mapOf("active" to "false")))
+
+			val findings = rule.lint(file)
+			Assertions.assertThat(findings).isEmpty()
+		}
+	}
+
+	given("a kt class with correctly ordered modifiers") {
+		val file = "internal data class Test(val test: String)"
+
+		it("should not report modifiers") {
+			val rule = ModifierOrder()
+
+			val findings = rule.lint(file)
+			Assertions.assertThat(findings).isEmpty()
+		}
+	}
+
+	given("a kt parameter with wrongly ordered modifiers") {
+		val code = "lateinit internal private val test: String"
+
+		it("should report modifiers") {
+			val rule = ModifierOrder()
+
+			val findings = rule.lint(code)
+			Assertions.assertThat(findings).hasSize(1)
+		}
+	}
+
+	given("a kt parameter with correctly ordered modifiers") {
+		val code = "private internal lateinit val test: String"
+
+		it("should not report modifiers") {
+			val rule = ModifierOrder()
+
+			val findings = rule.lint(code)
+			Assertions.assertThat(findings).isEmpty()
+		}
+	}
+
+	given("a kt file with correctly ordered modifiers") {
+		val file = compileForTest(Case.Default.path())
+
+		it("should not report modifiers") {
+			val rule = ModifierOrder()
+
+			val findings = rule.lint(file.text)
+			Assertions.assertThat(findings).isEmpty()
+		}
+	}
+
+	given("a kt file with correctly ordered modifiers") {
+		val file = compileForTest(Case.ModifierOrder.path())
+
+		it("should not report modifiers") {
+			val rule = ModifierOrder()
+
+			val findings = rule.lint(file.text)
+			Assertions.assertThat(findings).hasSize(2)
+		}
+	}
+
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
@@ -65,23 +65,19 @@ class ModifierOrderSpec : Spek({
 	}
 
 	given("a kt file with correctly ordered modifiers") {
-		val file = compileForTest(Case.Default.path())
-
 		it("should not report modifiers") {
 			val rule = ModifierOrder()
 
-			val findings = rule.lint(file.text)
+			val findings = rule.lint(Case.Default.path())
 			Assertions.assertThat(findings).isEmpty()
 		}
 	}
 
 	given("a kt file with correctly ordered modifiers") {
-		val file = compileForTest(Case.ModifierOrder.path())
-
 		it("should not report modifiers") {
 			val rule = ModifierOrder()
 
-			val findings = rule.lint(file.text)
+			val findings = rule.lint(Case.ModifierOrder.path())
 			Assertions.assertThat(findings).hasSize(3)
 		}
 	}

--- a/detekt-rules/src/test/resources/cases/ModifierOrder.kt
+++ b/detekt-rules/src/test/resources/cases/ModifierOrder.kt
@@ -1,0 +1,12 @@
+package cases
+
+abstract internal class Test(val test: String = "abc"): OpenTest() {
+	lateinit public var property: String
+
+	open override fun test() {
+	}
+}
+
+abstract class OpenTest {
+	abstract fun test()
+}

--- a/detekt-rules/src/test/resources/cases/ModifierOrder.kt
+++ b/detekt-rules/src/test/resources/cases/ModifierOrder.kt
@@ -1,9 +1,9 @@
 package cases
 
-abstract internal class Test(val test: String = "abc"): OpenTest() {
+abstract public class Test(val test: String = "abc"): OpenTest() {
 	lateinit public var property: String
 
-	open override fun test() {
+	override open fun test() {
 	}
 }
 


### PR DESCRIPTION
Resolves #129 

The modifier order and rule setup was inspired by ktlint: https://github.com/shyiko/ktlint/blob/master/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ModifierOrderRule.kt#L35

