### PR TITLE
False positive in ExceptionRaisedInUnexpectedLocation

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SplitPattern.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SplitPattern.kt
@@ -12,6 +12,7 @@ class SplitPattern(text: String,
 			.map { it.removeSuffix("*") }
 
 	fun contains(value: String?) = excludes.any { value?.contains(it, ignoreCase = true) == true }
+	fun equals(value: String?) = excludes.any { value?.equals(it, ignoreCase = true) == true }
 	fun none(value: String) = !contains(value)
 	fun matches(value: String): List<String> = excludes.filter { value.contains(it, ignoreCase = true) }
 	fun startWith(name: String?) = excludes.any { name?.startsWith(it) ?: false }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
@@ -33,7 +33,7 @@ class ExceptionRaisedInUnexpectedLocation(config: Config = Config.empty) : Rule(
 		}
 	}
 
-	private fun isPotentialMethod(function: KtNamedFunction) = methods.contains(function.name)
+	private fun isPotentialMethod(function: KtNamedFunction) = methods.equals(function.name)
 
 	private fun hasThrowExpression(declaration: KtExpression?) =
 			declaration?.collectByType<KtThrowExpression>()?.any() == true

--- a/detekt-rules/src/test/resources/cases/ExceptionRaisedInMethodsNegative.kt
+++ b/detekt-rules/src/test/resources/cases/ExceptionRaisedInMethodsNegative.kt
@@ -26,6 +26,10 @@ open class NoExceptionRaisedInMethods {
 		}
 	}
 
+	fun doSomeEqualsComparison() {
+		throw IllegalStateException()
+	}
+
 	protected fun finalize() {
 	}
 }


### PR DESCRIPTION
Fixes false positives when function names contains some of the keywords for this inspection, such as toString, hashCode, equals or finalize.

An usecase for this would be if an user would like to implement a function like:

`assertUsersNotEquals(...)`

Since it contains "equals" in the name, detekt would mark it as a violation.