### PR TITLE
Remove "native filesystem" warning on Windows

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ProjectExtension.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ProjectExtension.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.com.intellij.openapi.extensions.ExtensionPoint
 import org.jetbrains.kotlin.com.intellij.openapi.extensions.Extensions
+import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
 import org.jetbrains.kotlin.com.intellij.pom.PomModel
@@ -17,12 +18,17 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.psi.KtPsiFactory
 import sun.reflect.ReflectionFactory
 
-val psiProject = KotlinCoreEnvironment.createForProduction(Disposer.newDisposable(),
-		CompilerConfiguration(), EnvironmentConfigFiles.JVM_CONFIG_FILES).project.apply {
-	makeMutable(this as MockProject)
-}
+val psiProject = createKotlinCoreEnvironment()
 
 val psiFactory = KtPsiFactory(psiProject, false)
+
+private fun createKotlinCoreEnvironment(): Project {
+	System.setProperty("idea.io.use.fallback", "true")
+	return KotlinCoreEnvironment.createForProduction(Disposer.newDisposable(),
+			CompilerConfiguration(), EnvironmentConfigFiles.JVM_CONFIG_FILES).project.apply {
+		makeMutable(this as MockProject)
+	}
+}
 
 private fun makeMutable(project: MockProject) {
 	// Based on KtLint by Shyiko


### PR DESCRIPTION
Fixes this error when running Detekt:

WARN: Failed to initialize native filesystem for Windows
    java.lang.RuntimeException: Could not find installation home path. Please make sure bin/idea.properties is present in the installation directory.

Fixes #630 