### PR TITLE
Run Travis builds in containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk: oraclejdk8
+sudo: false
 script:
   - ./gradlew build
   - ./gradlew shadowJar


### PR DESCRIPTION
Travis claims dramatically reduced time between commit push to GitHub and the start of a job on Travis CI with sudo disabled.