### PR TITLE
allow suppressing `all`

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Suppressible.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Suppressible.kt
@@ -36,7 +36,7 @@ private fun KtElement.findAnnotatedSuppressedParent(id: String): Boolean {
  * Checks if this kt element is suppressed by @Suppress or @SuppressWarnings annotations.
  */
 fun KtAnnotated.isSuppressedBy(id: String): Boolean {
-	val valid = listOf(id, "ALL")
+	val valid = listOf(id, "ALL", "all")
 	return annotationEntries.find { it.typeReferenceName.let { it == "Suppress" || it == "SuppressWarnings" } }
 			?.valueArguments
 			?.find { it.getArgumentExpression()?.text?.replace("\"", "") in valid } != null


### PR DESCRIPTION
As discussed in #320 this adds "all" to the list of strings that will suppress a rule.