### PR TITLE
Add TooManyFunctions to test-pattern exclude-rules by default.

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -17,6 +17,7 @@ test-pattern: # Configure exclusions for test sources
     - 'LateinitUsage'
     - 'StringLiteralDuplication'
     - 'SpreadOperator'
+    - 'TooManyFunctions'
 
 build:
   warningThreshold: 5

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -73,6 +73,7 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
 			    - 'LateinitUsage'
 			    - 'StringLiteralDuplication'
 			    - 'SpreadOperator'
+			    - 'TooManyFunctions'
 			""".trimIndent()
 	}
 


### PR DESCRIPTION
Fixes #622 