### PR TITLE
Checkout *.md, *.yml & *.html with LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,7 @@ gradlew.bat text eol=crlf
 
 # Mark Gradle wrapper as a binary
 gradle/wrapper/gradle-wrapper.jar binary
+
+*.md eol=lf
+*.html eol=lf
+*.yml eol=lf


### PR DESCRIPTION
Fixes #602.

These file types are modified by detekt-generator. When checking out on Windows they're checked out with CRLF line endings by default, but when detekt-generator runs, the new files have LF line endings. This creates a bit of noise and confusion.

Tests in HtmlOutputFormatTest fail for the same reason (the HTML template is checked out with CRLF line endings but the test assumes LF line endings).

This change forces these files to be checked out with LF line endings, avoiding the problem.