### PR TITLE
Fix OutOfRange bag

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
@@ -18,7 +18,7 @@ class NewLineAtEndOfFile(config: Config = Config.empty) : Rule(config) {
 
 	override fun visitKtFile(file: KtFile) {
 		val text = file.text
-		if (text.lastOrNull() != '\n') {
+		if (text.isNotEmpty() && text.last() != '\n') {
 			report(CodeSmell(issue, Entity.from(file, text.length - 1)))
 		}
 	}


### PR DESCRIPTION
How example we have totally empty file.
In case when u call `lastOrNull()` function return `if (isEmpty()) null else this[length - 1]`
So. I agree that `null != '\n'`. And u go to function body. After that `text.length - 1` brake compiling process.

Thanks for ur project @arturbosch 