### PR TITLE
improve message of PackageDeclarationStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ style:
   ForbiddenImport:
     active: false
     imports: ''
-  PackageDeclarationStyle:
+  SpacingBetweenPackageAndImports:
     active: false
   ModifierOrder:
     active: true

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -240,7 +240,7 @@ style:
   ForbiddenImport:
     active: false
     imports: ''
-  PackageDeclarationStyle:
+  SpacingBetweenPackageAndImports:
     active: false
   LoopWithTooManyJumpStatements:
     active: false

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -19,7 +19,7 @@ import io.gitlab.arturbosch.detekt.rules.style.NestedClassesVisibility
 import io.gitlab.arturbosch.detekt.rules.style.NewLineAtEndOfFile
 import io.gitlab.arturbosch.detekt.rules.style.OptionalAbstractKeyword
 import io.gitlab.arturbosch.detekt.rules.style.OptionalWhenBraces
-import io.gitlab.arturbosch.detekt.rules.style.PackageDeclarationStyle
+import io.gitlab.arturbosch.detekt.rules.style.SpacingBetweenPackageAndImports
 import io.gitlab.arturbosch.detekt.rules.style.ProtectedMemberInFinalClass
 import io.gitlab.arturbosch.detekt.rules.style.RedundantVisibilityModifierRule
 import io.gitlab.arturbosch.detekt.rules.style.ReturnCount
@@ -56,7 +56,7 @@ class StyleGuideProvider : RuleSetProvider {
 				ForbiddenComment(config),
 				ForbiddenImport(config),
 				FunctionOnlyReturningConstant(config),
-				PackageDeclarationStyle(config),
+				SpacingBetweenPackageAndImports(config),
 				LoopWithTooManyJumpStatements(config),
 				MethodNameEqualsClassName(config),
 				NamingRules(config),

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtImportList
 import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 
-class PackageDeclarationStyle(config: Config = Config.empty) : Rule(config) {
+class SpacingBetweenPackageAndImports(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName, Severity.Style,
 			"Violation of the package declaration style.",

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/PackageDeclarationStyleSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/PackageDeclarationStyleSpec.kt
@@ -8,8 +8,8 @@ import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
 import org.jetbrains.spek.subject.dsl.SubjectProviderDsl
 
-class PackageDeclarationStyleSpec : SubjectSpek<PackageDeclarationStyle>({
-	subject { PackageDeclarationStyle(Config.empty) }
+class PackageDeclarationStyleSpec : SubjectSpek<SpacingBetweenPackageAndImports>({
+	subject { SpacingBetweenPackageAndImports(Config.empty) }
 
 	given("several package and import declarations") {
 
@@ -81,10 +81,10 @@ class PackageDeclarationStyleSpec : SubjectSpek<PackageDeclarationStyle>({
 	}
 })
 
-private fun SubjectProviderDsl<PackageDeclarationStyle>.assertCodeViolation(code: String, size: Int) {
+private fun SubjectProviderDsl<SpacingBetweenPackageAndImports>.assertCodeViolation(code: String, size: Int) {
 	assertThat(subject.lint(code)).hasSize(size)
 }
 
-private fun SubjectProviderDsl<PackageDeclarationStyle>.assertCodeWithoutViolation(code: String) {
+private fun SubjectProviderDsl<SpacingBetweenPackageAndImports>.assertCodeWithoutViolation(code: String) {
 	assertThat(subject.lint(code)).hasSize(0)
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/PackageDeclarationStyleSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/PackageDeclarationStyleSpec.kt
@@ -66,6 +66,18 @@ class PackageDeclarationStyleSpec : SubjectSpek<PackageDeclarationStyle>({
 			val code = "package test;import a.b;class A {}"
 			assertCodeViolation(code, 2)
 		}
+
+		it("should be valid") {
+			val code = """
+				package com.my.package
+
+				import android.util.Log
+				import java.util.concurrent.TimeUnit
+
+				class MyClass { }
+				"""
+			assertCodeViolation(code, 0)
+		}
 	}
 })
 


### PR DESCRIPTION
Was investigating an issue in a codebase today where a `PackageDeclarationStyle` issue was reported.

From the current issue description it was not really clear what was wrong in my code in the first place. This gives both cases this rule checks a clearer `CodeSmell#message`.

Should we rename this rule? Having it called `PackageDeclarationStyle` but it actually also checks the linebreak in between imports and the class declaration is a bit confusing.