### PR TITLE
Update FunctionNaming regex to work for sentences

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -277,7 +277,7 @@ style:
     enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
   FunctionNaming:
     active: true
-    functionPattern: '^[a-z$][a-zA-Z$0-9]*$'
+    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$
   FunctionMaxLength:
     active: false
     maximumFunctionNameLength: 30

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/FunctionNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/FunctionNaming.kt
@@ -13,7 +13,7 @@ class FunctionNaming(config: Config = Config.empty) : SubRule<KtNamedFunction>(c
 	override val issue = Issue(javaClass.simpleName,
 			Severity.Style,
 			debt = Debt.FIVE_MINS)
-	private val functionPattern = Regex(valueOrDefault(FUNCTION_PATTERN, "^[a-z$][a-zA-Z$0-9]*$"))
+	private val functionPattern = Regex(valueOrDefault(FUNCTION_PATTERN, "^([a-z$][a-zA-Z$0-9]*)|(`.*`)$"))
 
 	override fun apply(element: KtNamedFunction) {
 		if (!element.identifierName().matches(functionPattern)) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NamingConventionViolationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NamingConventionViolationSpec.kt
@@ -200,8 +200,14 @@ class NamingConventionLengthSpec : SubjectSpek<NamingRules>({
 		assertThat(subject.findings).hasSize(1)
 	}
 
-	it("should report a function name that is okay") {
+	it("should not report a function name that is okay") {
 		val code = "private fun three = 3"
+		subject.lint(code)
+		assertThat(subject.findings).isEmpty()
+	}
+
+	it("should not report a function name that begins with a backtick, capitals, and spaces") {
+		val code = "private fun `Hi bye` = 3"
 		subject.lint(code)
 		assertThat(subject.findings).isEmpty()
 	}


### PR DESCRIPTION
Currently the FunctionNaming regex does not match for kotlin backtick
sentence style. This sentence style is very useful in tests.

This is an update to the regex that, if the function name begins with
backticks, to accept it no matter what

Closes #423