### PR TITLE
Add message to CodeSmell

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -8,6 +8,7 @@ package io.gitlab.arturbosch.detekt.api
  */
 open class CodeSmell(final override val issue: Issue,
 					 override val entity: Entity,
+					 override val message: String,
 					 override val metrics: List<Metric> = listOf(),
 					 override val references: List<Entity> = listOf()) : Finding {
 
@@ -18,7 +19,12 @@ open class CodeSmell(final override val issue: Issue,
 	override fun compactWithSignature() = compact() + " - Signature=" + entity.signature
 
 	override fun toString(): String {
-		return "CodeSmell(issue=$issue, entity=$entity, metrics=$metrics, references=$references, id='$id')"
+		return "CodeSmell(issue=$issue, " +
+				"entity=$entity, " +
+				"message=$message, " +
+				"metrics=$metrics, " +
+				"references=$references, " +
+				"id='$id')"
 	}
 }
 
@@ -27,10 +33,10 @@ open class CodeSmell(final override val issue: Issue,
  * for the existence of this rule violation.
  */
 open class CodeSmellWithReferenceAndMetric(
-		issue: Issue, entity: Entity, val reference: Entity, metric: Metric) : ThresholdedCodeSmell(
-		issue, entity, metric, references = listOf(reference)) {
+		issue: Issue, entity: Entity, private val reference: Entity, message: String, metric: Metric) : ThresholdedCodeSmell(
+		issue, entity, metric, message, references = listOf(reference)) {
 
-	override fun compact() = "$id - $metric - ref=${reference.name} - ${entity.compact()}"
+	override fun compact() = "$id - $metric - ref=${reference.name} - ${entity.compact()} - message=$message"
 }
 
 /**
@@ -38,12 +44,16 @@ open class CodeSmellWithReferenceAndMetric(
  * for the existence of this rule violation.
  */
 open class ThresholdedCodeSmell(
-		issue: Issue, entity: Entity, val metric: Metric, references: List<Entity> = emptyList()) : CodeSmell(
-		issue, entity, metrics = listOf(metric), references = references) {
+		issue: Issue,
+		entity: Entity,
+		val metric: Metric,
+		message: String,
+		references: List<Entity> = emptyList()) : CodeSmell(
+		issue, entity, message, metrics = listOf(metric), references = references) {
 	val value: Int
 		get() = metric.value
 	val threshold: Int
 		get() = metric.threshold
 
-	override fun compact() = "$id - $metric - ${entity.compact()}"
+	override fun compact() = "$id - $metric - ${entity.compact()} = message=$message"
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -26,6 +26,11 @@ open class CodeSmell(final override val issue: Issue,
 				"references=$references, " +
 				"id='$id')"
 	}
+
+	override fun messageOrDescription() = when {
+		message.isEmpty() -> issue.description
+		else -> message
+	}
 }
 
 /**
@@ -36,7 +41,12 @@ open class CodeSmellWithReferenceAndMetric(
 		issue: Issue, entity: Entity, private val reference: Entity, message: String, metric: Metric) : ThresholdedCodeSmell(
 		issue, entity, metric, message, references = listOf(reference)) {
 
-	override fun compact() = "$id - $metric - ref=${reference.name} - ${entity.compact()} - message=$message"
+	override fun compact() = "$id - $metric - ref=${reference.name} - ${entity.compact()}"
+
+	override fun messageOrDescription() = when {
+		message.isEmpty() -> issue.description
+		else -> message
+	}
 }
 
 /**
@@ -55,5 +65,10 @@ open class ThresholdedCodeSmell(
 	val threshold: Int
 		get() = metric.threshold
 
-	override fun compact() = "$id - $metric - ${entity.compact()} = message=$message"
+	override fun compact() = "$id - $metric - ${entity.compact()}"
+
+	override fun messageOrDescription() = when {
+		message.isEmpty() -> issue.description
+		else -> message
+	}
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
@@ -15,6 +15,7 @@ interface Finding : Compactable, Reflective, HasEntity, HasMetrics {
 	val id: String
 	val issue: Issue
 	val references: List<Entity>
+	val message: String
 }
 
 /**

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
@@ -16,6 +16,8 @@ interface Finding : Compactable, Reflective, HasEntity, HasMetrics {
 	val issue: Issue
 	val references: List<Entity>
 	val message: String
+
+	fun messageOrDescription() : String
 }
 
 /**

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/MultiRuleTest.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/MultiRuleTest.kt
@@ -49,7 +49,7 @@ abstract class AbstractRule : Rule() {
 	override val issue: Issue = Issue(javaClass.simpleName, Severity.Minor)
 
 	override fun visitKtFile(file: KtFile) {
-		report(CodeSmell(issue, Entity.from(file)))
+		report(CodeSmell(issue, Entity.from(file), message = ""))
 	}
 }
 

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SuppressionSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SuppressionSpec.kt
@@ -96,7 +96,7 @@ class TestLM : Rule() {
 		val start = Location.startLineAndColumn(function.funKeyword!!).line
 		val end = Location.startLineAndColumn(function.lastBlockStatementOrThis()).line
 		val offset = end - start
-		if (offset > 10) report(CodeSmell(issue, Entity.from(function)))
+		if (offset > 10) report(CodeSmell(issue, Entity.from(function), message = ""))
 	}
 }
 
@@ -104,6 +104,6 @@ class TestLPL : Rule() {
 	override val issue = Issue("LongParameterList", Severity.CodeSmell, "")
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		val size = function.valueParameters.size
-		if (size > 5) report(CodeSmell(issue, Entity.from(function)))
+		if (size > 5) report(CodeSmell(issue, Entity.from(function), message = ""))
 	}
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/XmlOutputReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/XmlOutputReport.kt
@@ -30,16 +30,11 @@ class XmlOutputReport : OutputReport() {
 		smells.groupBy { it.location.file }.forEach { fileName, findings ->
 			lines += "<file name=\"${fileName.toXmlString()}\">"
 			findings.forEach {
-				val message = when {
-					it.message.isEmpty() -> it.issue.description
-					else -> it.message
-				}
-
 				lines += arrayOf(
 						"\t<error line=\"${it.location.source.line.toXmlString()}\"",
 						"column=\"${it.location.source.column.toXmlString()}\"",
 						"severity=\"${it.messageType.label.toXmlString()}\"",
-						"message=\"${message.toXmlString()}\"",
+						"message=\"${it.messageOrDescription().toXmlString()}\"",
 						"source=\"${"detekt.${it.id.toXmlString()}"}\" />"
 				).joinToString(separator = " ")
 			}

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/XmlOutputReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/XmlOutputReport.kt
@@ -30,11 +30,16 @@ class XmlOutputReport : OutputReport() {
 		smells.groupBy { it.location.file }.forEach { fileName, findings ->
 			lines += "<file name=\"${fileName.toXmlString()}\">"
 			findings.forEach {
+				val message = when {
+					it.message.isEmpty() -> it.issue.description
+					else -> it.message
+				}
+
 				lines += arrayOf(
 						"\t<error line=\"${it.location.source.line.toXmlString()}\"",
 						"column=\"${it.location.source.column.toXmlString()}\"",
 						"severity=\"${it.messageType.label.toXmlString()}\"",
-						"message=\"${it.issue.description.toXmlString()}\"",
+						"message=\"${message.toXmlString()}\"",
 						"source=\"${"detekt.${it.id.toXmlString()}"}\" />"
 				).joinToString(separator = " ")
 			}

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/XmlOutputFormatTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/XmlOutputFormatTest.kt
@@ -31,7 +31,7 @@ internal class XmlOutputFormatTest {
 
 	@Test
 	fun renderOneForSingleFile() {
-		val smell = CodeSmell(Issue("id_a", Severity.CodeSmell, ""), entity1)
+		val smell = CodeSmell(Issue("id_a", Severity.CodeSmell, ""), entity1, message = "")
 
 		val result = outputFormat.render(TestDetektion(smell))
 
@@ -41,8 +41,8 @@ internal class XmlOutputFormatTest {
 
 	@Test
 	fun renderTwoForSingleFile() {
-		val smell1 = CodeSmell(Issue("id_a", Severity.CodeSmell, ""), entity1)
-		val smell2 = CodeSmell(Issue("id_b", Severity.CodeSmell, ""), entity1)
+		val smell1 = CodeSmell(Issue("id_a", Severity.CodeSmell, ""), entity1, message = "")
+		val smell2 = CodeSmell(Issue("id_b", Severity.CodeSmell, ""), entity1, message = "")
 
 		val result = outputFormat.render(TestDetektion(smell1, smell2))
 
@@ -52,8 +52,8 @@ internal class XmlOutputFormatTest {
 
 	@Test
 	fun renderOneForMultipleFiles() {
-		val smell1 = CodeSmell(Issue("id_a", Severity.CodeSmell, ""), entity1)
-		val smell2 = CodeSmell(Issue("id_a", Severity.CodeSmell, ""), entity2)
+		val smell1 = CodeSmell(Issue("id_a", Severity.CodeSmell, ""), entity1, message = "")
+		val smell2 = CodeSmell(Issue("id_a", Severity.CodeSmell, ""), entity2, message = "")
 
 		val result = outputFormat.render(TestDetektion(smell1, smell2))
 
@@ -63,10 +63,10 @@ internal class XmlOutputFormatTest {
 
 	@Test
 	fun renderTwoForMultipleFiles() {
-		val smell1 = CodeSmell(Issue("id_a", Severity.CodeSmell, ""), entity1)
-		val smell2 = CodeSmell(Issue("id_b", Severity.CodeSmell, ""), entity1)
-		val smell3 = CodeSmell(Issue("id_a", Severity.CodeSmell, ""), entity2)
-		val smell4 = CodeSmell(Issue("id_b", Severity.CodeSmell, ""), entity2)
+		val smell1 = CodeSmell(Issue("id_a", Severity.CodeSmell, ""), entity1, message = "")
+		val smell2 = CodeSmell(Issue("id_b", Severity.CodeSmell, ""), entity1, message = "")
+		val smell3 = CodeSmell(Issue("id_a", Severity.CodeSmell, ""), entity2, message = "")
+		val smell4 = CodeSmell(Issue("id_b", Severity.CodeSmell, ""), entity2, message = "")
 
 		val result = outputFormat.render(TestDetektion(smell1, smell2, smell3, smell4))
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KT.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KT.kt
@@ -34,6 +34,6 @@ class TestProvider2(override val ruleSetId: String = "Test2") : RuleSetProvider 
 class FindName : Rule() {
 	override val issue: Issue = Issue(javaClass.simpleName, Severity.Minor)
 	override fun visitClassOrObject(classOrObject: KtClassOrObject) {
-		report(CodeSmell(issue, Entity.from(classOrObject)))
+		report(CodeSmell(issue, Entity.from(classOrObject), message = ""))
 	}
 }

--- a/detekt-migration/src/main/kotlin/io/gitlab/arturbosch/detekt/migration/ImportMigration.kt
+++ b/detekt-migration/src/main/kotlin/io/gitlab/arturbosch/detekt/migration/ImportMigration.kt
@@ -11,7 +11,8 @@ import io.gitlab.arturbosch.detekt.api.Severity
  */
 data class ImportMigration(private val toReplace: String,
 						   private val replacement: String,
-						   override val entity: Entity) : Finding {
+						   override val entity: Entity,
+						   override val message: String) : Finding {
 	override val id: String = "ImportMigration"
 	override val issue: Issue = Issue(id, Severity.Minor,
 			"$id - $toReplace migrated to $replacement @ ${entity.location.compact()}")

--- a/detekt-migration/src/main/kotlin/io/gitlab/arturbosch/detekt/migration/ImportMigration.kt
+++ b/detekt-migration/src/main/kotlin/io/gitlab/arturbosch/detekt/migration/ImportMigration.kt
@@ -19,4 +19,9 @@ data class ImportMigration(private val toReplace: String,
 	override val references: List<Entity> = emptyList()
 	override val metrics: List<Metric> = emptyList()
 	override fun compact(): String = issue.description
+
+	override fun messageOrDescription() = when {
+		message.isEmpty() -> issue.description
+		else -> message
+	}
 }

--- a/detekt-migration/src/main/kotlin/io/gitlab/arturbosch/detekt/migration/MigrateImportsRule.kt
+++ b/detekt-migration/src/main/kotlin/io/gitlab/arturbosch/detekt/migration/MigrateImportsRule.kt
@@ -36,7 +36,7 @@ class MigrateImportsRule(config: Config) : Rule(config) {
 						val importPath = ImportPath.fromString(it)
 						val newImport = factory.createImportDirectives(listOf(importPath)).toList()[0]
 						node.addChild(newImport.importedReference?.node!!)
-						report(ImportMigration(key!!, it, Entity.from(import)))
+						report(ImportMigration(key!!, it, Entity.from(import), message = ""))
 					}
 				}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/FeatureEnvy.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/FeatureEnvy.kt
@@ -75,7 +75,9 @@ class FeatureEnvy(config: Config = Config.empty) : Rule(config) {
 				println("factor: $value")
 				if (threshold < value) {
 					report(CodeSmellWithReferenceAndMetric(issue, entityOfFunction,
-							Entity.from(ktElement), Metric("FeatureEnvyFactor", value, threshold)))
+							Entity.from(ktElement),
+							message = "",
+							metric = Metric("FeatureEnvyFactor", value, threshold)))
 				}
 			}
 		}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
