### PR TITLE
Error message agrees with require condition

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/YamlConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/YamlConfig.kt
@@ -37,7 +37,8 @@ class YamlConfig internal constructor(val properties: Map<String, Any>) : BaseCo
 		 * Factory method to load a yaml configuration. Given path must exist and end with "yml".
 		 */
 		fun load(path: Path): Config {
-			require(Files.exists(path) && path.toString().endsWith(YAML)) { "File does not exist or end with .yaml!" }
+			require(Files.exists(path)) { "File does not exist!" }
+			require(path.toString().endsWith(YAML)) { "File does not end with $YAML!" }
 			return load(Files.newBufferedReader(path))
 		}
 


### PR DESCRIPTION
I just got bit by this. I had a "detekt.yaml" configuration and the error told me it either did not exist or it did not end on ".yaml"

The condition check actually checked that the file ends on ".yml" - no "a", but the error was misleading me to think that it couldn't find it because the ending was correct.