### PR TITLE
Remove inactive-by-default rules from test-pattern exclusions

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -14,8 +14,6 @@ test-pattern: # Configure exclusions for test sources
     - 'WildcardImport'
     - 'MagicNumber'
     - 'MaxLineLength'
-    - 'LateinitUsage'
-    - 'StringLiteralDuplication'
     - 'SpreadOperator'
     - 'TooManyFunctions'
 

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -70,8 +70,6 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
 			    - 'WildcardImport'
 			    - 'MagicNumber'
 			    - 'MaxLineLength'
-			    - 'LateinitUsage'
-			    - 'StringLiteralDuplication'
 			    - 'SpreadOperator'
 			    - 'TooManyFunctions'
 			""".trimIndent()


### PR DESCRIPTION
Both `LateinitUsage` and `StringLiteralDuplication` are disabled by default. There's no point in including them in the `test-pattern` section in the `default-detekt-config`.