### PR TITLE
removes active mark for StringLiteralDuplication

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
@@ -20,7 +20,6 @@ import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
  * @configuration excludeStringsWithLessThan5Characters - if short strings should be excluded (default: true)
  * @configuration ignoreStringsRegex - RegEx of Strings that should be ignored (default: '$^')
  *
- * @active since v1.0.0
  * @author schalkms
  * @author Artur Bosch
  * @author Marvin Ramin


### PR DESCRIPTION
While going through the generated `default-detekt-config.yml` and comparing it to the generated one it seems that I have marked the `StringLiteralDuplication` rule as `@active` even though it is not turned on in the current default config.