### PR TITLE
Remove double check in condition

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
@@ -18,7 +18,7 @@ class NewLineAtEndOfFile(config: Config = Config.empty) : Rule(config) {
 
 	override fun visitKtFile(file: KtFile) {
 		val text = file.text
-		if (text.isNotEmpty() && text.lastOrNull() != '\n') {
+		if (text.isNotEmpty() && text.last() != '\n') {
 			report(CodeSmell(issue, Entity.from(file, text.length - 1)))
 		}
 	}


### PR DESCRIPTION
Is this case u can simplify conditions because
1st check `isNotEmpty()`
2nd inside `if (isEmpty()) null else this[length - 1]` and u never get `null` in this condition

For me my variant is most readability.