### PR TITLE
run detekt for all defined profiles and allow different names

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCheckTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCheckTask.kt
@@ -23,10 +23,12 @@ open class DetektCheckTask : DefaultTask() {
 		project.buildscript.dependencies.add(configuration.name, DefaultExternalModuleDependency(
 				"io.gitlab.arturbosch.detekt", "detekt-cli", detektExtension.version))
 
-		project.javaexec {
-			it.main = "io.gitlab.arturbosch.detekt.cli.Main"
-			it.classpath = configuration
-			it.args(detektExtension.profileArgumentsOrDefault(project))
+		detektExtension.getProfiles().forEach { profile ->
+			project.javaexec {
+				it.main = "io.gitlab.arturbosch.detekt.cli.Main"
+				it.classpath = configuration
+				it.args(detektExtension.profileArgumentsOrDefault(project, profile))
+			}
 		}
 	}
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -25,10 +25,12 @@ open class DetektCreateBaselineTask : DefaultTask() {
 		project.buildscript.dependencies.add(configuration.name, DefaultExternalModuleDependency(
 				"io.gitlab.arturbosch.detekt", "detekt-cli", detektExtension.version))
 
-		project.javaexec {
-			it.main = "io.gitlab.arturbosch.detekt.cli.Main"
-			it.classpath = configuration
-			it.args(detektExtension.profileArgumentsOrDefault(project).plus(createBaseline))
+		detektExtension.getProfiles().forEach { profile ->
+			project.javaexec {
+				it.main = "io.gitlab.arturbosch.detekt.cli.Main"
+				it.classpath = configuration
+				it.args(detektExtension.profileArgumentsOrDefault(project, profile).plus(createBaseline))
+			}
 		}
 	}
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektMigrateTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektMigrateTask.kt
@@ -23,10 +23,12 @@ open class DetektMigrateTask : DefaultTask() {
 		project.buildscript.dependencies.add(migration.name, DefaultExternalModuleDependency(
 				"io.gitlab.arturbosch.detekt", "detekt-migration", detektExtension.version))
 
-		project.javaexec {
-			it.main = "io.gitlab.arturbosch.detekt.migration.Migration"
-			it.classpath = migration
-			it.args(detektExtension.profileArgumentsOrDefault(project))
+		detektExtension.getProfiles().forEach { profile ->
+			project.javaexec {
+				it.main = "io.gitlab.arturbosch.detekt.migration.Migration"
+				it.classpath = migration
+				it.args(detektExtension.profileArgumentsOrDefault(project, profile))
+			}
 		}
 	}
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -8,7 +8,6 @@ import org.gradle.api.Project
  */
 open class DetektExtension(open var version: String = SUPPORTED_DETEKT_VERSION,
 						   open var debug: Boolean = DEBUG_PARAMETER,
-						   open var profile: String = DEFAULT_PROFILE_NAME,
 						   open var ideaExtension: IdeaExtension = IdeaExtension()) {
 
 	private val profiles: MutableList<ProfileExtension> = mutableListOf()
@@ -28,8 +27,10 @@ open class DetektExtension(open var version: String = SUPPORTED_DETEKT_VERSION,
 		}
 	}
 
-	fun profileArgumentsOrDefault(project: Project): List<String> {
-		return with(createArgumentsForProfile()) {
+	fun getProfiles() = profiles
+
+	fun profileArgumentsOrDefault(project: Project, profile: ProfileExtension): List<String> {
+		return with(createArgumentsForProfile(profile)) {
 			if (isNotEmpty()) {
 				if (!contains(INPUT_PARAMETER)) {
 					add(INPUT_PARAMETER)
@@ -42,18 +43,17 @@ open class DetektExtension(open var version: String = SUPPORTED_DETEKT_VERSION,
 		}
 	}
 
-	private fun createArgumentsForProfile(): MutableList<String> {
-		val defaultProfile = getDefaultProfile()
+	private fun createArgumentsForProfile(defaultProfile: ProfileExtension): MutableList<String> {
 		val systemProfile = getSystemProfile()
-		val mainProfile = if (defaultProfile?.name != MAIN_PROFILE_NAME && systemProfile?.name != MAIN_PROFILE_NAME) {
-			searchProfileWithName(MAIN_PROFILE_NAME)
+		val mainProfile = if (defaultProfile.name != DEFAULT_PROFILE_NAME && systemProfile?.name != DEFAULT_PROFILE_NAME) {
+			searchProfileWithName(DEFAULT_PROFILE_NAME)
 		} else null
 
 		val allArguments = mainProfile?.arguments(debug) ?: mutableMapOf()
-		val defaultArguments = defaultProfile?.arguments(debug) ?: mutableMapOf()
+		val defaultArguments = defaultProfile.arguments(debug) ?: mutableMapOf()
 		val fallbackEmptyArguments = mutableMapOf<String, String>()
 
-		val overriddenArguments = if (systemProfile?.name == defaultProfile?.name) fallbackEmptyArguments
+		val overriddenArguments = if (systemProfile?.name == defaultProfile.name) fallbackEmptyArguments
 		else systemProfile?.arguments(debug) ?: fallbackEmptyArguments
 
 		defaultArguments.merge(allArguments)
@@ -69,17 +69,19 @@ open class DetektExtension(open var version: String = SUPPORTED_DETEKT_VERSION,
 	}
 
 	private fun searchProfileWithName(name: String) = profiles.find { it.name == name }
-	private fun getDefaultProfile() = searchProfileWithName(profile)
-	private fun getSystemProfile() = searchProfileWithName(System.getProperty(DETEKT_PROFILE) ?: profile)
+	private fun getDefaultProfile() = searchProfileWithName(DEFAULT_PROFILE_NAME)
+	private fun getSystemProfile(): ProfileExtension? {
+		return System.getProperty(DETEKT_PROFILE)?.let {
+			searchProfileWithName(it)
+		}
+	}
 
 	private fun flattenBoolValues(key: String, value: String)
 			= if (value == "true" || value == "false") listOf(key) else listOf(key, value)
 
 	override fun toString(): String = "DetektExtension(version='$version', " +
-			"debug=$debug, profile='$profile', ideaExtension=$ideaExtension, profiles=$profiles)"
+			"debug=$debug, ideaExtension=$ideaExtension, profiles=$profiles)"
 }
-
-private val MAIN_PROFILE_NAME = "main"
 
 private fun MutableMap<String, String>.merge(other: MutableMap<String, String>) {
 	for ((key, value) in this) {


### PR DESCRIPTION
I was looking at `detekt-gradle-plugin` a bit and realized two weird things. 

1. When I named my profile anything other than `"main"` it seemed not to work correctly.

This seems to have been caused by the `var profile` in `DetektExtension` that was initialized to `"main"` but would never be overwritten with the actual profile name. So detekt would run the `_fallback_` profile which only runs the defaults but considers none of the profiles configuration options.

2. When defining multiple profiles only one would be run by detekt.

While we collect all profiles defined in the `detekt { ... }` closure of the `build.gradle` file in a `profiles` variable we never did anything with them. By adding a getter and looping through all profiles for the `DetektCheckTask`, `DetektCreateBaselineTask` and `DetektMigrateTask` all profiles should now be executed. 