### PR TITLE
remove default description of modifier order rule

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
@@ -41,8 +41,7 @@ class ModifierOrder(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,
 			Severity.Style,
-			"Line detected that is longer than the defined maximum line length in the code style.",
-			Debt(mins = 1))
+			debt = Debt(mins = 1))
 
 	// subset of KtTokens.MODIFIER_KEYWORDS_ARRAY
 	private val order = arrayOf(


### PR DESCRIPTION
Resolves #452 

I did too much copy/paste a while back when writing this rule and missed removing the default description of the Issue.

As we always set a concrete description when reporting the Issue with the string: `Modifier order should be: <insert sorted list of modifiers>` I think it's okay to remove the default description alltogether.