### PR TITLE
Automatically run detekt-generator on detekt-rules build task

### DIFF
--- a/detekt-generator/build.gradle
+++ b/detekt-generator/build.gradle
@@ -1,23 +1,39 @@
 mainClassName = 'io.gitlab.arturbosch.detekt.generator.Main'
 
 jar {
-	manifest {
-		attributes 'Main-Class': 'io.gitlab.arturbosch.detekt.generator.Main'
-	}
+    manifest {
+        attributes 'Main-Class': 'io.gitlab.arturbosch.detekt.generator.Main'
+    }
 }
 
 configurations {
-	// implementation.extendsFrom kotlin is not enough for using cli in a gradle task - #58
-	testImplementation.extendsFrom kotlinTest
+    // implementation.extendsFrom kotlin is not enough for using cli in a gradle task - #58
+    testImplementation.extendsFrom kotlinTest
+}
+
+task generateDocumentation(dependsOn: ":detekt-generator:shadowJar") {
+    doLast {
+        javaexec {
+            main = "-jar"
+            args = [
+                    "$rootProject.rootDir/detekt-generator/build/libs/detekt-generator-$detektVersion-all.jar",
+                    "--input",
+                    "$rootProject.rootDir/detekt-rules/src/main/kotlin",
+                    "--output",
+                    "$rootProject.rootDir/detekt-generator/documentation"
+            ]
+        }
+    }
 }
 
 dependencies {
-	compile project(':detekt-core')
-	compile project(':detekt-rules')
-	compile "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinVersion"
-	
-	testImplementation project(':detekt-test')
-	testRuntime "org.junit.platform:junit-platform-launcher:$junitPlatformVersion"
-	testRuntime "org.junit.platform:junit-platform-console:$junitPlatformVersion"
-	testRuntime "org.jetbrains.spek:spek-junit-platform-engine:$spekVersion"
+    implementation project(':detekt-core')
+    implementation project(':detekt-rules')
+    implementation "com.beust:jcommander:$jcommanderVersion"
+    implementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinVersion"
+
+    testImplementation project(':detekt-test')
+    testRuntime "org.junit.platform:junit-platform-launcher:$junitPlatformVersion"
+    testRuntime "org.junit.platform:junit-platform-console:$junitPlatformVersion"
+    testRuntime "org.jetbrains.spek:spek-junit-platform-engine:$spekVersion"
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Args.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Args.kt
@@ -1,0 +1,43 @@
+package io.gitlab.arturbosch.detekt.generator
+
+import com.beust.jcommander.IStringConverter
+import com.beust.jcommander.Parameter
+import com.beust.jcommander.ParameterException
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * @author Artur Bosch
+ */
+class Args {
+
+	@Parameter(names = arrayOf("--input", "-i"),
+			required = true,
+			converter = ExistingPathConverter::class, description = "Input path to analyze (path/to/project).")
+	private var input: Path? = null
+
+	@Parameter(names = arrayOf("--output", "-o"),
+			required = true,
+			converter = ExistingPathConverter::class, description = "Output path for generated documentation.")
+	private var output: Path? = null
+
+	@Parameter(names = arrayOf("--help", "-h"),
+			help = true, description = "Shows the usage.")
+	var help: Boolean = false
+
+	val inputPath: Path
+		get() = input ?: throw IllegalStateException("Input path was not initialized by jcommander!")
+
+	val outputPath: Path
+		get() = output ?: throw IllegalStateException("Output path was not initialized by jcommander!")
+}
+
+class ExistingPathConverter : IStringConverter<Path> {
+	override fun convert(value: String): Path {
+		val config = File(value).toPath()
+		if (Files.notExists(config))
+			throw ParameterException("Provided path '$value' does not exist!")
+		return config
+	}
+}

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/JCommander.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/JCommander.kt
@@ -1,0 +1,40 @@
+package io.gitlab.arturbosch.detekt.cli
+
+import com.beust.jcommander.JCommander
+import com.beust.jcommander.ParameterException
+import io.gitlab.arturbosch.detekt.generator.Args
+
+private val jCommander = JCommander()
+
+fun parseArguments(args: Array<String>): Args {
+	val cli = Args()
+	jCommander.addObject(cli)
+	jCommander.programName = "detekt-generator"
+
+	try {
+		jCommander.parse(*args)
+	} catch (ex: ParameterException) {
+		val message = ex.message
+		failWithErrorMessages(message)
+	}
+
+	if (cli.help) {
+		jCommander.usage()
+		System.exit(0)
+	}
+
+	return cli
+}
+
+fun failWithErrorMessages(vararg messages: String?) {
+	failWithErrorMessages(messages.asIterable())
+}
+
+fun failWithErrorMessages(messages: Iterable<String?>) {
+	messages.forEach {
+		println(it)
+	}
+	println()
+	jCommander.usage()
+	System.exit(-1)
+}

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Main.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Main.kt
@@ -2,22 +2,40 @@
 
 package io.gitlab.arturbosch.detekt.generator
 
-import io.gitlab.arturbosch.detekt.core.exists
-import java.nio.file.Path
-import java.nio.file.Paths
+import io.gitlab.arturbosch.detekt.cli.failWithErrorMessages
+import io.gitlab.arturbosch.detekt.cli.parseArguments
+import io.gitlab.arturbosch.detekt.core.isFile
+import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
+import java.nio.file.Files
 
 /**
  * @author Marvin Ramin
  */
 fun main(args: Array<String>) {
-	val path = getPath()
-	val executable = Runner(path)
+	val arguments = parseArgumentsCheckingReportDirectory(args)
+	val executable = Runner(arguments)
 	executable.execute()
 }
 
-private const val RULES_SOURCES_PATH = "./detekt-rules/src/main/kotlin"
-fun getPath(): Path {
-	val path = Paths.get(RULES_SOURCES_PATH)
-	require(path.exists()) { "Path to detekt-rules module does not exist." }
-	return path
+private fun parseArgumentsCheckingReportDirectory(args: Array<String>): Args {
+	val arguments = parseArguments(args)
+	val messages = validateCli(arguments)
+	messages.ifNotEmpty {
+		failWithErrorMessages(messages)
+	}
+	return arguments
+}
+
+private fun validateCli(arguments: Args): List<String> {
+	val violations = ArrayList<String>()
+	with(arguments) {
+		if (Files.exists(outputPath) && outputPath.isFile()) {
+			violations += "Output file must be a directory."
+		}
+
+		if (!Files.exists(inputPath) || outputPath.isFile()) {
+			violations += "Input path must exist"
+		}
+	}
+	return violations
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Main.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Main.kt
@@ -33,7 +33,7 @@ private fun validateCli(arguments: Args): List<String> {
 			violations += "Output file must be a directory."
 		}
 
-		if (!Files.exists(inputPath) || outputPath.isFile()) {
+		if (!Files.exists(inputPath) || inputPath.isFile()) {
 			violations += "Input path must exist"
 		}
 	}

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Runner.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Runner.kt
@@ -3,20 +3,19 @@ package io.gitlab.arturbosch.detekt.generator
 import io.gitlab.arturbosch.detekt.core.KtTreeCompiler
 import io.gitlab.arturbosch.detekt.generator.collection.DetektCollector
 import io.gitlab.arturbosch.detekt.generator.printer.DetektPrinter
-import java.nio.file.Path
 import kotlin.system.measureTimeMillis
 
 /**
  * @author Marvin Ramin
  */
-class Runner(val path: Path) {
+class Runner(private val arguments: Args) {
 	private val listeners = listOf(DetektProgressListener())
 	private val collector = DetektCollector()
 	private val printer = DetektPrinter()
 
 	fun execute() {
 		val time = measureTimeMillis {
-			val ktFiles = KtTreeCompiler(path).compile()
+			val ktFiles = KtTreeCompiler(arguments.inputPath).compile()
 			listeners.forEach { it.onStart(ktFiles) }
 
 			ktFiles.forEach { file ->
@@ -24,7 +23,7 @@ class Runner(val path: Path) {
 						collector.visit(file)
 					}
 
-			printer.print(collector.items)
+			printer.print(arguments.outputPath, collector.items)
 		}
 
 		println("\nGenerated all detekt documentation in $time ms.")

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/MarkdownWriter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/MarkdownWriter.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.generator.out
 
 import java.nio.file.Files
-import java.nio.file.Paths
+import java.nio.file.Path
 
 /**
  * @author Marvin Ramin
@@ -9,14 +9,14 @@ import java.nio.file.Paths
 object MarkdownWriter {
 	private val ending: String = "md"
 
-	fun write(fileName: String, content: String) {
-		val filePath = Paths.get("./detekt-generator/documentation/").resolve("$fileName.$ending")
+	fun write(path: Path, fileName: String, content: String) {
+		val filePath = path.resolve("$fileName.$ending")
 		filePath.parent?.let { Files.createDirectories(it) }
 		Files.write(filePath, content.toByteArray())
 		println("Wrote: $fileName.$ending")
 	}
 }
 
-fun markdownFile(fileName: String, content: () -> String) {
-	MarkdownWriter.write(fileName, content())
+fun markdownFile(path: Path, fileName: String, content: () -> String) {
+	MarkdownWriter.write(path, fileName, content())
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/YamlWriter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/YamlWriter.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.generator.out
 
 import java.nio.file.Files
-import java.nio.file.Paths
+import java.nio.file.Path
 
 /**
  * @author Marvin Ramin
@@ -9,14 +9,14 @@ import java.nio.file.Paths
 object YamlWriter {
 	private val ending: String = "yml"
 
-	fun write(fileName: String, content: String) {
-		val filePath = Paths.get("./detekt-generator/documentation/").resolve("$fileName.$ending")
+	fun write(path: Path, fileName: String, content: String) {
+		val filePath = path.resolve("$fileName.$ending")
 		filePath.parent?.let { Files.createDirectories(it) }
 		Files.write(filePath, content.toByteArray())
 		println("Wrote: $fileName.$ending")
 	}
 }
 
-fun yamlFile(fileName: String, content: () -> String) {
-	YamlWriter.write(fileName, content())
+fun yamlFile(path: Path, fileName: String, content: () -> String) {
+	YamlWriter.write(path, fileName, content())
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/DetektPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/DetektPrinter.kt
@@ -5,15 +5,16 @@ import io.gitlab.arturbosch.detekt.generator.out.yamlFile
 import io.gitlab.arturbosch.detekt.generator.printer.rulesetpage.ConfigPrinter
 import io.gitlab.arturbosch.detekt.generator.printer.rulesetpage.RuleSetPage
 import io.gitlab.arturbosch.detekt.generator.printer.rulesetpage.RuleSetPagePrinter
+import java.nio.file.Path
 
 class DetektPrinter {
 
-	fun print(pages: List<RuleSetPage>) {
+	fun print(path: Path, pages: List<RuleSetPage>) {
 		pages.forEach {
-			markdownFile(it.ruleSet.name) { RuleSetPagePrinter.print(it) }
+			markdownFile(path, it.ruleSet.name) { RuleSetPagePrinter.print(it) }
 		}
 
-		yamlFile("default-detekt-config") { ConfigPrinter.print(pages) }
+		yamlFile(path, "default-detekt-config") { ConfigPrinter.print(pages) }
 	}
 
 }

--- a/detekt-rules/build.gradle
+++ b/detekt-rules/build.gradle
@@ -3,6 +3,8 @@ configurations {
 	testImplementation.extendsFrom kotlinTest
 }
 
+build.finalizedBy(":detekt-generator:generateDocumentation")
+
 dependencies {
 	implementation project(':detekt-api')
 	


### PR DESCRIPTION
The Jar generated from the `detekt-generator` module now has an `--input` and `--output` argument to define both directories.

Adds `generateDocumentation` task in the `detekt-generator` module. This builds and executes the generator jar to generate the latest documentation.

I also added a rule that every time the `detekt-rules` module is built the `generateDocumentation` task will be executed to update the documentation. 