### PR TITLE
add rule to forbid certain class names

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ style:
   EnumNaming:
     active: true
     enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
-  FunctionNaming :
+  FunctionNaming:
     active: true
     functionPattern: '^[a-z$][a-zA-Z$0-9]*$'
   FunctionMaxLength:
@@ -443,10 +443,10 @@ style:
   FunctionMinLength:
     active: false
     minimumFunctionNameLength: 3
-  VariableNaming :
+  VariableNaming:
     active: true
     variablePattern: '^(_)?[a-z$][a-zA-Z$0-9]*$'
-  ConstantNaming :
+  ConstantNaming:
     active: true
     constantPattern: '^([A-Z_]*|serialVersionUID)$'
   VariableMaxLength:
@@ -455,6 +455,9 @@ style:
   VariableMinLength:
     active: false
     minimumVariableNameLength: 3
+  ForbiddenClassName:
+    active: false
+    forbiddenName: ''
   MaxLineLength:
     active: true
     maxLineLength: 120

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Excludes.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Excludes.kt
@@ -7,6 +7,7 @@ class Excludes(excludeParameter: String) {
 			.filter { it.isNotBlank() }
 			.map { it.removeSuffix("*") }
 
-	fun contains(value: String) = excludes.any { value.contains(it) }
+	fun contains(value: String) = excludes.any { value.contains(it, ignoreCase = true) }
 	fun none(value: String) = !contains(value)
+	fun matches(value: String): List<String> = excludes.filter { value.contains(it, ignoreCase = true) }
 }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ExcludesSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ExcludesSpec.kt
@@ -27,6 +27,13 @@ class ExcludesSpec : Spek({
 			assertThat(excludes.contains(parameter)).isFalse()
 			assertThat(excludes.none(parameter)).isTrue()
 		}
+
+		it("returns all matches") {
+			val parameter = "test.com"
+			val matches = excludes.matches(parameter)
+			assertThat(matches).hasSize(1)
+			assertThat(matches).contains("test")
+		}
 	}
 
 	given("an excludes rule with multiple excludes") {
@@ -83,6 +90,5 @@ class ExcludesSpec : Spek({
 			assertThat(excludes.contains(parameter)).isFalse()
 			assertThat(excludes.none(parameter)).isTrue()
 		}
-
 	}
 })

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -264,6 +264,9 @@ style:
   VariableMinLength:
     active: false
     minimumVariableNameLength: 3
+  ForbiddenClassName:
+    active: false
+    forbiddenName: ''
   ProtectedMemberInFinalClass:
     active: false
   UnnecessaryParentheses:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ForbiddenClassName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ForbiddenClassName.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Excludes
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.SubRule
@@ -13,15 +14,11 @@ class ForbiddenClassName(config: Config = Config.empty) : SubRule<KtClassOrObjec
 	override val issue = Issue(javaClass.simpleName,
 			Severity.Style,
 			debt = Debt.FIVE_MINS)
