### PR TITLE
WIP: Type and symbol resolving

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/BaseRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/BaseRule.kt
@@ -1,17 +1,20 @@
 package io.gitlab.arturbosch.detekt.api
 
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
 
 @Suppress("EmptyFunctionBlock")
 abstract class BaseRule(protected val context: Context = DefaultContext()) : DetektVisitor(), Context by context {
 
 	open val id: String = javaClass.simpleName
+	var bindingContext: BindingContext = BindingContext.EMPTY
 
 	/**
 	 * Before starting visiting kotlin elements, a check is performed if this rule should be triggered.
 	 * Pre- and post-visit-hooks are executed before/after the visiting process.
 	 */
-	fun visitFile(root: KtFile) {
+	fun visitFile(root: KtFile, bindingContext: BindingContext = BindingContext.EMPTY) {
+		this.bindingContext = bindingContext
 		if (visitCondition(root)) {
 			clearFindings()
 			preVisit(root)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/BaseRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/BaseRule.kt
@@ -12,6 +12,10 @@ abstract class BaseRule(protected val context: Context = DefaultContext()) : Det
 	/**
 	 * Before starting visiting kotlin elements, a check is performed if this rule should be triggered.
 	 * Pre- and post-visit-hooks are executed before/after the visiting process.
+	 * BindingContext holds the result of the semantic analysis of the source code by the Kotlin compiler. Rules that
+	 * rely on symbols and types being resolved can use the BindingContext for this analysis. Note that
+	 * BindingContext will have the value BindingContext.EMPTY unless detekt is provided the correct classpath while
+	 * analyzing the code.
 	 */
 	fun visitFile(root: KtFile, bindingContext: BindingContext = BindingContext.EMPTY) {
 		this.bindingContext = bindingContext

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.api
 
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * A rule set is a collection of rules and must be defined within a rule set provider implementation.
@@ -17,7 +18,9 @@ class RuleSet(val id: String, val rules: List<BaseRule>) {
 	 * Visits given file with all rules of this rule set, returning a list
 	 * of all code smell findings.
 	 */
-	fun accept(file: KtFile): List<Finding> = rules.flatMap { it.visitFile(file); it.findings }
+	fun accept(file: KtFile, bindingContext: BindingContext = BindingContext.EMPTY): List<Finding> = rules.flatMap {
+		it.visitFile(file, bindingContext); it.findings
+	}
 
 	/**
 	 * Visits given file with all non-filtered rules of this rule set.
@@ -26,8 +29,10 @@ class RuleSet(val id: String, val rules: List<BaseRule>) {
 	 *
 	 * A list of findings is returned for given [KtFile]
 	 */
-	fun accept(file: KtFile, ruleFilters: Set<String>): List<Finding> =
+	fun accept(file: KtFile,
+			   ruleFilters: Set<String>,
+			   bindingContext: BindingContext = BindingContext.EMPTY): List<Finding> =
 			rules.filterNot { it.id in ruleFilters }
 					.onEach { if (it is MultiRule) it.ruleFilters = ruleFilters }
-					.flatMap { it.visitFile(file); it.findings }
+					.flatMap { it.visitFile(file, bindingContext); it.findings }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Args.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Args.kt
@@ -13,6 +13,9 @@ class Args {
 			converter = ExistingPathConverter::class, description = "Input path to analyze (path/to/project).")
 	private var input: Path? = null
 
+	@Parameter(names = arrayOf("--classpath", "-cp"))
+	var classpath: String? = null
+
 	@Parameter(names = arrayOf("--filters", "-f"),
 			description = "Path filters defined through regex with separator ';' (\".*test.*\").")
 	var filters: String? = null // Using a converter for List<PathFilter> resulted in a ClassCastException

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -19,6 +19,10 @@ fun Args.createPlugins(): List<Path> = plugins.letIfNonEmpty {
 	MultipleExistingPathConverter().convert(this)
 }
 
+fun Args.createClasspath(): List<String> = classpath.letIfNonEmpty {
+	this.split(";")
+}
+
 private fun <T> String?.letIfNonEmpty(init: String.() -> List<T>): List<T> =
 		if (this == null || this.isEmpty()) listOf() else this.init()
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Runner.kt
@@ -28,8 +28,10 @@ class Runner(private val arguments: Args) : Executable {
 		with(arguments) {
 			val pathFilters = createPathFilters()
 			val plugins = createPlugins()
+			val classpath = createClasspath()
 			val config = loadConfiguration()
-			return ProcessingSettings(inputPath, config, pathFilters, parallel, disableDefaultRuleSets, plugins)
+			return ProcessingSettings(inputPath, config, pathFilters, parallel, disableDefaultRuleSets, plugins,
+					classpath)
 		}
 	}
 }

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -325,6 +325,8 @@ style:
     active: false
   OptionalReturnKeyword:
     active: false
+  UselessCallOnNotNull:
+    active: false
   OptionalUnit:
     active: false
   ProtectedMemberInFinalClass:

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/AnalysisEnvironment.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/AnalysisEnvironment.kt
@@ -6,14 +6,13 @@ import org.jetbrains.kotlin.cli.jvm.compiler.CliLightClassGenerationSupport
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
-import org.jetbrains.kotlin.cli.jvm.config.addJavaSourceRoot
 import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoot
 import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
 import org.jetbrains.kotlin.com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.config.addKotlinSourceRoot
+import org.jetbrains.kotlin.config.addKotlinSourceRoots
 import org.jetbrains.kotlin.container.ComponentProvider
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProviderFactory
@@ -52,13 +51,7 @@ class AnalysisEnvironment : Disposable {
 	}
 
 	fun addSources(list: List<String>) {
-		list.forEach {
-			configuration.addKotlinSourceRoot(it)
-			val file = File(it)
-			if (file.isDirectory || file.extension == ".java") {
-				configuration.addJavaSourceRoot(file)
-			}
-		}
+		configuration.addKotlinSourceRoots(list)
 	}
 
 	override fun dispose() {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/AnalysisEnvironment.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/AnalysisEnvironment.kt
@@ -1,0 +1,66 @@
+package io.gitlab.arturbosch.detekt.core
+
+import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.jvm.compiler.CliLightClassGenerationSupport
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
+import org.jetbrains.kotlin.cli.jvm.config.addJavaSourceRoot
+import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoot
+import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
+import org.jetbrains.kotlin.com.intellij.openapi.Disposable
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.addKotlinSourceRoot
+import org.jetbrains.kotlin.container.ComponentProvider
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProviderFactory
+import java.io.File
+
+class AnalysisEnvironment : Disposable {
+	val configuration = CompilerConfiguration()
+
+	init {
+		configuration.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
+		configuration.put(CommonConfigurationKeys.MODULE_NAME, "module for detekt static analysis")
+	}
+
+	fun createCoreEnvironment(trace: CliLightClassGenerationSupport.CliBindingTrace, files: List<KtFile>):
+			ComponentProvider {
+		System.setProperty("idea.io.use.fallback", "true") //otherwise will complain bin/idea.properties is missing
+		val environment = KotlinCoreEnvironment.createForProduction(this, configuration, EnvironmentConfigFiles.JVM_CONFIG_FILES)
+
+		return TopDownAnalyzerFacadeForJVM.createContainer(
+				environment.project,
+				files,
+				trace,
+				environment.configuration,
+				environment::createPackagePartProvider,
+				::FileBasedDeclarationProviderFactory
+		)
+	}
+
+	fun addClasspaths(paths: List<File>) {
+		configuration.addJvmClasspathRoots(paths)
+	}
+
+	fun addClasspath(path: File) {
+		configuration.addJvmClasspathRoot(path)
+	}
+
+	fun addSources(list: List<String>) {
+		list.forEach {
+			configuration.addKotlinSourceRoot(it)
+			val file = File(it)
+			if (file.isDirectory || file.extension == ".java") {
+				configuration.addJavaSourceRoot(file)
+			}
+		}
+	}
+
+	override fun dispose() {
+		Disposer.dispose(this)
+	}
+}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/AnalysisEnvironment.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/AnalysisEnvironment.kt
@@ -30,7 +30,8 @@ class AnalysisEnvironment : Disposable {
 	fun createCoreEnvironment(trace: CliLightClassGenerationSupport.CliBindingTrace, files: List<KtFile>):
 			ComponentProvider {
 		System.setProperty("idea.io.use.fallback", "true") //otherwise will complain bin/idea.properties is missing
-		val environment = KotlinCoreEnvironment.createForProduction(this, configuration, EnvironmentConfigFiles.JVM_CONFIG_FILES)
+		val environment = KotlinCoreEnvironment.createForProduction(this, configuration,
+				EnvironmentConfigFiles.JVM_CONFIG_FILES)
 
 		return TopDownAnalyzerFacadeForJVM.createContainer(
 				environment.project,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektResolver.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektResolver.kt
@@ -1,0 +1,51 @@
+package io.gitlab.arturbosch.detekt.core
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import org.jetbrains.kotlin.analyzer.AnalysisResult
+import org.jetbrains.kotlin.cli.jvm.compiler.CliLightClassGenerationSupport
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.container.get
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.LazyTopDownAnalyzer
+import org.jetbrains.kotlin.resolve.TopDownAnalysisMode
+import org.jetbrains.kotlin.utils.PathUtil
+import java.io.File
+
+class DetektResolver(val classpath: List<String>,
+					 private val sources: List<SourceRoot>,
+					 val providers: List<RuleSetProvider>,
+					 val config: Config) {
+
+	fun generate(files: List<KtFile>) : BindingContext {
+		val sourcePaths = sources.map { it.path }
+		val environment = createAnalysisEnvironment(sourcePaths)
+		return try {
+			val trace = CliLightClassGenerationSupport.NoScopeRecordCliBindingTrace()
+			val container = environment.createCoreEnvironment(trace, files)
+			val module = container.get<ModuleDescriptor>()
+			container.get<LazyTopDownAnalyzer>().analyzeDeclarations(TopDownAnalysisMode.TopLevelDeclarations, files)
+
+			AnalysisResult.success(trace.bindingContext, module).bindingContext
+		} finally {
+			Disposer.dispose(environment)
+		}
+	}
+
+	private fun createAnalysisEnvironment(sourcePaths: List<String>): AnalysisEnvironment {
+		val environment = AnalysisEnvironment()
+
+		environment.apply {
+			addClasspaths(PathUtil.getJdkClassesRootsFromCurrentJre())
+			for (element in this@DetektResolver.classpath) {
+				addClasspath(File(element))
+			}
+
+			addSources(sourcePaths)
+		}
+
+		return environment
+	}
+}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektResolver.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektResolver.kt
@@ -15,12 +15,11 @@ import org.jetbrains.kotlin.utils.PathUtil
 import java.io.File
 
 class DetektResolver(val classpath: List<String>,
-					 private val sources: List<SourceRoot>,
+					 private val sourcePaths: List<String>,
 					 val providers: List<RuleSetProvider>,
 					 val config: Config) {
 
 	fun generate(files: List<KtFile>) : BindingContext {
-		val sourcePaths = sources.map { it.path }
 		val environment = createAnalysisEnvironment(sourcePaths)
 		return try {
 			val trace = CliLightClassGenerationSupport.NoScopeRecordCliBindingTrace()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektor.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.toMergedMap
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
+import java.io.File
 
 /**
  * @author Artur Bosch
@@ -27,12 +28,8 @@ class Detektor(private val settings: ProcessingSettings,
 
 	fun run(ktFiles: List<KtFile>): Detektion = withExecutor {
 
-		val paths = ktFiles.map { SourceRoot(it.getUserData(KtCompiler.RELATIVE_PATH)!!) }
-
-		val resolver = DetektResolver(
-				settings.classpath,
-				paths, providers, settings.config)
-
+		val paths = ktFiles.map { File(it.getUserData(KtCompiler.RELATIVE_PATH)!!).absolutePath }
+		val resolver = DetektResolver(settings.classpath, paths, providers, settings.config)
 		val bindingContext = resolver.generate(ktFiles)
 
 		processors.forEach { it.onStart(ktFiles) }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektor.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.toMergedMap
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * @author Artur Bosch
@@ -26,11 +27,19 @@ class Detektor(private val settings: ProcessingSettings,
 
 	fun run(ktFiles: List<KtFile>): Detektion = withExecutor {
 
+		val paths = ktFiles.map { SourceRoot(it.getUserData(KtCompiler.RELATIVE_PATH)!!) }
+
+		val resolver = DetektResolver(
+				settings.classpath,
+				paths, providers, settings.config)
+
+		val bindingContext = resolver.generate(ktFiles)
+
 		processors.forEach { it.onStart(ktFiles) }
 		val futures = ktFiles.map { file ->
 			runAsync {
 				processors.forEach { it.onProcess(file) }
-				file.analyze().apply {
+				file.analyze(bindingContext).apply {
 					processors.forEach { it.onProcessComplete(file, FindingsForFile(this)) }
 				}
 			}
@@ -48,16 +57,16 @@ class Detektor(private val settings: ProcessingSettings,
 		}
 	}
 
-	private fun KtFile.analyze(): List<Pair<String, List<Finding>>> {
+	private fun KtFile.analyze(bindingContext: BindingContext): List<Pair<String, List<Finding>>> {
 		var ruleSets = providers.mapNotNull { it.buildRuleset(config) }
 				.sortedBy { it.id }
 				.distinctBy { it.id }
 
 		return if (testPattern.isTestSource(this)) {
 			ruleSets = ruleSets.filterNot { testPattern.matchesRuleSet(it.id) }
-			ruleSets.map { ruleSet -> ruleSet.id to ruleSet.accept(this, testPattern.excludingRules) }
+			ruleSets.map { ruleSet -> ruleSet.id to ruleSet.accept(this, testPattern.excludingRules, bindingContext) }
 		} else {
-			ruleSets.map { ruleSet -> ruleSet.id to ruleSet.accept(this) }
+			ruleSets.map { ruleSet -> ruleSet.id to ruleSet.accept(this, bindingContext) }
 		}
 	}
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -13,7 +13,8 @@ data class ProcessingSettings(val project: Path,
 							  val pathFilters: List<PathFilter> = listOf(),
 							  val parallelCompilation: Boolean = false,
 							  val excludeDefaultRuleSets: Boolean = false,
-							  val pluginPaths: List<Path> = emptyList()) {
+							  val pluginPaths: List<Path> = emptyList(),
+							  val classpath: List<String> = emptyList()) {
 
 	init {
 		pluginPaths.forEach {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/SourceRoot.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/SourceRoot.kt
@@ -1,0 +1,7 @@
+package io.gitlab.arturbosch.detekt.core
+
+import java.io.File
+
+class SourceRoot(path: String) {
+	val path: String = File(path).absolutePath
+}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/SourceRoot.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/SourceRoot.kt
@@ -1,7 +1,0 @@
-package io.gitlab.arturbosch.detekt.core
-
-import java.io.File
-
-class SourceRoot(path: String) {
-	val path: String = File(path).absolutePath
-}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -31,6 +31,7 @@ import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryInheritance
 import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryParentheses
 import io.gitlab.arturbosch.detekt.rules.style.UnusedImports
 import io.gitlab.arturbosch.detekt.rules.style.UseDataClass
+import io.gitlab.arturbosch.detekt.rules.style.UselessCallOnNotNull
 import io.gitlab.arturbosch.detekt.rules.style.UtilityClassWithPublicConstructor
 import io.gitlab.arturbosch.detekt.rules.style.WildcardImport
 import io.gitlab.arturbosch.detekt.rules.style.naming.NamingRules
@@ -83,6 +84,7 @@ class StyleGuideProvider : RuleSetProvider {
 				UnusedImports(config),
 				ExpressionBodySyntax(config),
 				NestedClassesVisibility(config),
+				UselessCallOnNotNull(config),
 				RedundantVisibilityModifierRule(config)
 		))
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
@@ -27,6 +27,7 @@ class UselessCallOnNotNull(config: Config = Config.empty) : Rule(config) {
 
 	private val uselessNames = toShortFqNames(uselessFqNames.keys)
 
+	@Suppress("ReturnCount")
 	override fun visitQualifiedExpression(expression: KtQualifiedExpression) {
 		if (bindingContext == BindingContext.EMPTY) return
 		val selector = expression.selectorExpression as? KtCallExpression ?: return

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
@@ -18,7 +18,9 @@ import org.jetbrains.kotlin.types.TypeUtils
 class UselessCallOnNotNull(config: Config = Config.empty) : Rule(config) {
 	override val issue: Issue = Issue("UselessCallOnNotNull",
 			Severity.Performance,
-			"This call on not-null type may be reduced or removed.")
+			"This call on not-null type may be reduced or removed. Some calls are intended to be called on nullable " +
+					"collection or text types (e.g. String?). When this call is used on a not-null type (e.g. String)" +
+					" it is redundant and will have no effect, so it can be removed.")
 
 	private val uselessFqNames = mapOf("kotlin.collections.orEmpty" to deleteConversion,
 			"kotlin.text.orEmpty" to deleteConversion,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
@@ -1,0 +1,61 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.resolve.calls.callUtil.getType
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
+import org.jetbrains.kotlin.types.TypeUtils
+
+class UselessCallOnNotNull(config: Config = Config.empty) : Rule(config) {
+	override val issue: Issue = Issue("UselessCallOnNotNull",
+			Severity.Performance,
+			"This call on not-null type may be reduced or removed.")
+
+	private val uselessFqNames = mapOf("kotlin.collections.orEmpty" to deleteConversion,
+			"kotlin.text.orEmpty" to deleteConversion,
+			"kotlin.text.isNullOrEmpty" to Conversion("isEmpty"),
+			"kotlin.text.isNullOrBlank" to Conversion("isBlank"))
+
+	private val uselessNames = toShortFqNames(uselessFqNames.keys)
+
+	override fun visitQualifiedExpression(expression: KtQualifiedExpression) {
+		if (bindingContext == BindingContext.EMPTY) return
+		val selector = expression.selectorExpression as? KtCallExpression ?: return
+		val calleeExpression = selector.calleeExpression ?: return
+		if (calleeExpression.text !in uselessNames) return
+
+		val resolvedCall = expression.getResolvedCall(bindingContext) ?: return
+		if (uselessFqNames.contains(resolvedCall.resultingDescriptor.fqNameOrNull()?.asString()))
+			suggestConversionIfNeeded(expression, bindingContext)
+	}
+
+	private fun suggestConversionIfNeeded(
+			expression: KtQualifiedExpression,
+			context: BindingContext
+	) {
+		val safeExpression = expression as? KtSafeQualifiedExpression
+		val notNullType = expression.receiverExpression.getType(context)?.let { TypeUtils.isNullableType(it) } == false
+		if (notNullType || safeExpression != null) {
+			report(CodeSmell(issue, Entity.from(expression), ""))
+		}
+	}
+
+	private companion object {
+		data class Conversion(val replacementName: String? = null)
+
+		val deleteConversion = Conversion()
+
+		private fun toShortFqNames(longNames: Set<String>): Set<String> {
+			return longNames.mapTo(mutableSetOf()) { fqName -> fqName.takeLastWhile { it != '.' } }
+		}
+	}
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,4 @@ jcommanderVersion=1.72
 assertjVersion=3.8.0
 
 systemProp.sonar.host.url=http://localhost:9000
+systemProp.file.encoding=UTF-8


### PR DESCRIPTION
This PR adds type and symbol resolving for Kotlin code that targets the JVM.

A lot of work is required before it's ready to merge, but I wanted to share it now so that people can provide early feedback.

Some things that are missing (others will surely have things to add to this list):

- [ ] Gradle integration
- [ ] Auto-setting classpath in Gradle
- [ ] Make type resolution optional in Gradle
- [ ] Tests for the new classes
- [ ] Tests for the new `UselessCallOnNotNull` rule (if the rule seems worth introducing)
- [ ] Sharing compiler errors/warnings with the user (they are not shown, so user has to know that their code compiles before running detekt, otherwise there'll be an error)
- [ ] Support for JS modules
- [ ] Support for "common" modules
- [ ] Description for `--classpath` command line option

I've seen concerns around the possible performance hit of type and symbol resolving, which seem warranted - this analysis takes time as a lot more work is being done. But this allows for much more complex analysis to be performed by detekt and will make the tool a lot more useful, so I think the tradeoff will be worth it.

To test, enable the `UselessCallOnNotNull` rule, add kotlin-stdlib to the classpath with the `-cp` or `--classpath` flag, and try running on a file like this:
```kotlin
package demo

val nextTest = mutableListOf<String>().orEmpty()
```
The new rule will resolve the `orEmpty()` call to `kotlin.collections.orEmpty` which will trigger a detekt issue because the `orEmpty()` call is never needed on a not-null collection.