### PR TITLE
Fix MatchingDeclarationName false positives

### DIFF
--- a/detekt-generator/documentation/style.md
+++ b/detekt-generator/documentation/style.md
@@ -946,7 +946,7 @@ interface Foo {
 
 ### MatchingDeclarationName
 
-"If a Kotlin file contains a single class (potentially with related top-level declarations),
+"If a Kotlin file contains a single non-private class (potentially with related top-level declarations),
 its name should be the same as the name of the class, with the .kt extension appended.
 If a file contains multiple classes, or only top-level declarations,
 choose a name describing what the file contains, and name the file accordingly.

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MatchingDeclarationName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MatchingDeclarationName.kt
@@ -1,6 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MatchingDeclarationName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MatchingDeclarationName.kt
@@ -1,12 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
@@ -55,7 +49,7 @@ class MatchingDeclarationName(config: Config = Config.empty) : Rule(config) {
 	override fun visitKtFile(file: KtFile) {
 		val declarations = file.declarations
 				.filterIsInstance<KtClassOrObject>()
-				.filterNot { it.isPrivate()  }
+				.filterNot { it.isPrivate() }
 		if (declarations.size == 1) {
 			val declaration = declarations[0] as? KtClassOrObject
 			val declarationName = declaration?.name ?: return

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MatchingDeclarationName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MatchingDeclarationName.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
 /**
  * "If a Kotlin file contains a single class (potentially with related top-level declarations),
@@ -47,13 +48,14 @@ import org.jetbrains.kotlin.psi.KtFile
 class MatchingDeclarationName(config: Config = Config.empty) : Rule(config) {
 
 	override val issue: Issue = Issue(javaClass.simpleName, Severity.Style,
-			"If a source file contains only a single top-level class or object, " +
+			"If a source file contains only a single non-private top-level class or object, " +
 					"the file name should reflect the case-sensitive name plus the .kt extension.",
 			Debt.FIVE_MINS)
 
 	override fun visitKtFile(file: KtFile) {
 		val declarations = file.declarations
 				.filterIsInstance<KtClassOrObject>()
+				.filterNot { it.isPrivate()  }
 		if (declarations.size == 1) {
 			val declaration = declarations[0] as? KtClassOrObject
 			val declarationName = declaration?.name ?: return

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MatchingDeclarationName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MatchingDeclarationName.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
 /**
- * "If a Kotlin file contains a single class (potentially with related top-level declarations),
+ * "If a Kotlin file contains a single non-private class (potentially with related top-level declarations),
  * its name should be the same as the name of the class, with the .kt extension appended.
  * If a file contains multiple classes, or only top-level declarations,
  * choose a name describing what the file contains, and name the file accordingly.

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MatchingDeclarationNameSpec.kt
@@ -85,14 +85,14 @@ internal class MatchingDeclarationNameSpec : Spek({
 			val ktFile = compileContentForTest("object O")
 			ktFile.name = "Objects.kt"
 			val findings = MatchingDeclarationName().lint(ktFile)
-			assertThat(findings).hasSize(1)
+			assertThat(findings).hasLocationStrings("'object O' at (1,1) in /Objects.kt")
 		}
 
 		it("should not pass for class declaration") {
 			val ktFile = compileContentForTest("class C")
 			ktFile.name = "Classes.kt"
 			val findings = MatchingDeclarationName().lint(ktFile)
-			assertThat(findings).hasSize(1)
+			assertThat(findings).hasLocationStrings("'class C' at (1,1) in /Classes.kt")
 		}
 
 		it("should not pass for class declaration with utility functions") {
@@ -103,17 +103,21 @@ internal class MatchingDeclarationNameSpec : Spek({
 			""")
 			ktFile.name = "ClassUtils.kt"
 			val findings = MatchingDeclarationName().lint(ktFile)
-			assertThat(findings).hasSize(1)
+			assertThat(findings).hasLocationStrings("""'
+				class C
+				fun a() = 5
+				fun C.b() = 5
+			' at (1,1) in /ClassUtils.kt""", trimIndent = true)
 		}
 
 		it("should not pass for interface declaration") {
 			val ktFile = compileContentForTest("interface I")
 			ktFile.name = "Not_I.kt"
 			val findings = MatchingDeclarationName().lint(ktFile)
-			assertThat(findings).hasSize(1)
+			assertThat(findings).hasLocationStrings("'interface I' at (1,1) in /Not_I.kt")
 		}
 
-		it("should pass for enum declaration") {
+		it("should not pass for enum declaration") {
 			val ktFile = compileContentForTest("""
 				enum class NOT_E {
 					ONE, TWO, THREE
@@ -121,7 +125,11 @@ internal class MatchingDeclarationNameSpec : Spek({
 			""")
 			ktFile.name = "E.kt"
 			val findings = MatchingDeclarationName().lint(ktFile)
-			assertThat(findings).hasSize(1)
+			assertThat(findings).hasLocationStrings("""'
+				enum class NOT_E {
+					ONE, TWO, THREE
+				}
+			' at (1,1) in /E.kt""", trimIndent = true)
 		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MatchingDeclarationNameSpec.kt
@@ -67,6 +67,16 @@ internal class MatchingDeclarationNameSpec : Spek({
 			val findings = MatchingDeclarationName().lint(ktFile)
 			assertThat(findings).isEmpty()
 		}
+
+		it("should pass for private class declaration") {
+			val ktFile = compileContentForTest("""
+				private class C
+				fun a() = 5
+			""")
+			ktFile.name = "b.kt"
+			val findings = MatchingDeclarationName().lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
 	}
 
 	given("non-compliant test cases") {

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -8,26 +8,26 @@ import org.assertj.core.internal.Objects
 fun assertThat(findings: List<Finding>) = FindingsAssert(findings)
 
 class FindingsAssert(actual: List<Finding>) :
-        AbstractListAssert<FindingsAssert, List<Finding>,
-                Finding, FindingAssert>(actual, FindingsAssert::class.java) {
+		AbstractListAssert<FindingsAssert, List<Finding>,
+				Finding, FindingAssert>(actual, FindingsAssert::class.java) {
 
-    override fun toAssert(value: Finding?, description: String?): FindingAssert =
-            FindingAssert(value).`as`(description)
+	override fun toAssert(value: Finding?, description: String?): FindingAssert =
+			FindingAssert(value).`as`(description)
 
-    fun hasLocationStrings(vararg expected: String, trimIndent: Boolean = false) {
-        isNotNull
-        val locationStrings = actual.map { it.locationAsString }
-        if (trimIndent) {
-            areEqual(locationStrings.map { it.trimIndent() }, expected.map { it.trimIndent() })
-        } else {
-            areEqual(locationStrings, expected.toList())
-        }
-    }
+	fun hasLocationStrings(vararg expected: String, trimIndent: Boolean = false) {
+		isNotNull
+		val locationStrings = actual.map { it.locationAsString }
+		if (trimIndent) {
+			areEqual(locationStrings.map { it.trimIndent() }, expected.map { it.trimIndent() })
+		} else {
+			areEqual(locationStrings, expected.toList())
+		}
+	}
 
-    private fun areEqual(actualLocationStrings: List<String>, expectedLocationStrings: List<String>) {
-        Objects.instance()
-                .assertEqual(writableAssertionInfo, actualLocationStrings, expectedLocationStrings.toList())
-    }
+	private fun areEqual(actualLocationStrings: List<String>, expectedLocationStrings: List<String>) {
+		Objects.instance()
+				.assertEqual(writableAssertionInfo, actualLocationStrings, expectedLocationStrings.toList())
+	}
 }
 
 class FindingAssert(actual: Finding?) : AbstractAssert<FindingAssert, Finding>(actual, FindingAssert::class.java)

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -6,23 +6,28 @@ import org.assertj.core.api.AbstractListAssert
 import org.assertj.core.internal.Objects
 
 fun assertThat(findings: List<Finding>) = FindingsAssert(findings)
+
 class FindingsAssert(actual: List<Finding>) :
-		AbstractListAssert<FindingsAssert, List<Finding>,
-				Finding, FindingAssert>(actual, FindingsAssert::class.java) {
+        AbstractListAssert<FindingsAssert, List<Finding>,
+                Finding, FindingAssert>(actual, FindingsAssert::class.java) {
 
-	override fun toAssert(value: Finding?, description: String?): FindingAssert =
-			FindingAssert(value).`as`(description)
+    override fun toAssert(value: Finding?, description: String?): FindingAssert =
+            FindingAssert(value).`as`(description)
 
-	fun hasLocationStrings(vararg expected: String) {
-		isNotNull
-		val actualLocationStrings = actual.map { it.locationAsString }
-		areEqual(actualLocationStrings, expected)
-	}
+    fun hasLocationStrings(vararg expected: String, trimIndent: Boolean = false) {
+        isNotNull
+        val locationStrings = actual.map { it.locationAsString }
+        if (trimIndent) {
+            areEqual(locationStrings.map { it.trimIndent() }, expected.map { it.trimIndent() })
+        } else {
+            areEqual(locationStrings, expected.toList())
+        }
+    }
 
-	private fun areEqual(actualLocationStrings: List<String>, expectedLocationStrings: Array<out String>) {
-		Objects.instance()
-				.assertEqual(writableAssertionInfo, actualLocationStrings, expectedLocationStrings.toList())
-	}
+    private fun areEqual(actualLocationStrings: List<String>, expectedLocationStrings: List<String>) {
+        Objects.instance()
+                .assertEqual(writableAssertionInfo, actualLocationStrings, expectedLocationStrings.toList())
+    }
 }
 
 class FindingAssert(actual: Finding?) : AbstractAssert<FindingAssert, Finding>(actual, FindingAssert::class.java)


### PR DESCRIPTION
This PR fixes #686 in that it filters out private classes/interfaces/objects from the `MatchingDeclarationName` rule. These private classes/interfaces/objects are an implementation detail and should not determine the name of a file, whose only public member may well be a function.

In addition to the visibility filter, this PR also improves upon FindingsAssertions and uses them in the rule's negative cases tests in lieu of the more lax `assertThat(findings).hasSize(1)`.