### PR TITLE
remove unnecessary parentheses in the main codebase

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -46,7 +46,7 @@ data class Location(val source: SourceLocation,
 				= (this.containingFile.viewProvider.virtualFile as LightVirtualFile).originalFile?.name
 
 		private fun PsiElement.getTextAtLocationSafe()
-				= getTextSafe(defaultValue = { searchName() }) { getTextWithLocation() }
+				= getTextSafe({ searchName() }, { getTextWithLocation() })
 	}
 
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Metric.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Metric.kt
@@ -23,7 +23,7 @@ data class Metric(val type: String,
 	fun doubleValue(): Double = value.convertAsDouble()
 	fun doubleThreshold(): Double = threshold.convertAsDouble()
 
-	private fun Int.convertAsDouble() = if (isDouble) (this.toDouble() / conversionFactor)
+	private fun Int.convertAsDouble() = if (isDouble) this.toDouble() / conversionFactor
 	else throw IllegalStateException("This metric was not marked as double!")
 
 	override fun toString() = if (isDouble) "${doubleValue()}/${doubleThreshold()}" else "$value/$threshold"

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Signatures.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Signatures.kt
@@ -32,7 +32,7 @@ internal fun PsiElement.buildFullSignature(): String {
 			.fold("") { sig, sig2 -> "$sig2${dotOrNot(sig, sig2)}$sig" }
 	val filename = this.containingFile.name
 	return (if (!fullClassSignature.startsWith(filename)) filename + "\$" else "") +
-			(if (fullClassSignature.isNotEmpty()) "$fullClassSignature\$$signature" else signature)
+			if (fullClassSignature.isNotEmpty()) "$fullClassSignature\$$signature" else signature
 }
 
 private fun PsiElement.extractClassName() =
@@ -82,7 +82,7 @@ private fun buildFunctionSignature(element: KtNamedFunction): String {
 	require(methodStart < methodEnd) {
 		"Error building function signature with range $methodStart - $methodEnd for element: ${element.text}"
 	}
-	return getTextSafe(defaultValue = { element.nameAsSafeName.identifier }) {
-		element.text.substring(methodStart, methodEnd)
-	}
+	return getTextSafe(
+			{ element.nameAsSafeName.identifier },
+			{ element.text.substring(methodStart, methodEnd) })
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -63,7 +63,7 @@ data class FormatConfig(private val useTabs: Boolean) : Config {
 		@Suppress("UNCHECKED_CAST")
 		return when (key) {
 			"autoCorrect" -> true as T
-			"useTabs" -> (useTabs) as T
+			"useTabs" -> useTabs as T
 			else -> default
 		}
 	}

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/XmlOutputReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/XmlOutputReport.kt
@@ -34,7 +34,7 @@ class XmlOutputReport : OutputReport() {
 						"\t<error line=\"${it.location.source.line.toXmlString()}\"",
 						"column=\"${it.location.source.column.toXmlString()}\"",
 						"severity=\"${it.messageType.label.toXmlString()}\"",
-						"message=\"${(it.issue.description).toXmlString()}\"",
+						"message=\"${it.issue.description.toXmlString()}\"",
 						"source=\"${"detekt.${it.id.toXmlString()}"}\" />"
 				).joinToString(separator = " ")
 			}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAroundBraces.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/SpacingAroundBraces.kt
@@ -70,8 +70,8 @@ class SpacingAroundBraces(config: Config) : TokenRule(config) {
 	}
 
 	private fun LeafPsiElement.isPartOfLambda(prevLeaf: PsiElement?)
-			= (prevLeaf?.node?.elementType == KtTokens.LPAR &&
-			(parent is KtLambdaExpression || parent.parent is KtLambdaExpression))
+			= prevLeaf?.node?.elementType == KtTokens.LPAR &&
+			(parent is KtLambdaExpression || parent.parent is KtLambdaExpression)
 
 	private fun shouldNotToBeSeparatedBySpace(leaf: PsiElement?): Boolean {
 		val nextElementType = leaf?.node?.elementType

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -33,7 +33,7 @@ class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
 	}
 
 	private fun requiresDocumentation(
-			klass: KtClass) = (klass.isTopLevel() || klass.isInnerClass() || klass.isNestedClass() || klass.isInnerInterface())
+			klass: KtClass) = klass.isTopLevel() || klass.isInnerClass() || klass.isNestedClass() || klass.isInnerInterface()
 
 	override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {
 		if (declaration.isCompanionWithoutName() || declaration.isLocal) {


### PR DESCRIPTION
The new `UnnecessaryParentheses` rule from #328 picked these up so we should clean these Issues up before we enable the rule in the detekt codebase.