### PR TITLE
Add documentation to generate default config

### DIFF
--- a/detekt-generator/documentation/comments.md
+++ b/detekt-generator/documentation/comments.md
@@ -23,6 +23,24 @@ TODO: Specify description
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `searchInNestedClass` (default: `true`)
+
+   if nested classes should be searched
+
+* `searchInInnerClass` (default: `true`)
+
+   if inner classes should be searched
+
+* `searchInInnerObject` (default: `true`)
+
+   if inner objects should be searched
+
+* `searchInInnerInterface` (default: `true`)
+
+   if inner interfaces should be searched
+
 ### UndocumentedPublicFunction
 
 TODO: Specify description

--- a/detekt-generator/documentation/complexity.md
+++ b/detekt-generator/documentation/complexity.md
@@ -21,41 +21,133 @@ This rule set contains rules that report complex code.
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `threshold` (default: `5`)
+
+   maximum number of parameters
+
 ### LongMethod
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `threshold` (default: `20`)
+
+   maximum lines in a method
 
 ### LargeClass
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `threshold` (default: `150`)
+
+   maximum size of a class
+
 ### ComplexInterface
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `threshold` (default: `10`)
+
+   maximum amount of definitions in an interface
+
+* `includeStaticDeclarations` (default: `false`)
+
+   whether static declarations should be included
 
 ### ComplexMethod
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `threshold` (default: `10`)
+
+   maximum amount of functions in a class
+
 ### StringLiteralDuplication
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `threshold` (default: `2`)
+
+   maximum allowed duplication
+
+* `ignoreAnnotation` (default: `true`)
+
+   if values in Annotations should be ignored
+
+* `excludeStringsWithLessThan5Characters` (default: `true`)
+
+   if short strings should be excluded
+
+* `ignoreStringsRegex` (default: `'$^'`)
+
+   RegEx of Strings that should be ignored
 
 ### MethodOverloading
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `threshold` (default: `5`)
+
+   
+
 ### NestedBlockDepth
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `threshold` (default: `3`)
+
+   maximum nesting depth
 
 ### TooManyFunctions
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `thresholdInFiles` (default: `10`)
+
+   threshold in files
+
+* `thresholdInClasses` (default: `10`)
+
+   threshold in classes
+
+* `thresholdInInterfaces` (default: `10`)
+
+   threshold in interfaces
+
+* `thresholdInObjects` (default: `10`)
+
+   threshold in objects
+
+* `thresholdInEnums` (default: `10`)
+
+   threshold in enums
+
 ### ComplexCondition
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `threshold` (default: `3`)
+
+   
 
 ### LabeledExpression
 

--- a/detekt-generator/documentation/default-detekt-config.yml
+++ b/detekt-generator/documentation/default-detekt-config.yml
@@ -56,78 +56,116 @@ code-smell:
 comments:
   active: true
   CommentOverPrivateFunction:
-    active: false
+    active: true
   CommentOverPrivateProperty:
-    active: false
+    active: true
   UndocumentedPublicClass:
     active: false
+    searchInNestedClass: true
+    searchInInnerClass: true
+    searchInInnerObject: true
+    searchInInnerInterface: true
   UndocumentedPublicFunction:
     active: false
 
 complexity:
   active: true
   LongParameterList:
-    active: false
+    active: true
+    threshold: 5
   LongMethod:
-    active: false
+    active: true
+    threshold: 20
   LargeClass:
-    active: false
+    active: true
+    threshold: 150
   ComplexInterface:
     active: false
+    threshold: 10
+    includeStaticDeclarations: false
   ComplexMethod:
-    active: false
+    active: true
+    threshold: 10
   StringLiteralDuplication:
-    active: false
+    active: true
+    threshold: 2
+    ignoreAnnotation: true
+    excludeStringsWithLessThan5Characters: true
+    ignoreStringsRegex: '$^'
   MethodOverloading:
     active: false
+    threshold: 5
   NestedBlockDepth:
-    active: false
+    active: true
+    threshold: 3
   TooManyFunctions:
-    active: false
+    active: true
+    thresholdInFiles: 10
+    thresholdInClasses: 10
+    thresholdInInterfaces: 10
+    thresholdInObjects: 10
+    thresholdInEnums: 10
   ComplexCondition:
-    active: false
+    active: true
+    threshold: 3
   LabeledExpression:
     active: false
 
 empty-blocks:
   active: true
   EmptyCatchBlock:
-    active: false
+    active: true
   EmptyClassBlock:
-    active: false
+    active: true
   EmptyDefaultConstructor:
-    active: false
+    active: true
   EmptyDoWhileBlock:
-    active: false
+    active: true
   EmptyElseBlock:
-    active: false
+    active: true
   EmptyFinallyBlock:
-    active: false
+    active: true
   EmptyForBlock:
-    active: false
+    active: true
   EmptyFunctionBlock:
-    active: false
+    active: true
   EmptyIfBlock:
-    active: false
+    active: true
   EmptyInitBlock:
-    active: false
+    active: true
   EmptyKtFile:
-    active: false
+    active: true
   EmptySecondaryConstructor:
-    active: false
+    active: true
   EmptyWhenBlock:
-    active: false
+    active: true
   EmptyWhileBlock:
-    active: false
+    active: true
 
 exceptions:
   active: true
   TooGenericExceptionCaught:
-    active: false
+    active: true
+    exceptions:
+     - ArrayIndexOutOfBoundsException
+     - Error
+     - Exception
+     - IllegalMonitorStateException
+     - NullPointerException
+     - IndexOutOfBoundsException
+     - RuntimeException
+     - Throwable
   ExceptionRaisedInUnexpectedLocation:
     active: false
+    methodNames: 'toString,hashCode,equals,finalize'
   TooGenericExceptionThrown:
-    active: false
+    active: true
+    exceptions:
+     - Error
+     - Exception
+     - NullPointerException
+     - Throwable
+     - RuntimeException
   NotImplementedDeclaration:
     active: false
   PrintStackTrace:
@@ -136,6 +174,7 @@ exceptions:
     active: false
   ThrowingExceptionsWithoutMessageOrCause:
     active: false
