### PR TITLE
[WIP] Do not depend on a specific project path in core classes - #605

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/FileProcessListener.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/FileProcessListener.kt
@@ -27,7 +27,7 @@ interface FileProcessListener : Extension {
 	 * Called when processing of a file completes.
 	 * This method is called from a thread pool thread. Heavy computations allowed.
 	 */
-	fun onProcessComplete(file: KtFile, findingsForFile: FindingsForFile) {}
+	fun onProcessComplete(file: KtFile, findings: Map<String, List<Finding>>) {}
 
 	/**
 	 * Mainly use this method to save computed metrics from KtFile's to the {@link Detektion} container.
@@ -36,10 +36,3 @@ interface FileProcessListener : Extension {
 	fun onFinish(files: List<KtFile>, result: Detektion) {}
 }
 
-class FindingsForFile(findings: List<Pair<String, List<Finding>>>) {
-
-	private val ruleSetFindings: Map<String, List<Finding>> by lazy { findings.toMergedMap() }
-
-	fun queryForRuleSet(name: String) = ruleSetFindings[name]
-
-}

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Args.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Args.kt
@@ -10,8 +10,8 @@ class Args {
 
 	@Parameter(names = ["--input", "-i"],
 			required = true,
-			converter = ExistingPathConverter::class, description = "Input path to analyze (path/to/project).")
-	private var input: Path? = null
+			description = "Input paths to analyze.")
+	private var input: String? = null
 
 	@Parameter(names = ["--filters", "-f"],
 			description = "Path filters defined through regex with separator ';' (\".*test.*\").")
@@ -69,6 +69,8 @@ class Args {
 			help = true, description = "Shows the usage.")
 	var help: Boolean = false
 
-	val inputPath: Path
-		get() = input ?: throw IllegalStateException("Input path was not initialized by jcommander!")
+	val inputPath: List<Path> by lazy {
+		MultipleExistingPathConverter().convert(input
+				?: throw IllegalStateException("Input parameter was not initialized by jcommander!"))
+	}
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Args.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Args.kt
@@ -8,64 +8,64 @@ import java.nio.file.Path
  */
 class Args {
 
-	@Parameter(names = arrayOf("--input", "-i"),
+	@Parameter(names = ["--input", "-i"],
 			required = true,
 			converter = ExistingPathConverter::class, description = "Input path to analyze (path/to/project).")
 	private var input: Path? = null
 
-	@Parameter(names = arrayOf("--filters", "-f"),
+	@Parameter(names = ["--filters", "-f"],
 			description = "Path filters defined through regex with separator ';' (\".*test.*\").")
 	var filters: String? = null // Using a converter for List<PathFilter> resulted in a ClassCastException
 
-	@Parameter(names = arrayOf("--config", "-c"),
+	@Parameter(names = ["--config", "-c"],
 			description = "Path to the config file (path/to/config.yml).")
 	var config: String? = null
 
-	@Parameter(names = arrayOf("--config-resource", "-cr"),
+	@Parameter(names = ["--config-resource", "-cr"],
 			description = "Path to the config resource on detekt's classpath (path/to/config.yml).")
 	var configResource: String? = null
 
-	@Parameter(names = arrayOf("--generate-config", "-gc"),
+	@Parameter(names = ["--generate-config", "-gc"],
 			description = "Export default config to default-detekt-config.yml.")
 	var generateConfig: Boolean = false
 
-	@Parameter(names = arrayOf("--plugins", "-p"),
+	@Parameter(names = ["--plugins", "-p"],
 			description = "Extra paths to plugin jars separated by ',' or ';'.")
 	var plugins: String? = null
 
-	@Parameter(names = arrayOf("--parallel"),
+	@Parameter(names = ["--parallel"],
 			description = "Enables parallel compilation of source files." +
 					" Should only be used if the analyzing project has more than ~200 kotlin files.")
 	var parallel: Boolean = false
 
-	@Parameter(names = arrayOf("--baseline", "-b"),
+	@Parameter(names = ["--baseline", "-b"],
 			description = "If a baseline xml file is passed in," +
 					" only new code smells not in the baseline are printed in the console.",
 			converter = PathConverter::class)
 	var baseline: Path? = null
 
-	@Parameter(names = arrayOf("--create-baseline", "-cb"),
+	@Parameter(names = ["--create-baseline", "-cb"],
 			description = "Treats current analysis findings as a smell baseline for future detekt runs.")
 	var createBaseline: Boolean = false
 
-	@Parameter(names = arrayOf("--output", "-o"),
+	@Parameter(names = ["--output", "-o"],
 			description = "Directory where output reports are stored.",
 			converter = PathConverter::class)
 	var output: Path? = null
 
-	@Parameter(names = arrayOf("--output-name", "-on"),
+	@Parameter(names = ["--output-name", "-on"],
 			description = "The base name for output reports is derived from this parameter.")
 	var outputName: String? = null
 
-	@Parameter(names = arrayOf("--disable-default-rulesets", "-dd"),
+	@Parameter(names = ["--disable-default-rulesets", "-dd"],
 			description = "Disables default rule sets.")
 	var disableDefaultRuleSets: Boolean = false
 
-	@Parameter(names = arrayOf("--debug"),
+	@Parameter(names = ["--debug"],
 			description = "Debugs given ktFile by printing its elements.")
 	var debug: Boolean = false
 
-	@Parameter(names = arrayOf("--help", "-h"),
+	@Parameter(names = ["--help", "-h"],
 			help = true, description = "Shows the usage.")
 	var help: Boolean = false
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Runner.kt
@@ -17,7 +17,7 @@ class Runner(private val arguments: Args) : Executable {
 		val settings = createSettings()
 
 		val time = measureTimeMillis {
-			val detektion = DetektFacade.instance(settings).run()
+			val detektion = DetektFacade.create(settings).run()
 			OutputFacade(arguments, detektion, settings).run()
 		}
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.psi.KtFile
  * @author Artur Bosch
  */
 class DetektFacade(
-		val detektor: Detektor,
+		private val detektor: Detektor,
 		private val settings: ProcessingSettings,
 		private val processors: List<FileProcessListener>) {
 
@@ -41,24 +41,18 @@ class DetektFacade(
 
 	companion object {
 
-		fun instance(settings: ProcessingSettings): DetektFacade {
+		fun create(settings: ProcessingSettings): DetektFacade {
 			val providers = RuleSetLocator(settings).load()
 			val processors = FileProcessorLocator(settings).load()
-			return instance(settings, providers, processors)
-		}
-
-		fun instance(settings: ProcessingSettings, vararg providers: RuleSetProvider): DetektFacade {
-			return instance(settings, providers.toList(), emptyList())
-		}
-
-		fun instance(settings: ProcessingSettings, vararg processors: FileProcessListener): DetektFacade {
-			return instance(settings, emptyList(), processors.toList())
-		}
-
-		fun instance(settings: ProcessingSettings,
-					 providers: List<RuleSetProvider>,
-					 processors: List<FileProcessListener>): DetektFacade {
 			return create(settings, providers, processors)
+		}
+
+		fun create(settings: ProcessingSettings, vararg providers: RuleSetProvider): DetektFacade {
+			return create(settings, providers.toList(), emptyList())
+		}
+
+		fun create(settings: ProcessingSettings, vararg processors: FileProcessListener): DetektFacade {
+			return create(settings, emptyList(), processors.toList())
 		}
 
 		fun create(settings: ProcessingSettings,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektion.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektion.kt
@@ -10,9 +10,9 @@ import org.jetbrains.kotlin.com.intellij.util.keyFMap.KeyFMap
 /**
  * @author Artur Bosch
  */
-data class DetektResult(override val findings: Map<String, List<Finding>>,
-						override val notifications: MutableCollection<Notification>) : Detektion {
+data class DetektResult(override val findings: Map<String, List<Finding>>) : Detektion {
 
+	override val notifications: MutableCollection<Notification> = ArrayList()
 	private var userData = KeyFMap.EMPTY_MAP
 	private val _metrics = ArrayList<ProjectMetric>()
 	override val metrics: Collection<ProjectMetric> = _metrics

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektor.kt
@@ -30,9 +30,7 @@ class Detektor(settings: ProcessingSettings,
 
 		val result = HashMap<String, List<Finding>>()
 		for (map in awaitAll(futures)) {
-			for ((key, findings) in map.entries) {
-				result.merge(key, findings) { f1, f2 -> f1.plus(f2) }
-			}
+			result.mergeSmells(map)
 		}
 
 		result

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektor.kt
@@ -1,11 +1,8 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Finding
-import io.gitlab.arturbosch.detekt.api.FindingsForFile
-import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.toMergedMap
 import org.jetbrains.kotlin.psi.KtFile
@@ -13,42 +10,35 @@ import org.jetbrains.kotlin.psi.KtFile
 /**
  * @author Artur Bosch
  */
-class Detektor(private val settings: ProcessingSettings,
+class Detektor(settings: ProcessingSettings,
 			   private val providers: List<RuleSetProvider>,
 			   private val processors: List<FileProcessListener> = emptyList()) {
 
 	private val config: Config = settings.config
-	private val modifier: KtFileModifier = KtFileModifier(settings.project)
 	private val testPattern: TestPattern = settings.loadTestPattern()
-	private val notifications: MutableList<Notification> = mutableListOf()
 
-	fun run(compiler: KtTreeCompiler = KtTreeCompiler.instance(settings)): Detektion = run(compiler.compile())
+	fun run(ktFiles: List<KtFile>): Map<String, List<Finding>> = withExecutor {
 
-	fun run(ktFiles: List<KtFile>): Detektion = withExecutor {
-
-		processors.forEach { it.onStart(ktFiles) }
 		val futures = ktFiles.map { file ->
 			runAsync {
 				processors.forEach { it.onProcess(file) }
 				file.analyze().apply {
-					processors.forEach { it.onProcessComplete(file, FindingsForFile(this)) }
+					processors.forEach { it.onProcessComplete(file, this) }
 				}
 			}
 		}
-		val findings = awaitAll(futures).flatMap { it }.toMergedMap()
 
-		if (config.valueOrDefault("autoCorrect", false)) {
-			modifier.saveModifiedFiles(ktFiles) {
-				notifications.add(it)
+		val result = HashMap<String, List<Finding>>()
+		for (map in awaitAll(futures)) {
+			for ((key, findings) in map.entries) {
+				result.merge(key, findings) { f1, f2 -> f1.plus(f2) }
 			}
 		}
 
-		DetektResult(findings.toSortedMap(), notifications).apply {
-			processors.forEach { it.onFinish(ktFiles, this) }
-		}
+		result
 	}
 
-	private fun KtFile.analyze(): List<Pair<String, List<Finding>>> {
+	private fun KtFile.analyze(): Map<String, List<Finding>> {
 		var ruleSets = providers.mapNotNull { it.buildRuleset(config) }
 				.sortedBy { it.id }
 				.distinctBy { it.id }
@@ -58,6 +48,6 @@ class Detektor(private val settings: ProcessingSettings,
 			ruleSets.map { ruleSet -> ruleSet.id to ruleSet.accept(this, testPattern.excludingRules) }
 		} else {
 			ruleSets.map { ruleSet -> ruleSet.id to ruleSet.accept(this) }
-		}
+		}.toMergedMap()
 	}
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Junk.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Junk.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.core
 
+import io.gitlab.arturbosch.detekt.api.Finding
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Files
 import java.nio.file.Path
@@ -17,3 +18,9 @@ fun Path.isFile(): Boolean = Files.isRegularFile(this)
 fun Path.isDirectory(): Boolean = Files.isDirectory(this)
 
 fun KtFile.relativePath(): String? = getUserData(KtCompiler.RELATIVE_PATH)
+
+fun MutableMap<String, List<Finding>>.mergeSmells(other: Map<String, List<Finding>>) {
+	for ((key, findings) in other.entries) {
+		merge(key, findings) { f1, f2 -> f1.plus(f2) }
+	}
+}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
@@ -12,15 +12,15 @@ import java.nio.file.Path
 /**
  * @author Artur Bosch
  */
-open class KtCompiler(val project: Path) {
+open class KtCompiler {
 
 	protected val psiFileFactory: PsiFileFactory = PsiFileFactory.getInstance(psiProject)
 
-	fun compile(subPath: Path): KtFile {
+	fun compile(root: Path, subPath: Path): KtFile {
 		require(subPath.isFile()) { "Given sub path should be a regular file!" }
 		val relativePath =
-				if (project == subPath) subPath
-				else project.fileName.resolve(project.relativize(subPath))
+				if (root == subPath) subPath
+				else root.fileName.resolve(root.relativize(subPath))
 		val content = subPath.toFile().readText()
 		val lineSeparator = content.determineLineSeparator()
 		val normalizedContent = StringUtilRt.convertLineSeparators(content)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -8,12 +8,20 @@ import java.nio.file.Path
  * @author Artur Bosch
  */
 @Suppress("LongParameterList")
-data class ProcessingSettings(val project: Path,
+data class ProcessingSettings(val project: List<Path>,
 							  val config: Config = Config.empty,
 							  val pathFilters: List<PathFilter> = listOf(),
 							  val parallelCompilation: Boolean = false,
 							  val excludeDefaultRuleSets: Boolean = false,
 							  val pluginPaths: List<Path> = emptyList()) {
+
+	constructor(project: Path,
+				config: Config = Config.empty,
+				pathFilters: List<PathFilter> = listOf(),
+				parallelCompilation: Boolean = false,
+				excludeDefaultRuleSets: Boolean = false,
+				pluginPaths: List<Path> = emptyList()) :
+			this(listOf(project), config, pathFilters, parallelCompilation, excludeDefaultRuleSets, pluginPaths)
 
 	init {
 		pluginPaths.forEach {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CustomRuleSetProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CustomRuleSetProviderSpec.kt
@@ -18,7 +18,7 @@ class CustomRuleSetProviderSpec : Spek({
 
 		it("should load the sample provider") {
 			val settings = ProcessingSettings(path, excludeDefaultRuleSets = true, pluginPaths = listOf(sampleRuleSet))
-			val detekt = DetektFacade.instance(settings)
+			val detekt = DetektFacade.create(settings)
 			val result = detekt.run()
 
 			assertThat(result.findings.keys).contains("sample")

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektSpec.kt
@@ -12,7 +12,7 @@ class DetektSpec : Spek({
 
 	describe("default providers must be registered in META-INF/services") {
 
-		val detekt = DetektFacade.instance(ProcessingSettings(path))
+		val detekt = DetektFacade.create(ProcessingSettings(path))
 
 		it("should detect findings from more than one provider") {
 			assertTrue { detekt.run().findings.isNotEmpty() }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektorTest.kt
@@ -20,7 +20,7 @@ class DetektorTest {
 	}
 
 	private fun runDetektWithPattern(patternToUse: String) {
-		val instance = DetektFacade.instance(ProcessingSettings(path,
+		val instance = DetektFacade.create(ProcessingSettings(path,
 				config = yamlConfig(patternToUse)),
 				listOf(TestProvider(), TestProvider2()), emptyList())
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtCompilerTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtCompilerTest.kt
@@ -10,9 +10,9 @@ internal class KtCompilerTest {
 
 	@Test
 	fun ktFileHasExtraUserData() {
-		val ktCompiler = KtCompiler(path)
+		val ktCompiler = KtCompiler()
 
-		val ktFile = ktCompiler.compile(path.resolve("Default.kt"))
+		val ktFile = ktCompiler.compile(path, path.resolve("Default.kt"))
 
 		assertThat(ktFile.getUserData(KtCompiler.LINE_SEPARATOR)).isEqualTo("\n")
 		assertThat(ktFile.getUserData(KtCompiler.RELATIVE_PATH)).isEqualTo(path.fileName.resolve("Default.kt").toString())

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
@@ -15,13 +15,13 @@ class KtTreeCompilerSpec : Spek({
 	describe("tree compiler functionality") {
 
 		it("should compile all files") {
-			val ktFiles = KtTreeCompiler(path).compile()
+			val ktFiles = KtTreeCompiler().compile(path)
 			assertTrue(ktFiles.size >= 2, "It should compile more than two files, but did ${ktFiles.size}")
 		}
 
 		it("should filter the file 'Default.kt'") {
 			val filter = PathFilter(".*Default.kt")
-			val ktFiles = KtTreeCompiler(path, listOf(filter)).compile()
+			val ktFiles = KtTreeCompiler(filters = listOf(filter)).compile(path)
 			val ktFile = ktFiles.find { it.name == "Default.kt" }
 			assertNull(ktFile, "It should have no Default.kt file")
 		}
@@ -30,12 +30,12 @@ class KtTreeCompilerSpec : Spek({
 			val filter = PathFilter(".*Default.kt")
 			val filterTwo = PathFilter(".*Test.*")
 			val filterThree = PathFilter(".*Complex.*")
-			val ktFiles = KtTreeCompiler(path, listOf(filter, filterTwo, filterThree)).compile()
+			val ktFiles = KtTreeCompiler(filters = listOf(filter, filterTwo, filterThree)).compile(path)
 			assertThat(ktFiles).isEmpty()
 		}
 
 		it("should also compile regular files") {
-			assertTrue { KtTreeCompiler(path.resolve("Default.kt")).compile().size == 1 }
+			assertTrue { KtTreeCompiler().compile(path.resolve("Default.kt")).size == 1 }
 		}
 	}
 

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Runner.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Runner.kt
@@ -15,13 +15,13 @@ class Runner(private val arguments: Args) {
 
 	fun execute() {
 		val time = measureTimeMillis {
-			val ktFiles = KtTreeCompiler(arguments.inputPath).compile()
+			val ktFiles = KtTreeCompiler().compile(arguments.inputPath)
 			listeners.forEach { it.onStart(ktFiles) }
 
 			ktFiles.forEach { file ->
-						listeners.forEach { it.onProcess(file) }
-						collector.visit(file)
-					}
+				listeners.forEach { it.onProcess(file) }
+				collector.visit(file)
+			}
 
 			printer.print(collector.items)
 		}

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.core.KtCompiler
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.KtFile
+import java.nio.file.Path
 import java.nio.file.Paths
 
 /**
@@ -11,7 +12,11 @@ import java.nio.file.Paths
  *
  * @author Artur Bosch
  */
-object KtTestCompiler : KtCompiler(Paths.get(resource("/"))) {
+object KtTestCompiler : KtCompiler() {
+
+	private val root = Paths.get(resource("/"))
+
+	fun compile(path: Path) = compile(root, path)
 
 	fun compileFromContent(content: String): KtFile
 			= psiFileFactory.createFileFromText(KotlinLanguage.INSTANCE, StringUtilRt.convertLineSeparators(content)) as KtFile

--- a/detekt-watch-service/src/main/kotlin/io/gitlab/arturbosch/detekt/watchservice/DetektService.kt
+++ b/detekt-watch-service/src/main/kotlin/io/gitlab/arturbosch/detekt/watchservice/DetektService.kt
@@ -43,7 +43,7 @@ class DetektService(parameters: Parameters) {
 
 		if (ktFiles.isNotEmpty()) {
 			paths.forEach { println("Change detected for $it") }
-			val detektion = detektor.run(ktFiles)
+			val detektion = detektor.run(watchedDir, ktFiles)
 			println(reporter.render(detektion))
 		}
 	}

--- a/detekt-watch-service/src/main/kotlin/io/gitlab/arturbosch/detekt/watchservice/DetektService.kt
+++ b/detekt-watch-service/src/main/kotlin/io/gitlab/arturbosch/detekt/watchservice/DetektService.kt
@@ -24,7 +24,7 @@ class DetektService(parameters: Parameters) {
 		)
 	}
 
-	private val detektor = DetektFacade.instance(settings, RuleSetLocator(settings).load(), emptyList())
+	private val detektor = DetektFacade.create(settings, RuleSetLocator(settings).load(), emptyList())
 	private val reporter = FindingsReport()
 
 	fun check(dir: WatchedDir) {

--- a/detekt-watch-service/src/main/kotlin/io/gitlab/arturbosch/detekt/watchservice/DetektService.kt
+++ b/detekt-watch-service/src/main/kotlin/io/gitlab/arturbosch/detekt/watchservice/DetektService.kt
@@ -36,9 +36,9 @@ class DetektService(parameters: Parameters) {
 				.distinct()
 				.fold(mutableListOf<Path>()) { acc, path -> acc.add(path); acc }
 
-		val compiler = KtCompiler(watchedDir)
+		val compiler = KtCompiler()
 		val ktFiles = paths
-				.map { compiler.compile(it) }
+				.map { compiler.compile(watchedDir, it) }
 				.fold(mutableListOf<KtFile>()) { acc, ktFile -> acc.add(ktFile); acc }
 
 		if (ktFiles.isNotEmpty()) {


### PR DESCRIPTION
@3flex we now support multiple paths. Please check if something is still missing for your PR.

Unfortunately the console reporting is now broken ....
```
Analyzing 1 kotlin files: .Analyzing 8 kotlin files: ........
```

How about changing it to something like:
```
.........

9 kotlin files were analyzed.
```

@Mauin , @schalkms 

@Mauin hmmm somehow the default config verification fails ...
```
Execution failed for task ':detekt-generator:verifyGeneratorOutput'.

> The default-detekt-config.yml is not up-to-date. Please build detekt locally to update it.
```
Actually it got changed for this PR.