### PR TITLE
Use the default-config.yml as default configuration

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -27,6 +27,8 @@ interface Config {
 	companion object {
 		/**
 		 * An empty configuration with no properties.
+		 * This config should only be used in test cases.
+		 * Always returns the default value except when 'active' is queried, it returns true .
 		 */
 		val empty: Config = EmptyConfig
 	}
@@ -37,7 +39,11 @@ interface Config {
  */
 internal object EmptyConfig : Config {
 	override fun subConfig(key: String) = this
-	override fun <T : Any> valueOrDefault(key: String, default: T): T = default
+	@Suppress("UNCHECKED_CAST")
+	override fun <T : Any> valueOrDefault(key: String, default: T): T = when (key) {
+		"active" -> true as T
+		else -> default
+	}
 }
 
 /**

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigAware.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigAware.kt
@@ -33,8 +33,9 @@ interface ConfigAware : Config {
 
 	/**
 	 * Is this rule specified as active in configuration?
+	 * If an rule is not specified in the underlying configuration, we assume it should not be run.
 	 */
-	val active get() = valueOrDefault("active", true)
+	val active get() = valueOrDefault("active", false)
 
 	override fun subConfig(key: String): Config
 			= config.subConfig(id).subConfig(key)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtFile
  */
 @Suppress("EmptyFunctionBlock")
 abstract class Rule(override val config: Config = Config.empty,
-					private val ruleContext: Context = DefaultContext()) :
+					ruleContext: Context = DefaultContext()) :
 		BaseRule(ruleContext), ConfigAware {
 
 	abstract val issue: Issue

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -27,7 +27,7 @@ fun Args.loadConfiguration(): Config {
 		!config.isNullOrBlank() -> parsePathConfig(config!!)
 		!configResource.isNullOrBlank() -> parseResourceConfig(configResource!!)
 		formatting -> FormatConfig(useTabs)
-		else -> Config.empty
+		else -> loadDefaultConfig()
 	}
 
 	if (config.valueOrDefault("failFast", false)) {

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -148,18 +148,25 @@ empty-blocks:
 complexity:
   active: true
   LongMethod:
+    active: true
     threshold: 20
   NestedBlockDepth:
+    active: true
     threshold: 3
   LongParameterList:
+    active: true
     threshold: 5
   LargeClass:
+    active: true
     threshold: 150
   ComplexMethod:
+    active: true
     threshold: 10
   TooManyFunctions:
+    active: true
     threshold: 10
   ComplexCondition:
+    active: true
     threshold: 3
   LabeledExpression:
     active: false


### PR DESCRIPTION
The EmptyConfig with the old behaviour of isActive check being true on default could lead to scared users. No one wants to use a tool which reports that your project has hundreds of code smells. The motivation bar is low. By just using the default configuration with a subset of all rules, we can achieve better adoption.

This should also resolve #407 