### PR TITLE
Ignore companion object properties

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -239,6 +239,8 @@ style:
     ignoreNumbers: '-1,0,1,2'
     ignoreHashCodeFunction: false
     ignorePropertyDeclaration: false
+    ignoreConstantDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
     ignoreAnnotation: false
     ignoreNamedArgument: true
     ignoreEnums: false

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -45,7 +45,8 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 	private val ignoreNamedArgument = valueOrDefault(IGNORE_NAMED_ARGUMENT, false)
 	private val ignoreEnums = valueOrDefault(IGNORE_ENUMS, false)
 	private val ignoreConstantDeclaration = valueOrDefault(IGNORE_CONSTANT_DECLARATION, true)
-	private val ignoreCompanionObjectPropertyDeclaration = valueOrDefault(IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION, true)
+	private val ignoreCompanionObjectPropertyDeclaration =
+			valueOrDefault(IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION, true)
 
 	override fun visitConstantExpression(expression: KtConstantExpression) {
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/FindingsAssertions.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/FindingsAssertions.kt
@@ -1,0 +1,28 @@
+package io.gitlab.arturbosch.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.Finding
+import org.assertj.core.api.AbstractAssert
+import org.assertj.core.api.AbstractListAssert
+import org.assertj.core.internal.Objects
+
+fun assertThat(findings: List<Finding>) = FindingsAssert(findings)
+class FindingsAssert(actual: List<Finding>) :
+		AbstractListAssert<FindingsAssert, List<Finding>,
+				Finding, FindingAssert>(actual, FindingsAssert::class.java) {
+
+	override fun toAssert(value: Finding?, description: String?): FindingAssert =
+			FindingAssert(value).`as`(description)
+
+	fun hasLocationStrings(vararg expected: String) {
+		isNotNull
+		val actualLocationStrings = actual.map { it.entity.location.locationString }
+		areEqual(actualLocationStrings, expected)
+	}
+
+	private fun areEqual(actualLocationStrings: List<String>, expectedLocationStrings: Array<out String>) {
+		Objects.instance()
+				.assertEqual(writableAssertionInfo, actualLocationStrings, expectedLocationStrings.toList())
+	}
+}
+
+class FindingAssert(actual: Finding?) : AbstractAssert<FindingAssert, Finding>(actual, FindingAssert::class.java)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.rules.assertThat
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Java6Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
@@ -348,59 +348,41 @@ class MagicNumberSpec : Spek({
 					const val anotherBoringConstant = 93872
 				}
 			}
-		""")
+		""".trimMargin())
 
 		it("should report all without ignore flags") {
-			val config = TestConfig(mapOf(
-					MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-					MagicNumber.IGNORE_ANNOTATION to "false",
-					MagicNumber.IGNORE_HASH_CODE to "false",
-					MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-					MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"))
+			val config = TestConfig(
+					mapOf(
+							MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+							MagicNumber.IGNORE_ANNOTATION to "false",
+							MagicNumber.IGNORE_HASH_CODE to "false",
+							MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+							MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+					)
+			)
 
 			val findings = MagicNumber(config).lint(ktFile)
-
-			val locationStrings = findings.map { it.entity.location.locationString }
-			assertThat(locationStrings == listOf("69", "42", "93871", "7328672", "43", "93872"))
-		}
-
-		it("should not report number in properties when ignored") {
-			val config = TestConfig(mapOf(MagicNumber.IGNORE_PROPERTY_DECLARATION to "true"))
-			val findings = MagicNumber(config).lint(ktFile)
-			assertThat(findings).hasSize(2)
-		}
-
-		it("should report number in properties when not ignored") {
-			val config = TestConfig(mapOf(MagicNumber.IGNORE_PROPERTY_DECLARATION to "false"))
-			val findings = MagicNumber(config).lint(ktFile)
-			assertThat(findings).hasSize(3)
-		}
-
-		it("should not report number in annotation when ignored") {
-			val config = TestConfig(mapOf(MagicNumber.IGNORE_ANNOTATION to "true"))
-			val findings = MagicNumber(config).lint(ktFile)
-			assertThat(findings).hasSize(2)
-		}
-
-		it("should not report number in hashCode when ignored") {
-			val config = TestConfig(mapOf(MagicNumber.IGNORE_HASH_CODE to "true"))
-			val findings = MagicNumber(config).lint(ktFile)
-			assertThat(findings).hasSize(2)
-		}
-
-		it("should not report number in hashCode when ignored") {
-			val config = TestConfig(mapOf(MagicNumber.IGNORE_HASH_CODE to "true"))
-			val findings = MagicNumber(config).lint(ktFile)
-			assertThat(findings).hasSize(2)
+			assertThat(findings).hasLocationStrings(
+					"'69' at (1,20) in /foo.bar",
+					"'42' at (3,24) in /foo.bar",
+					"'93871' at (4,32) in /foo.bar",
+					"'7328672' at (7,23) in /foo.bar",
+					"'43' at (11,35) in /foo.bar",
+					"'93872' at (12,40) in /foo.bar"
+			)
 		}
 
 		it("should not report any issues with all ignore flags") {
-			val config = TestConfig(mapOf(
-					MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-					MagicNumber.IGNORE_ANNOTATION to "true",
-					MagicNumber.IGNORE_HASH_CODE to "true",
-					MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-					MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"))
+			val config = TestConfig(
+					mapOf(
+							MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
+							MagicNumber.IGNORE_ANNOTATION to "true",
+							MagicNumber.IGNORE_HASH_CODE to "true",
+							MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+							MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
+					)
+			)
+
 			val findings = MagicNumber(config).lint(ktFile)
 			assertThat(findings).isEmpty()
 		}
@@ -415,11 +397,89 @@ class MagicNumberSpec : Spek({
 					const val anotherBoringConstant = 93872
 				}
 			}
-		""")
+		""".trimMargin())
 
-		it("should not report any issues in those assignments") {
+		it("should not report any issues by default") {
 			val findings = MagicNumber().lint(ktFile)
 			assertThat(findings).isEmpty()
+		}
+
+		it("should not report any issues when ignoring properties but not constants nor companion objects") {
+			val config = TestConfig(
+					mapOf(
+							MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
+							MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+							MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+					)
+			)
+
+			val findings = MagicNumber(config).lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+
+		it("should not report any issues when ignoring properties and constants but not companion objects") {
+			val config = TestConfig(
+					mapOf(
+							MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
+							MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+							MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+					)
+			)
+
+			val findings = MagicNumber(config).lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+
+		it("should not report any issues when ignoring properties, constants and companion objects") {
+			val config = TestConfig(
+					mapOf(
+							MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
+							MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+							MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
+					)
+			)
+
+			val findings = MagicNumber(config).lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+
+		it("should not report any issues when ignoring companion objects but not properties and constants") {
+			val config = TestConfig(
+					mapOf(
+							MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+							MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+							MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
+					)
+			)
+
+			val findings = MagicNumber(config).lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+
+		it("should report property when ignoring constants but not properties and companion objects") {
+			val config = TestConfig(
+					mapOf(
+							MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+							MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+							MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+					)
+			)
+
+			val findings = MagicNumber(config).lint(ktFile)
+			assertThat(findings).hasLocationStrings("'43' at (4,35) in /foo.bar")
+		}
+
+		it("should report property and constant when not ignoring properties, constants nor companion objects") {
+			val config = TestConfig(
+					mapOf(
+							MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+							MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+							MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+					)
+			)
+
+			val findings = MagicNumber(config).lint(ktFile)
+			assertThat(findings).hasLocationStrings("'43' at (4,35) in /foo.bar", "'93872' at (5,40) in /foo.bar")
 		}
 	}
 
@@ -428,7 +488,8 @@ class MagicNumberSpec : Spek({
 		val code = "private var pair: Pair<String, Int>? = null"
 
 		it("should not lead to a crash #276") {
-			assertThat(MagicNumber().lint(code)).isEmpty()
+			val findings = MagicNumber().lint(code)
+			assertThat(findings).isEmpty()
 		}
 	}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -16,7 +16,7 @@ class MagicNumberSpec : Spek({
 
 		it("should not be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should be reported when ignoredNumbers is empty") {
@@ -30,12 +30,12 @@ class MagicNumberSpec : Spek({
 
 		it("should not be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should not be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 	}
 
@@ -44,7 +44,7 @@ class MagicNumberSpec : Spek({
 
 		it("should not be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should be reported when ignoredNumbers is empty") {
@@ -58,12 +58,12 @@ class MagicNumberSpec : Spek({
 
 		it("should not be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should not be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 	}
 
@@ -72,7 +72,7 @@ class MagicNumberSpec : Spek({
 
 		it("should not be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should be reported when ignoredNumbers is empty") {
@@ -86,7 +86,7 @@ class MagicNumberSpec : Spek({
 
 		it("should not be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should be reported when ignoredNumbers is empty") {
@@ -124,12 +124,12 @@ class MagicNumberSpec : Spek({
 
 		it("should not be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should not be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 	}
 
@@ -138,7 +138,7 @@ class MagicNumberSpec : Spek({
 
 		it("should not be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should be reported when ignoredNumbers is empty") {
@@ -152,12 +152,12 @@ class MagicNumberSpec : Spek({
 
 		it("should not be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should not be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 	}
 
@@ -166,7 +166,7 @@ class MagicNumberSpec : Spek({
 
 		it("should not be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should be reported when ignoredNumbers is empty") {
@@ -180,12 +180,12 @@ class MagicNumberSpec : Spek({
 
 		it("should not be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should not be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 	}
 
@@ -194,12 +194,12 @@ class MagicNumberSpec : Spek({
 
 		it("should not be reported when ignoredNumbers contains 300") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "300"))).lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should not be reported when ignoredNumbers contains a floating point 300") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "300.0"))).lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 	}
 
@@ -213,7 +213,7 @@ class MagicNumberSpec : Spek({
 
 		it("should not be reported when ignoredNumbers contains a binary literal 0b01001") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "0b01001"))).lint(ktFile)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 	}
 
@@ -312,7 +312,7 @@ class MagicNumberSpec : Spek({
 
 		it("should not be reported when ignoredNumbers contains it") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ".5"))).lint(code)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 	}
 
@@ -342,27 +342,53 @@ class MagicNumberSpec : Spek({
 				fun hashCode(): Int {
 					val iAmSoMagic = 7328672
 				}
+
+				companion object {
+				    val anotherBoringNumber = 43
+					const val anotherBoringConstant = 93872
+				}
 			}
 		""")
 
 		it("should report all without ignore flags") {
-			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(3)
+			val config = TestConfig(mapOf(
+					MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+					MagicNumber.IGNORE_ANNOTATION to "false",
+					MagicNumber.IGNORE_HASH_CODE to "false",
+					MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+					MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"))
+
+			val findings = MagicNumber(config).lint(ktFile)
+
+			val locationStrings = findings.map { it.entity.location.locationString }
+			assertThat(locationStrings == listOf("69", "42", "93871", "7328672", "43", "93872"))
 		}
 
-		it("should not report number in properties") {
+		it("should not report number in properties when ignored") {
 			val config = TestConfig(mapOf(MagicNumber.IGNORE_PROPERTY_DECLARATION to "true"))
 			val findings = MagicNumber(config).lint(ktFile)
 			assertThat(findings).hasSize(2)
 		}
 
-		it("should not report number in annotation") {
+		it("should report number in properties when not ignored") {
+			val config = TestConfig(mapOf(MagicNumber.IGNORE_PROPERTY_DECLARATION to "false"))
+			val findings = MagicNumber(config).lint(ktFile)
+			assertThat(findings).hasSize(3)
+		}
+
+		it("should not report number in annotation when ignored") {
 			val config = TestConfig(mapOf(MagicNumber.IGNORE_ANNOTATION to "true"))
 			val findings = MagicNumber(config).lint(ktFile)
 			assertThat(findings).hasSize(2)
 		}
 
-		it("should not report number in hashCode") {
+		it("should not report number in hashCode when ignored") {
+			val config = TestConfig(mapOf(MagicNumber.IGNORE_HASH_CODE to "true"))
+			val findings = MagicNumber(config).lint(ktFile)
+			assertThat(findings).hasSize(2)
+		}
+
+		it("should not report number in hashCode when ignored") {
 			val config = TestConfig(mapOf(MagicNumber.IGNORE_HASH_CODE to "true"))
 			val findings = MagicNumber(config).lint(ktFile)
 			assertThat(findings).hasSize(2)
@@ -372,7 +398,9 @@ class MagicNumberSpec : Spek({
 			val config = TestConfig(mapOf(
 					MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
 					MagicNumber.IGNORE_ANNOTATION to "true",
-					MagicNumber.IGNORE_HASH_CODE to "true"))
+					MagicNumber.IGNORE_HASH_CODE to "true",
+					MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+					MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"))
 			val findings = MagicNumber(config).lint(ktFile)
 			assertThat(findings).isEmpty()
 		}
@@ -395,7 +423,7 @@ class MagicNumberSpec : Spek({
 		}
 	}
 
-	given("a property without number number") {
+	given("a property without number") {
 
 		val code = "private var pair: Pair<String, Int>? = null"
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -21,7 +21,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasSize(1)
+			assertThat(findings).hasLocationStrings("'1.0f' at (1,15) in /foo.bar")
 		}
 	}
 
@@ -49,7 +49,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasSize(1)
+			assertThat(findings).hasLocationStrings("'1' at (1,13) in /foo.bar")
 		}
 	}
 
@@ -77,7 +77,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasSize(1)
+			assertThat(findings).hasLocationStrings("'1L' at (1,14) in /foo.bar")
 		}
 	}
 
@@ -91,7 +91,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasSize(1)
+			assertThat(findings).hasLocationStrings("'1L' at (1,15) in /foo.bar")
 		}
 	}
 
@@ -100,7 +100,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(1)
+			assertThat(findings).hasLocationStrings("'2L' at (1,15) in /foo.bar")
 		}
 
 		it("should be ignored when ignoredNumbers contains it verbatim") {
@@ -115,7 +115,7 @@ class MagicNumberSpec : Spek({
 
 		it("should not be ignored when ignoredNumbers contains 2 but not -2") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "1,2,3,-1,0"))).lint(ktFile)
-			assertThat(findings).hasSize(1)
+			assertThat(findings).hasLocationStrings("'2L' at (1,15) in /foo.bar")
 		}
 	}
 
@@ -143,7 +143,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasSize(1)
+			assertThat(findings).hasLocationStrings("'1.0' at (1,16) in /foo.bar")
 		}
 	}
 
@@ -171,7 +171,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasSize(1)
+			assertThat(findings).hasLocationStrings("'0x1' at (1,13) in /foo.bar")
 		}
 	}
 
@@ -222,7 +222,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(1)
+			assertThat(findings).hasLocationStrings("'100_000' at (1,13) in /foo.bar")
 		}
 
 		it("should not be reported when ignored verbatim") {
@@ -246,7 +246,12 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(4)
+			assertThat(findings).hasLocationStrings(
+					"'5' at (1,17) in /foo.bar",
+					"'6' at (1,21) in /foo.bar",
+					"'7' at (1,24) in /foo.bar",
+					"'8' at (1,31) in /foo.bar"
+			)
 		}
 	}
 
@@ -263,7 +268,14 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(6)
+			assertThat(findings).hasLocationStrings(
+					"'5' at (3,6) in /foo.bar",
+					"'5' at (3,18) in /foo.bar",
+					"'4' at (4,6) in /foo.bar",
+					"'4' at (4,18) in /foo.bar",
+					"'3' at (5,6) in /foo.bar",
+					"'3' at (5,18) in /foo.bar"
+			)
 		}
 	}
 
@@ -276,7 +288,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(1)
+			assertThat(findings).hasLocationStrings("'5' at (2,13) in /foo.bar")
 		}
 	}
 
@@ -307,7 +319,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasSize(1)
+			assertThat(findings).hasLocationStrings("'0.5f' at (1,12) in /foo.bar")
 		}
 
 		it("should not be reported when ignoredNumbers contains it") {
@@ -365,7 +377,7 @@ class MagicNumberSpec : Spek({
 			assertThat(findings).hasLocationStrings(
 					"'69' at (1,20) in /foo.bar",
 					"'42' at (3,24) in /foo.bar",
-					"'93871' at (4,32) in /foo.bar",
+					"'93871' at (4,33) in /foo.bar",
 					"'7328672' at (7,23) in /foo.bar",
 					"'43' at (11,35) in /foo.bar",
 					"'93872' at (12,40) in /foo.bar"

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -378,6 +378,23 @@ class MagicNumberSpec : Spek({
 		}
 	}
 
+	given("magic numbers in companion object property assignments") {
+		val ktFile = compileContentForTest("""
+			class A {
+
+				companion object {
+				    val anotherBoringNumber = 43
+					const val anotherBoringConstant = 93872
+				}
+			}
+		""")
+
+		it("should not report any issues in those assignments") {
+			val findings = MagicNumber().lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+	}
+
 	given("a property without number number") {
 
 		val code = "private var pair: Pair<String, Int>? = null"

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -242,16 +242,16 @@ class MagicNumberSpec : Spek({
 	}
 
 	given("an if statement with magic numbers") {
-		val code = "val myInt = if (5 < 6) 7 else 8"
+		val ktFile = compileContentForTest("val myInt = if (5 < 6) 7 else 8")
 
 		it("should be reported") {
-			val findings = MagicNumber().lint(code)
+			val findings = MagicNumber().lint(ktFile)
 			assertThat(findings).hasSize(4)
 		}
 	}
 
 	given("a when statement with magic numbers") {
-		val code = """
+		val ktFile = compileContentForTest("""
 			fun test(x: Int) {
 				when (x) {
 					5 -> return 5
@@ -259,59 +259,59 @@ class MagicNumberSpec : Spek({
 					3 -> return 3
 				}
 			}
-		"""
+		""".trimMargin())
 
 		it("should be reported") {
-			val findings = MagicNumber().lint(code)
+			val findings = MagicNumber().lint(ktFile)
 			assertThat(findings).hasSize(6)
 		}
 	}
 
 	given("a method containing variables with magic numbers") {
-		val code = """
+		val ktFile = compileContentForTest("""
 			fun test(x: Int) {
 				val i = 5
 			}
-		"""
+		""".trimMargin())
 
 		it("should be reported") {
-			val findings = MagicNumber().lint(code)
+			val findings = MagicNumber().lint(ktFile)
 			assertThat(findings).hasSize(1)
 		}
 	}
 
 	given("a boolean value") {
-		val code = """
+		val ktFile = compileContentForTest("""
 			fun test() : Boolean {
 				return true;
 			}
-		"""
+		""".trimMargin())
 
 		it("should not be reported") {
-			val findings = MagicNumber().lint(code)
+			val findings = MagicNumber().lint(ktFile)
 			assertThat(findings).isEmpty()
 		}
 	}
 
 	given("a non-numeric constant expression") {
-		val code = "val surprise = true"
+		val ktFile = compileContentForTest("val surprise = true")
 
 		it("should not be reported") {
-			val findings = MagicNumber().lint(code)
+			val findings = MagicNumber().lint(ktFile)
 			assertThat(findings).isEmpty()
 		}
 	}
 
 	given("a float of 0.5") {
-		val code = compileContentForTest("val test = 0.5f")
+		val ktFile = compileContentForTest("val test = 0.5f")
 
 		it("should be reported by default") {
-			val findings = MagicNumber().lint(code)
+			val findings = MagicNumber().lint(ktFile)
 			assertThat(findings).hasSize(1)
 		}
 
 		it("should not be reported when ignoredNumbers contains it") {
-			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ".5"))).lint(code)
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ".5"))).lint(ktFile)
 			assertThat(findings).isEmpty()
 		}
 	}
@@ -484,11 +484,10 @@ class MagicNumberSpec : Spek({
 	}
 
 	given("a property without number") {
-
-		val code = "private var pair: Pair<String, Int>? = null"
+		val ktFile = compileContentForTest("private var pair: Pair<String, Int>? = null")
 
 		it("should not lead to a crash #276") {
-			val findings = MagicNumber().lint(code)
+			val findings = MagicNumber().lint(ktFile)
 			assertThat(findings).isEmpty()
 		}
 	}


### PR DESCRIPTION
This PR relates to the discussion on #467. It contains a few changes:
 * Allow to ignore magic numbers inside of companion object properties (ignored by default)
    * This allows to have the check point out magic numbers in any other property declaration that is not in a companion object
 * Allow to ignore magic numbers in constant declarations
   * It was the only non-configurable parameter in the check
 * Create `FindingAssertions.kt` that contain custom assertions for AssertJ to allow to check specific finding properties
   * This allows for more precise testing in that we can now easily assert what findings the check should bring up, instead of only relying on the number of findings which can hide errors
   * For now the best way to properly assert findings is to rely on their location, which contains the value too; this is checked with `hasLocationStrings()`