### PR TITLE
ignore "_" named variables for VariableNaming and VariableMinLength

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/VariableMinLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/VariableMinLength.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.SubRule
 import org.jetbrains.kotlin.psi.KtVariableDeclaration
+import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
 
 class VariableMinLength(config: Config = Config.empty) : SubRule<KtVariableDeclaration>(config) {
 	override val issue = Issue(javaClass.simpleName,
@@ -17,6 +18,10 @@ class VariableMinLength(config: Config = Config.empty) : SubRule<KtVariableDecla
 			= valueOrDefault(MINIMUM_VARIABLE_NAME_LENGTH, DEFAULT_MINIMUM_VARIABLE_NAME_LENGTH)
 
 	override fun apply(element: KtVariableDeclaration) {
+		if (element.isSingleUnderscore) {
+			return
+		}
+
 		if (element.identifierName().length < minimumVariableNameLength) {
 			report(CodeSmell(
 					issue.copy(description = "Variable names should be at least $minimumVariableNameLength characters long."),

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/VariableNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/VariableNaming.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.SubRule
 import org.jetbrains.kotlin.psi.KtVariableDeclaration
+import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
 
 class VariableNaming(config: Config = Config.empty) : SubRule<KtVariableDeclaration>(config) {
 	override val issue = Issue(javaClass.simpleName,
@@ -16,6 +17,10 @@ class VariableNaming(config: Config = Config.empty) : SubRule<KtVariableDeclarat
 	private val variablePattern = Regex(valueOrDefault(VARIABLE_PATTERN, "^(_)?[a-z$][a-zA-Z$0-9]*$"))
 
 	override fun apply(element: KtVariableDeclaration) {
+		if (element.isSingleUnderscore) {
+			return
+		}
+
 		if (!element.identifierName().matches(variablePattern)) {
 			report(CodeSmell(
 					issue.copy(description = "Variable names should match the pattern: $variablePattern"),

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NamingConventionViolationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NamingConventionViolationSpec.kt
@@ -170,6 +170,12 @@ class NamingConventionLengthSpec : SubjectSpek<NamingRules>({
 
 	subject { NamingRules() }
 
+	it("should not report underscore variable names") {
+		val code = "val (_, status) = getResult()"
+		subject.lint(code)
+		assertThat(subject.findings).isEmpty()
+	}
+
 	it("should report a variable name that is too short") {
 		val code = "private val a = 3"
 		subject.lint(code)

--- a/detekt-rules/src/test/resources/cases/NamingConventions.kt
+++ b/detekt-rules/src/test/resources/cases/NamingConventions.kt
@@ -40,6 +40,10 @@ class NamingConventions {
 	fun classMethod() {
 	}
 
+	fun underscoreTestMethod() {
+		val (_, status) = Pair(1, 2) // _ should not be reported
+	}
+
 	//invalid
 	fun _classmethod() {
 	}


### PR DESCRIPTION
Resolves #481 

This excludes variables named `_` from the `VariableNaming` rule and the `VariableMinLength` rule.

In case of the `VariableNaming` we could also rely on having it in the Regex. What do you think?