### PR TITLE
Bugfix FunctionMaxLength typo

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/FunctionMaxLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/FunctionMaxLength.kt
@@ -25,7 +25,7 @@ class FunctionMaxLength(config: Config = Config.empty) : SubRule<KtNamedFunction
 	}
 
 	companion object {
-		const val MAXIMUM_FUNCTION_NAME_LENGTH = "minimumFunctionNameLength"
+		const val MAXIMUM_FUNCTION_NAME_LENGTH = "maximumFunctionNameLength"
 		private const val DEFAULT_MAXIMUM_FUNCTION_NAME_LENGTH = 30
 	}
 }


### PR DESCRIPTION
minimumFunctionNameLength -> maximumFunctionNameLength