### PR TITLE
Adds 'ignoreDefaultParameters' config to LongParameterList rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,7 @@ inside the report file.
 - [Ilya Zorin](https://github.com/geralt-encore) - Rule improvement: UnnecessaryAbstractClass
 - [Gesh Markov](https://github.com/markov) - Improve error message for incorrect configuration file
 - [Patrick Pilch](https://github.com/patrickpilch) - Rule improvement: ReturnCount
+- [Serj Lotutovici](https://github.com/serj-lotutovici) - Rule improvement: LongParameterList
 
 ### <a name="mentions">Mentions</a>
 

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -72,6 +72,7 @@ complexity:
   LongParameterList:
     active: true
     threshold: 5
+    ignoreDefaultParameters: false
   LongMethod:
     active: true
     threshold: 20

--- a/detekt-generator/documentation/complexity.md
+++ b/detekt-generator/documentation/complexity.md
@@ -19,13 +19,17 @@ This rule set contains rules that report complex code.
 
 ### LongParameterList
 
-TODO: Specify description
+Reports functions which have more parameters then a certain threshold (default: 5).
 
 #### Configuration options:
 
 * `threshold` (default: `5`)
 
    maximum number of parameters
+
+* `ignoreDefaultParameters` (default: `false`)
+
+   ignore parameters that have a default value
 
 ### LongMethod
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.given
@@ -22,6 +23,18 @@ class LongParameterListSpec : SubjectSpek<LongParameterList>({
 		it("does not reports short parameter list") {
 			val code = "fun long(a: Int, b: Int, c: Int, d: Int, e: Int) {}"
 			assertThat(subject.lint(code)).isEmpty()
+		}
+
+		it("reports too long parameter list event for parameters with defaults") {
+			val code = "fun long(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int = 1) {}"
+			assertThat(subject.lint(code)).hasSize(1)
+		}
+
+		it("does not report long parameter list if parameters with defaults should be ignored") {
+			val config = TestConfig(mapOf(LongParameterList.IGNORE_DEFAULT_PARAMETERS to "true"))
+			val rule = LongParameterList(config)
+			val code = "fun long(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int = 1, g: Int = 2) {}"
+			assertThat(rule.lint(code)).isEmpty()
 		}
 	}
 })


### PR DESCRIPTION
Went with `ignoreDefaultParameters` over `ignoreOptionalParameters` because it's more consistend with kotlin documentation.

Closes #673 