### PR TITLE
reword detekt timing message and use measureTimeMillis

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Runner.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.cli
 
 import io.gitlab.arturbosch.detekt.core.DetektFacade
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
+import kotlin.system.measureTimeMillis
 
 interface Executable {
 	fun execute()
@@ -15,12 +16,12 @@ class Runner(private val arguments: Args) : Executable {
 	override fun execute() {
 		val settings = createSettings()
 
-		val start = System.currentTimeMillis()
-		val detektion = DetektFacade.instance(settings).run()
-		val end = System.currentTimeMillis() - start
+		val time = measureTimeMillis {
+			val detektion = DetektFacade.instance(settings).run()
+			OutputFacade(arguments, detektion, settings).run()
+		}
 
-		OutputFacade(arguments, detektion, settings).run()
-		println("\ndetekt run within $end ms")
+		println("\ndetekt finished in $time ms.")
 	}
 
 	private fun createSettings(): ProcessingSettings {


### PR DESCRIPTION
I initially looked at this because "detekt run within 12345ms" is not really a correct sentence. So I changed to "detekt finished in x ms."

I think using `measureTimeMillis` is a good fit here. I now also included generating the outputs to the total time we calculate. Happy to change it back to only account for running detekt without the outputs if that's preferred.