### PR TITLE
don't report UselessPostfixExpressions on fields in return expressions

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
@@ -1,10 +1,10 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
-import org.assertj.core.api.Assertions.assertThat
 
 class UselessPostfixExpressionSpec : SubjectSpek<UselessPostfixExpression>({
 	subject { UselessPostfixExpression() }
@@ -32,6 +32,23 @@ class UselessPostfixExpressionSpec : SubjectSpek<UselessPostfixExpression>({
 					return i++
 				}"""
 			assertThat(subject.lint(code)).hasSize(2)
+		}
+
+		it("should not report field increments") {
+			val code = """
+				class Test {
+					private var runningId: Long = 0
+
+					fun increment() {
+						runningId++
+					}
+
+					fun getId(): Long {
+						return runningId++
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).isEmpty()
 		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
@@ -50,5 +50,19 @@ class UselessPostfixExpressionSpec : SubjectSpek<UselessPostfixExpression>({
 				"""
 			assertThat(subject.lint(code)).isEmpty()
 		}
+
+		it("should detect properties shadowing fields that are incremented") {
+			val code = """
+				class Test {
+					private var runningId: Long = 0
+
+					fun getId(): Long {
+						val runningId: Long = 0
+						return runningId++
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).hasSize(1)
+		}
 	}
 })


### PR DESCRIPTION
Fixes #466

This would probably be even easier with full type resolution but it also works like this.

We keep a list of all fields and check each postfix expression on return types against that list.