### PR TITLE
Add OutputReport implementation that generates an HTML report

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReport.kt
@@ -1,0 +1,55 @@
+package io.gitlab.arturbosch.detekt.cli.out
+
+import io.gitlab.arturbosch.detekt.api.Detektion
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.OutputReport
+import io.gitlab.arturbosch.detekt.api.ProjectMetric
+import io.gitlab.arturbosch.detekt.cli.ClasspathResourceConverter
+
+private const val DEFAULT_TEMPLATE = "default-html-report-template.html"
+private const val PLACEHOLDER_METRICS =  "@@@metrics@@@"
+private const val PLACEHOLDER_FINDINGS = "@@@findings@@@"
+
+/**
+ * Generates a HTML report containing rule violations and metrics.
+ */
+class HtmlOutputReport : OutputReport() {
+
+	override var fileName = "detekt-report"
+	override val ending = "html"
+
+	override fun render(detektion: Detektion) =
+			ClasspathResourceConverter().convert(DEFAULT_TEMPLATE).openStream().bufferedReader().use { it.readText() }
+					.replace(PLACEHOLDER_METRICS, renderMetrics(detektion.metrics))
+					.replace(PLACEHOLDER_FINDINGS, renderFindings(detektion.findings))
+
+	private fun renderMetrics(metrics: Collection<ProjectMetric>) = htmlSnippet {
+		list(metrics) {
+			text { "${it.type}: ${it.value}" }
+		}
+	}
+
+	private fun renderFindings(findings: Map<String, List<Finding>>) = htmlSnippet {
+		for ((group, groupFindings) in findings.filter { !it.value.isEmpty() }) {
+			h3 { group }
+
+			groupFindings.groupBy { it.id }.forEach { rule, findings ->
+				if (!findings.isEmpty()) {
+					div("rule-container") {
+						span("rule") { rule }
+						span("description") { findings.first().issue.description }
+					}
+				}
+
+				list(findings) {
+					span("location") { "${it.file}:${it.location.source.line}:${it.location.source.column}" }
+
+					if (!it.message.isEmpty()) {
+						br()
+						span("message") { it.message }
+					}
+				}
+			}
+		}
+	}
+}

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlSnippet.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlSnippet.kt
@@ -1,0 +1,57 @@
+package io.gitlab.arturbosch.detekt.cli.out
+
+/**
+ * A very simple DSL for generating HTML.
+ */
+internal class HTMLSnippet {
+
+	private val lines = mutableListOf<String>()
+
+	fun h3(body: () -> String) {
+		lines.add("<h3>${body()}</h3>")
+	}
+
+	fun div(cssClass: String, body: HTMLSnippet.() -> Unit) {
+		lines.add("<div class=\"$cssClass\">")
+
+		body()
+
+		lines.add("</div>")
+	}
+
+	fun text(body: () -> String) {
+		lines.add(body())
+	}
+
+	fun br() {
+		lines.add("<br />")
+	}
+
+	fun span(cssClass: String, text: () -> String) {
+		lines.add("<span class=\"$cssClass\">")
+		lines.add(text())
+		lines.add("</span>")
+	}
+
+	fun <T> list(collection: Collection<T>, body: HTMLSnippet.(T) -> Unit) {
+		lines.add("<ul>")
+
+		collection.forEach {
+			lines.add("<li>")
+			body(it)
+			lines.add("</li>")
+		}
+
+		lines.add("</ul>")
+	}
+
+	override fun toString(): String {
+		return lines.joinToString("\n")
+	}
+}
+
+internal fun htmlSnippet(init: HTMLSnippet.() -> Unit): String {
+	val snippet = HTMLSnippet()
+	snippet.init()
+	return snippet.toString()
+}

--- a/detekt-cli/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.OutputReport
+++ b/detekt-cli/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.OutputReport
@@ -1,2 +1,3 @@
 io.gitlab.arturbosch.detekt.cli.out.PlainOutputReport
 io.gitlab.arturbosch.detekt.cli.out.XmlOutputReport
+io.gitlab.arturbosch.detekt.cli.out.HtmlOutputReport

