### PR TITLE
Add documentation in bugs rules

### DIFF
--- a/detekt-generator/documentation/default-detekt-config.yml
+++ b/detekt-generator/documentation/default-detekt-config.yml
@@ -161,11 +161,11 @@ performance:
 potential-bugs:
   active: true
   DuplicateCaseInWhenExpression:
-    active: false
+    active: true
   EqualsAlwaysReturnsTrueOrFalse:
     active: false
   EqualsWithHashCodeExist:
-    active: false
+    active: true
   IteratorNotThrowingNoSuchElementException:
     active: false
   IteratorHasNextCallsNextMethod:
@@ -177,7 +177,7 @@ potential-bugs:
   WrongEqualsTypeParameter:
     active: false
   ExplicitGarbageCollectionCall:
-    active: false
+    active: true
   LateinitUsage:
     active: false
     excludeAnnotatedProperties: ""
@@ -185,7 +185,7 @@ potential-bugs:
   UnconditionalJumpStatementInLoop:
     active: false
   UnreachableCode:
-    active: false
+    active: true
   UnsafeCallOnNullableType:
     active: false
   UnsafeCast:

--- a/detekt-generator/documentation/potential-bugs.md
+++ b/detekt-generator/documentation/potential-bugs.md
@@ -22,39 +22,63 @@ The potential-bugs rule set provides rules that detect potential bugs.
 
 ### DuplicateCaseInWhenExpression
 
-TODO: Specify description
+Flags duplicate case statements in when expressions.
+
+If a when expression contains the same case statement multiple times they should be merged. Otherwise it might be
+easy to miss one of the cases when reading the code, leading to unwanted side effects.
 
 ### EqualsAlwaysReturnsTrueOrFalse
 
-TODO: Specify description
+Reports equals() methods which will always return true or false.
+
+Equals methods should always report if some other object is equal to the current object.
+See the Kotlin documentation for Any.equals(other: Any?):
+https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html
 
 ### EqualsWithHashCodeExist
 
-TODO: Specify description
+When a class overrides the equals() method it should also override the hashCode() method.
+
+All hash-based collections depend on objects meeting the equals-contract. Two equal objects must produce the
+same hashcode. When inheriting equals or hashcode, override the inherited and call the super method for
+clarification.
 
 ### IteratorNotThrowingNoSuchElementException
 
-TODO: Specify description
+Reports implementations of the Iterator interface which do not throw a NoSuchElementException in the
+implementation of the next() method. When there are no more elements to return an Iterator should throw a
+NoSuchElementException.
+
+See: https://docs.oracle.com/javase/7/docs/api/java/util/Iterator.html#next()
 
 ### IteratorHasNextCallsNextMethod
 
-TODO: Specify description
+Verifies implementations of the Iterator interface.
+The hasNext() method of an Iterator implementation should not have any side effects.
+This rule reports implementations that call the next() method of the Iterator inside the hasNext() method.
 
 ### UselessPostfixExpression
 
-TODO: Specify description
+This rule reports postfix expressions (++, --) which are unused and thus unnecessary.
+This leads to confusion as a reader of the code might think the value will be incremented/decremented.
+However the value is replaced with the original value which might lead to bugs.
 
 ### InvalidLoopCondition
 
-TODO: Specify description
+Reports loop conditions which will never be triggered.
+This might be due to invalid ranges like (10..9) which will cause the loop to never be entered.
 
 ### WrongEqualsTypeParameter
 
-TODO: Specify description
+Reports equals() methods which take in a wrongly typed parameter.
+Correct implementations of the equals() method should only take in a parameter of type Any?
+See: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html
 
 ### ExplicitGarbageCollectionCall
 
-TODO: Specify description
+Reports all calls to explicitly trigger the Garbage Collector.
+Code should work independently of the garbage collector and should not require the GC to be triggered in certain
+points in time.
 
 ### LateinitUsage
 
@@ -76,16 +100,22 @@ this check.
 
 ### UnconditionalJumpStatementInLoop
 
-TODO: Specify description
+Reports loops which contain jump statements that jump regardless of any conditions.
+This implies that the loop is only executed once and thus could be rewritten without a
+loop alltogether.
 
 ### UnreachableCode
 
-TODO: Specify description
+Reports unreachable code.
+Code can be unreachable because it is behind return, throw, continue or break expressions.
+This unreachable code should be removed as it serves no purpose.
 
 ### UnsafeCallOnNullableType
 
-TODO: Specify description
+Reports unsafe calls on nullable types. These calls will throw a NullPointerException in case
+the nullable value is null. Kotlin provides many ways to work with nullable types to increase
+null safety. Guard the code appropriately to prevent NullPointerExceptions.
 
 ### UnsafeCast
 
