### PR TITLE
Apply java-gradle-plugin to detekt-gradle-plugin

### DIFF
--- a/detekt-gradle-plugin/build.gradle
+++ b/detekt-gradle-plugin/build.gradle
@@ -9,6 +9,7 @@ buildscript {
 	}
 }
 
+apply plugin: "java-gradle-plugin"
 apply plugin: "com.gradle.plugin-publish"
 
 version = "$detektGradleVersion"
@@ -26,6 +27,15 @@ dependencies {
 	testRuntime "org.junit.platform:junit-platform-launcher:$junitPlatformVersion"
 	testRuntime "org.junit.platform:junit-platform-console:$junitPlatformVersion"
 	testRuntime "org.jetbrains.spek:spek-junit-platform-engine:$spekVersion"
+}
+
+gradlePlugin {
+	plugins {
+		detektPlugin {
+			id = 'io.gitlab.arturbosch.detekt'
+			implementationClass = 'io.gitlab.arturbosch.detekt.DetektPlugin'
+		}
+	}
 }
 
 pluginBundle {

--- a/detekt-gradle-plugin/src/main/resources/META-INF/gradle-plugins/io.gitlab.arturbosch.detekt.properties
+++ b/detekt-gradle-plugin/src/main/resources/META-INF/gradle-plugins/io.gitlab.arturbosch.detekt.properties
@@ -1,1 +1,0 @@
-implementation-class=io.gitlab.arturbosch.detekt.DetektPlugin


### PR DESCRIPTION
- validates task properties annotations
- generates plugin descriptors
- etc..

See https://docs.gradle.org/current/userguide/javaGradle_plugin.html