### PR TITLE
ReturnCount augmented to ignore specified function names

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -237,6 +237,7 @@ style:
   ReturnCount:
     active: true
     max: 2
+    ignoredFunctionNames: "equals"
   ThrowsCount:
     active: true
     max: 2

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -237,7 +237,7 @@ style:
   ReturnCount:
     active: true
     max: 2
-    ignoredFunctionNames: "equals"
+    excludedFunctions: "equals"
   ThrowsCount:
     active: true
     max: 2

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.SplitPattern
 import io.gitlab.arturbosch.detekt.rules.collectByType
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtReturnExpression
@@ -19,7 +20,10 @@ import org.jetbrains.kotlin.psi.KtReturnExpression
  *
  * @configuration max - define the maximum number of return statements allowed per function
  * (default: 2)
+ * @configuration ignoredFunctionNames - define functions to be ignored by this check
+ * (default: none)
  * @active since v1.0.0
+ * @author Patrick Pilch
  */
 class ReturnCount(config: Config = Config.empty) : Rule(config) {
 
@@ -27,18 +31,24 @@ class ReturnCount(config: Config = Config.empty) : Rule(config) {
 			"Restrict the number of return statements in methods.", Debt.TEN_MINS)
 
 	private val max = valueOrDefault(MAX, 2)
+	private val ignoredFunctions = SplitPattern(valueOrDefault(IGNORED_FUNCTION_NAMES, ""))
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		super.visitNamedFunction(function)
 
-		val numberOfReturns = function.collectByType<KtReturnExpression>().count()
+		if (!isIgnoredFunction(function)) {
+			val numberOfReturns = function.collectByType<KtReturnExpression>().count()
 
-		if (numberOfReturns > max) {
-			report(CodeSmell(issue, Entity.from(function), message = ""))
+			if (numberOfReturns > max) {
+				report(CodeSmell(issue, Entity.from(function), message = ""))
+			}
 		}
 	}
 
+	private fun isIgnoredFunction(function: KtNamedFunction) = ignoredFunctions.contains(function.name)
+
 	companion object {
 		const val MAX = "max"
+		const val IGNORED_FUNCTION_NAMES = "ignoredFunctionNames"
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -20,8 +20,8 @@ import org.jetbrains.kotlin.psi.KtReturnExpression
  *
  * @configuration max - define the maximum number of return statements allowed per function
  * (default: 2)
- * @configuration ignoredFunctionNames - define functions to be ignored by this check
- * (default: none)
+ * @configuration excludedFunctions - define functions to be ignored by this check
+ * (default: "equals")
  * @active since v1.0.0
  * @author Patrick Pilch
  */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -31,7 +31,7 @@ class ReturnCount(config: Config = Config.empty) : Rule(config) {
 			"Restrict the number of return statements in methods.", Debt.TEN_MINS)
 
 	private val max = valueOrDefault(MAX, 2)
-	private val ignoredFunctions = SplitPattern(valueOrDefault(IGNORED_FUNCTION_NAMES, ""))
+	private val excludedFunctions = SplitPattern(valueOrDefault(EXCLUDED_FUNCTIONS, ""))
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		super.visitNamedFunction(function)
@@ -45,10 +45,10 @@ class ReturnCount(config: Config = Config.empty) : Rule(config) {
 		}
 	}
 
-	private fun isIgnoredFunction(function: KtNamedFunction) = ignoredFunctions.contains(function.name)
+	private fun isIgnoredFunction(function: KtNamedFunction) = excludedFunctions.contains(function.name)
 
 	companion object {
 		const val MAX = "max"
-		const val IGNORED_FUNCTION_NAMES = "ignoredFunctionNames"
+		const val EXCLUDED_FUNCTIONS = "excludedFunctions"
 	}
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -78,7 +78,7 @@ class ReturnCountSpec : Spek({
 		it("should not get flagged") {
 			val findings = ReturnCount(TestConfig(mapOf(
 					ReturnCount.MAX to "2",
-					ReturnCount.IGNORED_FUNCTION_NAMES to "test")
+					ReturnCount.EXCLUDED_FUNCTIONS to "test")
 			)).lint(code)
 			assertThat(findings).isEmpty()
 		}
@@ -114,7 +114,7 @@ class ReturnCountSpec : Spek({
 		it("should flag none of the ignored functions") {
 			val findings = ReturnCount(TestConfig(mapOf(
 					ReturnCount.MAX to "2",
-					ReturnCount.IGNORED_FUNCTION_NAMES to "test1,test2")
+					ReturnCount.EXCLUDED_FUNCTIONS to "test1,test2")
 			)).lint(code)
 			assertThat(findings).hasSize(1)
 		}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -64,4 +64,60 @@ class ReturnCountSpec : Spek({
 
 	}
 
+	given("a function is ignored") {
+		val code = """
+    		fun test(x: Int) {
+				when (x) {
+					5 -> return 5
+					4 -> return 4
+					3 -> return 3
+				}
+			}
+		"""
+
+		it("should not get flagged") {
+			val findings = ReturnCount(TestConfig(mapOf(
+					ReturnCount.MAX to "2",
+					ReturnCount.IGNORED_FUNCTION_NAMES to "test")
+			)).lint(code)
+			assertThat(findings).isEmpty()
+		}
+	}
+
+	given("a subset of functions are ignored") {
+		val code = """
+    		fun test1(x: Int) {
+				when (x) {
+					5 -> return 5
+					4 -> return 4
+					3 -> return 3
+				}
+			}
+
+			fun test2(x: Int) {
+				when (x) {
+					5 -> return 5
+					4 -> return 4
+					3 -> return 3
+				}
+			}
+
+			fun test3(x: Int) {
+				when (x) {
+					5 -> return 5
+					4 -> return 4
+					3 -> return 3
+				}
+			}
+		"""
+
+		it("should flag none of the ignored functions") {
+			val findings = ReturnCount(TestConfig(mapOf(
+					ReturnCount.MAX to "2",
+					ReturnCount.IGNORED_FUNCTION_NAMES to "test1,test2")
+			)).lint(code)
+			assertThat(findings).hasSize(1)
+		}
+	}
+
 })


### PR DESCRIPTION
Hi, thanks for the neat library!

I wanted to contribute due to me running into situations where the `ReturnCount` rule would flag some auto generated code like the following:
```kotlin
override fun equals(other: Any?): Boolean {
        if (this === other) return true
        if (javaClass != other?.javaClass) return false

        other as TestClass

        if (someList != other.someList) return false

        return true
    }
```
I thought that this would be a common occurrence, and I still wanted to use the `ReturnCount` rule without having to sprinkle suppression annotations all over, so I thought a function name whitelist would be useful.