### PR TITLE
remove spaces in default-detekt-config.yml

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -241,7 +241,7 @@ style:
   EnumNaming:
     active: true
     enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
-  FunctionNaming :
+  FunctionNaming:
     active: true
     functionPattern: '^[a-z$][a-zA-Z$0-9]*$'
   FunctionMaxLength:
@@ -250,10 +250,10 @@ style:
   FunctionMinLength:
     active: false
     minimumFunctionNameLength: 3
-  VariableNaming :
+  VariableNaming:
     active: true
     variablePattern: '^(_)?[a-z$][a-zA-Z$0-9]*$'
-  ConstantNaming :
+  ConstantNaming:
     active: true
     constantPattern: '^([A-Z_]*|serialVersionUID)$'
   VariableMaxLength:


### PR DESCRIPTION
Removes some extra spaces in the default config.