### PR TITLE
Rule: UnusedPrivateMember

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -360,6 +360,8 @@ style:
     active: false
   UnusedImports:
     active: false
+  UnusedPrivateMember:
+    active: false
   UseDataClass:
     active: false
     excludeAnnotatedClasses: ""

--- a/detekt-generator/documentation/style.md
+++ b/detekt-generator/documentation/style.md
@@ -35,9 +35,10 @@ code style guidelines.
 27. [UnnecessaryParentheses](#unnecessaryparentheses)
 28. [UntilInsteadOfRangeTo](#untilinsteadofrangeto)
 29. [UnusedImports](#unusedimports)
-30. [UseDataClass](#usedataclass)
-31. [UtilityClassWithPublicConstructor](#utilityclasswithpublicconstructor)
-32. [WildcardImport](#wildcardimport)
+30. [UnusedPrivateMember](#unusedprivatemember)
+31. [UseDataClass](#usedataclass)
+32. [UtilityClassWithPublicConstructor](#utilityclasswithpublicconstructor)
+33. [WildcardImport](#wildcardimport)
 ## Rules in the `style` rule set:
 
 ### CollapsibleIfStatements
@@ -712,6 +713,12 @@ val range = 0 until 10
 ### UnusedImports
 
 This rule reports unused imports. Unused imports are dead code and should be removed.
+
+### UnusedPrivateMember
+
+Reports unused private properties, function parameters and functions.
+If private properties are unused they should be removed. Otherwise this dead code
+can lead to confusion and potential bugs.
 
 ### UseDataClass
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -30,6 +30,7 @@ import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryInheritance
 import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryParentheses
 import io.gitlab.arturbosch.detekt.rules.style.UntilInsteadOfRangeTo
 import io.gitlab.arturbosch.detekt.rules.style.UnusedImports
+import io.gitlab.arturbosch.detekt.rules.style.UnusedPrivateMember
 import io.gitlab.arturbosch.detekt.rules.style.UseDataClass
 import io.gitlab.arturbosch.detekt.rules.style.UtilityClassWithPublicConstructor
 import io.gitlab.arturbosch.detekt.rules.style.WildcardImport
@@ -78,6 +79,7 @@ class StyleGuideProvider : RuleSetProvider {
 				DataClassContainsFunctions(config),
 				UseDataClass(config),
 				UnusedImports(config),
+				UnusedPrivateMember(config),
 				ExpressionBodySyntax(config),
 				NestedClassesVisibility(config),
 				RedundantVisibilityModifierRule(config),

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -1,0 +1,80 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.DetektVisitor
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
+import org.jetbrains.kotlin.psi.psiUtil.isPrivate
+
+/**
+ * Reports unused private properties. If private properties are unused they should be removed. Otherwise this dead code
+ * can lead to confusion and potential bugs.
+ *
+ * @author Marvin Ramin
+ */
+class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
+	override val issue: Issue = Issue("UnusedPrivateMember",
+			Severity.Maintainability,
+			"Private property is unused.")
+
+	override fun visitClassOrObject(classOrObject: KtClassOrObject) {
+		val visitor = UnusedPropertyVisitor()
+		classOrObject.accept(visitor)
+
+		visitor.properties.forEach {
+			report(CodeSmell(issue, Entity.from(it.value), "Private property ${it.key} is unused."))
+		}
+
+		super.visitClassOrObject(classOrObject)
+	}
+
+	class UnusedPropertyVisitor : DetektVisitor() {
+		val properties = mutableMapOf<String, KtElement>()
+
+		override fun visitProperty(property: KtProperty) {
+			if (property.isPrivate() && property.isMember) {
+				val name = property.name ?: throw IllegalStateException("Private properties should have a name")
+				properties.put(name, property)
+			}
+			super.visitProperty(property)
+		}
+
+		override fun visitReferenceExpression(expression: KtReferenceExpression) {
+			val function = expression.getNonStrictParentOfType(KtFunction::class.java)
+			val localProperties = mutableMapOf<String, KtElement>()
+
+			function?.accept(object : DetektVisitor() {
+				override fun visitProperty(property: KtProperty) {
+					if (property.isLocal) {
+						val name = property.name ?: throw IllegalStateException("Properties should have a name")
+						localProperties.put(name, property)
+					}
+					super.visitProperty(property)
+				}
+			})
+
+			val name = expression.text
+			if (!localProperties.contains(name) && properties.contains(name)) {
+				properties.remove(name)
+			}
+			super.visitReferenceExpression(expression)
+		}
+	}
+
+	class Test {
+		private val unused = "This is not used"
+
+		inner class Something {
+			val test = unused
+		}
+	}
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -94,6 +94,22 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 	class UnusedPropertyVisitor : DetektVisitor() {
 		val properties = mutableMapOf<String, KtElement>()
 
+		override fun visitParameter(parameter: KtParameter) {
+			super.visitParameter(parameter)
+			if (parameter.isLoopParameter) {
+				val destructuringDeclaration = parameter.destructuringDeclaration
+				if (destructuringDeclaration != null) {
+					destructuringDeclaration.entries.forEach {
+						val name = it.nameAsSafeName.identifier
+						properties[name] = it
+					}
+				} else {
+					val name = parameter.nameAsSafeName.identifier
+					properties[name] = parameter
+				}
+			}
+		}
+
 		override fun visitProperty(property: KtProperty) {
 			if ((property.isPrivate() && property.isMember) || property.isLocal) {
 				val name = property.nameAsSafeName.identifier

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -69,12 +69,4 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 			super.visitReferenceExpression(expression)
 		}
 	}
-
-	class Test {
-		private val unused = "This is not used"
-
-		inner class Something {
-			val test = unused
-		}
-	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -20,7 +20,8 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 
 /**
- * Reports unused private properties. If private properties are unused they should be removed. Otherwise this dead code
+ * Reports unused private properties, function parameters and functions.
+ * If private properties are unused they should be removed. Otherwise this dead code
  * can lead to confusion and potential bugs.
  *
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -7,13 +7,17 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
+import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 
 /**
  * Reports unused private properties. If private properties are unused they should be removed. Otherwise this dead code
@@ -24,24 +28,73 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 	override val issue: Issue = Issue("UnusedPrivateMember",
 			Severity.Maintainability,
-			"Private property is unused.")
+			"Private member is unused.")
 
 	override fun visitClassOrObject(classOrObject: KtClassOrObject) {
-		val visitor = UnusedPropertyVisitor()
-		classOrObject.accept(visitor)
+		val propertyVisitor = UnusedPropertyVisitor()
+		classOrObject.accept(propertyVisitor)
 
-		visitor.properties.forEach {
+		propertyVisitor.properties.forEach {
 			report(CodeSmell(issue, Entity.from(it.value), "Private property ${it.key} is unused."))
 		}
 
+		val functionParameterVisitor = UnusedFunctionParameterVisitor()
+		classOrObject.accept(functionParameterVisitor)
+
+		functionParameterVisitor.parameters.forEach {
+			report(CodeSmell(issue, Entity.from(it.value), "Function parameter ${it.key} is unused."))
+		}
+
+		val functionVisitor = UnusedFunctionVisitor()
+		classOrObject.accept(functionVisitor)
+
+		functionVisitor.getFunctions().forEach {
+			report(CodeSmell(issue, Entity.from(it.value), "Private function ${it.key} is unused."))
+		}
+
 		super.visitClassOrObject(classOrObject)
+	}
+
+	class UnusedFunctionParameterVisitor : DetektVisitor() {
+		var parameters: MutableMap<String, KtParameter> = mutableMapOf()
+
+		override fun visitNamedFunction(function: KtNamedFunction) {
+			super.visitNamedFunction(function)
+
+			function.valueParameterList?.parameters?.forEach {
+				val name = it.name ?: throw IllegalStateException("Value parameter should have a name.")
+				parameters.put(name, it)
+			}
+
+			val localProperties = mutableListOf<String>()
+			function.accept(object : DetektVisitor() {
+				override fun visitProperty(property: KtProperty) {
+					if (property.isLocal) {
+						val name = property.name ?: throw IllegalStateException("Properties should have a name")
+						localProperties.add(name)
+					}
+					super.visitProperty(property)
+				}
+
+				override fun visitReferenceExpression(expression: KtReferenceExpression) {
+					localProperties.add(expression.text)
+					super.visitReferenceExpression(expression)
+				}
+			})
+
+			parameters.forEach {
+				if (localProperties.contains(it.key)) {
+					parameters.remove(it.key)
+				}
+			}
+		}
 	}
 
 	class UnusedPropertyVisitor : DetektVisitor() {
 		val properties = mutableMapOf<String, KtElement>()
 
 		override fun visitProperty(property: KtProperty) {
-			if (property.isPrivate() && property.isMember) {
+			if ((property.isPrivate() && property.isMember) || property.isLocal) {
 				val name = property.name ?: throw IllegalStateException("Private properties should have a name")
 				properties.put(name, property)
 			}
@@ -49,24 +102,51 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 		}
 
 		override fun visitReferenceExpression(expression: KtReferenceExpression) {
-			val function = expression.getNonStrictParentOfType(KtFunction::class.java)
-			val localProperties = mutableMapOf<String, KtElement>()
-
-			function?.accept(object : DetektVisitor() {
-				override fun visitProperty(property: KtProperty) {
-					if (property.isLocal) {
-						val name = property.name ?: throw IllegalStateException("Properties should have a name")
-						localProperties.put(name, property)
-					}
-					super.visitProperty(property)
-				}
-			})
-
 			val name = expression.text
-			if (!localProperties.contains(name) && properties.contains(name)) {
+			if (properties.contains(name)) {
 				properties.remove(name)
 			}
+
 			super.visitReferenceExpression(expression)
+		}
+	}
+
+	class UnusedFunctionVisitor : DetektVisitor() {
+		private val callExpressions = mutableMapOf<KtFunction?, String>()
+		private val functions = mutableMapOf<String, KtFunction>()
+
+		fun getFunctions(): Map<String, KtFunction> {
+			val unusedFunctions = mutableMapOf<String, KtFunction>()
+			var change = true
+			while (change) {
+				unusedFunctions.putAll(functions.filterNot { callExpressions.containsValue(it.key) })
+				val validExpressions = callExpressions.filterNot { unusedFunctions.containsValue(it.key) }
+				change = validExpressions != callExpressions
+				callExpressions.clear()
+				callExpressions.putAll(validExpressions)
+			}
+
+			return unusedFunctions
+		}
+
+		override fun visitNamedFunction(function: KtNamedFunction) {
+			if (!function.isPrivate()) {
+				return
+			}
+
+			val name = function.name ?: throw IllegalStateException("Functions should have a name.")
+			functions.put(name, function)
+			super.visitNamedFunction(function)
+		}
+
+		override fun visitCallExpression(expression: KtCallExpression) {
+			super.visitCallExpression(expression)
+			val calledMethodName = expression.referenceExpression()?.text
+			val function = expression.getNonStrictParentOfType(KtFunction::class.java)
+
+			if (calledMethodName != null) {
+				callExpressions.put(function, calledMethodName)
+			}
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -63,15 +63,15 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 			super.visitNamedFunction(function)
 
 			function.valueParameterList?.parameters?.forEach {
-				val name = it.name ?: throw IllegalStateException("Value parameter should have a name.")
-				parameters.put(name, it)
+				val name = it.nameAsSafeName.identifier
+				parameters[name] = it
 			}
 
 			val localProperties = mutableListOf<String>()
 			function.accept(object : DetektVisitor() {
 				override fun visitProperty(property: KtProperty) {
 					if (property.isLocal) {
-						val name = property.name ?: throw IllegalStateException("Properties should have a name")
+						val name = property.nameAsSafeName.identifier
 						localProperties.add(name)
 					}
 					super.visitProperty(property)
@@ -96,8 +96,8 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 
 		override fun visitProperty(property: KtProperty) {
 			if ((property.isPrivate() && property.isMember) || property.isLocal) {
-				val name = property.name ?: throw IllegalStateException("Private properties should have a name")
-				properties.put(name, property)
+				val name = property.nameAsSafeName.identifier
+				properties[name] = property
 			}
 			super.visitProperty(property)
 		}
@@ -135,8 +135,8 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 				return
 			}
 
-			val name = function.name ?: throw IllegalStateException("Functions should have a name.")
-			functions.put(name, function)
+			val name = function.nameAsSafeName.identifier
+			functions[name] = function
 			super.visitNamedFunction(function)
 		}
 
@@ -146,7 +146,7 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 			val function = expression.getNonStrictParentOfType(KtFunction::class.java)
 
 			if (calledMethodName != null) {
-				callExpressions.put(function, calledMethodName)
+				callExpressions[function] = calledMethodName
 			}
 		}
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -110,6 +110,75 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 		}
 	}
 
+	given("loop iterators") {
+		it("doesn't report loop properties") {
+			val code = """
+				class Test {
+					fun use() {
+						for (i in 0 until 10) {
+							println(i)
+						}
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+
+		it("reports unused loop property") {
+			val code = """
+				class Test {
+					fun use() {
+						for (i in 0 until 10) {
+						}
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).hasSize(1)
+		}
+
+		it("reports unused loop property in indexed array") {
+			val code = """
+				class Test {
+					fun use() {
+						val array = intArrayOf(1, 2, 3)
+						for ((index, value) in array.withIndex()) {
+							println(index)
+						}
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).hasSize(1)
+		}
+
+		it("reports all unused loop properties in indexed array") {
+			val code = """
+				class Test {
+					fun use() {
+						val array = intArrayOf(1, 2, 3)
+						for ((index, value) in array.withIndex()) {
+						}
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).hasSize(2)
+		}
+
+		it("does not report used loop properties in indexed array") {
+			val code = """
+				class Test {
+					fun use() {
+						val array = intArrayOf(1, 2, 3)
+						for ((index, value) in array.withIndex()) {
+							println(index)
+							println(value)
+						}
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+	}
+
 	given("properties used to initialize other properties") {
 
 		it("does not report properties used by other properties") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -1,0 +1,143 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.rules.style.UnusedPrivateMember
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
+
+class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
+	subject { UnusedPrivateMember() }
+
+	given("several classes with properties") {
+
+		it("reports an unused member") {
+			val code = """
+				class Test {
+				    private val unused = "This is not used"
+
+					fun use() {
+						println("This is not using a property")
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).hasSize(1)
+		}
+
+		it("does not report unused public members") {
+			val code = """
+				class Test {
+				    val unused = "This is not used"
+
+					fun use() {
+						println("This is not using a property")
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).hasSize(0)
+		}
+
+		it("does not report used members") {
+			val code = """
+				class Test {
+				    private val used = "This is used"
+
+					fun use() {
+						println(used)
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).hasSize(0)
+		}
+
+		it("does not report used members but reports unused members") {
+			val code = """
+				class Test {
+				    private val used = "This is used"
+				    private val unused = "This is not used"
+
+					fun use() {
+						println(used)
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).hasSize(1)
+		}
+	}
+
+	given("several classes with properties and local properties") {
+
+		it("reports an unused member") {
+			val code = """
+				class Test {
+				    private val unused = "This is not used"
+
+					fun use() {
+						val used = "This is used"
+						println(used)
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).hasSize(1)
+		}
+
+		it("does not report used members") {
+			val code = """
+				class Test {
+				    private val used = "This is used"
+
+					fun use() {
+						val text = used
+						println(text)
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).hasSize(0)
+		}
+
+		it("reports unused members shadowed by local properties") {
+			val code = """
+				class Test {
+				    private val unused = "This is not used"
+
+					fun use() {
+						val unused = "This is used"
+						println(unused)
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).hasSize(1)
+		}
+	}
+
+	given("properties used to initialize other properties") {
+
+		it("does not report properties used by other properties") {
+			val code = """
+				class Test {
+				    private val used = "This is used"
+					private val text = used
+
+					fun use() {
+						println(text)
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).hasSize(0)
+		}
+
+		it("does not report properties used by inner classes") {
+			val code = """
+				class Test {
+					private val unused = "This is not used"
+
+					inner class Something {
+						val test = unused
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).hasSize(0)
+		}
+	}
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -14,7 +14,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 		it("reports an unused member") {
 			val code = """
 				class Test {
-				    private val unused = "This is not used"
+					private val unused = "This is not used"
 
 					fun use() {
 						println("This is not using a property")
@@ -27,7 +27,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 		it("does not report unused public members") {
 			val code = """
 				class Test {
-				    val unused = "This is not used"
+					val unused = "This is not used"
 
 					fun use() {
 						println("This is not using a property")
@@ -40,7 +40,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 		it("does not report used members") {
 			val code = """
 				class Test {
-				    private val used = "This is used"
+					private val used = "This is used"
 
 					fun use() {
 						println(used)
@@ -53,8 +53,8 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 		it("does not report used members but reports unused members") {
 			val code = """
 				class Test {
-				    private val used = "This is used"
-				    private val unused = "This is not used"
+					private val used = "This is used"
+					private val unused = "This is not used"
 
 					fun use() {
 						println(used)
@@ -70,7 +70,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 		it("reports an unused member") {
 			val code = """
 				class Test {
-				    private val unused = "This is not used"
+					private val unused = "This is not used"
 
 					fun use() {
 						val used = "This is used"
@@ -84,7 +84,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 		it("does not report used members") {
 			val code = """
 				class Test {
-				    private val used = "This is used"
+					private val used = "This is used"
 
 					fun use() {
 						val text = used
@@ -98,7 +98,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 		it("reports unused local properties") {
 			val code = """
 				class Test {
-				    private val used = "This is used"
+					private val used = "This is used"
 
 					fun use() {
 						val unused = used
@@ -115,7 +115,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 		it("does not report properties used by other properties") {
 			val code = """
 				class Test {
-				    private val used = "This is used"
+					private val used = "This is used"
 					private val text = used
 
 					fun use() {


### PR DESCRIPTION
Resolves #8 

This should cover unused private properties. Public properties are ignored as they might be used from other files.