--- a/detekt-cli/src/main/resources/default-html-report-template.html
+++ b/detekt-cli/src/main/resources/default-html-report-template.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>detekt report</title>
+    <style>
+h2 {
+  background-color: #666666;
+  padding: 0.2em;
+  color: #ffffff;
+}
+h3 {
+  background-color:#f8dfdf;
+  padding:0.5em;
+}
+.rule {
+  background-color: #dddddd;
+  padding: 0.3em;
+  font-weight: bold;
+}
+.description {
+  color:#000000;
+  padding:0.3em;
+}
+.location {
+  color: #690505;
+  font-family: monospace;
+}
+.message {
+  font-size: 0.8em;
+  color: #444444;
+}
+.rule-container {
+  border: 0.1em dashed #dddddd;
+  padding: 0.1em;
+  line-height: 1.5em;
+}
+</style>
+</head>
+<body>
+
+<h1>detekt report</h1>
+
+<h2>Metrics</h2>
+
+@@@metrics@@@
+
+<h2>Findings</h2>
+@@@findings@@@
+
+</body>
+</html>

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
@@ -1,0 +1,76 @@
+package io.gitlab.arturbosch.detekt.cli.out
+
+import io.gitlab.arturbosch.detekt.api.*
+import org.junit.jupiter.api.Test
+
+import org.assertj.core.api.Assertions.assertThat
+
+internal class HtmlOutputFormatTest {
+
+	private val outputFormat = HtmlOutputReport()
+
+	@Test
+	fun testRenderResultLooksLikeHtml() {
+		val result = outputFormat.render(TestDetektion())
+
+		assertThat(result).startsWith("<!DOCTYPE html>\n<html lang=\"en\">")
+		assertThat(result).endsWith("</html>\n")
+
+		assertThat(result).contains("<h1>detekt report</h1>")
+		assertThat(result).contains("<h2>Metrics</h2>")
+		assertThat(result).contains("<h2>Findings</h2>")
+	}
+
+	@Test
+	fun testRenderResultContainsFileLocations() {
+		val result = outputFormat.render(createTestDetektionWithMultipleSmells())
+
+		assertThat(result).contains("<span class=\"location\">\nsrc/main/com/sample/Sample1.kt:11:1\n</span>")
+		assertThat(result).contains("<span class=\"location\">\nsrc/main/com/sample/Sample2.kt:22:2\n</span>")
+		assertThat(result).contains("<span class=\"location\">\nsrc/main/com/sample/Sample3.kt:33:3\n</span>")
+	}
+
+	@Test
+	fun testRenderResultContainsRules() {
+		val result = outputFormat.render(createTestDetektionWithMultipleSmells())
+
+		assertThat(result).contains("<span class=\"rule\">\nid_a\n</span>")
+		assertThat(result).contains("<span class=\"rule\">\nid_a\n</span>")
+		assertThat(result).contains("<span class=\"rule\">\nid_a\n</span>")
+	}
+
+	@Test
+	fun testRenderResultContainsMessages() {
+		val result = outputFormat.render(createTestDetektionWithMultipleSmells())
+
+		assertThat(result).contains("<span class=\"message\">\nB1\n</span>")
+		assertThat(result).contains("<span class=\"message\">\nB2\n</span>")
+		assertThat(result).contains("<span class=\"message\">\nB3\n</span>")
+	}
+
+	@Test
+	fun testRenderResultContainsDescriptions() {
+		val result = outputFormat.render(createTestDetektionWithMultipleSmells())
+
+		assertThat(result).contains("<span class=\"description\">\nA1\n</span>")
+		assertThat(result).contains("<span class=\"description\">\nA2\n</span>")
+		assertThat(result).contains("<span class=\"description\">\nA3\n</span>")
+	}
+
+	private fun createTestDetektionWithMultipleSmells() : Detektion {
+		val entity1 = Entity("Sample1", "com.sample.Sample1", "",
+				Location(SourceLocation(11, 1), TextLocation(0, 10),
+						"abcd", "src/main/com/sample/Sample1.kt"))
+		val entity2 = Entity("Sample2", "com.sample.Sample2", "",
+				Location(SourceLocation(22, 2), TextLocation(0, 20),
+						"efgh", "src/main/com/sample/Sample2.kt"))
+		val entity3 = Entity("Sample2", "com.sample.Sample3", "",
+				Location(SourceLocation(33, 3), TextLocation(0, 30),
+						"ijkl", "src/main/com/sample/Sample3.kt"))
+
+		return TestDetektion(
+				CodeSmell(Issue("id_a", Severity.CodeSmell, "A1"), entity1, message = "B1"),
+				CodeSmell(Issue("id_b", Severity.CodeSmell, "A2"), entity2, message = "B2"),
+				CodeSmell(Issue("id_c", Severity.CodeSmell, "A3"), entity3, message = "B3"))
+	}
+}

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlSnippetTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlSnippetTest.kt
@@ -1,0 +1,33 @@
+package io.gitlab.arturbosch.detekt.cli.out
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class HtmlSnippetTest {
+
+	@Test
+	fun testGeneratingSimpleHtmlSnippet() {
+		val snippet = htmlSnippet {
+			h3 { "Hello World" }
+			div("box") {
+				text {"Test" }
+				br()
+			}
+		}
+
+		assertEquals("<h3>Hello World</h3>\n<div class=\"box\">\nTest\n<br />\n</div>", snippet)
+	}
+
+	@Test
+	fun testGeneratingList() {
+		val items = listOf("Apple", "Banana", "Orange")
+
+		val snippet = htmlSnippet {
+			list(items) {
+				span("fruit") { it }
+			}
+		}
+
+		assertEquals("<ul>\n<li>\n<span class=\"fruit\">\nApple\n</span>\n</li>\n<li>\n<span class=\"fruit\">\nBanana\n</span>\n</li>\n<li>\n<span class=\"fruit\">\nOrange\n</span>\n</li>\n</ul>", snippet)
+	}
+}


### PR DESCRIPTION
Fixes #490

I didn't want to include some big HTML library or whatever. So I wrote my own little helper ("htmlSnippet")

A generated report looks like this:

![screenshot-2017-11-30 detekt report](https://user-images.githubusercontent.com/89638/33437408-1f5c4fce-d5e8-11e7-9666-df308e349acf.png)

Not super beautiful. But hopefully a good start. :)