### PR TITLE
correcly handle imports used in KDoc tags in UnusedImports rule

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -61,13 +61,14 @@ class UnusedImports(config: Config) : Rule(config) {
 	}
 
 	override fun visitDeclaration(dcl: KtDeclaration) {
-		dcl.docComment?.getDefaultSection()?.children
+		val kdoc = dcl.docComment?.getDefaultSection()
+
+		kdoc?.children
 				?.filter { it is KDocTag }
 				?.map { it.text }
 				?.forEach { handleKDoc(it) }
 
-
-		dcl.docComment?.getDefaultSection()?.getContent()?.let {
+		kdoc?.getContent()?.let {
 			handleKDoc(it)
 		}
 		super.visitDeclaration(dcl)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsTest.kt
@@ -118,4 +118,25 @@ class UnusedImportsTest : RuleTest {
             """
 		)).hasSize(3)
 	}
+
+	@Test
+	fun `imports used in KDoc tags`() {
+		val code = """
+			package com.acme
+
+			import com.acme.cathedral.TheDome   // here
+			import com.acme.bazar.SomeException // and here
+
+			/**
+			 * Do something.
+			 * @throws [SomeException] when ...
+			 * @see [TheDome.someMethod]
+			 */
+			fun doSomething() {
+				TODO()
+			}
+		"""
+
+		assertThat(rule.lint(code)).hasSize(0)
+	}
 }


### PR DESCRIPTION
Resolves #457

The `UnusedImports` rule did only take the Content of KDoc into account, but it did not visit any KDoc tags.
