### PR TITLE
Appveyor: Use default git config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,8 @@ environment:
   TERM: dumb
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+init:
+  - git config --global --unset core.autocrlf
 install:
   - SET PATH=%JAVA_HOME%\bin;%PATH%
   # remove Ruby entry (C:\Ruby193\bin;) from PATH


### PR DESCRIPTION
Appveyor uses `git config --global core.autocrlf input` by default. However this is not
the default on Windows machines, meaning some tests that pass on Appveyor may not pass when
checked out on a Windows machine if the tests are affected by a file's line endings.
This causes issues like https://github.com/arturbosch/detekt/issues/602 which could be picked up earlier.
  