### PR TITLE
Do not run EmptyClassBlock on objects of anonymous classes

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
@@ -7,9 +7,12 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
+import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 
 /**
  * @author Artur Bosch
@@ -18,6 +21,9 @@ import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
 fun KtExpression?.asBlockExpression(): KtBlockExpression? = this as? KtBlockExpression
 
 fun KtClass.isDataClass() = this.modifierList?.hasModifier(KtTokens.DATA_KEYWORD) == true
+
+fun KtClassOrObject.isObjectOfAnonymousClass() =
+		this.getNonStrictParentOfType(KtObjectDeclaration::class.java) != null && this.name == null
 
 fun KtCallExpression.isUsedForNesting(): Boolean = when (getCallNameExpression()?.text) {
 	"run", "let", "apply", "with", "use", "forEach" -> true

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
  * @active since v1.0.0
  * @author Artur Bosch
  * @author Marvin Ramin
+ * @author Egor Neliuba
  */
 class EmptyClassBlock(config: Config) : EmptyRule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.empty
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.rules.isObjectOfAnonymousClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
 /**
@@ -15,6 +16,8 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
 class EmptyClassBlock(config: Config) : EmptyRule(config) {
 
 	override fun visitClassOrObject(classOrObject: KtClassOrObject) {
+		if (classOrObject.isObjectOfAnonymousClass()) return
+
 		classOrObject.getBody()?.declarations?.let {
 			if (it.isEmpty()) report(CodeSmell(issue, Entity.from(classOrObject), "The class or object " +
 					" ${classOrObject.name} is empty."))

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
@@ -1,0 +1,37 @@
+package io.gitlab.arturbosch.detekt.rules.empty
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
+
+/**
+ * @author Egor Neliuba
+ */
+class EmptyClassBlockSpec : SubjectSpek<EmptyClassBlock>({
+
+	subject { EmptyClassBlock(Config.empty) }
+
+	given("a class with an empty body") {
+
+		it("flags the empty body") {
+			val findings = subject.lint("class SomeClass {}")
+			assertThat(findings).hasSize(1)
+		}
+	}
+
+	given("an object with an empty body") {
+
+		it("flags the object if it is of a non-anonymous class") {
+			val findings = subject.lint("object SomeObject {}")
+			assertThat(findings).hasSize(1)
+		}
+
+		it("does not flag the object if it is of an anonymous class") {
+			val findings = subject.lint("object : SomeClass {}")
+			assertThat(findings).isEmpty()
+		}
+	}
+})


### PR DESCRIPTION
There's no way to create an object of an anonymous class without specifying the body. For example, Gson's TypeToken:

```kotlin
val type = object : TypeToken<Map<String, String>>() {}.type
```

This empty body should not be flagged as there's no other way to write it.