-	private val forbiddenNames = valueOrDefault(FORBIDDEN_NAME, "")
-			.split(",")
-			.map { it.trim() }
-			.filter { it.isNotBlank() }
+	private val forbiddenNames = Excludes(valueOrDefault(FORBIDDEN_NAME, ""))
 
 	override fun apply(element: KtClassOrObject) {
 		val name = element.name ?: ""
-
-		val forbiddenEntries = forbiddenNames.filter { name.contains(it, ignoreCase = true) }
+		val forbiddenEntries = forbiddenNames.matches(name)
 
 		if (forbiddenEntries.isNotEmpty()) {
 			var description = "Class name $name is forbidden as it contains:"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ForbiddenClassName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ForbiddenClassName.kt
@@ -16,11 +16,12 @@ class ForbiddenClassName(config: Config = Config.empty) : SubRule<KtClassOrObjec
 	private val forbiddenNames = valueOrDefault(FORBIDDEN_NAME, "")
 			.split(",")
 			.map { it.trim() }
+			.filter { it.isNotBlank() }
 
 	override fun apply(element: KtClassOrObject) {
 		val name = element.name ?: ""
 
-		val forbiddenEntries = forbiddenNames.filter { name.contains(it) }
+		val forbiddenEntries = forbiddenNames.filter { name.contains(it, ignoreCase = true) }
 
 		if (forbiddenEntries.isNotEmpty()) {
 			var description = "Class name $name is forbidden as it contains:"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ForbiddenClassName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ForbiddenClassName.kt
@@ -1,0 +1,37 @@
+package io.gitlab.arturbosch.detekt.rules.style.naming
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.SubRule
+import org.jetbrains.kotlin.psi.KtClassOrObject
+
+class ForbiddenClassName(config: Config = Config.empty) : SubRule<KtClassOrObject>(config) {
+	override val issue = Issue(javaClass.simpleName,
+			Severity.Style,
+			debt = Debt.FIVE_MINS)
+	private val forbiddenNames = valueOrDefault(FORBIDDEN_NAME, "")
+			.split(",")
+			.map { it.trim() }
+
+	override fun apply(element: KtClassOrObject) {
+		val name = element.name ?: ""
+
+		val forbiddenEntries = forbiddenNames.filter { name.contains(it) }
+
+		if (forbiddenEntries.isNotEmpty()) {
+			var description = "Class name $name is forbidden as it contains:"
+			forbiddenEntries.forEach { description += " $it," }
+			description.trimEnd { it.equals(",") }
+
+			report(CodeSmell(issue.copy(description = description), Entity.from(element)))
+		}
+	}
+
+	companion object {
+		const val FORBIDDEN_NAME = "forbiddenName"
+	}
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/NamingRules.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/NamingRules.kt
@@ -6,7 +6,15 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.rules.reportFindings
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.SpecialNames
-import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtEnumEntry
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtPackageDirective
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtVariableDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 
 /**
@@ -37,7 +45,7 @@ class NamingRules(config: Config = Config.empty) : MultiRule() {
 			functionNamingRule,
 			functionMaxNameLengthRule,
 			functionMinNameLengthRule,
-            forbiddenClassNameRule
+			forbiddenClassNameRule
 	)
 
 	override fun postVisit(root: KtFile) {
@@ -64,12 +72,12 @@ class NamingRules(config: Config = Config.empty) : MultiRule() {
 		super.visitNamedDeclaration(declaration)
 	}
 
-    private fun handleClassOrObject(declaration: KtClassOrObject) {
-        declaration.reportFindings(classOrObjectNamingRule)
-        declaration.reportFindings(forbiddenClassNameRule)
-    }
+	private fun handleClassOrObject(declaration: KtClassOrObject) {
+		declaration.reportFindings(classOrObjectNamingRule)
+		declaration.reportFindings(forbiddenClassNameRule)
+	}
 
-    private fun handleFunction(declaration: KtNamedFunction) {
+	private fun handleFunction(declaration: KtNamedFunction) {
 		declaration.reportFindings(functionNamingRule)
 		declaration.reportFindings(functionMaxNameLengthRule)
 		declaration.reportFindings(functionMinNameLengthRule)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenNameSpec.kt
@@ -3,39 +3,20 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.style.naming.ForbiddenClassName
 import io.gitlab.arturbosch.detekt.rules.style.naming.NamingRules
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 
 
-class ForbiddenNameSpec: Spek({
+class ForbiddenNameSpec : Spek({
 
 	given("forbidden naming rules") {
-		val configCustomRules =
-				object : Config {
-					override fun subConfig(key: String): Config = Config.empty
-
-					@Suppress("UNCHECKED_CAST")
-					override fun <T : Any> valueOrDefault(key: String, default: T): T =
-							when (key) {
-								ForbiddenClassName.FORBIDDEN_NAME -> "Manager ,  Provider" as T
-								else -> default
-							}
-				}
-		val config = object : Config {
-			override fun subConfig(key: String): Config =
-					when (key) {
-						ForbiddenClassName::class.simpleName -> configCustomRules
-						else -> Config.empty
-					}
-
-			override fun <T : Any> valueOrDefault(key: String, default: T): T = default
-		}
-
 		it("should report classes with forbidden names") {
-			Assertions.assertThat(NamingRules(config).lint("""
+			assertThat(NamingRules(TestConfig(mapOf(ForbiddenClassName.FORBIDDEN_NAME to "Manager ,  Provider")))
+					.lint("""
 			class TestManager {
 				fun getTest() {
 					return "Test"
@@ -45,7 +26,19 @@ class ForbiddenNameSpec: Spek({
 		}
 
 		it("should report another class with a forbidden name") {
-			Assertions.assertThat(NamingRules(config).lint("""
+			assertThat(NamingRules(TestConfig(mapOf(ForbiddenClassName.FORBIDDEN_NAME to "Manager ,  Provider")))
+					.lint("""
+			class TestProvider {
+				fun getTest() {
+					return "Test"
+				}
+			}
+			""")).hasSize(1)
+		}
+
+		it("should report a class that starts with a forbidden name") {
+			assertThat(NamingRules(TestConfig(mapOf(ForbiddenClassName.FORBIDDEN_NAME to "test")))
+					.lint("""
 			class TestProvider {
 				fun getTest() {
 					return "Test"
@@ -55,7 +48,8 @@ class ForbiddenNameSpec: Spek({
 		}
 
 		it("should not report classes that don't contain any forbidden names") {
-			Assertions.assertThat(NamingRules(config).lint("""
+			assertThat(NamingRules(TestConfig(mapOf(ForbiddenClassName.FORBIDDEN_NAME to "Manager ,  Provider")))
+					.lint("""
 			class TestHolder {
 				fun getTest() {
 					return "Test"

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenNameSpec.kt
@@ -1,0 +1,67 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.rules.style.naming.ForbiddenClassName
+import io.gitlab.arturbosch.detekt.rules.style.naming.NamingRules
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+
+
+class ForbiddenNameSpec: Spek({
+
+	given("forbidden naming rules") {
+		val configCustomRules =
+				object : Config {
+					override fun subConfig(key: String): Config = Config.empty
+
+					@Suppress("UNCHECKED_CAST")
+					override fun <T : Any> valueOrDefault(key: String, default: T): T =
+							when (key) {
+								ForbiddenClassName.FORBIDDEN_NAME -> "Manager ,  Provider" as T
+								else -> default
+							}
+				}
+		val config = object : Config {
+			override fun subConfig(key: String): Config =
+					when (key) {
+						ForbiddenClassName::class.simpleName -> configCustomRules
+						else -> Config.empty
+					}
+
+			override fun <T : Any> valueOrDefault(key: String, default: T): T = default
+		}
+
+		it("should report classes with forbidden names") {
+			Assertions.assertThat(NamingRules(config).lint("""
+			class TestManager {
+				fun getTest() {
+					return "Test"
+				}
+			}
+			""")).hasSize(1)
+		}
+
+		it("should report another class with a forbidden name") {
+			Assertions.assertThat(NamingRules(config).lint("""
+			class TestProvider {
+				fun getTest() {
+					return "Test"
+				}
+			}
+			""")).hasSize(1)
+		}
+
+		it("should not report classes that don't contain any forbidden names") {
+			Assertions.assertThat(NamingRules(config).lint("""
+			class TestHolder {
+				fun getTest() {
+					return "Test"
+				}
+			}
+			""")).hasSize(0)
+		}
+	}
+})


### PR DESCRIPTION
One more naming rule that was mentioned in #302.

Allows to forbid certain names for classes. Empty and disabled by default.