### PR TITLE
Fix magic number check

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -16,6 +16,10 @@ open class CodeSmell(final override val issue: Issue,
 	override fun compact() = "$id - ${entity.compact()}"
 
 	override fun compactWithSignature() = compact() + " - Signature=" + entity.signature
+
+	override fun toString(): String {
+		return "CodeSmell(issue=$issue, entity=$entity, metrics=$metrics, references=$references, id='$id')"
+	}
 }
 
 /**

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -11,6 +11,10 @@ data class Issue(val id: String,
 	init {
 		validateIdentifier(id)
 	}
+
+	override fun toString(): String {
+		return "Issue(id='$id', severity=$severity, debt=$debt)"
+	}
 }
 
 /**

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -156,7 +156,7 @@ style:
     active: true
   MagicNumber:
     active: true
-    ignoreNumbers: '-1,0,1,2'
+    ignoredNumbers: '-1,0,1,2'
   WildcardImport:
     active: true
   SafeCast:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -1,12 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtProperty
@@ -15,9 +9,9 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName, Severity.Style,
 			"Report magic numbers. Magic number is a numeric literal that is not defined as a constant" +
-					"and hence it's unclear what the purpose of this number is." +
-					"It's better to declare such numbers as constants and give them a proper name." +
-					"By default, -1, 0, 1, and 2 are not considered to be magic numbers. ", Debt.TEN_MINS)
+					"and hence it's unclear what the purpose of this number is. " +
+					"It's better to declare such numbers as constants and give them a proper name. " +
+					"By default, -1, 0, 1, and 2 are not considered to be magic numbers.", Debt.TEN_MINS)
 
 	private val ignoreNumbers = valueOrDefault(IGNORE_NUMBERS, "-1,0,1,2")
 			.split(",")

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -8,12 +8,12 @@ import org.jetbrains.kotlin.psi.KtProperty
 class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName, Severity.Style,
-			"Report magic numbers. Magic number is a numeric literal that is not defined as a constant" +
+			"Report magic numbers. Magic number is a numeric literal that is not defined as a constant " +
 					"and hence it's unclear what the purpose of this number is. " +
 					"It's better to declare such numbers as constants and give them a proper name. " +
 					"By default, -1, 0, 1, and 2 are not considered to be magic numbers.", Debt.TEN_MINS)
 
-	private val ignoreNumbers = valueOrDefault(IGNORE_NUMBERS, "-1,0,1,2")
+	private val ignoredNumbers = valueOrDefault(IGNORED_NUMBERS, "-1,0,1,2")
 			.split(",")
 			.map { it.toLongOrNull() }
 			.filterNotNull()
@@ -24,7 +24,7 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 		val isConst = parent is KtProperty && parent.modifierList?.hasModifier(KtTokens.CONST_KEYWORD) ?: false
 		val possibleNumber = getNumber(expression)
 
-		if (!isConst && !ignoreNumbers.contains(possibleNumber)) {
+		if (!isConst && !ignoredNumbers.contains(possibleNumber)) {
 			report(CodeSmell(issue, Entity.from(expression)))
 		}
 	}
@@ -33,15 +33,15 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 		val text = element.text
 
 		return when {
-      text.endsWith("L") -> text.replace("L", "").toLongOrNull()
-      text.startsWith("0x") -> text.substring("0x".length).toIntOrNull(HEX_RADIX)?.toLong()
-      text.contains(".") -> text.toFloatOrNull()?.toLong()
-      else -> text.toLongOrNull()
-    }
+			text.endsWith("L") -> text.replace("L", "").toLongOrNull()
+			text.startsWith("0x") -> text.substring("0x".length).toIntOrNull(HEX_RADIX)?.toLong()
+			text.contains(".") -> text.toFloatOrNull()?.toLong()
+			else -> text.toLongOrNull()
+		}
 	}
 
 	companion object {
-		const val IGNORE_NUMBERS = "ignoreNumbers"
+		const val IGNORED_NUMBERS = "ignoredNumbers"
 
 		private const val HEX_RADIX = 16
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtOperationReferenceExpression
 import org.jetbrains.kotlin.psi.KtPrefixExpression
 import org.jetbrains.kotlin.psi.KtProperty
-import java.util.*
+import java.util.Locale
 
 class MagicNumber(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -1,6 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtConstantExpression

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -18,7 +18,7 @@ class MagicNumberSpec : Spek({
 		}
 
 		it("it should be reported when ignoreNumbers are overridden") {
-			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(code)
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(1)
 		}
 	}
@@ -32,7 +32,7 @@ class MagicNumberSpec : Spek({
 		}
 
 		it("it should not be reported when ignoreNumbers are overridden") {
-			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(code)
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(0)
 		}
 	}
@@ -46,7 +46,7 @@ class MagicNumberSpec : Spek({
 		}
 
 		it("it should be reported when ignoreNumbers are overridden") {
-			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(code)
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(1)
 		}
 	}
@@ -60,7 +60,7 @@ class MagicNumberSpec : Spek({
 		}
 
 		it("it should not be reported when ignoreNumbers are overridden") {
-			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(code)
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(0)
 		}
 	}
@@ -74,7 +74,7 @@ class MagicNumberSpec : Spek({
 		}
 
 		it("it should be reported when ignoreNumbers are overridden") {
-			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(code)
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(1)
 		}
 	}
@@ -88,7 +88,7 @@ class MagicNumberSpec : Spek({
 		}
 
 		it("it should not be reported when ignoreNumbers are overridden") {
-			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(code)
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(0)
 		}
 	}
@@ -102,7 +102,7 @@ class MagicNumberSpec : Spek({
 		}
 
 		it("it should be reported when ignoreNumbers are overridden") {
-			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(code)
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(1)
 		}
 	}
@@ -116,7 +116,7 @@ class MagicNumberSpec : Spek({
 		}
 
 		it("it should not be reported when ignoreNumbers are overridden") {
-			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(code)
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(0)
 		}
 	}
@@ -130,7 +130,7 @@ class MagicNumberSpec : Spek({
 		}
 
 		it("it should be reported when ignoreNumbers are overridden") {
-			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(code)
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(1)
 		}
 	}
@@ -144,7 +144,7 @@ class MagicNumberSpec : Spek({
 		}
 
 		it("it should not be reported when ignoreNumbers are overridden") {
-			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(code)
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(0)
 		}
 	}
@@ -153,7 +153,7 @@ class MagicNumberSpec : Spek({
 		val code = "val myInt = 300"
 
 		it("it should not be reported when ignoreNumbers contains 300") {
-			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "300"))).lint(code)
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to "300"))).lint(code)
 			assertThat(findings).hasSize(0)
 		}
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -122,7 +122,7 @@ class MagicNumberSpec : Spek({
 	}
 
 	given("a hex of 1") {
-		val code = "val myHex = 0x0"
+		val code = "val myHex = 0x1"
 
 		it("it should not be reported by default") {
 			val findings = MagicNumber().lint(code)
@@ -136,7 +136,7 @@ class MagicNumberSpec : Spek({
 	}
 
 	given("a const hex of 1") {
-		val code = "const val MY_HEX = 0x0"
+		val code = "const val MY_HEX = 0x1"
 
 		it("it should not be reported by default") {
 			val findings = MagicNumber().lint(code)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -6,18 +6,19 @@ import org.assertj.core.api.Java6Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
+import kotlin.test.assertFailsWith
 
 class MagicNumberSpec : Spek({
 
 	given("a float of 1") {
 		val code = "val myFloat = 1.0f"
 
-		it("it should not be reported by default") {
+		it("should not be reported by default") {
 			val findings = MagicNumber().lint(code)
 			assertThat(findings).hasSize(0)
 		}
 
-		it("it should be reported when ignoreNumbers are overridden") {
+		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(1)
 		}
@@ -26,12 +27,12 @@ class MagicNumberSpec : Spek({
 	given("a const float of 1") {
 		val code = "const val MY_FLOAT = 1.0f"
 
-		it("it should not be reported by default") {
+		it("should not be reported by default") {
 			val findings = MagicNumber().lint(code)
 			assertThat(findings).hasSize(0)
 		}
 
-		it("it should not be reported when ignoreNumbers are overridden") {
+		it("should not be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(0)
 		}
@@ -40,12 +41,12 @@ class MagicNumberSpec : Spek({
 	given("an integer of 1") {
 		val code = "val myInt = 1"
 
-		it("it should not be reported by default") {
+		it("should not be reported by default") {
 			val findings = MagicNumber().lint(code)
 			assertThat(findings).hasSize(0)
 		}
 
-		it("it should be reported when ignoreNumbers are overridden") {
+		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(1)
 		}
@@ -54,12 +55,12 @@ class MagicNumberSpec : Spek({
 	given("a const integer of 1") {
 		val code = "const val MY_INT = 1"
 
-		it("it should not be reported by default") {
+		it("should not be reported by default") {
 			val findings = MagicNumber().lint(code)
 			assertThat(findings).hasSize(0)
 		}
 
-		it("it should not be reported when ignoreNumbers are overridden") {
+		it("should not be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(0)
 		}
@@ -68,13 +69,51 @@ class MagicNumberSpec : Spek({
 	given("a long of 1") {
 		val code = "val myLong = 1L"
 
-		it("it should not be reported by default") {
+		it("should not be reported by default") {
 			val findings = MagicNumber().lint(code)
 			assertThat(findings).hasSize(0)
 		}
 
-		it("it should be reported when ignoreNumbers are overridden") {
+		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
+			assertThat(findings).hasSize(1)
+		}
+	}
+
+	given("a long of -1") {
+		val code = "val myLong = -1L"
+
+		it("should not be reported by default") {
+			val findings = MagicNumber().lint(code)
+			assertThat(findings).hasSize(0)
+		}
+
+		it("should be reported when ignoredNumbers is empty") {
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
+			assertThat(findings).hasSize(1)
+		}
+	}
+
+	given("a long of -2") {
+		val code = "val myLong = -2L"
+
+		it("should be reported by default") {
+			val findings = MagicNumber().lint(code)
+			assertThat(findings).hasSize(1)
+		}
+
+		it("should be ignored when ignoredNumbers contains it verbatim") {
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to "-2L"))).lint(code)
+			assertThat(findings).isEmpty()
+		}
+
+		it("should be ignored when ignoredNumbers contains it as floating point") {
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to "-2f"))).lint(code)
+			assertThat(findings).isEmpty()
+		}
+
+		it("should not be ignored when ignoredNumbers contains 2 but not -2") {
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to "1,2,3,-1,0"))).lint(code)
 			assertThat(findings).hasSize(1)
 		}
 	}
@@ -82,12 +121,12 @@ class MagicNumberSpec : Spek({
 	given("a const long of 1") {
 		val code = "const val MY_LONG = 1L"
 
-		it("it should not be reported by default") {
+		it("should not be reported by default") {
 			val findings = MagicNumber().lint(code)
 			assertThat(findings).hasSize(0)
 		}
 
-		it("it should not be reported when ignoreNumbers are overridden") {
+		it("should not be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(0)
 		}
@@ -96,12 +135,12 @@ class MagicNumberSpec : Spek({
 	given("a double of 1") {
 		val code = "val myDouble = 1.0"
 
-		it("it should not be reported by default") {
+		it("should not be reported by default") {
 			val findings = MagicNumber().lint(code)
 			assertThat(findings).hasSize(0)
 		}
 
-		it("it should be reported when ignoreNumbers are overridden") {
+		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(1)
 		}
@@ -110,12 +149,12 @@ class MagicNumberSpec : Spek({
 	given("a const double of 1") {
 		val code = "const val MY_DOUBLE = 1.0"
 
-		it("it should not be reported by default") {
+		it("should not be reported by default") {
 			val findings = MagicNumber().lint(code)
 			assertThat(findings).hasSize(0)
 		}
 
-		it("it should not be reported when ignoreNumbers are overridden") {
+		it("should not be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(0)
 		}
@@ -124,12 +163,12 @@ class MagicNumberSpec : Spek({
 	given("a hex of 1") {
 		val code = "val myHex = 0x1"
 
-		it("it should not be reported by default") {
+		it("should not be reported by default") {
 			val findings = MagicNumber().lint(code)
 			assertThat(findings).hasSize(0)
 		}
 
-		it("it should be reported when ignoreNumbers are overridden") {
+		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(1)
 		}
@@ -138,12 +177,12 @@ class MagicNumberSpec : Spek({
 	given("a const hex of 1") {
 		val code = "const val MY_HEX = 0x1"
 
-		it("it should not be reported by default") {
+		it("should not be reported by default") {
 			val findings = MagicNumber().lint(code)
 			assertThat(findings).hasSize(0)
 		}
 
-		it("it should not be reported when ignoreNumbers are overridden") {
+		it("should not be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ""))).lint(code)
 			assertThat(findings).hasSize(0)
 		}
@@ -152,16 +191,54 @@ class MagicNumberSpec : Spek({
 	given("an integer of 300") {
 		val code = "val myInt = 300"
 
-		it("it should not be reported when ignoreNumbers contains 300") {
+		it("should not be reported when ignoredNumbers contains 300") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to "300"))).lint(code)
 			assertThat(findings).hasSize(0)
+		}
+
+		it("should not be reported when ignoredNumbers contains a floating point 300") {
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to "300.0"))).lint(code)
+			assertThat(findings).hasSize(0)
+		}
+	}
+
+	given("a binary literal") {
+		val code = "val myBinary = 0b01001"
+
+		it("should not be reported") {
+			val findings = MagicNumber().lint(code)
+			assertThat(findings).hasSize(0)
+		}
+	}
+
+	given("an integer literal with underscores") {
+		val code = "val myInt = 100_000"
+
+		it("should be reported by default") {
+			val findings = MagicNumber().lint(code)
+			assertThat(findings).hasSize(1)
+		}
+
+		it("should not be reported when ignored verbatim") {
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to "100_000"))).lint(code)
+			assertThat(findings).isEmpty()
+		}
+
+		it("should not be reported when ignored with different underscores") {
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to "10_00_00"))).lint(code)
+			assertThat(findings).isEmpty()
+		}
+
+		it("should not be reported when ignored without underscores") {
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to "100000"))).lint(code)
+			assertThat(findings).isEmpty()
 		}
 	}
 
 	given("an if statement with magic numbers") {
 		val code = "val myInt = if (5 < 6) 7 else 8"
 
-		it("it should be reported") {
+		it("should be reported") {
 			val findings = MagicNumber().lint(code)
 			assertThat(findings).hasSize(4)
 		}
@@ -178,7 +255,7 @@ class MagicNumberSpec : Spek({
 			}
 		"""
 
-		it("it should be reported") {
+		it("should be reported") {
 			val findings = MagicNumber().lint(code)
 			assertThat(findings).hasSize(6)
 		}
@@ -191,9 +268,61 @@ class MagicNumberSpec : Spek({
 			}
 		"""
 
-		it("it should be reported") {
+		it("should be reported") {
 			val findings = MagicNumber().lint(code)
 			assertThat(findings).hasSize(1)
+		}
+	}
+
+	given("a boolean value") {
+		val code = """
+			fun test() : Boolean {
+				return true;
+			}
+		"""
+
+		it("should not be reported") {
+			val findings = MagicNumber().lint(code)
+			assertThat(findings).isEmpty()
+		}
+	}
+
+	given("a non-numeric constant expression") {
+		val code = "val surprise = true"
+
+		it("should not be reported") {
+			val findings = MagicNumber().lint(code)
+			assertThat(findings).isEmpty()
+		}
+	}
+
+	given("a float of 0.5") {
+		val code = "val test = 0.5f"
+
+		it("should be reported by default") {
+			val findings = MagicNumber().lint(code)
+			assertThat(findings).hasSize(1)
+		}
+
+		it("should not be reported when ignoredNumbers contains it") {
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to ".5"))).lint(code)
+			assertThat(findings).hasSize(0)
+		}
+	}
+
+	given("an invalid ignoredNumber") {
+
+		it("throws a NumberFormatException") {
+			assertFailsWith(NumberFormatException::class) {
+				MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to "banana")))
+			}
+		}
+	}
+
+	given("an empty ignoredNumber") {
+
+		it("doesn't throw an exception") {
+			MagicNumber(TestConfig(mapOf(MagicNumber.IGNORED_NUMBERS to "")))
 		}
 	}
 })

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,6 @@ kotlinVersion=1.1.3-2
 spekVersion=1.1.2
 junitPlatformVersion=1.0.0-M4
 junitEngineVersion=5.0.0-M4
-hamkrestVersion=1.2.3.0
 yamlVersion=1.18
 jcommanderVersion=1.72
 assertjVersion=3.6.2


### PR DESCRIPTION
This PR fixes a number of issues in the `MagicNumber` check:
 * flagging non-numeric constant expressions (e.g., `true`, `null`)
 * inability to ignore floating point values correctly (due to casting to `long`)
 * incorrect hex number parsing in some cases
 * silently ignores invalid `ignoredNumbers` configuration parameters
 * ignores negative values when the corresponding positive number is
   ignored (e.g., -2 is ignored when 2 is in `ignoredNumbers`)
 * floating point numbers are not correctly parsed in some cases
 * numeric literals that contain underscores are not correctly parsed

I noticed these issues because I got false positives all over the place in [my codebase](https://squanchy.net) as soon as I updated. Unfortunately the tests for the rule in this case were omitting any false positive and any edge case, so that the rule seemed formally valid but was actually severely bugged. I would recommend double checking the test suite for new rules before shipping them in the future.

To be fair, the test suite is still not optimal, but at least captures all the bugs I identified so far. There can/will be more bugs, possibly, but this seems a good starting point. It's not Checkstyle's omonimous check, and the tests are not nearly as exhaustive, but better than it was.

On top of that there are a couple of minor tweaks to make the testing of the class easier (not that Spek ever worked for me in the IDE... but at least from the command line it does), removes an unused Gradle property, adds missing spaces in the `MagicNumber` check description, and renames the `ignoreNumbers` config setting to `ignoredNumbers`.

The rule still doesn't parse binary numbers because it was originally not, but that could be a separate PR if required.