### PR TITLE
Do not run EmptyFunctionBlock on open functions

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
@@ -22,5 +22,5 @@ class EmptyFunctionBlock(config: Config) : EmptyRule(config) {
 		}
 	}
 
-	private fun KtNamedFunction.notMeantForOverriding() = !(isOpen() && isProtected())
+	private fun KtNamedFunction.notMeantForOverriding() = !isOpen()
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
@@ -16,11 +16,6 @@ class EmptyFunctionBlockSpec : SubjectSpek<EmptyFunctionBlock>({
 
 	describe("should not flag functions meant to be overridden") {
 
-		it("should not flag function with protected and open modifier") {
-			val findings = subject.lint("protected open fun stuff() {}")
-			assertThat(findings).isEmpty()
-		}
-
 		it("should flag function with protected modifier") {
 			val findings = subject.lint("protected fun stuff() {}")
 			assertThat(findings).hasSize(1)
@@ -28,7 +23,7 @@ class EmptyFunctionBlockSpec : SubjectSpek<EmptyFunctionBlock>({
 
 		it("should not flag function with open modifier") {
 			val findings = subject.lint("open fun stuff() {}")
-			assertThat(findings).hasSize(1)
+			assertThat(findings).isEmpty()
 		}
 	}
 


### PR DESCRIPTION
Overridable functions do not have to be `protected`.

Fixes #666.