+    exceptions: 'IllegalArgumentException,IllegalStateException,IOException'
   ReturnFromFinally:
     active: false
   ThrowingExceptionFromFinally:
@@ -199,54 +238,79 @@ style:
     active: true
     max: 2
   ThrowsCount:
-    active: false
+    active: true
+    max: 2
   NewLineAtEndOfFile:
-    active: false
+    active: true
   WildcardImport:
-    active: false
-    excludeImports: ""
+    active: true
+    excludeImports: 'java.util.*,kotlinx.android.synthetic.*'
   MaxLineLength:
-    active: false
+    active: true
+    maxLineLength: 120
+    excludePackageStatements: false
+    excludeImportStatements: false
   EqualsNullCall:
     active: false
   ForbiddenComment:
-    active: false
+    active: true
+    values: 'TODO:,FIXME:,STOPSHIP:'
   ForbiddenImport:
     active: false
+    imports: ''
   FunctionOnlyReturningConstant:
     active: false
+    ignoreOverridableFunction: true
+    excludedFunctions: 'describeContents'
   SpacingBetweenPackageAndImports:
     active: false
   LoopWithTooManyJumpStatements:
     active: false
+    maxJumpCount: 1
   MethodNameEqualsClassName:
     active: false
+    ignoreOverriddenFunction: true
   VariableNaming:
-    active: false
+    active: true
+    variablePattern: '[a-z][A-Za-z0-9]*'
+    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
   VariableMinLength:
     active: false
+    minimumVariableNameLength: 3
   VariableMaxLength:
     active: false
+    maximumVariableNameLength: 30
   TopLevelPropertyNaming:
-    active: false
+    active: true
+    constantPattern: '[A-Z][_A-Z0-9]*'
+    propertyPattern: '[a-z][A-Za-z\d]*'
+    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
   ObjectPropertyNaming:
-    active: false
+    active: true
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
   PackageNaming:
-    active: false
+    active: true
+    packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
   ClassNaming:
-    active: false
+    active: true
+    classPattern: '[A-Z$][a-zA-Z$]*'
   EnumNaming:
-    active: false
+    active: true
+    enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
   FunctionNaming:
-    active: false
+    active: true
+    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
   FunctionMaxLength:
     active: false
+    maximumFunctionNameLength: 30
   FunctionMinLength:
     active: false
+    minimumFunctionNameLength: 3
   ForbiddenClassName:
     active: false
+    forbiddenName: ''
   SafeCast:
-    active: false
+    active: true
   UnnecessaryAbstractClass:
     active: false
   UnnecessaryParentheses:
@@ -256,7 +320,7 @@ style:
   UtilityClassWithPublicConstructor:
     active: false
   OptionalAbstractKeyword:
-    active: false
+    active: true
   OptionalWhenBraces:
     active: false
   OptionalReturnKeyword:
@@ -268,11 +332,20 @@ style:
   SerialVersionUIDInSerializableClass:
     active: false
   MagicNumber:
-    active: false
+    active: true
+    ignoreNumbers: '-1,0,1,2'
+    ignoreHashCodeFunction: false
+    ignorePropertyDeclaration: false
+    ignoreConstantDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+    ignoreAnnotation: false
+    ignoreNamedArgument: true
+    ignoreEnums: false
   ModifierOrder:
-    active: false
+    active: true
   DataClassContainsFunctions:
     active: false
+    conversionFunctionPrefix: 'to'
   UseDataClass:
     active: false
   UnusedImports:

--- a/detekt-generator/documentation/default-detekt-config.yml
+++ b/detekt-generator/documentation/default-detekt-config.yml
@@ -161,11 +161,11 @@ performance:
 potential-bugs:
   active: true
   DuplicateCaseInWhenExpression:
-    active: false
+    active: true
   EqualsAlwaysReturnsTrueOrFalse:
     active: false
   EqualsWithHashCodeExist:
-    active: false
+    active: true
   IteratorNotThrowingNoSuchElementException:
     active: false
   IteratorHasNextCallsNextMethod:
@@ -177,7 +177,7 @@ potential-bugs:
   WrongEqualsTypeParameter:
     active: false
   ExplicitGarbageCollectionCall:
-    active: false
+    active: true
   LateinitUsage:
     active: false
     excludeAnnotatedProperties: ""
@@ -185,7 +185,7 @@ potential-bugs:
   UnconditionalJumpStatementInLoop:
     active: false
   UnreachableCode:
-    active: false
+    active: true
   UnsafeCallOnNullableType:
     active: false
   UnsafeCast:

