### PR TITLE
Fixed #389 in ProtectedMemberInFinalClass rule

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
@@ -20,6 +20,9 @@ class ProtectedMemberInFinalClass(config: Config = Config.empty) : Rule(config) 
 
 	private val visitor = DeclarationVisitor()
 
+	/**
+	 * Only classes and companion objects can contain protected members.
+	 */
 	override fun visitClass(klass: KtClass) {
 		if (hasModifiers(klass)) {
 			klass.primaryConstructor?.accept(visitor)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
@@ -9,7 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtDeclaration
 
 class ProtectedMemberInFinalClass(config: Config = Config.empty) : Rule(config) {
@@ -20,26 +20,20 @@ class ProtectedMemberInFinalClass(config: Config = Config.empty) : Rule(config) 
 
 	private val visitor = DeclarationVisitor()
 
-	override fun visitClassOrObject(classOrObject: KtClassOrObject) {
-		val isNotAbstract = !classOrObject.hasModifier(KtTokens.ABSTRACT_KEYWORD)
-		val isFinal = !classOrObject.hasModifier(KtTokens.OPEN_KEYWORD)
-		val isNotSealed = !classOrObject.hasModifier(KtTokens.SEALED_KEYWORD)
-		if (isNotAbstract && isFinal && isNotSealed) {
-			visitPrimaryConstructor(classOrObject)
-			visitKlassDeclarations(classOrObject)
-		} else {
-			super.visitClassOrObject(classOrObject)
+	override fun visitClass(klass: KtClass) {
+		if (hasModifiers(klass)) {
+			klass.primaryConstructor?.accept(visitor)
+			klass.getBody()?.declarations?.forEach { it.accept(visitor) }
+			klass.companionObjects.forEach { it.accept(visitor) }
 		}
+		super.visitClassOrObject(klass)
 	}
 
-	private fun visitPrimaryConstructor(classOrObject: KtClassOrObject) {
-		classOrObject.primaryConstructor?.accept(visitor)
-	}
-
-	private fun visitKlassDeclarations(klass: KtClassOrObject) {
-		klass.getBody()?.declarations?.forEach {
-			it.accept(visitor)
-		}
+	private fun hasModifiers(klass: KtClass): Boolean {
+		val isNotAbstract = !klass.hasModifier(KtTokens.ABSTRACT_KEYWORD)
+		val isFinal = !klass.hasModifier(KtTokens.OPEN_KEYWORD)
+		val isNotSealed = !klass.hasModifier(KtTokens.SEALED_KEYWORD)
+		return isNotAbstract && isFinal && isNotSealed
 	}
 
 	internal inner class DeclarationVisitor : DetektVisitor() {
@@ -50,7 +44,6 @@ class ProtectedMemberInFinalClass(config: Config = Config.empty) : Rule(config) 
 			if (isProtected && isNotOverridden) {
 				report(CodeSmell(issue, Entity.from(dcl)))
 			}
-			super.visitDeclaration(dcl)
 		}
 	}
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
@@ -17,7 +17,7 @@ class ProtectedMemberInFinalClassSpec : SubjectSpek<ProtectedMemberInFinalClass>
 
 		it("has protected visibility") {
 			val findings = subject.lint(file.text)
-			Assertions.assertThat(findings).hasSize(9)
+			Assertions.assertThat(findings).hasSize(13)
 		}
 	}
 })

--- a/detekt-rules/src/test/resources/cases/FinalClass.kt
+++ b/detekt-rules/src/test/resources/cases/FinalClass.kt
@@ -33,6 +33,12 @@ class FinalClass : BaseClass {
 	}
 
 	protected object InnerObject // positive case
+
+	protected companion object { // positive case
+		protected class A { // positive case
+			protected var x = 0 // positive case
+		}
+	}
 }
 
 @Suppress("unused")
@@ -40,6 +46,14 @@ abstract class BaseClass {
 
 	protected abstract val abstractProp: Int
 	protected abstract fun abstractFunction()
+
+	protected object InnerObject
+
+	protected companion object {
+		protected class A {
+			protected var x = 0 // positive case
+		}
+	}
 }
 
 @Suppress("unused")
@@ -47,8 +61,7 @@ open class OpenClass {
 
 	inner class InnerClass {
 
-		// positive case
-		protected val i = 0
+		protected val i = 0 // positive case
 	}
 }
 
@@ -58,6 +71,5 @@ sealed class SealedClass {
 	protected fun a() {}
 }
 
-// positive case
 @Suppress("unused")
-class FinalClassWithProtectedConstructor protected constructor()
+class FinalClassWithProtectedConstructor protected constructor() // positive case


### PR DESCRIPTION
Detekt doesn't report protected member in companion object of an
abstract class. New test cases for companion objects were added.
The rule itself was refactored.