### PR TITLE
Add SpreadOperator to exclude-rules in test-pattern.

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -16,6 +16,7 @@ test-pattern: # Configure exclusions for test sources
     - 'MaxLineLength'
     - 'LateinitUsage'
     - 'StringLiteralDuplication'
+    - 'SpreadOperator'
 
 build:
   warningThreshold: 5

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -72,6 +72,7 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
 			    - 'MaxLineLength'
 			    - 'LateinitUsage'
 			    - 'StringLiteralDuplication'
+			    - 'SpreadOperator'
 			""".trimIndent()
 	}
 


### PR DESCRIPTION
I don't think the performance cost is really an issue when running tests and hence we should disable it by default.

Is there anything else where I would need to add this? I lost track of where things belong.