--- a/detekt-generator/documentation/exceptions.md
+++ b/detekt-generator/documentation/exceptions.md
@@ -23,13 +23,44 @@ Rules in this rule set report issues related to how code throws and handles Exce
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `exceptions` (default: `- ArrayIndexOutOfBoundsException
+- Error
+- Exception
+- IllegalMonitorStateException
+- NullPointerException
+- IndexOutOfBoundsException
+- RuntimeException
+- Throwable`)
+
+   exceptions which are too generic and should not be caught
+(default:
+
 ### ExceptionRaisedInUnexpectedLocation
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `methodNames` (default: `'toString,hashCode,equals,finalize'`)
+
+   methods which should not throw exceptions
+
 ### TooGenericExceptionThrown
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `exceptions` (default: `- Error
+- Exception
+- NullPointerException
+- Throwable
+- RuntimeException`)
+
+   exceptions which are too generic and should not be thrown
+(default:
 
 ### NotImplementedDeclaration
 
@@ -46,6 +77,12 @@ TODO: Specify description
 ### ThrowingExceptionsWithoutMessageOrCause
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `exceptions` (default: `'IllegalArgumentException,IllegalStateException,IOException'`)
+
+   exceptions which should not be thrown without message or cause
 
 ### ReturnFromFinally
 

--- a/detekt-generator/documentation/potential-bugs.md
+++ b/detekt-generator/documentation/potential-bugs.md
@@ -22,39 +22,63 @@ The potential-bugs rule set provides rules that detect potential bugs.
 
 ### DuplicateCaseInWhenExpression
 
-TODO: Specify description
+Flags duplicate case statements in when expressions.
+
+If a when expression contains the same case statement multiple times they should be merged. Otherwise it might be
+easy to miss one of the cases when reading the code, leading to unwanted side effects.
 
 ### EqualsAlwaysReturnsTrueOrFalse
 
-TODO: Specify description
+Reports equals() methods which will always return true or false.
+
+Equals methods should always report if some other object is equal to the current object.
+See the Kotlin documentation for Any.equals(other: Any?):
+https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html
 
 ### EqualsWithHashCodeExist
 
-TODO: Specify description
+When a class overrides the equals() method it should also override the hashCode() method.
+
+All hash-based collections depend on objects meeting the equals-contract. Two equal objects must produce the
+same hashcode. When inheriting equals or hashcode, override the inherited and call the super method for
+clarification.
 
 ### IteratorNotThrowingNoSuchElementException
 
-TODO: Specify description
+Reports implementations of the Iterator interface which do not throw a NoSuchElementException in the
+implementation of the next() method. When there are no more elements to return an Iterator should throw a
+NoSuchElementException.
+
+See: https://docs.oracle.com/javase/7/docs/api/java/util/Iterator.html#next()
 
 ### IteratorHasNextCallsNextMethod
 
-TODO: Specify description
+Verifies implementations of the Iterator interface.
+The hasNext() method of an Iterator implementation should not have any side effects.
+This rule reports implementations that call the next() method of the Iterator inside the hasNext() method.
 
 ### UselessPostfixExpression
 
-TODO: Specify description
+This rule reports postfix expressions (++, --) which are unused and thus unnecessary.
+This leads to confusion as a reader of the code might think the value will be incremented/decremented.
+However the value is replaced with the original value which might lead to bugs.
 
 ### InvalidLoopCondition
 
-TODO: Specify description
+Reports loop conditions which will never be triggered.
+This might be due to invalid ranges like (10..9) which will cause the loop to never be entered.
 
 ### WrongEqualsTypeParameter
 
-TODO: Specify description
+Reports equals() methods which take in a wrongly typed parameter.
+Correct implementations of the equals() method should only take in a parameter of type Any?
+See: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html
 
 ### ExplicitGarbageCollectionCall
 
-TODO: Specify description
+Reports all calls to explicitly trigger the Garbage Collector.
+Code should work independently of the garbage collector and should not require the GC to be triggered in certain
+points in time.
 
 ### LateinitUsage
 
@@ -76,16 +100,22 @@ this check.
 
 ### UnconditionalJumpStatementInLoop
 
-TODO: Specify description
+Reports loops which contain jump statements that jump regardless of any conditions.
+This implies that the loop is only executed once and thus could be rewritten without a
+loop alltogether.
 
 ### UnreachableCode
 
-TODO: Specify description
+Reports unreachable code.
+Code can be unreachable because it is behind return, throw, continue or break expressions.
+This unreachable code should be removed as it serves no purpose.
 
 ### UnsafeCallOnNullableType
 
-TODO: Specify description
+Reports unsafe calls on nullable types. These calls will throw a NullPointerException in case
+the nullable value is null. Kotlin provides many ways to work with nullable types to increase
+null safety. Guard the code appropriately to prevent NullPointerExceptions.
 
 ### UnsafeCast
 
-TODO: Specify description
+Reports casts which are unsafe. In case the cast is not possible it will throw an exception.

--- a/detekt-generator/documentation/style.md
+++ b/detekt-generator/documentation/style.md
@@ -73,6 +73,12 @@ code.
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `max` (default: `2`)
+
+   maximum amount of throw statements in a method
+
 ### NewLineAtEndOfFile
 
 TODO: Specify description
@@ -86,7 +92,7 @@ Library updates can introduce naming clashes with your own classes which might r
 
 #### Configuration options:
 
-* `excludeImports` (default: `""`)
+* `excludeImports` (default: `'java.util.*,kotlinx.android.synthetic.*'`)
 
    Define a whitelist of package names that should be allowed to be imported
 with wildcard imports.
@@ -94,6 +100,20 @@ with wildcard imports.
 ### MaxLineLength
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `maxLineLength` (default: `120`)
+
+   maximum line length
+
+* `excludePackageStatements` (default: `false`)
+
+   if package statements should be ignored
+
+* `excludeImportStatements` (default: `false`)
+
+   if import statements should be ignored
 
 ### EqualsNullCall
 
@@ -103,13 +123,35 @@ TODO: Specify description
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `values` (default: `'TODO:,FIXME:,STOPSHIP:'`)
+
+   forbidden comment strings
+
 ### ForbiddenImport
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `imports` (default: `''`)
+
+   imports which should not be used
+
 ### FunctionOnlyReturningConstant
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `ignoreOverridableFunction` (default: `true`)
+
+   if overriden functions should be ignored
+
+* `excludedFunctions` (default: `'describeContents'`)
+
+   excluded functions
 
 ### SpacingBetweenPackageAndImports
 
@@ -119,57 +161,153 @@ TODO: Specify description
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `maxJumpCount` (default: `1`)
+
+   maximum allowed jumps in a loop
+
 ### MethodNameEqualsClassName
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `ignoreOverriddenFunction` (default: `true`)
+
+   if overridden functions should be ignored
 
 ### VariableNaming
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `variablePattern` (default: `'[a-z][A-Za-z0-9]*'`)
+
+   naming pattern (default: '[a
+
+* `privateVariablePattern` (default: `'(_)?[a-z][A-Za-z0-9]*'`)
+
+   naming pattern ?[a
+
 ### VariableMinLength
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `minimumVariableNameLength` (default: `3`)
+
+   maximum name length
 
 ### VariableMaxLength
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `maximumVariableNameLength` (default: `30`)
+
+   maximum name length
+
 ### TopLevelPropertyNaming
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `constantPattern` (default: `'[A-Z][_A-Z0-9]*'`)
+
+   naming pattern (default: '[A
+
+* `propertyPattern` (default: `'[a-z][A-Za-z\d]*'`)
+
+   naming pattern (default: '[a
+
+* `privatePropertyPattern` (default: `'(_)?[a-z][A-Za-z0-9]*'`)
+
+   naming pattern ?[a
 
 ### ObjectPropertyNaming
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `propertyPattern` (default: `'[A-Za-z][_A-Za-z0-9]*'`)
+
+   naming pattern (default: '[A
+
 ### PackageNaming
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `packagePattern` (default: `'^[a-z]+(\.[a-z][a-z0-9]*)*$'`)
+
+   naming pattern (default: '^[a
 
 ### ClassNaming
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `classPattern` (default: `'[A-Z$][a-zA-Z$]*'`)
+
+   naming pattern (default: '[A
+
 ### EnumNaming
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `enumEntryPattern` (default: `'^[A-Z$][a-zA-Z_$]*$'`)
+
+   naming pattern (default: '^[A
 
 ### FunctionNaming
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `functionPattern` (default: `'^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'`)
+
+   naming pattern (default: '^([a
+
 ### FunctionMaxLength
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `maximumFunctionNameLength` (default: `30`)
+
+   maximum name length
 
 ### FunctionMinLength
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `minimumFunctionNameLength` (default: `3`)
+
+   minimum name length
+
 ### ForbiddenClassName
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `forbiddenName` (default: `''`)
+
+   forbidden class names
 
 ### SafeCast
 
@@ -221,6 +359,41 @@ TODO: Specify description
 
 TODO: Specify description
 
+#### Configuration options:
+
+* `ignoreNumbers` (default: `'-1,0,1,2'`)
+
+   numbers which do not count as magic numbers (default: '
+
+* `ignoreHashCodeFunction` (default: `false`)
+
+   whether magic numbers in hashCode functions should be ignored
+
+* `ignorePropertyDeclaration` (default: `false`)
+
+   whether magic numbers in property declarations should be ignored
+
+* `ignoreConstantDeclaration` (default: `true`)
+
+   whether magic numbers in property declarations should be ignored
+
+* `ignoreCompanionObjectPropertyDeclaration` (default: `true`)
+
+   whether magic numbers in companion object
+declarations should be ignored
+
+* `ignoreAnnotation` (default: `false`)
+
+   whether magic numbers in annotations should be ignored
+
+* `ignoreNamedArgument` (default: `true`)
+
+   whether magic numbers in named arguments should be ignored
+
+* `ignoreEnums` (default: `false`)
+
+   whether magic numbers in enums should be ignored
+
 ### ModifierOrder
 
 Modifier order array taken from ktlint: https://github.com/shyiko/ktlint
@@ -228,6 +401,12 @@ Modifier order array taken from ktlint: https://github.com/shyiko/ktlint
 ### DataClassContainsFunctions
 
 TODO: Specify description
+
+#### Configuration options:
+
+* `conversionFunctionPrefix` (default: `'to'`)
+
+   allowed conversion function names
 
 ### UseDataClass
 

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollector.kt
@@ -47,7 +47,7 @@ class RuleCollector : Collector<Rule> {
 
 private const val TAG_ACTIVE = "active"
 private const val TAG_CONFIGURATION = "configuration"
-private val configurationDefaultValueRegex = "\\(default: (.+)\\)".toRegex()
+private val configurationDefaultValueRegex = "\\(default: (.+)\\)".toRegex(RegexOption.DOT_MATCHES_ALL)
 
 class RuleVisitor : DetektVisitor() {
 	val containsRule

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Yaml.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Yaml.kt
@@ -49,4 +49,11 @@ inline fun YamlNode.keyValue(keyValue: () -> Pair<String, String>) {
 	val (key, value) = keyValue()
 	append("$key: $value")
 }
+
+inline fun YamlNode.list(name: String, list: List<String>) {
+	append("$name:")
+	list.forEach {
+		append(" - $it")
+	}
+}
 inline fun YamlNode.yaml(yaml: () -> String) = append(yaml())

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.generator.printer.rulesetpage
 
 import io.gitlab.arturbosch.detekt.generator.out.keyValue
+import io.gitlab.arturbosch.detekt.generator.out.list
 import io.gitlab.arturbosch.detekt.generator.out.node
 import io.gitlab.arturbosch.detekt.generator.out.yaml
 import io.gitlab.arturbosch.detekt.generator.printer.DocumentationPrinter
@@ -33,7 +34,11 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
 						node(rule.name) {
 							keyValue { "active" to "${rule.active}" }
 							rule.configuration.forEach { configuration ->
-								keyValue { configuration.name to configuration.defaultValue }
+								if (configuration.defaultValue.isYamlList()) {
+									list(configuration.name, configuration.defaultValue.toList())
+								} else {
+									keyValue { configuration.name to configuration.defaultValue }
+								}
 							}
 						}
 					}
@@ -118,4 +123,10 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
 			  #  - 'XmlOutputReport'
 			""".trimIndent()
 	}
+}
+
+private fun String.isYamlList() = trim().startsWith("-")
+private fun String.toList(): List<String> {
+	return split("\n").map { it.replace("-", "") }
+			.map { it.trim() }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
@@ -10,7 +10,14 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtWhenExpression
 
 /**
+ * Flags duplicate case statements in when expressions.
+ *
+ * If a when expression contains the same case statement multiple times they should be merged. Otherwise it might be
+ * easy to miss one of the cases when reading the code, leading to unwanted side effects.
+ *
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class DuplicateCaseInWhenExpression(config: Config) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
@@ -12,6 +12,16 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtReturnExpression
 
+/**
+ * Reports equals() methods which will always return true or false.
+ *
+ * Equals methods should always report if some other object is equal to the current object.
+ * See the Kotlin documentation for Any.equals(other: Any?):
+ * https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html
+ *
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class EqualsAlwaysReturnsTrueOrFalse(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue("EqualsAlwaysReturnsTrueOrFalse",

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
@@ -16,7 +16,15 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import java.util.ArrayDeque
 
 /**
+ * When a class overrides the equals() method it should also override the hashCode() method.
+ *
+ * All hash-based collections depend on objects meeting the equals-contract. Two equal objects must produce the
+ * same hashcode. When inheriting equals or hashcode, override the inherited and call the super method for
+ * clarification.
+ *
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class EqualsWithHashCodeExist(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
@@ -12,7 +12,13 @@ import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
 import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
 
 /**
+ * Reports all calls to explicitly trigger the Garbage Collector.
+ * Code should work independently of the garbage collector and should not require the GC to be triggered in certain
+ * points in time.
+ *
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class ExplicitGarbageCollectionCall(config: Config) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidLoopCondition.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidLoopCondition.kt
@@ -11,6 +11,13 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtForExpression
 
+/**
+ * Reports loop conditions which will never be triggered.
+ * This might be due to invalid ranges like (10..9) which will cause the loop to never be entered.
+ *
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class InvalidLoopCondition(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
@@ -14,6 +14,14 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
+/**
+ * Verifies implementations of the Iterator interface.
+ * The hasNext() method of an Iterator implementation should not have any side effects.
+ * This rule reports implementations that call the next() method of the Iterator inside the hasNext() method.
+ *
+ * @author Marvin Ramin
+ * @author schalkms
+ */
 class IteratorHasNextCallsNextMethod(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue("IteratorHasNextCallsNextMethod", Severity.Defect,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
@@ -12,6 +12,16 @@ import io.gitlab.arturbosch.detekt.rules.bugs.util.isImplementingIterator
 import io.gitlab.arturbosch.detekt.rules.bugs.util.throwsNoSuchElementExceptionThrown
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
+/**
+ * Reports implementations of the Iterator interface which do not throw a NoSuchElementException in the
+ * implementation of the next() method. When there are no more elements to return an Iterator should throw a
+ * NoSuchElementException.
+ *
+ * See: https://docs.oracle.com/javase/7/docs/api/java/util/Iterator.html#next()
+ *
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class IteratorNotThrowingNoSuchElementException(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue("IteratorNotThrowingNoSuchElementException", Severity.Defect,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
@@ -15,6 +15,14 @@ import org.jetbrains.kotlin.psi.KtLoopExpression
 import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.KtThrowExpression
 
+/**
+ * Reports loops which contain jump statements that jump regardless of any conditions.
+ * This implies that the loop is only executed once and thus could be rewritten without a
+ * loop alltogether.
+ *
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class UnconditionalJumpStatementInLoop(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName, Severity.Defect,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
@@ -14,6 +14,15 @@ import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.KtThrowExpression
 
+/**
+ * Reports unreachable code.
+ * Code can be unreachable because it is behind return, throw, continue or break expressions.
+ * This unreachable code should be removed as it serves no purpose.
+ *
+ * @active since v1.0.0
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class UnreachableCode(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue("UnreachableCode", Severity.Warning,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
@@ -10,7 +10,12 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtUnaryExpression
 
 /**
+ * Reports unsafe calls on nullable types. These calls will throw a NullPointerException in case
+ * the nullable value is null. Kotlin provides many ways to work with nullable types to increase
+ * null safety. Guard the code appropriately to prevent NullPointerExceptions.
+ *
  * @author Ivan Balaksha
+ * @author Marvin Ramin
  */
 class UnsafeCallOnNullableType(config: Config = Config.empty) : Rule(config) {
 	override val issue: Issue = Issue("UnsafeCallOnNullableType",

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
@@ -10,7 +10,10 @@ import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
 import org.jetbrains.kotlin.psi.KtPsiUtil
 
 /**
+ * Reports casts which are unsafe. In case the cast is not possible it will throw an exception.
+ *
  * @author Ivan Balaksha
+ * @author Marvin Ramin
  */
 class UnsafeCast(config: Config = Config.empty) : Rule(config) {
 	override val issue: Issue = Issue("UnsafeCast",

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
@@ -18,6 +18,15 @@ import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 
+/**
+ * This rule reports postfix expressions (++, --) which are unused and thus unnecessary.
+ * This leads to confusion as a reader of the code might think the value will be incremented/decremented.
+ * However the value is replaced with the original value which might lead to bugs.
+ *
+ * @author schalkms
+ * @author Artur Bosch
+ * @author Marvin Ramin
+ */
 class UselessPostfixExpression(config: Config = Config.empty) : Rule(config) {
 
 	override val issue: Issue = Issue("UselessPostfixExpression", Severity.Defect,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameter.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameter.kt
@@ -10,6 +10,14 @@ import io.gitlab.arturbosch.detekt.rules.hasCorrectEqualsParameter
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
+/**
+ * Reports equals() methods which take in a wrongly typed parameter.
+ * Correct implementations of the equals() method should only take in a parameter of type Any?
+ * See: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html
+ *
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class WrongEqualsTypeParameter(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue("WrongEqualsTypeParameter", Severity.Defect,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
@@ -15,7 +15,11 @@ import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.KtWhileExpression
 
 /**
+ * @configuration threshold - (default: 3)
+ *
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class ComplexCondition(config: Config = Config.empty,
 					   threshold: Int = DEFAULT_ACCEPTED_NESTING) : ThresholdRule(config, threshold) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
@@ -14,6 +14,13 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtProperty
 
+/**
+ * @configuration threshold - maximum amount of definitions in an interface (default: 10)
+ * @configuration includeStaticDeclarations - whether static declarations should be included (default: false)
+ *
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class ComplexInterface(config: Config = Config.empty,
 					   threshold: Int = DEFAULT_LARGE_INTERFACE_COUNT) : ThresholdRule(config, threshold) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -11,7 +11,11 @@ import io.gitlab.arturbosch.detekt.api.internal.McCabeVisitor
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
+ * @configuration threshold - maximum amount of functions in a class (default: 10)
+ *
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class ComplexMethod(config: Config = Config.empty,
 					threshold: Int = DEFAULT_ACCEPTED_METHOD_COMPLEXITY) : ThresholdRule(config, threshold) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -22,7 +22,11 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
 import java.util.ArrayDeque
 
 /**
+ * @configuration threshold - maximum size of a class (default: 150)
+ *
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class LargeClass(config: Config = Config.empty,
 				 threshold: Int = DEFAULT_ACCEPTED_CLASS_LENGTH) : ThresholdRule(config, threshold) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -12,7 +12,11 @@ import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
+ * @configuration threshold - maximum lines in a method (default: 20)
+ *
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class LongMethod(config: Config = Config.empty,
 				 threshold: Int = DEFAULT_ACCEPTED_METHOD_LENGTH) : ThresholdRule(config, threshold) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -12,7 +12,11 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameterList
 
 /**
+ * @configuration threshold - maximum number of parameters (default: 5)
+ *
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class LongParameterList(config: Config = Config.empty,
 						threshold: Int = DEFAULT_ACCEPTED_PARAMETER_LENGTH) : ThresholdRule(config, threshold) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
@@ -13,6 +13,12 @@ import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
+/**
+ * @configuration threshold - (default: 5)
+ *
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class MethodOverloading(config: Config = Config.empty,
 						threshold: Int = ACCEPTED_OVERLOAD_COUNT) : ThresholdRule(config, threshold) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
@@ -19,7 +19,11 @@ import org.jetbrains.kotlin.psi.KtTryExpression
 import org.jetbrains.kotlin.psi.KtWhenExpression
 
 /**
+ * @configuration threshold - maximum nesting depth (default: 3)
+ *
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class NestedBlockDepth(config: Config = Config.empty,
 					   threshold: Int = DEFAULT_ACCEPTED_NESTING) : ThresholdRule(config, threshold) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
@@ -14,6 +14,17 @@ import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
 
+/**
+ * @configuration threshold - maximum allowed duplication (default: 2)
+ * @configuration ignoreAnnotation - if values in Annotations should be ignored (default: true)
+ * @configuration excludeStringsWithLessThan5Characters - if short strings should be excluded (default: true)
+ * @configuration ignoreStringsRegex - RegEx of Strings that should be ignored (default: '$^')
+ *
+ * @active since v1.0.0
+ * @author schalkms
+ * @author Artur Bosch
+ * @author Marvin Ramin
+ */
 class StringLiteralDuplication(
 		config: Config = Config.empty,
 		threshold: Int = DEFAULT_DUPLICATION

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -14,7 +14,15 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 
 /**
+ * @configuration thresholdInFiles - threshold in files (default: 10)
+ * @configuration thresholdInClasses - threshold in classes (default: 10)
+ * @configuration thresholdInInterfaces - threshold in interfaces (default: 10)
+ * @configuration thresholdInObjects - threshold in objects (default: 10)
+ * @configuration thresholdInEnums - threshold in enums (default: 10)
+ *
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
@@ -10,7 +10,9 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class CommentOverPrivateFunction(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
@@ -10,7 +10,9 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtProperty
 
 /**
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class CommentOverPrivateProperty(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -13,6 +13,11 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 
 /**
+ * @configuration searchInNestedClass - if nested classes should be searched (default: true)
+ * @configuration searchInInnerClass - if inner classes should be searched (default: true)
+ * @configuration searchInInnerObject - if inner objects should be searched (default: true)
+ * @configuration searchInInnerInterface - if inner interfaces should be searched (default: true)
+ *
  * @author Artur Bosch
  */
 class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocks.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocks.kt
@@ -18,7 +18,9 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
 import org.jetbrains.kotlin.psi.KtWhileExpression
 
 /**
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 @Suppress("TooManyFunctions")
 class EmptyBlocks(val config: Config = Config.empty) : MultiRule() {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
@@ -4,7 +4,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import org.jetbrains.kotlin.psi.KtCatchClause
 
 /**
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class EmptyCatchBlock(config: Config) : EmptyRule(config = config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
@@ -6,7 +6,9 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
 /**
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class EmptyClassBlock(config: Config) : EmptyRule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDefaultConstructor.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDefaultConstructor.kt
@@ -8,6 +8,11 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtPrimaryConstructor
 import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierType
 
+/**
+ * @active since v1.0.0
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class EmptyDefaultConstructor(config: Config) : EmptyRule(config = config) {
 
 	override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDoWhileBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDoWhileBlock.kt
@@ -4,7 +4,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import org.jetbrains.kotlin.psi.KtDoWhileExpression
 
 /**
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class EmptyDoWhileBlock(config: Config) : EmptyRule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyElseBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyElseBlock.kt
@@ -4,7 +4,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import org.jetbrains.kotlin.psi.KtIfExpression
 
 /**
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class EmptyElseBlock(config: Config) : EmptyRule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFinallyBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFinallyBlock.kt
@@ -4,7 +4,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import org.jetbrains.kotlin.psi.KtFinallySection
 
 /**
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class EmptyFinallyBlock(config: Config) : EmptyRule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyForBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyForBlock.kt
@@ -4,7 +4,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import org.jetbrains.kotlin.psi.KtForExpression
 
 /**
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class EmptyForBlock(config: Config) : EmptyRule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
@@ -7,7 +7,9 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.isProtected
 
 /**
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class EmptyFunctionBlock(config: Config) : EmptyRule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlock.kt
@@ -8,7 +8,9 @@ import org.jetbrains.kotlin.lexer.KtSingleValueToken
 import org.jetbrains.kotlin.psi.KtIfExpression
 
 /**
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class EmptyIfBlock(config: Config) : EmptyRule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyInitBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyInitBlock.kt
@@ -3,6 +3,11 @@ package io.gitlab.arturbosch.detekt.rules.empty
 import io.gitlab.arturbosch.detekt.api.Config
 import org.jetbrains.kotlin.psi.KtClassInitializer
 
+/**
+ * @active since v1.0.0
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class EmptyInitBlock(config: Config) : EmptyRule(config) {
 
 	override fun visitClassInitializer(initializer: KtClassInitializer) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKtFile.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKtFile.kt
@@ -5,6 +5,11 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import org.jetbrains.kotlin.psi.KtFile
 
+/**
+ * @active since v1.0.0
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class EmptyKtFile(config: Config) : EmptyRule(config) {
 
 	override fun visitKtFile(file: KtFile) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
@@ -12,7 +12,9 @@ import io.gitlab.arturbosch.detekt.rules.hasCommentInside
 import org.jetbrains.kotlin.psi.KtExpression
 
 /**
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 abstract class EmptyRule(config: Config) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptySecondaryConstructor.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptySecondaryConstructor.kt
@@ -3,6 +3,11 @@ package io.gitlab.arturbosch.detekt.rules.empty
 import io.gitlab.arturbosch.detekt.api.Config
 import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 
+/**
+ * @active since v1.0.0
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class EmptySecondaryConstructor(config: Config) : EmptyRule(config) {
 
 	override fun visitSecondaryConstructor(constructor: KtSecondaryConstructor) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyWhenBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyWhenBlock.kt
@@ -6,7 +6,9 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import org.jetbrains.kotlin.psi.KtWhenExpression
 
 /**
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class EmptyWhenBlock(config: Config) : EmptyRule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyWhileBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyWhileBlock.kt
@@ -4,7 +4,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import org.jetbrains.kotlin.psi.KtWhileExpression
 
 /**
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class EmptyWhileBlock(config: Config) : EmptyRule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
@@ -12,6 +12,14 @@ import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtThrowExpression
 
+/**
+ * @configuration methodNames - methods which should not throw exceptions
+ * (default: 'toString,hashCode,equals,finalize')
+ *
+ * @author schalkms
+ * @author Artur Bosch
+ * @author Marvin Ramin
+ */
 class ExceptionRaisedInUnexpectedLocation(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue("ExceptionRaisedInUnexpectedLocation", Severity.CodeSmell,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
@@ -4,12 +4,19 @@ import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.SplitPattern
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.SplitPattern
 import org.jetbrains.kotlin.psi.KtCallExpression
 
+/**
+ * @configuration exceptions - exceptions which should not be thrown without message or cause
+ * (default: 'IllegalArgumentException,IllegalStateException,IOException')
+ *
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class ThrowingExceptionsWithoutMessageOrCause(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue("ThrowingExceptionsWithoutMessageOrCause", Severity.Warning,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
@@ -9,7 +9,19 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtCatchClause
 
 /**
+ * @configuration exceptions - exceptions which are too generic and should not be caught
+ * (default: - ArrayIndexOutOfBoundsException
+ *			 - Error
+ *			 - Exception
+ *			 - IllegalMonitorStateException
+ *			 - NullPointerException
+ *			 - IndexOutOfBoundsException
+ *			 - RuntimeException
+ *			 - Throwable)
+ *
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class TooGenericExceptionCaught(config: Config) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
@@ -9,7 +9,16 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtThrowExpression
 
 /**
+ * @configuration exceptions - exceptions which are too generic and should not be thrown
+ * (default: - Error
+ * 			 - Exception
+ * 			 - NullPointerException
+ *			 - Throwable
+ * 			 - RuntimeException)
+ *
+ * @active since v1.0.0
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class TooGenericExceptionThrown(config: Config) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
@@ -11,6 +11,10 @@ import io.gitlab.arturbosch.detekt.rules.isOverridden
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
+/**
+ * @configuration conversionFunctionPrefix - allowed conversion function names (default: 'to')
+ * @author Marvin Ramin
+ */
 class DataClassContainsFunctions(config: Config = Config.empty) : Rule(config) {
 
 	override val issue: Issue = Issue("DataClassContainsFunctions",

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
@@ -25,6 +25,14 @@ class FileParsingRule(val config: Config = Config.empty) : MultiRule() {
 
 data class KtFileContent(val file: KtFile, val content: Sequence<String>)
 
+/**
+ * @configuration maxLineLength - maximum line length (default: 120)
+ * @configuration excludePackageStatements - if package statements should be ignored (default: false)
+ * @configuration excludeImportStatements - if import statements should be ignored (default: false)
+ *
+ * @active since v1.0.0
+ * @author Marvin Ramin
+ */
 class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -9,6 +9,12 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 
+/**
+ * @configuration values - forbidden comment strings (default: 'TODO:,FIXME:,STOPSHIP:')
+ *
+ * @active since v1.0.0
+ * @author Marvin Ramin
+ */
 class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -4,12 +4,17 @@ import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.SplitPattern
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.SplitPattern
 import org.jetbrains.kotlin.psi.KtImportList
 
+/**
+ * @configuration imports - imports which should not be used (default: '')
+ *
+ * @author Marvin Ramin
+ */
 class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName, Severity.Style,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -16,6 +16,11 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 
+/**
+ * @configuration ignoreOverridableFunction - if overriden functions should be ignored (default: true)
+ * @configuration excludedFunctions - excluded functions (default: 'describeContents')
+ * @author Marvin Ramin
+ */
 class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName, Severity.Style,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
@@ -14,6 +14,11 @@ import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtLoopExpression
 
+/**
+ * @configuration maxJumpCount - maximum allowed jumps in a loop (default: 1)
+ *
+ * @author Marvin Ramin
+ */
 class LoopWithTooManyJumpStatements(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName, Severity.Style,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -25,6 +25,25 @@ import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 import java.util.Locale
 
+/**
+ * @configuration ignoreNumbers - numbers which do not count as magic numbers (default: '-1,0,1,2')
+ * @configuration ignoreHashCodeFunction - whether magic numbers in hashCode functions should be ignored
+ * (default: false)
+ * @configuration ignorePropertyDeclaration - whether magic numbers in property declarations should be ignored
+ * (default: false)
+ * @configuration ignoreConstantDeclaration - whether magic numbers in property declarations should be ignored
+ * (default: true)
+ * @configuration ignoreCompanionObjectPropertyDeclaration - whether magic numbers in companion object
+ * declarations should be ignored (default: true)
+ * @configuration ignoreAnnotation - whether magic numbers in annotations should be ignored
+ * (default: false)
+ * @configuration ignoreNamedArgument - whether magic numbers in named arguments should be ignored
+ * (default: true)
+ * @configuration ignoreEnums - whether magic numbers in enums should be ignored (default: false)
+ *
+ * @active since v1.0.0
+ * @author Marvin Ramin
+ */
 class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName, Severity.Style,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MethodNameEqualsClassName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MethodNameEqualsClassName.kt
@@ -13,6 +13,11 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 
+/**
+ * @configuration ignoreOverriddenFunction - if overridden functions should be ignored (default: true)
+ *
+ * @author Marvin Ramin
+ */
 class MethodNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName, Severity.Style,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
@@ -36,6 +36,9 @@ import java.util.Arrays
 
 /**
  * Modifier order array taken from ktlint: https://github.com/shyiko/ktlint
+ *
+ * @active since v1.0.0
+ * @author Marvin Ramin
  */
 class ModifierOrder(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
@@ -9,6 +9,10 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtFile
 
+/**
+ * @active since v1.0.0
+ * @author Marvin Ramin
+ */
 class NewLineAtEndOfFile(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeyword.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeyword.kt
@@ -14,6 +14,10 @@ import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtProperty
 
+/**
+ * @active since v1.0.0
+ * @author Marvin Ramin
+ */
 class OptionalAbstractKeyword(config: Config = Config.empty) : Rule(config) {
 
 	private val visitor = AbstractDeclarationVisitor(this)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
@@ -15,6 +15,10 @@ import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.KtIsExpression
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 
+/**
+ * @active since v1.0.0
+ * @author Marvin Ramin
+ */
 class SafeCast(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName, Severity.Style, "Safe cast instead of if-else-null", Debt.FIVE_MINS)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
@@ -12,6 +12,13 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtThrowExpression
 
+/**
+ * @configuration max - maximum amount of throw statements in a method (default: 2)
+ *
+ * @active since v1.0.0
+ * @author schalkms
+ * @author Marvin Ramin
+ */
 class ThrowsCount(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName, Severity.Style,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -17,8 +17,9 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  * Library updates can introduce naming clashes with your own classes which might result in compilation errors.
  *
  * @configuration excludeImports - Define a whitelist of package names that should be allowed to be imported
- * with wildcard imports. (default: "")
+ * with wildcard imports. (default: 'java.util.*,kotlinx.android.synthetic.*')
  *
+ * @active since v1.0.0
  * @author Artur Bosch
  */
 class WildcardImport(config: Config = Config.empty) : Rule(config) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ClassNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ClassNaming.kt
@@ -9,6 +9,11 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
+/**
+ * @configuration classPattern - naming pattern (default: '[A-Z$][a-zA-Z$]*')
+ * @active since v1.0.0
+ * @author Marvin Ramin
+ */
 class ClassNaming(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/EnumNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/EnumNaming.kt
@@ -9,6 +9,11 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtEnumEntry
 
+/**
+ * @configuration enumEntryPattern - naming pattern (default: '^[A-Z$][a-zA-Z_$]*$')
+ * @active since v1.0.0
+ * @author Marvin Ramin
+ */
 class EnumNaming(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ForbiddenClassName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ForbiddenClassName.kt
@@ -4,12 +4,16 @@ import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.SplitPattern
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.SplitPattern
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
+/**
+ * @configuration forbiddenName - forbidden class names (default: '')
+ * @author Marvin Ramin
+ */
 class ForbiddenClassName(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/FunctionMaxLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/FunctionMaxLength.kt
@@ -9,6 +9,10 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
+/**
+ * @configuration maximumFunctionNameLength - maximum name length (default: 30)
+ * @author Marvin Ramin
+ */
 class FunctionMaxLength(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/FunctionMinLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/FunctionMinLength.kt
@@ -9,6 +9,10 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
+/**
+ * @configuration minimumFunctionNameLength - minimum name length (default: 3)
+ * @author Marvin Ramin
+ */
 class FunctionMinLength(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/FunctionNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/FunctionNaming.kt
@@ -9,6 +9,11 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
+/**
+ * @configuration functionPattern - naming pattern (default: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$')
+ * @active since v1.0.0
+ * @author Marvin Ramin
+ */
 class FunctionNaming(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/ObjectPropertyNaming.kt
@@ -10,6 +10,11 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtVariableDeclaration
 
+/**
+ * @configuration propertyPattern - naming pattern (default: '[A-Za-z][_A-Za-z0-9]*')
+ * @active since v1.0.0
+ * @author Marvin Ramin
+ */
 class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/PackageNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/PackageNaming.kt
@@ -9,6 +9,11 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtPackageDirective
 
+/**
+ * @configuration packagePattern - naming pattern (default: '^[a-z]+(\.[a-z][a-z0-9]*)*$')
+ * @active since v1.0.0
+ * @author Marvin Ramin
+ */
 class PackageNaming(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/TopLevelPropertyNaming.kt
@@ -12,6 +12,14 @@ import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtVariableDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
+/**
+ * @configuration constantPattern - naming pattern (default: '[A-Z][_A-Z0-9]*')
+ * @configuration propertyPattern - naming pattern (default: '[a-z][A-Za-z\d]*')
+ * @configuration privatePropertyPattern - naming pattern (default: '(_)?[a-z][A-Za-z0-9]*')
+ *
+ * @active since v1.0.0
+ * @author Marvin Ramin
+ */
 class TopLevelPropertyNaming(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/VariableMaxLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/VariableMaxLength.kt
@@ -9,6 +9,10 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtProperty
 
+/**
+ * @configuration maximumVariableNameLength - maximum name length (default: 30)
+ * @author Marvin Ramin
+ */
 class VariableMaxLength(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/VariableMinLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/VariableMinLength.kt
@@ -10,6 +10,10 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
 
+/**
+ * @configuration minimumVariableNameLength - maximum name length (default: 3)
+ * @author Marvin Ramin
+ */
 class VariableMinLength(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/VariableNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/naming/VariableNaming.kt
@@ -11,6 +11,13 @@ import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
 
+/**
+ * @configuration variablePattern - naming pattern (default: '[a-z][A-Za-z0-9]*')
+ * @configuration privateVariablePattern - naming pattern (default: '(_)?[a-z][A-Za-z0-9]*')
+ *
+ * @active since v1.0.0
+ * @author Marvin Ramin
+ */
 class VariableNaming(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,


### PR DESCRIPTION
This PR adds all KDoc necessary to generate the `default-detekt-config.yml`. The generated config on this branch should be equal to the config we manually maintain currently.

I didn't update all the other documentation for the rules, but only added those parameters needed to get this working.

Also had to make some changes to allow for lists as default parameters (used in `TooGenericExceptionCaught` and `TooGenericExceptionThrown`). 

Resolves #189
Touches on #496

**Note:** This branch also contains the changes from #588 