### PR TITLE
fix link to default-detekt-config.yml in migration guide for RC4

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -7,7 +7,7 @@ TooGenericExceptionThrown rules. Own exceptions can be added to the list.
 - EmptyXXXBlock rules were reimplemented and can be turned off individually 
 - The rule NamingConventions was reimplemented and now every case is separately configurable and new cases were added
 
-See [default-detekt-config.yaml](detekt-cli/src/main/kotlin/resources/default-detekt-config.yaml)
+See [default-detekt-config.yaml](detekt-cli/src/main/resources/default-detekt-config.yaml)
 
 ### RC2 -> RC3
 


### PR DESCRIPTION
Resolves #356 