### PR TITLE
[WIP] throw on missing arguments during documentation collection

### DIFF
--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DetektCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DetektCollector.kt
@@ -38,7 +38,7 @@ class DetektCollector : Collector<RuleSetPage> {
 	private fun List<Rule>.findRuleByName(ruleName: String): Rule? {
 		val rule = this.find { it.name == ruleName }
 		if (rule == null) {
-			println("Rule $ruleName was specified in provider but not collected.")
+			throw InvalidDocumentationException("Rule $ruleName was specified in a provider but it was not defined.")
 		}
 		return rule
 	}

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/InvalidDocumentationException.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/InvalidDocumentationException.kt
@@ -1,0 +1,9 @@
+package io.gitlab.arturbosch.detekt.generator.collection
+
+/**
+ * Thrown to indicate that rule documentation in KDoc is missing or invalid.
+ *
+ * @author Marvin Ramin
+ */
+class InvalidDocumentationException(message: String)
+	: RuntimeException(message)

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollector.kt
@@ -51,8 +51,11 @@ class MultiRuleVisitor : DetektVisitor() {
 		rules.addAll(ruleProperties)
 		rules.addAll(rulesVisitor.ruleNames)
 
+		if (name.isEmpty()) {
+			throw InvalidDocumentationException("MultiRule without name found.")
+		}
 		if (rules.isEmpty()) {
-			println("MultiRule $name contains no rules.")
+			throw InvalidDocumentationException("MultiRule $name contains no rules.")
 		}
 		return MultiRule(name, rules)
 	}

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollector.kt
@@ -45,8 +45,12 @@ class RuleSetProviderVisitor : DetektVisitor() {
 	private val ruleNames: MutableList<String> = mutableListOf()
 
 	fun getRuleSetProvider(): RuleSetProvider {
+		if (name.isEmpty()) {
+			throw InvalidDocumentationException("RuleSetProvider without name found.")
+		}
+
 		if (description.isEmpty()) {
-			println("Missing description for RuleSet $name")
+			throw InvalidDocumentationException("Missing description for RuleSet $name.")
 		}
 
 		return RuleSetProvider(name, description, active, ruleNames)
@@ -69,7 +73,7 @@ class RuleSetProviderVisitor : DetektVisitor() {
 		super.visitProperty(property)
 		if (property.isOverridden() && property.name != null && property.name == PROPERTY_RULE_SET_ID) {
 			name = (property.initializer as? KtStringTemplateExpression)?.entries?.get(0)?.text
-					?: throw InvalidRuleSetProviderException("RuleSetProvider class " +
+					?: throw InvalidDocumentationException("RuleSetProvider class " +
 					"${property.containingClass()?.name ?: ""} doesn't provide list of rules.")
 		}
 	}
@@ -81,7 +85,7 @@ class RuleSetProviderVisitor : DetektVisitor() {
 			val ruleListExpression = expression.valueArguments
 					.map { it.getArgumentExpression() }
 					.firstOrNull { it?.referenceExpression()?.text == "listOf" }
-					?: throw InvalidRuleSetProviderException("RuleSetProvider $name doesn't provide list of rules.")
+					?: throw InvalidDocumentationException("RuleSetProvider $name doesn't provide list of rules.")
 
 			val ruleArgumentNames = (ruleListExpression as? KtCallExpression)
 					?.valueArguments
@@ -93,5 +97,3 @@ class RuleSetProviderVisitor : DetektVisitor() {
 		}
 	}
 }
-
-class InvalidRuleSetProviderException(message: String) : Exception(message)

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -22,7 +22,7 @@ internal class RuleVisitor : DetektVisitor() {
 
 	fun getRule(): Rule {
 		if (description.isEmpty()) {
-			println("Rule $name is missing a description")
+			throw InvalidDocumentationException("Rule $name is missing a description in its KDoc.")
 		}
 
 		return Rule(name, description, nonCompliant, compliant, active, configuration)
@@ -87,7 +87,8 @@ internal class RuleVisitor : DetektVisitor() {
 				.filter {
 					val valid = it.contains("-") && it.contains(configurationDefaultValueRegex)
 					if (!valid) {
-						println("Rule $name contains an incorrect configuration option KDoc.")
+						throw InvalidDocumentationException("Rule $name contains an incorrect configuration option" +
+								"tag in the KDoc.")
 					}
 					valid
 				}

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollectorSpec.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
+import kotlin.test.assertFailsWith
 
 class MultiRuleCollectorSpec : SubjectSpek<MultiRuleCollector>({
 
@@ -34,18 +35,7 @@ class MultiRuleCollectorSpec : SubjectSpek<MultiRuleCollector>({
 			assertThat(items).isEmpty()
 		}
 
-		it("collects a rule when class extends MultiRule") {
-			val code = """
-				package foo
-
-				class SomeRandomClass: MultiRule {
-				}
-			"""
-			val items = subject.run(code)
-			assertThat(items).hasSize(1)
-		}
-
-		it("sets the class name as the rule name") {
+		it("throws when no rules are added") {
 			val name = "SomeRandomClass"
 			val code = """
 				package foo
@@ -53,20 +43,9 @@ class MultiRuleCollectorSpec : SubjectSpek<MultiRuleCollector>({
 				class $name: MultiRule {
 				}
 			"""
-			val items = subject.run(code)
-			assertThat(items[0].name).isEqualTo(name)
-		}
-
-		it("contains no rules by default") {
-			val name = "SomeRandomClass"
-			val code = """
-				package foo
-
-				class $name: MultiRule {
-				}
-			"""
-			val items = subject.run(code)
-			assertThat(items[0].rules).isEmpty()
+			assertFailsWith<InvalidDocumentationException> {
+				subject.run(code)
+			}
 		}
 
 		it("collects all rules in fields and in the rule property") {

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
@@ -43,6 +43,25 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 		}
 	}
 
+
+
+	given("a RuleSetProvider without documentation") {
+		val code = """
+			package foo
+
+			class TestProvider: RuleSetProvider {
+				fun logSomething(message: String) {
+					println(message)
+				}
+			}
+		"""
+		it("throws an exception") {
+			assertFailsWith<InvalidDocumentationException> {
+				subject.run(code)
+			}
+		}
+	}
+
 	given("a correct RuleSetProvider class extending RuleSetProvider but missing parameters") {
 		val code = """
 			package foo
@@ -54,27 +73,10 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 			}
 		"""
 
-		it("collects a RuleSetProvider") {
-			val items = subject.run(code)
-			assertThat(items).hasSize(1)
-		}
-
-		it("has no rules") {
-			val items = subject.run(code)
-			val provider = items[0]
-			assertThat(provider.rules).isEmpty()
-		}
-
-		it("has no name") {
-			val items = subject.run(code)
-			val provider = items[0]
-			assertThat(provider.name).isEmpty()
-		}
-
-		it("has no description") {
-			val items = subject.run(code)
-			val provider = items[0]
-			assertThat(provider.description).isEmpty()
+		it("throws an exception") {
+			assertFailsWith<InvalidDocumentationException> {
+				subject.run(code)
+			}
 		}
 	}
 
@@ -178,10 +180,10 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 			}
 		"""
 
-		it("is has no name") {
-			val items = subject.run(code)
-			val provider = items[0]
-			assertThat(provider.name).isEmpty()
+		it("throws an exception") {
+			assertFailsWith<InvalidDocumentationException> {
+				subject.run(code)
+			}
 		}
 	}
 
@@ -202,10 +204,10 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 			}
 		"""
 
-		it("is not active") {
-			val items = subject.run(code)
-			val provider = items[0]
-			assertThat(provider.description).isEmpty()
+		it("throws an exception") {
+			assertFailsWith<InvalidDocumentationException> {
+				subject.run(code)
+			}
 		}
 	}
 
@@ -224,7 +226,7 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 		"""
 
 		it("throws an exception") {
-			assertFailsWith<InvalidRuleSetProviderException> {
+			assertFailsWith<InvalidDocumentationException> {
 				subject.run(code)
 			}
 		}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/FeatureEnvy.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/FeatureEnvy.kt
@@ -18,6 +18,8 @@ import org.jetbrains.kotlin.psi.KtVariableDeclaration
 import java.util.IdentityHashMap
 
 /**
+ * Rule that detects feature envy in classes.
+ *
  * @author Artur Bosch
  */
 class FeatureEnvy(config: Config = Config.empty) : Rule(config) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
@@ -12,6 +12,8 @@ import io.gitlab.arturbosch.detekt.rules.hasCommentInside
 import org.jetbrains.kotlin.psi.KtExpression
 
 /**
+ * Rule to detect empty blocks of code.
+ *
  * @author Artur Bosch
  * @author Marvin Ramin
  */


### PR DESCRIPTION
Resolves #623

Until all rules are correctly and fully documented this not be usable as it will throw all the time.