### PR TITLE
add gradle task to assert config and documentation are generated up-to-date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ script:
   - java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar --help
   - java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar -i . --baseline ./reports/baseline.xml -f ".*/resources/.*, .*/build/.*" -c ./detekt-cli/src/main/resources/default-detekt-config.yml,./reports/failfast.yml
   - ./gradlew detektCheck
+  - ./gradlew verifyGeneratorOutput
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/detekt-generator/build.gradle
+++ b/detekt-generator/build.gradle
@@ -12,6 +12,7 @@ configurations {
 }
 
 task generateDocumentation(dependsOn: ":detekt-generator:shadowJar") {
+    description "Generates detekt documentation and the default config.yml based on Rule KDoc"
     doLast {
         javaexec {
             main = "-jar"
@@ -25,6 +26,40 @@ task generateDocumentation(dependsOn: ":detekt-generator:shadowJar") {
                     "$rootProject.rootDir/detekt-cli/src/main/resources"
             ]
         }
+    }
+}
+
+task verifyGeneratorOutput(dependsOn: [":detekt-generator:shadowJar", ":detekt-generator:generateDocumentation"]) {
+    description "Verifies that all documentation and the config.yml are up-to-date"
+    doLast {
+        assertDefaultConfigUpToDate()
+        assertDocumentationUpToDate()
+    }
+}
+
+def assertDefaultConfigUpToDate() {
+    def configDiff = new ByteArrayOutputStream()
+    exec {
+        commandLine "git", "diff", "$rootProject.rootDir/detekt-cli/src/main/resources/default-detekt-config.yml"
+        standardOutput = configDiff
+    }
+
+    if (!configDiff.toString().isEmpty()) {
+        throw new RuntimeException("The default-detekt-config.yml is not up-to-date. " +
+                "Please build detekt locally to update it.")
+    }
+}
+
+def assertDocumentationUpToDate() {
+    def configDiff = new ByteArrayOutputStream()
+    exec {
+        commandLine "git", "diff", "$rootProject.rootDir/detekt-generator/documentation"
+        standardOutput = configDiff
+    }
+
+    if (!configDiff.toString().isEmpty()) {
+        throw new RuntimeException("The detekt documentation is not up-to-date. " +
+                "Please build detekt locally to update it.")
     }
 }
 


### PR DESCRIPTION
Adds a Gradle task to the travis build to assert that all generated contents are updated correctly on the branch. 

Essentially this runs the `generateDocumentation` task and then does a `git diff` on the `default-detekt-config.yml` as well as the `.../documentation` directory and fails the build if any differences were detected.