@@ -30,7 +30,7 @@ class DuplicateCaseInWhenExpression(config: Config) : Rule(config) {
 				.distinct().size
 
 		if (numberOfEntries > distinctNumber) {
-			report(CodeSmell(issue, Entity.from(expression)))
+			report(CodeSmell(issue, Entity.from(expression), message = ""))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
@@ -30,7 +30,7 @@ class EqualsAlwaysReturnsTrueOrFalse(config: Config = Config.empty) : Rule(confi
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		if (function.isEqualsFunction() && isReturningBooleanConstant(function)) {
-			report(CodeSmell(issue, Entity.from(function)))
+			report(CodeSmell(issue, Entity.from(function), message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
@@ -45,7 +45,7 @@ class EqualsWithHashCodeExist(config: Config = Config.empty) : Rule(config) {
 		}
 		queue.push(ViolationHolder())
 		super.visitClassOrObject(classOrObject)
-		if (queue.pop().violation()) report(CodeSmell(issue, Entity.from(classOrObject)))
+		if (queue.pop().violation()) report(CodeSmell(issue, Entity.from(classOrObject), message = ""))
 	}
 
 	override fun visitNamedFunction(function: KtNamedFunction) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
@@ -32,7 +32,7 @@ class ExplicitGarbageCollectionCall(config: Config) : Rule(config) {
 		if (it.textMatches("gc") || it.textMatches("runFinalization")) {
 			it.getReceiverExpression()?.let {
 				when (it.text) {
-					"System", "Runtime.getRuntime()" -> report(CodeSmell(issue, Entity.Companion.from(expression)))
+					"System", "Runtime.getRuntime()" -> report(CodeSmell(issue, Entity.Companion.from(expression), message = ""))
 				}
 			}
 		}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidLoopCondition.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidLoopCondition.kt
@@ -24,7 +24,7 @@ class InvalidLoopCondition(config: Config = Config.empty) : Rule(config) {
 		val loopRange = expression.loopRange
 		val range = loopRange?.children
 		if (range != null && range.size >= minimumSize && hasInvalidLoopRange(range)) {
-			report(CodeSmell(issue, Entity.from(loopRange)))
+			report(CodeSmell(issue, Entity.from(loopRange), message = ""))
 		}
 		super.visitForExpression(expression)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
@@ -26,7 +26,7 @@ class IteratorHasNextCallsNextMethod(config: Config = Config.empty) : Rule(confi
 		if (classOrObject.isImplementingIterator()) {
 			val hasNextMethod = classOrObject.getMethod("hasNext")
 			if (hasNextMethod != null && callsNextMethod(hasNextMethod)) {
-				report(CodeSmell(issue, Entity.from(classOrObject)))
+				report(CodeSmell(issue, Entity.from(classOrObject), message = ""))
 			}
 		}
 		super.visitClassOrObject(classOrObject)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
@@ -23,7 +23,7 @@ class IteratorNotThrowingNoSuchElementException(config: Config = Config.empty) :
 		if (classOrObject.isImplementingIterator()) {
 			val nextMethod = classOrObject.getMethod("next")
 			if (nextMethod != null && !nextMethod.throwsNoSuchElementExceptionThrown()) {
-				report(CodeSmell(issue, Entity.from(classOrObject)))
+				report(CodeSmell(issue, Entity.from(classOrObject), message = ""))
 			}
 		}
 		super.visitClassOrObject(classOrObject)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -42,7 +42,7 @@ class LateinitUsage(config: Config = Config.empty) : Rule(config) {
 		properties.filterNot { annotationExcluder.shouldExclude(it.annotationEntries) }
 				.filterNot { it.containingClass()?.name?.matches(ignoreOnClassesPattern) == true }
 				.forEach {
-					report(CodeSmell(issue, Entity.from(it)))
+					report(CodeSmell(issue, Entity.from(it), message = ""))
 				}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
@@ -23,7 +23,7 @@ class UnconditionalJumpStatementInLoop(config: Config = Config.empty) : Rule(con
 
 	override fun visitLoopExpression(loopExpression: KtLoopExpression) {
 		if (hasJumpStatement(loopExpression.body)) {
-			report(CodeSmell(issue, Entity.from(loopExpression)))
+			report(CodeSmell(issue, Entity.from(loopExpression), message = ""))
 		}
 		super.visitLoopExpression(loopExpression)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
@@ -41,7 +41,7 @@ class UnreachableCode(config: Config = Config.empty) : Rule(config) {
 		val statements = (expression.parent as? KtBlockExpression)?.statements ?: return
 		val indexOfStatement = statements.indexOf(expression)
 		if (indexOfStatement < statements.size - 1) {
-			report(CodeSmell(issue, Entity.from(expression)))
+			report(CodeSmell(issue, Entity.from(expression), message = ""))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
@@ -20,7 +20,7 @@ class UnsafeCallOnNullableType(config: Config = Config.empty) : Rule(config) {
 	override fun visitUnaryExpression(expression: KtUnaryExpression) {
 		super.visitUnaryExpression(expression)
 		if (expression.operationToken == KtTokens.EXCLEXCL) {
-			report(CodeSmell(issue, Entity.from(expression)))
+			report(CodeSmell(issue, Entity.from(expression), message = ""))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
@@ -19,7 +19,7 @@ class UnsafeCast(config: Config = Config.empty) : Rule(config) {
 
 	override fun visitBinaryWithTypeRHSExpression(expression: KtBinaryExpressionWithTypeRHS) {
 		if (KtPsiUtil.isUnsafeCast(expression)) {
-			report(CodeSmell(issue, Entity.from(expression)))
+			report(CodeSmell(issue, Entity.from(expression), message = ""))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
@@ -75,7 +75,7 @@ class UselessPostfixExpression(config: Config = Config.empty) : Rule(config) {
 	}
 
 	private fun report(postfixExpression: KtPostfixExpression) {
-		report(CodeSmell(issue, Entity.from(postfixExpression)))
+		report(CodeSmell(issue, Entity.from(postfixExpression), message = ""))
 	}
 
 	private fun getPostfixExpressionChilds(expression: KtExpression?) =

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameter.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameter.kt
@@ -25,7 +25,7 @@ class WrongEqualsTypeParameter(config: Config = Config.empty) : Rule(config) {
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		if (function.name == "equals" && !function.hasCorrectEqualsParameter()) {
-			report(CodeSmell(issue, Entity.from(function)))
+			report(CodeSmell(issue, Entity.from(function), message = ""))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
@@ -52,7 +52,10 @@ class ComplexCondition(config: Config = Config.empty,
 			val conditionString = longestBinExpr.text
 			val count = frequency(conditionString, "&&") + frequency(conditionString, "||") + 1
 			if (count > threshold) {
-				report(ThresholdedCodeSmell(issue, Entity.from(condition), Metric("SIZE", count, threshold)))
+				report(ThresholdedCodeSmell(issue,
+						Entity.from(condition),
+						Metric("SIZE", count, threshold),
+						message = ""))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
@@ -33,7 +33,10 @@ class ComplexInterface(config: Config = Config.empty,
 				size += countStaticDeclarations(klass.companionObject())
 			}
 			if (size > threshold) {
-				report(ThresholdedCodeSmell(issue, Entity.from(klass), Metric("SIZE: ", size, threshold)))
+				report(ThresholdedCodeSmell(issue,
+						Entity.from(klass),
+						Metric("SIZE: ", size, threshold),
+						message = ""))
 			}
 		}
 		super.visitClass(klass)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -26,7 +26,10 @@ class ComplexMethod(config: Config = Config.empty,
 		visitor.visitNamedFunction(function)
 		val mcc = visitor.mcc
 		if (mcc > threshold) {
-			report(ThresholdedCodeSmell(issue, Entity.from(function), Metric("MCC", mcc, threshold)))
+			report(ThresholdedCodeSmell(issue,
+					Entity.from(function),
+					Metric("MCC", mcc, threshold),
+					message = ""))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
@@ -19,7 +19,7 @@ class LabeledExpression(config: Config = Config.empty) : Rule(config) {
 	override fun visitExpressionWithLabel(expression: KtExpressionWithLabel) {
 		super.visitExpressionWithLabel(expression)
 		expression.getLabelName()?.let {
-			report(CodeSmell(issue, Entity.from(expression)))
+			report(CodeSmell(issue, Entity.from(expression), message = ""))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -56,7 +56,10 @@ class LargeClass(config: Config = Config.empty,
 		super.visitClassOrObject(classOrObject)
 		val loc = locStack.pop()
 		if (loc > threshold) {
-			report(ThresholdedCodeSmell(issue, Entity.from(classOrObject), Metric("SIZE", loc, threshold)))
+			report(ThresholdedCodeSmell(issue,
+					Entity.from(classOrObject),
+					Metric("SIZE", loc, threshold),
+					message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -27,7 +27,10 @@ class LongMethod(config: Config = Config.empty,
 		body?.let {
 			val size = body.statements.size
 			if (size > threshold) report(
-					ThresholdedCodeSmell(issue, Entity.from(function), Metric("SIZE", size, threshold)))
+					ThresholdedCodeSmell(issue,
+							Entity.from(function),
+							Metric("SIZE", size, threshold),
+							message = ""))
 		}
 		super.visitNamedFunction(function)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -31,7 +31,10 @@ class LongParameterList(config: Config = Config.empty,
 	private fun KtParameterList.checkThreshold() {
 		val size = parameters.size
 		if (size > threshold) {
-			report(ThresholdedCodeSmell(issue, Entity.from(this), Metric("SIZE", size, threshold)))
+			report(ThresholdedCodeSmell(issue,
+					Entity.from(this),
+					Metric("SIZE", size, threshold),
+					message = ""))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
@@ -41,7 +41,10 @@ class MethodOverloading(config: Config = Config.empty,
 
 		fun reportIfThresholdExceeded(element: PsiElement) {
 			methods.filterValues { it > threshold }.forEach {
-				report(ThresholdedCodeSmell(issue, Entity.from(element), Metric("OVERLOAD SIZE: ", it.value, threshold)))
+				report(ThresholdedCodeSmell(issue,
+						Entity.from(element),
+						Metric("OVERLOAD SIZE: ", it.value, threshold),
+						message = ""))
 			}
 		}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
@@ -33,7 +33,10 @@ class NestedBlockDepth(config: Config = Config.empty,
 		val visitor = FunctionDepthVisitor(threshold)
 		visitor.visitNamedFunction(function)
 		if (visitor.isTooDeep)
-			report(ThresholdedCodeSmell(issue, Entity.from(function), Metric("SIZE", visitor.maxDepth, threshold)))
+			report(ThresholdedCodeSmell(issue,
+					Entity.from(function),
+					Metric("SIZE", visitor.maxDepth, threshold),
+					message = ""))
 	}
 
 	private class FunctionDepthVisitor(val threshold: Int) : DetektVisitor() {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
@@ -33,7 +33,11 @@ class StringLiteralDuplication(
 		val type = "SIZE: "
 		for ((name, value) in visitor.getLiteralsOverThreshold()) {
 			val (main, references) = visitor.entitiesForLiteral(name)
-			report(ThresholdedCodeSmell(issue, main, Metric(type + name, value, threshold), references))
+			report(ThresholdedCodeSmell(issue,
+					main,
+					Metric(type + name, value, threshold),
+					"",
+					references))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -28,7 +28,10 @@ class TooManyFunctions(config: Config = Config.empty,
 	override fun visitKtFile(file: KtFile) {
 		super.visitKtFile(file)
 		if (amount > threshold) {
-			report(ThresholdedCodeSmell(issue, Entity.from(file), Metric("SIZE", amount, threshold)))
+			report(ThresholdedCodeSmell(issue,
+					Entity.from(file),
+					Metric("SIZE", amount, threshold),
+					message = ""))
 		}
 		amount = 0
 	}
@@ -39,8 +42,10 @@ class TooManyFunctions(config: Config = Config.empty,
 				?.size
 
 		if (amountOfFunctions != null && amountOfFunctions > threshold) {
-			report(ThresholdedCodeSmell(issue, Entity.from(classOrObject),
-					Metric("SIZE", amountOfFunctions, threshold)))
+			report(ThresholdedCodeSmell(issue,
+					Entity.from(classOrObject),
+					Metric("SIZE", amountOfFunctions, threshold),
+					message = ""))
 		}
 
 		super.visitClassOrObject(classOrObject)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
@@ -24,7 +24,7 @@ class CommentOverPrivateFunction(config: Config = Config.empty) : Rule(config) {
 		val modifierList = function.modifierList
 		if (modifierList != null && function.docComment != null) {
 			if (modifierList.hasModifier(KtTokens.PRIVATE_KEYWORD)) {
-				report(CodeSmell(issue, Entity.from(function.docComment!!)))
+				report(CodeSmell(issue, Entity.from(function.docComment!!), message = ""))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
@@ -22,7 +22,7 @@ class CommentOverPrivateProperty(config: Config = Config.empty) : Rule(config) {
 		val modifierList = property.modifierList
 		if (modifierList != null && property.docComment != null) {
 			if (modifierList.hasModifier(KtTokens.PRIVATE_KEYWORD)) {
-				report(CodeSmell(issue, Entity.from(property.docComment!!)))
+				report(CodeSmell(issue, Entity.from(property.docComment!!), message = ""))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -48,7 +48,7 @@ class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
 
 	private fun reportIfUndocumented(element: KtClassOrObject) {
 		if (element.isPublicNotOverridden() && element.notEnumEntry() && element.docComment == null) {
-			report(CodeSmell(issue, Entity.Companion.from(element)))
+			report(CodeSmell(issue, Entity.Companion.from(element), message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
@@ -24,11 +24,11 @@ class UndocumentedPublicFunction(config: Config = Config.empty) : Rule(config) {
 		val modifierList = function.modifierList
 		if (function.docComment == null) {
 			if (modifierList == null) {
-				report(CodeSmell(issue, methodHeaderLocation(function)))
+				report(CodeSmell(issue, methodHeaderLocation(function), message = ""))
 			}
 			if (modifierList != null) {
 				if (function.isPublicNotOverridden()) {
-					report(CodeSmell(issue, methodHeaderLocation(function)))
+					report(CodeSmell(issue, methodHeaderLocation(function), message = ""))
 				}
 			}
 		}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
@@ -12,7 +12,7 @@ class EmptyClassBlock(config: Config) : EmptyRule(config) {
 
 	override fun visitClassOrObject(classOrObject: KtClassOrObject) {
 		classOrObject.getBody()?.declarations?.let {
-			if (it.isEmpty()) report(CodeSmell(issue, Entity.from(classOrObject)))
+			if (it.isEmpty()) report(CodeSmell(issue, Entity.from(classOrObject), message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDefaultConstructor.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDefaultConstructor.kt
@@ -14,7 +14,7 @@ class EmptyDefaultConstructor(config: Config) : EmptyRule(config = config) {
 		if (hasPublicVisibility(constructor.visibilityModifierType())
 				&& constructor.annotationEntries.isEmpty()
 				&& constructor.valueParameters.isEmpty()) {
-			report(CodeSmell(issue, Entity.from(constructor)))
+			report(CodeSmell(issue, Entity.from(constructor), message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlock.kt
@@ -20,7 +20,7 @@ class EmptyIfBlock(config: Config) : EmptyRule(config) {
 	private fun checkThenBodyForLoneSemicolon(expression: KtIfExpression) {
 		val valueOfNextSibling = (expression.nextSibling as? LeafPsiElement)?.elementType as? KtSingleValueToken
 		if (valueOfNextSibling?.value?.trim() == ";") {
-			report(CodeSmell(issue, Entity.from(expression)))
+			report(CodeSmell(issue, Entity.from(expression), message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKtFile.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKtFile.kt
@@ -9,7 +9,7 @@ class EmptyKtFile(config: Config) : EmptyRule(config) {
 
 	override fun visitKtFile(file: KtFile) {
 		if (file.text.isNullOrBlank()) {
-			report(CodeSmell(issue, Entity.from(file)))
+			report(CodeSmell(issue, Entity.from(file), message = ""))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
@@ -24,7 +24,7 @@ abstract class EmptyRule(config: Config) : Rule(config) {
 	fun KtExpression.addFindingIfBlockExprIsEmpty() {
 		val blockExpression = this.asBlockExpression()
 		blockExpression?.statements?.let {
-			if (it.isEmpty() && !blockExpression.hasCommentInside()) report(CodeSmell(issue, Entity.from(this)))
+			if (it.isEmpty() && !blockExpression.hasCommentInside()) report(CodeSmell(issue, Entity.from(this), message = ""))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyWhenBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyWhenBlock.kt
@@ -12,7 +12,7 @@ class EmptyWhenBlock(config: Config) : EmptyRule(config) {
 
 	override fun visitWhenExpression(expression: KtWhenExpression) {
 		if (expression.entries.isEmpty()) {
-			report(CodeSmell(issue, Entity.from(expression)))
+			report(CodeSmell(issue, Entity.from(expression), message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
@@ -22,13 +22,13 @@ class ExceptionRaisedInUnexpectedLocation(config: Config = Config.empty) : Rule(
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		if (isPotentialMethod(function) && hasThrowExpression(function.bodyExpression)) {
-			report(CodeSmell(issue, Entity.from(function)))
+			report(CodeSmell(issue, Entity.from(function), message = ""))
 		}
 	}
 
 	override fun visitClassInitializer(initializer: KtClassInitializer) {
 		if (hasThrowExpression(initializer.body)) {
-			report(CodeSmell(issue, Entity.from(initializer)))
+			report(CodeSmell(issue, Entity.from(initializer), message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForException.kt
@@ -20,11 +20,11 @@ class InstanceOfCheckForException(config: Config = Config.empty) : Rule(config) 
 
 	override fun visitCatchSection(catchClause: KtCatchClause) {
 		catchClause.catchBody?.collectByType<KtIsExpression>()?.forEach {
-			report(CodeSmell(issue, Entity.from(it)))
+			report(CodeSmell(issue, Entity.from(it), message = ""))
 		}
 		catchClause.catchBody?.collectByType<KtBinaryExpressionWithTypeRHS>()?.forEach {
 			if (KtPsiUtil.isUnsafeCast(it)) {
-				report(CodeSmell(issue, Entity.from(it)))
+				report(CodeSmell(issue, Entity.from(it), message = ""))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclaration.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclaration.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtThrowExpression
 import org.jetbrains.kotlin.resolve.calls.callUtil.getCalleeExpressionIfAny
 
@@ -22,7 +21,7 @@ class NotImplementedDeclaration(config: Config = Config.empty) : Rule(config) {
 	override fun visitThrowExpression(expression: KtThrowExpression) {
 		val calleeExpression = expression.thrownExpression?.getCalleeExpressionIfAny()
 		if (calleeExpression?.text == "NotImplementedError") {
-			report(CodeSmell(issue, Entity.from(expression)))
+			report(CodeSmell(issue, Entity.from(expression), message = ""))
 		}
 	}
 
@@ -30,7 +29,7 @@ class NotImplementedDeclaration(config: Config = Config.empty) : Rule(config) {
 		if (expression.calleeExpression?.text == "TODO") {
 			val size = expression.valueArguments.size
 			if (size == 0 || size == 1) {
-				report(CodeSmell(issue, Entity.from(expression)))
+				report(CodeSmell(issue, Entity.from(expression), message = ""))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTrace.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTrace.kt
@@ -25,14 +25,14 @@ class PrintStackTrace(config: Config = Config.empty) : Rule(config) {
 		val callNameExpression = expression.getCallNameExpression()
 		if (callNameExpression?.text == "dumpStack"
 				&& callNameExpression.getReceiverExpression()?.text == "Thread") {
-			report(CodeSmell(issue, Entity.from(expression)))
+			report(CodeSmell(issue, Entity.from(expression), message = ""))
 		}
 	}
 
 	override fun visitCatchSection(catchClause: KtCatchClause) {
 		catchClause.catchBody?.collectByType<KtNameReferenceExpression>()?.forEach {
 			if (it.text == catchClause.catchParameter?.name && hasPrintStacktraceCallExpression(it)) {
-				report(CodeSmell(issue, Entity.from(it)))
+				report(CodeSmell(issue, Entity.from(it), message = ""))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtException.kt
@@ -22,7 +22,7 @@ class RethrowCaughtException(config: Config = Config.empty) : Rule(config) {
 			it.thrownExpression?.text == catchClause.catchParameter?.name
 		}
 		if (throwExpression != null) {
-			report(CodeSmell(issue, Entity.from(throwExpression)))
+			report(CodeSmell(issue, Entity.from(throwExpression), message = ""))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
@@ -22,7 +22,7 @@ class ReturnFromFinally(config: Config = Config.empty) : Rule(config) {
 		val innerFunctions = finallySection.finalExpression.collectByType<KtNamedFunction>()
 		returnExpressions.forEach {
 			if (isNotInInnerFunction(it, innerFunctions)) {
-				report(CodeSmell(issue, Entity.from(it)))
+				report(CodeSmell(issue, Entity.from(it), message = ""))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -18,7 +18,7 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
 
 	override fun visitCatchSection(catchClause: KtCatchClause) {
 		if (isExceptionSwallowed(catchClause) == true) {
-			report(CodeSmell(issue, Entity.from(catchClause)))
+			report(CodeSmell(issue, Entity.from(catchClause), message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinally.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinally.kt
@@ -18,7 +18,7 @@ class ThrowingExceptionFromFinally(config: Config = Config.empty) : Rule(config)
 	override fun visitFinallySection(finallySection: KtFinallySection) {
 		val throwExpressions = finallySection.finalExpression.collectByType<KtThrowExpression>()
 		throwExpressions.forEach {
-			report(CodeSmell(issue, Entity.from(it)))
+			report(CodeSmell(issue, Entity.from(it), message = ""))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
@@ -20,7 +20,7 @@ class ThrowingExceptionInMain(config: Config = Config.empty) : Rule(config) {
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		if (isMainFunction(function) && hasArgsParameter(function.valueParameters) && containsThrowExpression(function)) {
-			report(CodeSmell(issue, Entity.from(function)))
+			report(CodeSmell(issue, Entity.from(function), message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
@@ -23,7 +23,7 @@ class ThrowingExceptionsWithoutMessageOrCause(config: Config = Config.empty) : R
 	override fun visitCallExpression(expression: KtCallExpression) {
 		val calleeExpressionText = expression.calleeExpression?.text
 		if (exceptions.contains(calleeExpressionText) && expression.valueArguments.isEmpty()) {
-			report(CodeSmell(issue, Entity.from(expression)))
+			report(CodeSmell(issue, Entity.from(expression), message = ""))
 		}
 		super.visitCallExpression(expression)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameException.kt
@@ -27,7 +27,7 @@ class ThrowingNewInstanceOfSameException(config: Config = Config.empty) : Rule(c
 					&& hasSameExceptionParameter(thrownExpression.valueArguments, parameterName)
 		}
 		if (throwExpression != null) {
-			report(CodeSmell(issue, Entity.from(throwExpression)))
+			report(CodeSmell(issue, Entity.from(throwExpression), message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
@@ -24,7 +24,7 @@ class TooGenericExceptionCaught(config: Config) : Rule(config) {
 		catchClause.catchParameter?.let {
 			val text = it.typeReference?.text
 			if (text != null && text in exceptions)
-				report(CodeSmell(issue, Entity.from(it)))
+				report(CodeSmell(issue, Entity.from(it), message = ""))
 		}
 		super.visitCatchSection(catchClause)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
@@ -22,7 +22,7 @@ class TooGenericExceptionThrown(config: Config) : Rule(config) {
 
 	override fun visitThrowExpression(expression: KtThrowExpression) {
 		expression.thrownExpression?.text?.substringBefore("(")?.let {
-			if (it in exceptions) report(CodeSmell(issue, Entity.from(expression)))
+			if (it in exceptions) report(CodeSmell(issue, Entity.from(expression), message = ""))
 		}
 		super.visitThrowExpression(expression)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
@@ -25,7 +25,7 @@ class ForEachOnRange(config: Config = Config.empty) : Rule(config) {
 
 			it.getReceiverExpression()?.text?.let {
 				if (it matches rangeRegex) {
-					report(CodeSmell(issue, Entity.from(expression)))
+					report(CodeSmell(issue, Entity.from(expression), message = ""))
 				}
 			}
 		}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
@@ -21,7 +21,7 @@ class SpreadOperator(config: Config = Config.empty) : Rule(config) {
 		super.visitValueArgumentList(list)
 		list.arguments.filter { it.getSpreadElement() != null }
 				.forEach {
-					report(CodeSmell(issue, Entity.from(list)))
+					report(CodeSmell(issue, Entity.from(list), message = ""))
 				}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiation.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiation.kt
@@ -20,7 +20,7 @@ class UnnecessaryTemporaryInstantiation(config: Config = Config.empty) : Rule(co
 	override fun visitCallExpression(expression: KtCallExpression) {
 		if (isPrimitiveWrapperType(expression.calleeExpression)
 				&& isToStringMethod(expression.nextSibling?.nextSibling)) {
-			report(CodeSmell(issue, Entity.from(expression)))
+			report(CodeSmell(issue, Entity.from(expression), message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollabsibleIfStatements.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollabsibleIfStatements.kt
@@ -21,7 +21,7 @@ class CollapsibleIfStatements(config: Config = Config.empty) : Rule(config) {
 
 	override fun visitIfExpression(expression: KtIfExpression) {
 		if (isNotElseIfOrElse(expression) && hasOneKtIfExpression(expression)) {
-			report(CodeSmell(issue, Entity.from(expression)))
+			report(CodeSmell(issue, Entity.from(expression), message = ""))
 		}
 		super.visitIfExpression(expression)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
@@ -31,7 +31,7 @@ class DataClassContainsFunctions(config: Config = Config.empty) : Rule(config) {
 
 	private fun checkFunction(function: KtNamedFunction) {
 		if (!function.isOverridden() && !conversionFunctionPrefix.startWith(function.name)) {
-			report(CodeSmell(issue, Entity.from(function)))
+			report(CodeSmell(issue, Entity.from(function), message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCall.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCall.kt
@@ -15,7 +15,7 @@ class EqualsNullCall(config: Config = Config.empty) : Rule(config) {
 
 	override fun visitCallExpression(expression: KtCallExpression) {
 		if (expression.calleeExpression?.text == "equals" && hasNullParameter(expression)) {
-			report(CodeSmell(issue, Entity.from(expression)))
+			report(CodeSmell(issue, Entity.from(expression), message = ""))
 		} else {
 			super.visitCallExpression(expression)
 		}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
@@ -28,7 +28,7 @@ class ExpressionBodySyntax(config: Config = Config.empty) : Rule(config) {
 		if (function.bodyExpression != null) {
 			val body = function.bodyExpression!!
 			body.singleReturnStatement()?.let { returnStmt ->
-				report(CodeSmell(issue, Entity.from(returnStmt)))
+				report(CodeSmell(issue, Entity.from(returnStmt), message = ""))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
@@ -46,7 +46,7 @@ class MaxLineLength(config: Config = Config.empty) : SubRule<KtFileContent>(conf
 		lines.forEach { line ->
 			offset += line.length
 			if (!isValidLine(line)) {
-				report(CodeSmell(issue, Entity.from(file, offset)))
+				report(CodeSmell(issue, Entity.from(file, offset), message = ""))
 			}
 
 			offset += 1 /* '\n' */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -28,7 +28,7 @@ class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
 
 		values.forEach {
 			if (text.contains(it, ignoreCase = true)) {
-				report(CodeSmell(issue, Entity.from(comment)))
+				report(CodeSmell(issue, Entity.from(comment), message = ""))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -25,7 +25,7 @@ class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
 				.imports
 				.filterNot { it.isAllUnder }
 				.filter { forbiddenImports.contains(it.importedFqName?.asString() ?: "") }
-				.forEach { report(CodeSmell(issue, Entity.from(it))) }
+				.forEach { report(CodeSmell(issue, Entity.from(it), message = "")) }
 	}
 
 	companion object {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -28,7 +28,7 @@ class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		if (checkOverridableFunction(function) && isNotExcluded(function) && isReturningAConstant(function)) {
-			report(CodeSmell(issue, Entity.from(function)))
+			report(CodeSmell(issue, Entity.from(function), message = ""))
 		}
 		super.visitNamedFunction(function)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
@@ -24,7 +24,7 @@ class LoopWithTooManyJumpStatements(config: Config = Config.empty) : Rule(config
 
 	override fun visitLoopExpression(loopExpression: KtLoopExpression) {
 		if (countBreakAndReturnStatements(loopExpression.body) > maxJumpCount) {
-			report(CodeSmell(issue, Entity.from(loopExpression)))
+			report(CodeSmell(issue, Entity.from(loopExpression), message = ""))
 		}
 		super.visitLoopExpression(loopExpression)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -62,7 +62,7 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
 		val number = parseAsDoubleOrNull(rawNumber) ?: return
 		if (!ignoredNumbers.contains(number)) {
-			report(CodeSmell(issue, Entity.from(expression)))
+			report(CodeSmell(issue, Entity.from(expression), message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
@@ -75,7 +75,7 @@ class ModifierOrder(config: Config = Config.empty) : Rule(config) {
 			val modifierString = sortedModifiers.joinToString(" ") { it.text }
 
 			report(CodeSmell(Issue(javaClass.simpleName, Severity.Style,
-					"Modifier order should be: $modifierString", Debt(mins = 1)), Entity.from(list)))
+					"Modifier order should be: $modifierString", Debt(mins = 1)), Entity.from(list), message = ""))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
@@ -29,7 +29,10 @@ class NestedClassesVisibility(config: Config = Config.empty) : Rule(config) {
 		klass.declarations
 				.filterIsInstance<KtClass>()
 				.filter { it.isPublic() && !it.isEnum() && it !is KtEnumEntry }
-				.forEach { report(CodeSmell(issue, Entity.from(it)))
+				.forEach { report(CodeSmell(issue,
+						Entity.from(it),
+						"Nested types are often used for implementing private functionality. " +
+								"However the visibility of ${klass.name} makes it visible externally."))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
@@ -19,7 +19,7 @@ class NewLineAtEndOfFile(config: Config = Config.empty) : Rule(config) {
 	override fun visitKtFile(file: KtFile) {
 		val text = file.text
 		if (text.isNotEmpty() && text.last() != '\n') {
-			report(CodeSmell(issue, Entity.from(file, text.length - 1)))
+			report(CodeSmell(issue, Entity.from(file, text.length - 1), message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeyword.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeyword.kt
@@ -33,7 +33,7 @@ class OptionalAbstractKeyword(config: Config = Config.empty) : Rule(config) {
 		dcl.modifierList?.let {
 			val abstractModifier = it.getModifier(KtTokens.ABSTRACT_KEYWORD)
 			if (abstractModifier != null) {
-				report(CodeSmell(issue, Entity.from(dcl)))
+				report(CodeSmell(issue, Entity.from(dcl), message = ""))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBraces.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBraces.kt
@@ -20,7 +20,7 @@ class OptionalWhenBraces(config: Config = Config.empty) : Rule(config) {
 		for (entry in expression.entries) {
 			val blockExpression = entry.expression as? KtBlockExpression
 			if (hasOneStatement(blockExpression) && hasOptionalBrace(blockExpression)) {
-				report(CodeSmell(issue, Entity.from(entry)))
+				report(CodeSmell(issue, Entity.from(entry), message = ""))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/PackageDeclarationStyle.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/PackageDeclarationStyle.kt
@@ -51,7 +51,7 @@ class PackageDeclarationStyle(config: Config = Config.empty) : Rule(config) {
 		if (element is PsiWhiteSpace || element is KtElement) {
 			val count = element.text.count { it == '\n' }
 			if (count != 2) {
-				report(CodeSmell(issue, Entity.from(element)))
+				report(CodeSmell(issue, Entity.from(element), message = ""))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
@@ -45,7 +45,7 @@ class ProtectedMemberInFinalClass(config: Config = Config.empty) : Rule(config) 
 
 		override fun visitDeclaration(dcl: KtDeclaration) {
 			if (dcl.isProtected() && !dcl.isOverridden()) {
-				report(CodeSmell(issue, Entity.from(dcl)))
+				report(CodeSmell(issue, Entity.from(dcl), message = ""))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
@@ -41,9 +41,10 @@ class RedundantVisibilityModifierRule(config: Config = Config.empty) : Rule(conf
 		override fun visitClass(klass: KtClass) {
 			super.visitClass(klass)
 			if (klass.isExplicitlyPublic()) {
-				report(CodeSmell(issue.copy(description = "${klass.name} is explicitly marked as public. " +
-						"Public is the default visibility for classes. The public modifier is redundant."),
-						Entity.from(klass))
+				report(CodeSmell(issue,
+						Entity.from(klass),
+						message = "${klass.name} is explicitly marked as public. " +
+						"Public is the default visibility for classes. The public modifier is redundant.")
 				)
 			}
 		}
@@ -53,9 +54,10 @@ class RedundantVisibilityModifierRule(config: Config = Config.empty) : Rule(conf
 		override fun visitNamedFunction(function: KtNamedFunction) {
 			super.visitNamedFunction(function)
 			if (function.isExplicitlyPublicNotOverridden()) {
-				report(CodeSmell(issue.copy(description = "${function.name} is explicitly marked as public. " +
-						"Functions are public by default so this modifier is redundant."),
-						Entity.from(function))
+				report(CodeSmell(issue,
+						Entity.from(function),
+						message = "${function.name} is explicitly marked as public. " +
+						"Functions are public by default so this modifier is redundant.")
 				)
 			}
 		}
@@ -63,9 +65,10 @@ class RedundantVisibilityModifierRule(config: Config = Config.empty) : Rule(conf
 		override fun visitProperty(property: KtProperty) {
 			super.visitProperty(property)
 			if (property.isExplicitlyPublicNotOverridden()) {
-				report(CodeSmell(issue.copy(description = "${property.name} is explicitly marked as public. " +
-						"Properties are public by default so this modifier is redundant."),
-						Entity.from(property))
+				report(CodeSmell(issue,
+						Entity.from(property),
+						message = "${property.name} is explicitly marked as public. " +
+						"Properties are public by default so this modifier is redundant.")
 				)
 			}
 		}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -24,7 +24,7 @@ class ReturnCount(config: Config = Config.empty) : Rule(config) {
 		val numberOfReturns = function.collectByType<KtReturnExpression>().count()
 
 		if (numberOfReturns > max) {
-			report(CodeSmell(issue, Entity.from(function)))
+			report(CodeSmell(issue, Entity.from(function), message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
@@ -47,6 +47,6 @@ class SafeCast(config: Config = Config.empty) : Rule(config) {
 	}
 
 	private fun addReport(expression: KtIfExpression) {
-		report(CodeSmell(issue, Entity.from(expression)))
+		report(CodeSmell(issue, Entity.from(expression), message = ""))
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClass.kt
@@ -28,7 +28,7 @@ class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(
 		if (!klass.isInterface() && isImplementingSerializable(klass)) {
 			val companionObject = klass.companionObject()
 			if (companionObject == null || !hasCorrectSerialVersionUUID(companionObject)) {
-				report(CodeSmell(issue, Entity.from(klass)))
+				report(CodeSmell(issue, Entity.from(klass), message = ""))
 			}
 		}
 		super.visitClass(klass)
@@ -38,7 +38,7 @@ class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(
 		if (!declaration.isCompanion()
 				&& isImplementingSerializable(declaration)
 				&& !hasCorrectSerialVersionUUID(declaration)) {
-			report(CodeSmell(issue, Entity.from(declaration)))
+			report(CodeSmell(issue, Entity.from(declaration), message = ""))
 		}
 		super.visitObjectDeclaration(declaration)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
@@ -25,7 +25,7 @@ class ThrowsCount(config: Config = Config.empty) : Rule(config) {
 		if (!function.hasModifier(KtTokens.OVERRIDE_KEYWORD)) {
 			val count = function.collectByType<KtThrowExpression>().count()
 			if (count > max) {
-				report(CodeSmell(issue, Entity.from(function)))
+				report(CodeSmell(issue, Entity.from(function), message = ""))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -40,11 +40,13 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
 		fun detectAbstractAndConcreteType() {
 			val indexOfFirstAbstractMember = indexOfFirstMember(true)
 			if (indexOfFirstAbstractMember == -1) {
-				report(CodeSmell(issue.copy(description =
-						"An abstract class without an abstract member can be refactored to a concrete class."), Entity.from(klass)))
+				report(CodeSmell(issue,
+						Entity.from(klass),
+						"An abstract class without an abstract member can be refactored to a concrete class."))
 			} else if (indexOfFirstAbstractMember == 0 && hasNoConcreteMemberLeft()) {
-				report(CodeSmell(issue.copy(description =
-						"An abstract class without a concrete member can be refactored to an interface."), Entity.from(klass)))
+				report(CodeSmell(issue,
+						Entity.from(klass),
+						"An abstract class without a concrete member can be refactored to an interface."))
 			}
 		}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritance.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritance.kt
@@ -23,7 +23,7 @@ class UnnecessaryInheritance(config: Config = Config.empty) : Rule(config) {
 		}
 	}
 
-	private fun report(classOrObject: KtClassOrObject, newDescription: String) {
-		report(CodeSmell(issue.copy(description = newDescription), Entity.from(classOrObject)))
+	private fun report(classOrObject: KtClassOrObject, message: String) {
+		report(CodeSmell(issue, Entity.from(classOrObject), message))
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
@@ -20,15 +20,15 @@ import org.jetbrains.kotlin.psi.KtValueArgument
 class UnnecessaryParentheses(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue("UnnecessaryParentheses", Severity.Style,
-			"These parentheses are unnecessary and can be removed.")
+			"Unnecessary parentheses don't add any value to the code and should be removed.")
 
 	override fun visitParenthesizedExpression(expression: KtParenthesizedExpression) {
 		super.visitParenthesizedExpression(expression)
 
 		if (KtPsiUtil.areParenthesesUseless(expression)) {
-			val description = "Parentheses in ${expression.text} are unnecessary and can be replaced with: " +
+			val message = "Parentheses in ${expression.text} are unnecessary and can be replaced with: " +
 					"${KtPsiUtil.deparenthesize(expression)?.text}"
-			report(CodeSmell(issue.copy(description = description), Entity.from(expression)))
+			report(CodeSmell(issue, Entity.from(expression), message))
 		}
 	}
 
@@ -40,8 +40,8 @@ class UnnecessaryParentheses(config: Config = Config.empty) : Rule(config) {
 		val isSuperTypeCallEntry = argument.parent.parent is KtSuperTypeCallEntry
 
 		if (isLambdaExpression && isOnlyArgument && !isSuperTypeCallEntry) {
-			val description = "Parentheses around the lambda ${argument.parent.text} are unnecessary and can be removed."
-			report(CodeSmell(issue.copy(description = description), Entity.from(argument.parent)))
+			val message = "Parentheses around the lambda ${argument.parent.text} are unnecessary and can be removed."
+			report(CodeSmell(issue, Entity.from(argument.parent), message))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -36,7 +36,7 @@ class UnusedImports(config: Config) : Rule(config) {
 	override fun visitFile(file: PsiFile?) {
 		imports.clear()
 		super.visitFile(file)
-		imports.forEach { report(CodeSmell(issue, Entity.from(it.second))) }
+		imports.forEach { report(CodeSmell(issue, Entity.from(it.second), message = "")) }
 	}
 
 	override fun visitImportList(importList: KtImportList) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -44,7 +44,7 @@ class UseDataClass(config: Config = Config.empty) : Rule(config) {
 			val containsPropertyOrPropertyParameters = properties.isNotEmpty() || propertyParameters.isNotEmpty()
 
 			if (containsFunctions && containsPropertyOrPropertyParameters) {
-				report(CodeSmell(issue, Entity.from(klass)))
+				report(CodeSmell(issue, Entity.from(klass), message = ""))
 			}
 		}
 		super.visitClass(klass)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
@@ -27,7 +27,7 @@ class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(co
 		if (!klass.isInterface()) {
 			val declarations = klass.getBody()?.declarations
 			if (hasOnlyUtilityClassMembers(declarations) && hasPublicConstructor(klass)) {
-				report(CodeSmell(issue, Entity.from(klass)))
+				report(CodeSmell(issue, Entity.from(klass), message = ""))
 			}
 		}
 		super.visitClass(klass)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -35,7 +35,7 @@ class WildcardImport(config: Config = Config.empty) : Rule(config) {
 			if (excludedImports.contains(import)) {
 				return
 			}
-			report(CodeSmell(issue, Entity.from(importDirective)))
+			report(CodeSmell(issue, Entity.from(importDirective), message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ClassNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ClassNaming.kt
@@ -13,14 +13,16 @@ class ClassNaming(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,
 			Severity.Style,
+			"A classes name should fit the naming pattern defined in the projects configuration.",
 			debt = Debt.FIVE_MINS)
 	private val classPattern = Regex(valueOrDefault(CLASS_PATTERN, "^[A-Z$][a-zA-Z$]*$"))
 
 	override fun visitClassOrObject(classOrObject: KtClassOrObject) {
 		if (!classOrObject.identifierName().matches(classPattern)) {
 			report(CodeSmell(
-					issue.copy(description = "Class and Object names should match the pattern: $classPattern"),
-					Entity.from(classOrObject)))
+					issue,
+					Entity.from(classOrObject),
+					message = "Class and Object names should match the pattern: $classPattern"))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ConstantNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ConstantNaming.kt
@@ -14,6 +14,7 @@ class ConstantNaming(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,
 			Severity.Style,
+			"Constants names should follow the naming convention set in the projects configuraiton.",
 			debt = Debt.FIVE_MINS)
 
 	private val constantPattern = Regex(valueOrDefault(CONSTANT_PATTERN, "^([A-Z_]*|serialVersionUID)$"))
@@ -21,8 +22,9 @@ class ConstantNaming(config: Config = Config.empty) : Rule(config) {
 	override fun visitProperty(property: KtProperty) {
 		if (doesntMatchPattern((property))) {
 			report(CodeSmell(
-					issue.copy(description = "Constant names should match the pattern: $constantPattern"),
-					Entity.from(property)))
+					issue,
+					Entity.from(property),
+					message = "Constant names should match the pattern: $constantPattern"))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/EnumNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/EnumNaming.kt
@@ -13,14 +13,16 @@ class EnumNaming(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,
 			Severity.Style,
+			"Enum names should follow the naming convention set in the projects configuration.",
 			debt = Debt.FIVE_MINS)
 	private val enumEntryPattern = Regex(valueOrDefault(ENUM_PATTERN, "^[A-Z$][a-zA-Z_$]*$"))
 
 	override fun visitEnumEntry(enumEntry: KtEnumEntry) {
 		if (!enumEntry.identifierName().matches(enumEntryPattern)) {
 			report(CodeSmell(
-					issue.copy(description = "Enum entry names should match the pattern: $enumEntryPattern"),
-					Entity.from(enumEntry)))
+					issue,
+					Entity.from(enumEntry),
+					message = "Enum entry names should match the pattern: $enumEntryPattern"))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ForbiddenClassName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ForbiddenClassName.kt
@@ -22,11 +22,11 @@ class ForbiddenClassName(config: Config = Config.empty) : Rule(config) {
 		val forbiddenEntries = forbiddenNames.matches(name)
 
 		if (forbiddenEntries.isNotEmpty()) {
-			var description = "Class name $name is forbidden as it contains:"
-			forbiddenEntries.forEach { description += " $it," }
-			description.trimEnd { it == ',' }
+			var message = "Class name $name is forbidden as it contains:"
+			forbiddenEntries.forEach { message += " $it," }
+			message.trimEnd { it == ',' }
 
-			report(CodeSmell(issue.copy(description = description), Entity.from(classOrObject)))
+			report(CodeSmell(issue, Entity.from(classOrObject), message))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/FunctionMaxLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/FunctionMaxLength.kt
@@ -13,6 +13,7 @@ class FunctionMaxLength(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,
 			Severity.Style,
+			"Function names should not be longer than the maximum set in the project configuration.",
 			debt = Debt.FIVE_MINS)
 	private val maximumFunctionNameLength =
 			valueOrDefault(MAXIMUM_FUNCTION_NAME_LENGTH, DEFAULT_MAXIMUM_FUNCTION_NAME_LENGTH)
@@ -20,8 +21,9 @@ class FunctionMaxLength(config: Config = Config.empty) : Rule(config) {
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		if (function.identifierName().length > maximumFunctionNameLength) {
 			report(CodeSmell(
-					issue.copy(description = "Function names should be at most $maximumFunctionNameLength characters long."),
-					Entity.from(function)))
+					issue,
+					Entity.from(function),
+					message = "Function names should be at most $maximumFunctionNameLength characters long."))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/FunctionMinLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/FunctionMinLength.kt
@@ -13,6 +13,7 @@ class FunctionMinLength(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,
 			Severity.Style,
+			"Function names should not be shorter than the minimum defined in the configuration.",
 			debt = Debt.FIVE_MINS)
 	private val minimumFunctionNameLength
 			= valueOrDefault(MINIMUM_FUNCTION_NAME_LENGTH, DEFAULT_MINIMUM_FUNCTION_NAME_LENGTH)
@@ -20,8 +21,9 @@ class FunctionMinLength(config: Config = Config.empty) : Rule(config) {
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		if (function.identifierName().length < minimumFunctionNameLength) {
 			report(CodeSmell(
-					issue.copy(description = "Function names should be at least $minimumFunctionNameLength characters long."),
-					Entity.from(function)))
+					issue,
+					Entity.from(function),
+					message = "Function names should be at least $minimumFunctionNameLength characters long."))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/FunctionNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/FunctionNaming.kt
@@ -13,14 +13,16 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,
 			Severity.Style,
+			"Function names should follow the naming convention set in the configuration.",
 			debt = Debt.FIVE_MINS)
 	private val functionPattern = Regex(valueOrDefault(FUNCTION_PATTERN, "^([a-z$][a-zA-Z$0-9]*)|(`.*`)$"))
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		if (!function.identifierName().matches(functionPattern)) {
 			report(CodeSmell(
-					issue.copy(description = "Function names should match the pattern: $functionPattern"),
-					Entity.from(function)))
+					issue,
+					Entity.from(function),
+					message = "Function names should match the pattern: $functionPattern"))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/PackageNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/PackageNaming.kt
@@ -13,6 +13,7 @@ class PackageNaming(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,
 			Severity.Style,
+			"Package names should match the naming convention set in the configuration.",
 			debt = Debt.FIVE_MINS)
 	private val packagePattern = Regex(valueOrDefault(PACKAGE_PATTERN, "^[a-z]+(\\.[a-z][a-z0-9]*)*$"))
 
@@ -20,8 +21,9 @@ class PackageNaming(config: Config = Config.empty) : Rule(config) {
 		val name = directive.qualifiedName
 		if (name.isNotEmpty() && !name.matches(packagePattern)) {
 			report(CodeSmell(
-					issue.copy(description = "Package name should match the pattern: $packagePattern"),
-					Entity.from(directive)))
+					issue,
+					Entity.from(directive),
+					message = "Package name should match the pattern: $packagePattern"))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/VariableMaxLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/VariableMaxLength.kt
@@ -13,6 +13,7 @@ class VariableMaxLength(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,
 			Severity.Style,
+			"Variable names should not be longer than the maximum set in the configuration.",
 			debt = Debt.FIVE_MINS)
 	private val maximumVariableNameLength
 			= valueOrDefault(MAXIMUM_VARIABLE_NAME_LENGTH, DEFAULT_MAXIMUM_VARIABLE_NAME_LENGTH)
@@ -20,8 +21,9 @@ class VariableMaxLength(config: Config = Config.empty) : Rule(config) {
 	override fun visitProperty(property: KtProperty) {
 		if (property.identifierName().length > maximumVariableNameLength) {
 			report(CodeSmell(
-					issue.copy(description = "Variable names should be at most $maximumVariableNameLength characters long."),
-					Entity.from(property)))
+					issue,
+					Entity.from(property),
+					message = "Variable names should be at most $maximumVariableNameLength characters long."))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/VariableMinLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/VariableMinLength.kt
@@ -14,6 +14,7 @@ class VariableMinLength(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,
 			Severity.Style,
+			"Variable names should not be shorter than the minimum defined in the configuration.",
 			debt = Debt.FIVE_MINS)
 	private val minimumVariableNameLength
 			= valueOrDefault(MINIMUM_VARIABLE_NAME_LENGTH, DEFAULT_MINIMUM_VARIABLE_NAME_LENGTH)
@@ -25,8 +26,9 @@ class VariableMinLength(config: Config = Config.empty) : Rule(config) {
 
 		if (property.identifierName().length < minimumVariableNameLength) {
 			report(CodeSmell(
-					issue.copy(description = "Variable names should be at least $minimumVariableNameLength characters long."),
-					Entity.from(property)))
+					issue,
+					Entity.from(property),
+					message = "Variable names should be at least $minimumVariableNameLength characters long."))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/VariableNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/VariableNaming.kt
@@ -15,6 +15,7 @@ class VariableNaming(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,
 			Severity.Style,
+			"Variable names should follow the naming convention set in the projects configuration.",
 			debt = Debt.FIVE_MINS)
 	private val variablePattern = Regex(valueOrDefault(VARIABLE_PATTERN, "^(_)?[a-z$][a-zA-Z$0-9]*$"))
 
@@ -25,8 +26,9 @@ class VariableNaming(config: Config = Config.empty) : Rule(config) {
 
 		if (!property.identifierName().matches(variablePattern)) {
 			report(CodeSmell(
-					issue.copy(description = "Variable names should match the pattern: $variablePattern"),
-					Entity.from(property)))
+					issue,
+					Entity.from(property),
+					message = "Variable names should match the pattern: $variablePattern"))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalReturnKeyword.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalReturnKeyword.kt
@@ -22,7 +22,7 @@ class OptionalReturnKeyword(config: Config) : Rule(config) {
 			Debt.TEN_MINS)
 
 	private val visitor = ConditionalPathVisitor {
-		report(CodeSmell(issue, Entity.from(it)))
+		report(CodeSmell(issue, Entity.from(it), message = ""))
 	}
 
 	override fun visitDeclaration(dcl: KtDeclaration) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
@@ -27,7 +27,7 @@ class OptionalUnit(config: Config = Config.empty) : Rule(config) {
 			val typeReference = function.typeReference
 			typeReference?.typeElement?.text?.let {
 				if (it == "Unit") {
-					report(CodeSmell(issue, Entity.from(typeReference)))
+					report(CodeSmell(issue, Entity.from(typeReference), message = ""))
 				}
 			}
 		}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SubRuleSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SubRuleSpec.kt
@@ -18,7 +18,7 @@ class SubRuleSpec : Spek({
 	given("a SubRule that always reports") {
 		val rule = object: SubRule<String>(TestConfig(emptyMap())) {
 			override fun apply(element: String) {
-				report(CodeSmell(issue, Entity.from(file)))
+				report(CodeSmell(issue, Entity.from(file), message = ""))
 			}
 
 			override val issue = Issue("Test", Severity.Style, "Test")
@@ -35,7 +35,7 @@ class SubRuleSpec : Spek({
 	given("a SubRule that always reports but is inactive") {
 		val rule = object: SubRule<String>(TestConfig(mapOf("active" to "false"))) {
 			override fun apply(element: String) {
-				report(CodeSmell(issue, Entity.from(file)))
+				report(CodeSmell(issue, Entity.from(file), message = ""))
 			}
 
 			override val issue = Issue("Test", Severity.Style, "Test")

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MethodNameEqualsClassNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MethodNameEqualsClassNameSpec.kt
@@ -22,7 +22,7 @@ class MethodNameEqualsClassNameSpec : SubjectSpek<MethodNameEqualsClassName>({
 		}
 
 		it("reports methods which are named after the class object") {
-			val objectFindings = findings.filter { it.issue.description.contains("object") }
+			val objectFindings = findings.filter { it.message.contains("object") }
 			assertThat(objectFindings).hasSize(1)
 		}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -32,4 +32,4 @@ class UnnecessaryAbstractClassSpec : SubjectSpek<UnnecessaryAbstractClass>({
 })
 
 private fun countViolationsWithDescription(findings: List<Finding>, description: String) =
-		findings.count { it.issue.description.contains(description) }
+		findings.count { it.message.contains(description) }

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctions.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctions.kt
@@ -20,7 +20,7 @@ class TooManyFunctions : Rule() {
 	override fun visitFile(file: PsiFile) {
 		super.visitFile(file)
 		if (amount > THRESHOLD) {
-			report(CodeSmell(issue, Entity.from(file)))
+			report(CodeSmell(issue, Entity.from(file), message = ""))
 		}
 	}
 

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctionsTwo.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctionsTwo.kt
@@ -26,7 +26,7 @@ class TooManyFunctionsTwo(config: Config) : Rule(config) {
 			report(CodeSmell(issue,
 					entity = Entity.from(file),
 					metrics = listOf(Metric(type = "SIZE", value = amount, threshold = THRESHOLD)),
-					references = listOf())
+					references = listOf(), message = "")
 			)
 		}
 	}


### PR DESCRIPTION
This is just a suggestion and currently won't compile as we'd have to update every usage of `CodeSmell`.

After the discussions in #475 and #273 it seemed to me like splitting an Issues description from a CodeSmell's detailed message makes sense.

With this the Issue description can act as a rationale for the Issue, what it means, the reasoning behind the rule and how it can be fixed. (e.g. "Long function names should be avoided because.......<insert long and detailed description and reasoning here>")

The CodeSmell message can then point out the specific problem directly. (e.g. "The function ${function.name} has a ${function.name.lenght} character long name which is longer than the threshold of $maxFunctionLength. Give this function a shorter name")

Let me know what you think. If you agree with this I can go through all places we report CodeSmells and give them an empty message to start with `""` and we should update them over time.