-TODO: Specify description
+Reports casts which are unsafe. In case the cast is not possible it will throw an exception.

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
@@ -10,7 +10,14 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtWhenExpression
 
 /**
+ * Flags duplicate case statements in when expressions.
+ *
+ * If a when expression contains the same case statement multiple times they should be merged. Otherwise it might be
+ * easy to miss one of the cases when reading the code, leading to unwanted side effects.
+ *
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class DuplicateCaseInWhenExpression(config: Config) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
@@ -12,6 +12,16 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtReturnExpression
 
+/**
+ * Reports equals() methods which will always return true or false.
+ *
+ * Equals methods should always report if some other object is equal to the current object.
+ * See the Kotlin documentation for Any.equals(other: Any?):
+ * https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html
+ *
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class EqualsAlwaysReturnsTrueOrFalse(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue("EqualsAlwaysReturnsTrueOrFalse",

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
@@ -16,7 +16,15 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import java.util.ArrayDeque
 
 /**
+ * When a class overrides the equals() method it should also override the hashCode() method.
+ *
+ * All hash-based collections depend on objects meeting the equals-contract. Two equal objects must produce the
+ * same hashcode. When inheriting equals or hashcode, override the inherited and call the super method for
+ * clarification.
+ *
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class EqualsWithHashCodeExist(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
@@ -12,7 +12,13 @@ import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
 import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
 
 /**
+ * Reports all calls to explicitly trigger the Garbage Collector.
+ * Code should work independently of the garbage collector and should not require the GC to be triggered in certain
+ * points in time.
+ *
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class ExplicitGarbageCollectionCall(config: Config) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidLoopCondition.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidLoopCondition.kt
@@ -11,6 +11,13 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtForExpression
 
+/**
+ * Reports loop conditions which will never be triggered.
+ * This might be due to invalid ranges like (10..9) which will cause the loop to never be entered.
+ *
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class InvalidLoopCondition(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
@@ -14,6 +14,14 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
+/**
+ * Verifies implementations of the Iterator interface.
+ * The hasNext() method of an Iterator implementation should not have any side effects.
+ * This rule reports implementations that call the next() method of the Iterator inside the hasNext() method.
+ *
+ * @author Marvin Ramin
+ * @author schalkms
+ */
 class IteratorHasNextCallsNextMethod(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue("IteratorHasNextCallsNextMethod", Severity.Defect,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
@@ -12,6 +12,16 @@ import io.gitlab.arturbosch.detekt.rules.bugs.util.isImplementingIterator
 import io.gitlab.arturbosch.detekt.rules.bugs.util.throwsNoSuchElementExceptionThrown
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
+/**
+ * Reports implementations of the Iterator interface which do not throw a NoSuchElementException in the
+ * implementation of the next() method. When there are no more elements to return an Iterator should throw a
+ * NoSuchElementException.
+ *
+ * See: https://docs.oracle.com/javase/7/docs/api/java/util/Iterator.html#next()
+ *
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class IteratorNotThrowingNoSuchElementException(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue("IteratorNotThrowingNoSuchElementException", Severity.Defect,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
@@ -15,6 +15,14 @@ import org.jetbrains.kotlin.psi.KtLoopExpression
 import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.KtThrowExpression
 
+/**
+ * Reports loops which contain jump statements that jump regardless of any conditions.
+ * This implies that the loop is only executed once and thus could be rewritten without a
+ * loop alltogether.
+ *
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class UnconditionalJumpStatementInLoop(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName, Severity.Defect,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
@@ -14,6 +14,15 @@ import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.KtThrowExpression
 
+/**
+ * Reports unreachable code.
+ * Code can be unreachable because it is behind return, throw, continue or break expressions.
+ * This unreachable code should be removed as it serves no purpose.
+ *
+ * @active since v1.0.0
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class UnreachableCode(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue("UnreachableCode", Severity.Warning,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
@@ -10,7 +10,12 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtUnaryExpression
 
 /**
+ * Reports unsafe calls on nullable types. These calls will throw a NullPointerException in case
+ * the nullable value is null. Kotlin provides many ways to work with nullable types to increase
+ * null safety. Guard the code appropriately to prevent NullPointerExceptions.
+ *
  * @author Ivan Balaksha
+ * @author Marvin Ramin
  */
 class UnsafeCallOnNullableType(config: Config = Config.empty) : Rule(config) {
 	override val issue: Issue = Issue("UnsafeCallOnNullableType",

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
@@ -10,7 +10,10 @@ import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
 import org.jetbrains.kotlin.psi.KtPsiUtil
 
 /**
+ * Reports casts which are unsafe. In case the cast is not possible it will throw an exception.
+ *
  * @author Ivan Balaksha
+ * @author Marvin Ramin
  */
 class UnsafeCast(config: Config = Config.empty) : Rule(config) {
 	override val issue: Issue = Issue("UnsafeCast",

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
@@ -18,6 +18,15 @@ import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 
+/**
+ * This rule reports postfix expressions (++, --) which are unused and thus unnecessary.
+ * This leads to confusion as a reader of the code might think the value will be incremented/decremented.
+ * However the value is replaced with the original value which might lead to bugs.
+ *
+ * @author schalkms
+ * @author Artur Bosch
+ * @author Marvin Ramin
+ */
 class UselessPostfixExpression(config: Config = Config.empty) : Rule(config) {
 
 	override val issue: Issue = Issue("UselessPostfixExpression", Severity.Defect,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameter.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameter.kt
@@ -10,6 +10,14 @@ import io.gitlab.arturbosch.detekt.rules.hasCorrectEqualsParameter
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
+/**
+ * Reports equals() methods which take in a wrongly typed parameter.
+ * Correct implementations of the equals() method should only take in a parameter of type Any?
+ * See: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html
+ *
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class WrongEqualsTypeParameter(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue("WrongEqualsTypeParameter", Severity.Defect,


### PR DESCRIPTION
This adds some basic documentation in all rules of the `PotentialBugProvider`.  
I also added some more `@author` tags in the KDoc and marked the ones as `@active` that are currently enabled in the `default-detekt-config.yml`.