### PR TITLE
add rule to detect Unnecessary Parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,8 @@ style:
     maxLineLength: 120
     excludePackageStatements: false
     excludeImportStatements: false
+  UnnecessaryParentheses:
+    active: false
 
 comments:
   active: true

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -192,6 +192,8 @@ style:
     enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
   ProtectedMemberInFinalClass:
     active: false
+  UnnecessaryParentheses:
+    active: false
 
 comments:
   active: true

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -18,6 +18,7 @@ import io.gitlab.arturbosch.detekt.rules.style.OptionalAbstractKeyword
 import io.gitlab.arturbosch.detekt.rules.style.ProtectedMemberInFinalClass
 import io.gitlab.arturbosch.detekt.rules.style.ReturnCount
 import io.gitlab.arturbosch.detekt.rules.style.SafeCast
+import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryParentheses
 import io.gitlab.arturbosch.detekt.rules.style.WildcardImport
 
 /**
@@ -38,6 +39,7 @@ class StyleGuideProvider : RuleSetProvider {
 				ForbiddenImport(config),
 				NamingConventionViolation(config),
 				SafeCast(config),
+				UnnecessaryParentheses(config),
 				OptionalAbstractKeyword(config),
 				ProtectedMemberInFinalClass(config),
 				MagicNumber(config),

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
@@ -1,0 +1,47 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtParenthesizedExpression
+import org.jetbrains.kotlin.psi.KtPsiUtil
+import org.jetbrains.kotlin.psi.KtSuperTypeCallEntry
+import org.jetbrains.kotlin.psi.KtValueArgument
+
+/**
+ * Reports unnecessary parentheses around expressions.
+ *
+ * Added in v1.0.0.RC4
+ */
+class UnnecessaryParentheses(config: Config = Config.empty) : Rule(config) {
+
+	override val issue = Issue("UnnecessaryParentheses", Severity.Style,
+			"These parentheses are unnecessary and can be removed.")
+
+	override fun visitParenthesizedExpression(expression: KtParenthesizedExpression) {
+		super.visitParenthesizedExpression(expression)
+
+		if (KtPsiUtil.areParenthesesUseless(expression)) {
+			val description = "Parentheses in ${expression.text} are unnecessary and can be replaced with: " +
+					"${KtPsiUtil.deparenthesize(expression)?.text}"
+			report(CodeSmell(issue.copy(description = description), Entity.from(expression)))
+		}
+	}
+
+	override fun visitArgument(argument: KtValueArgument) {
+		super.visitArgument(argument)
+		val isLambdaExpression = argument.children.any { it is KtLambdaExpression }
+		val isOnlyArgument = argument.parent.children.size == 1
+
+		val isSuperTypeCallEntry = argument.parent.parent is KtSuperTypeCallEntry
+
+		if (isLambdaExpression && isOnlyArgument && !isSuperTypeCallEntry) {
+			val description = "Parentheses around the lambda ${argument.parent.text} are unnecessary and can be removed."
+			report(CodeSmell(issue.copy(description = description), Entity.from(argument.parent)))
+		}
+	}
+}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -1,0 +1,100 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
+
+class UnnecessaryParenthesesSpec : SubjectSpek<UnnecessaryParentheses>({
+	subject { UnnecessaryParentheses(Config.empty) }
+
+	given("parenthesized expressions") {
+
+		it("with unnecessary parentheses on val assignment") {
+			val code = "val local = (5)"
+			Assertions.assertThat(subject.lint(code).size).isEqualTo(1)
+		}
+
+		it("with unnecessary parentheses on val assignment operation") {
+			val code = "val local = (5 + 3)"
+			Assertions.assertThat(subject.lint(code).size).isEqualTo(1)
+		}
+
+		it("with unnecessary parentheses on function call") {
+			val code = "val local = 3.plus((5))"
+			Assertions.assertThat(subject.lint(code).size).isEqualTo(1)
+		}
+
+		it("unnecessary parentheses in other parentheses") {
+			val code = """
+				fun x(a: String, b: String) {
+					if ((a equals b)) {
+					 	println("Test")
+					}
+				}"""
+			Assertions.assertThat(subject.lint(code).size).isEqualTo(1)
+		}
+
+		it("reports unnecessary parentheses around lambdas") {
+			val code = """
+				fun function (a: (input: String) -> Unit) {
+					a.invoke("TEST")
+				}
+
+				fun test() {
+					function({ input -> println(input) })
+				}
+				"""
+			Assertions.assertThat(subject.lint(code).size).isEqualTo(1)
+		}
+
+		it("doesn't report function calls containing lambdas and other parameters") {
+			val code = """
+				fun function (integer: Int, a: (input: String) -> Unit) {
+					a.invoke("TEST")
+				}
+
+				fun test() {
+					function(1, { input -> println(input) })
+				}
+				"""
+			Assertions.assertThat(subject.lint(code).size).isEqualTo(0)
+		}
+
+		it("does not report well behaved parentheses") {
+			val code = """
+				fun x(a: String, b: String) {
+					if (a equals b) {
+					 	println("Test")
+					}
+				}"""
+			Assertions.assertThat(subject.lint(code).size).isEqualTo(0)
+		}
+
+		it("does not report well behaved parentheses in super constructors") {
+			val code = """
+				class TestSpek : SubjectSpek({
+					describe("a simple test") {
+						it("should do something") {
+						}
+					}
+				})
+				"""
+			Assertions.assertThat(subject.lint(code).size).isEqualTo(0)
+		}
+
+		it("does not report well behaved parentheses in constructors") {
+			val code = """
+				class TestSpek({
+					describe("a simple test") {
+						it("should do something") {
+						}
+					}
+				})
+				"""
+			Assertions.assertThat(subject.lint(code).size).isEqualTo(0)
+		}
+	}
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
@@ -14,17 +14,17 @@ class UnnecessaryParenthesesSpec : SubjectSpek<UnnecessaryParentheses>({
 
 		it("with unnecessary parentheses on val assignment") {
 			val code = "val local = (5)"
-			Assertions.assertThat(subject.lint(code).size).isEqualTo(1)
+			assertThat(subject.lint(code).size).isEqualTo(1)
 		}
 
 		it("with unnecessary parentheses on val assignment operation") {
 			val code = "val local = (5 + 3)"
-			Assertions.assertThat(subject.lint(code).size).isEqualTo(1)
+			assertThat(subject.lint(code).size).isEqualTo(1)
 		}
 
 		it("with unnecessary parentheses on function call") {
 			val code = "val local = 3.plus((5))"
-			Assertions.assertThat(subject.lint(code).size).isEqualTo(1)
+			assertThat(subject.lint(code).size).isEqualTo(1)
 		}
 
 		it("unnecessary parentheses in other parentheses") {
@@ -34,7 +34,7 @@ class UnnecessaryParenthesesSpec : SubjectSpek<UnnecessaryParentheses>({
 					 	println("Test")
 					}
 				}"""
-			Assertions.assertThat(subject.lint(code).size).isEqualTo(1)
+			assertThat(subject.lint(code).size).isEqualTo(1)
 		}
 
 		it("reports unnecessary parentheses around lambdas") {
@@ -47,7 +47,7 @@ class UnnecessaryParenthesesSpec : SubjectSpek<UnnecessaryParentheses>({
 					function({ input -> println(input) })
 				}
 				"""
-			Assertions.assertThat(subject.lint(code).size).isEqualTo(1)
+			assertThat(subject.lint(code).size).isEqualTo(1)
 		}
 
 		it("doesn't report function calls containing lambdas and other parameters") {
@@ -60,7 +60,7 @@ class UnnecessaryParenthesesSpec : SubjectSpek<UnnecessaryParentheses>({
 					function(1, { input -> println(input) })
 				}
 				"""
-			Assertions.assertThat(subject.lint(code).size).isEqualTo(0)
+			assertThat(subject.lint(code).size).isEqualTo(0)
 		}
 
 		it("does not report well behaved parentheses") {
@@ -70,7 +70,7 @@ class UnnecessaryParenthesesSpec : SubjectSpek<UnnecessaryParentheses>({
 					 	println("Test")
 					}
 				}"""
-			Assertions.assertThat(subject.lint(code).size).isEqualTo(0)
+			assertThat(subject.lint(code).size).isEqualTo(0)
 		}
 
 		it("does not report well behaved parentheses in super constructors") {
@@ -82,7 +82,7 @@ class UnnecessaryParenthesesSpec : SubjectSpek<UnnecessaryParentheses>({
 					}
 				})
 				"""
-			Assertions.assertThat(subject.lint(code).size).isEqualTo(0)
+			assertThat(subject.lint(code).size).isEqualTo(0)
 		}
 
 		it("does not report well behaved parentheses in constructors") {
@@ -94,7 +94,7 @@ class UnnecessaryParenthesesSpec : SubjectSpek<UnnecessaryParentheses>({
 					}
 				})
 				"""
-			Assertions.assertThat(subject.lint(code).size).isEqualTo(0)
+			assertThat(subject.lint(code).size).isEqualTo(0)
 		}
 	}
 })


### PR DESCRIPTION
Resolves #270 

Uses `KtPsiUtil` to figure out if parentheses are useless, which is the same that the IntelliJ warning and quick-fix use. 
But it doesn't detect the case described in #270 `itemView.setOnClickListener({ it.doSomething() })`

For this we check arguments to see if only a single lambda is provided (and it's not a supertype constructor because otherwise this reports Spek classes as well...)