### PR TITLE
Add rules property for multirule

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/MultiRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/MultiRule.kt
@@ -2,6 +2,9 @@ package io.gitlab.arturbosch.detekt.api
 
 import org.jetbrains.kotlin.psi.KtFile
 
-open class MultiRule : BaseRule() {
+abstract class MultiRule : BaseRule() {
+
+	protected abstract val rules: List<Rule>
+
 	override fun visitCondition(root: KtFile) = true
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
@@ -12,13 +12,13 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 /**
  * @author Artur Bosch
  */
-class CommentOverPrivateMethod(config: Config = Config.empty) : Rule(config) {
+class CommentOverPrivateFunction(config: Config = Config.empty) : Rule(config) {
 
-	override val issue = Issue("CommentOverPrivateMethod",
+	override val issue = Issue("CommentOverPrivateFunction",
 			Severity.Maintainability,
-			"Comments for private methods should be avoided. " +
-					"Prefer giving the method an expressive name. " +
-					"Split it up in smaller, self-explaining methods if necessary.")
+			"Comments for private functions should be avoided. " +
+					"Prefer giving the function an expressive name. " +
+					"Split it up in smaller, self-explaining functions if necessary.")
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		val modifierList = function.modifierList

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
@@ -16,7 +16,7 @@ class CommentOverPrivateProperty(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue("CommentOverPrivateProperty",
 			Severity.Maintainability,
-			"Private properties should be named such that they explain themselves.")
+			"Private properties should be named such that they explain themselves even without a comment.")
 
 	override fun visitProperty(property: KtProperty) {
 		val modifierList = property.modifierList

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CommentSmellProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CommentSmellProvider.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.providers
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import io.gitlab.arturbosch.detekt.rules.documentation.CommentOverPrivateMethod
+import io.gitlab.arturbosch.detekt.rules.documentation.CommentOverPrivateFunction
 import io.gitlab.arturbosch.detekt.rules.documentation.CommentOverPrivateProperty
 import io.gitlab.arturbosch.detekt.rules.documentation.UndocumentedPublicClass
 import io.gitlab.arturbosch.detekt.rules.documentation.UndocumentedPublicFunction
@@ -17,7 +17,7 @@ class CommentSmellProvider : RuleSetProvider {
 
 	override fun instance(config: Config): RuleSet {
 		return RuleSet(ruleSetId, listOf(
-				CommentOverPrivateMethod(config),
+				CommentOverPrivateFunction(config),
 				CommentOverPrivateProperty(config),
 				UndocumentedPublicClass(config),
 				UndocumentedPublicFunction(config)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtFile
 
 class FileParsingRule(val config: Config = Config.empty) : MultiRule() {
 
-	private val rules = listOf(MaxLineLength(config))
+	override val rules = listOf(MaxLineLength(config))
 
 	override fun visitKtFile(file: KtFile) {
 		val lines = file.text.splitToSequence("\n")

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/CommentOverPrivateMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/CommentOverPrivateMethodSpec.kt
@@ -1,13 +1,13 @@
 package io.gitlab.arturbosch.detekt.rules
 
-import io.gitlab.arturbosch.detekt.rules.documentation.CommentOverPrivateMethod
+import io.gitlab.arturbosch.detekt.rules.documentation.CommentOverPrivateFunction
 import org.jetbrains.spek.subject.SubjectSpek
 import org.jetbrains.spek.subject.itBehavesLike
 
 /**
  * @author Artur Bosch
  */
-class CommentOverPrivateMethodSpec : SubjectSpek<CommentOverPrivateMethod>({
-	subject { CommentOverPrivateMethod() }
+class CommentOverPrivateMethodSpec : SubjectSpek<CommentOverPrivateFunction>({
+	subject { CommentOverPrivateFunction() }
 	itBehavesLike(CommonSpec())
 })


### PR DESCRIPTION
All rules have an Issue property which is used for sonar-kotlin. Currently there is no way to let the plugin know about `MaxLineLength`. An Issue is needed to establish a RuleKey which sonar uses to link findings with rules.