### PR TITLE
Sort Rules in Config & Documentation alphabetically

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -69,16 +69,9 @@ comments:
 
 complexity:
   active: true
-  LongParameterList:
+  ComplexCondition:
     active: true
-    threshold: 5
-    ignoreDefaultParameters: false
-  LongMethod:
-    active: true
-    threshold: 20
-  LargeClass:
-    active: true
-    threshold: 150
+    threshold: 3
   ComplexInterface:
     active: false
     threshold: 10
@@ -86,18 +79,30 @@ complexity:
   ComplexMethod:
     active: true
     threshold: 10
-  StringLiteralDuplication:
+  LabeledExpression:
     active: false
-    threshold: 2
-    ignoreAnnotation: true
-    excludeStringsWithLessThan5Characters: true
-    ignoreStringsRegex: '$^'
+  LargeClass:
+    active: true
+    threshold: 150
+  LongMethod:
+    active: true
+    threshold: 20
+  LongParameterList:
+    active: true
+    threshold: 5
+    ignoreDefaultParameters: false
   MethodOverloading:
     active: false
     threshold: 5
   NestedBlockDepth:
     active: true
     threshold: 3
+  StringLiteralDuplication:
+    active: false
+    threshold: 2
+    ignoreAnnotation: true
+    excludeStringsWithLessThan5Characters: true
+    ignoreStringsRegex: '$^'
   TooManyFunctions:
     active: true
     thresholdInFiles: 10
@@ -105,11 +110,6 @@ complexity:
     thresholdInInterfaces: 10
     thresholdInObjects: 10
     thresholdInEnums: 10
-  ComplexCondition:
-    active: true
-    threshold: 3
-  LabeledExpression:
-    active: false
 
 empty-blocks:
   active: true
@@ -144,6 +144,30 @@ empty-blocks:
 
 exceptions:
   active: true
+  ExceptionRaisedInUnexpectedLocation:
+    active: false
+    methodNames: 'toString,hashCode,equals,finalize'
+  InstanceOfCheckForException:
+    active: false
+  NotImplementedDeclaration:
+    active: false
+  PrintStackTrace:
+    active: false
+  RethrowCaughtException:
+    active: false
+  ReturnFromFinally:
+    active: false
+  SwallowedException:
+    active: false
+  ThrowingExceptionFromFinally:
+    active: false
+  ThrowingExceptionInMain:
+    active: false
+  ThrowingExceptionsWithoutMessageOrCause:
+    active: false
+    exceptions: 'IllegalArgumentException,IllegalStateException,IOException'
+  ThrowingNewInstanceOfSameException:
+    active: false
   TooGenericExceptionCaught:
     active: true
     exceptions:
@@ -155,9 +179,6 @@ exceptions:
      - IndexOutOfBoundsException
      - RuntimeException
      - Throwable
-  ExceptionRaisedInUnexpectedLocation:
-    active: false
-    methodNames: 'toString,hashCode,equals,finalize'
   TooGenericExceptionThrown:
     active: true
     exceptions:
@@ -166,27 +187,6 @@ exceptions:
      - NullPointerException
      - Throwable
      - RuntimeException
-  NotImplementedDeclaration:
-    active: false
-  PrintStackTrace:
-    active: false
-  InstanceOfCheckForException:
-    active: false
-  ThrowingExceptionsWithoutMessageOrCause:
-    active: false
-    exceptions: 'IllegalArgumentException,IllegalStateException,IOException'
-  ReturnFromFinally:
-    active: false
-  ThrowingExceptionFromFinally:
-    active: false
-  ThrowingExceptionInMain:
-    active: false
-  RethrowCaughtException:
-    active: false
-  ThrowingNewInstanceOfSameException:
-    active: false
-  SwallowedException:
-    active: false
 
 performance:
   active: true
@@ -205,18 +205,14 @@ potential-bugs:
     active: false
   EqualsWithHashCodeExist:
     active: true
-  IteratorNotThrowingNoSuchElementException:
+  ExplicitGarbageCollectionCall:
+    active: true
+  InvalidRange:
     active: false
   IteratorHasNextCallsNextMethod:
     active: false
-  UselessPostfixExpression:
+  IteratorNotThrowingNoSuchElementException:
     active: false
-  InvalidRange:
-    active: false
-  WrongEqualsTypeParameter:
-    active: false
-  ExplicitGarbageCollectionCall:
-    active: true
   LateinitUsage:
     active: false
     excludeAnnotatedProperties: ""
@@ -229,109 +225,53 @@ potential-bugs:
     active: false
   UnsafeCast:
     active: false
+  UselessPostfixExpression:
+    active: false
+  WrongEqualsTypeParameter:
+    active: false
 
 style:
   active: true
+  ClassNaming:
+    active: true
+    classPattern: '[A-Z$][a-zA-Z0-9$]*'
   CollapsibleIfStatements:
     active: false
-  ReturnCount:
+  DataClassContainsFunctions:
+    active: false
+    conversionFunctionPrefix: 'to'
+  EnumNaming:
     active: true
-    max: 2
-    excludedFunctions: "equals"
-  ThrowsCount:
-    active: true
-    max: 2
-  NewLineAtEndOfFile:
-    active: true
-  WildcardImport:
-    active: true
-    excludeImports: 'java.util.*,kotlinx.android.synthetic.*'
-  MaxLineLength:
-    active: true
-    maxLineLength: 120
-    excludePackageStatements: false
-    excludeImportStatements: false
+    enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
   EqualsNullCall:
     active: false
+  ExpressionBodySyntax:
+    active: false
+  ForbiddenClassName:
+    active: false
+    forbiddenName: ''
   ForbiddenComment:
     active: true
     values: 'TODO:,FIXME:,STOPSHIP:'
   ForbiddenImport:
     active: false
     imports: ''
-  FunctionOnlyReturningConstant:
-    active: false
-    ignoreOverridableFunction: true
-    excludedFunctions: 'describeContents'
-  SpacingBetweenPackageAndImports:
-    active: false
-  LoopWithTooManyJumpStatements:
-    active: false
-    maxJumpCount: 1
-  MemberNameEqualsClassName:
-    active: false
-    ignoreOverriddenFunction: true
-  VariableNaming:
-    active: true
-    variablePattern: '[a-z][A-Za-z0-9]*'
-    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
-  VariableMinLength:
-    active: false
-    minimumVariableNameLength: 1
-  VariableMaxLength:
-    active: false
-    maximumVariableNameLength: 64
-  TopLevelPropertyNaming:
-    active: true
-    constantPattern: '[A-Z][_A-Z0-9]*'
-    propertyPattern: '[a-z][A-Za-z\d]*'
-    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
-  ObjectPropertyNaming:
-    active: true
-    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
-  PackageNaming:
-    active: true
-    packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
-  ClassNaming:
-    active: true
-    classPattern: '[A-Z$][a-zA-Z0-9$]*'
-  EnumNaming:
-    active: true
-    enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
-  FunctionNaming:
-    active: true
-    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
   FunctionMaxLength:
     active: false
     maximumFunctionNameLength: 30
   FunctionMinLength:
     active: false
     minimumFunctionNameLength: 3
-  ForbiddenClassName:
-    active: false
-    forbiddenName: ''
-  SafeCast:
+  FunctionNaming:
     active: true
-  UnnecessaryAbstractClass:
+    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
+  FunctionOnlyReturningConstant:
     active: false
-  UnnecessaryParentheses:
+    ignoreOverridableFunction: true
+    excludedFunctions: 'describeContents'
+  LoopWithTooManyJumpStatements:
     active: false
-  UnnecessaryInheritance:
-    active: false
-  UtilityClassWithPublicConstructor:
-    active: false
-  OptionalAbstractKeyword:
-    active: true
-  OptionalWhenBraces:
-    active: false
-  OptionalReturnKeyword:
-    active: false
-  OptionalUnit:
-    active: false
-  ProtectedMemberInFinalClass:
-    active: false
-  SerialVersionUIDInSerializableClass:
-    active: false
+    maxJumpCount: 1
   MagicNumber:
     active: true
     ignoreNumbers: '-1,0,1,2'
@@ -342,22 +282,82 @@ style:
     ignoreAnnotation: false
     ignoreNamedArgument: true
     ignoreEnums: false
+  MatchingDeclarationName:
+    active: true
+  MaxLineLength:
+    active: true
+    maxLineLength: 120
+    excludePackageStatements: false
+    excludeImportStatements: false
+  MemberNameEqualsClassName:
+    active: false
+    ignoreOverriddenFunction: true
   ModifierOrder:
     active: true
-  DataClassContainsFunctions:
-    active: false
-    conversionFunctionPrefix: 'to'
-  UseDataClass:
-    active: false
-  UnusedImports:
-    active: false
-  ExpressionBodySyntax:
-    active: false
   NestedClassesVisibility:
+    active: false
+  NewLineAtEndOfFile:
+    active: true
+  ObjectPropertyNaming:
+    active: true
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+  OptionalAbstractKeyword:
+    active: true
+  OptionalReturnKeyword:
+    active: false
+  OptionalUnit:
+    active: false
+  OptionalWhenBraces:
+    active: false
+  PackageNaming:
+    active: true
+    packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
+  ProtectedMemberInFinalClass:
     active: false
   RedundantVisibilityModifierRule:
     active: false
-  MatchingDeclarationName:
+  ReturnCount:
     active: true
+    max: 2
+    excludedFunctions: "equals"
+  SafeCast:
+    active: true
+  SerialVersionUIDInSerializableClass:
+    active: false
+  SpacingBetweenPackageAndImports:
+    active: false
+  ThrowsCount:
+    active: true
+    max: 2
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Z0-9]*'
+    propertyPattern: '[a-z][A-Za-z\d]*'
+    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
+  UnnecessaryAbstractClass:
+    active: false
+  UnnecessaryInheritance:
+    active: false
+  UnnecessaryParentheses:
+    active: false
   UntilInsteadOfRangeTo:
     active: false
+  UnusedImports:
+    active: false
+  UseDataClass:
+    active: false
+  UtilityClassWithPublicConstructor:
+    active: false
+  VariableMaxLength:
+    active: false
+    maximumVariableNameLength: 64
+  VariableMinLength:
+    active: false
+    minimumVariableNameLength: 1
+  VariableNaming:
+    active: true
+    variablePattern: '[a-z][A-Za-z0-9]*'
+    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
+  WildcardImport:
+    active: true
+    excludeImports: 'java.util.*,kotlinx.android.synthetic.*'

--- a/detekt-generator/documentation/complexity.md
+++ b/detekt-generator/documentation/complexity.md
@@ -4,52 +4,48 @@ This rule set contains rules that report complex code.
 
 ## Content
 
-1. [LongParameterList](#longparameterlist)
-2. [LongMethod](#longmethod)
-3. [LargeClass](#largeclass)
-4. [ComplexInterface](#complexinterface)
-5. [ComplexMethod](#complexmethod)
-6. [StringLiteralDuplication](#stringliteralduplication)
-7. [MethodOverloading](#methodoverloading)
-8. [NestedBlockDepth](#nestedblockdepth)
-9. [TooManyFunctions](#toomanyfunctions)
-10. [ComplexCondition](#complexcondition)
-11. [LabeledExpression](#labeledexpression)
+1. [ComplexCondition](#complexcondition)
+2. [ComplexInterface](#complexinterface)
+3. [ComplexMethod](#complexmethod)
+4. [LabeledExpression](#labeledexpression)
+5. [LargeClass](#largeclass)
+6. [LongMethod](#longmethod)
+7. [LongParameterList](#longparameterlist)
+8. [MethodOverloading](#methodoverloading)
+9. [NestedBlockDepth](#nestedblockdepth)
+10. [StringLiteralDuplication](#stringliteralduplication)
+11. [TooManyFunctions](#toomanyfunctions)
 ## Rules in the `complexity` rule set:
 
-### LongParameterList
-
-Reports functions which have more parameters then a certain threshold (default: 5).
-
-#### Configuration options:
-
-* `threshold` (default: `5`)
-
-   maximum number of parameters
-
-* `ignoreDefaultParameters` (default: `false`)
-
-   ignore parameters that have a default value
-
-### LongMethod
+### ComplexCondition
 
 TODO: Specify description
 
 #### Configuration options:
 
-* `threshold` (default: `20`)
+* `threshold` (default: `3`)
 
-   maximum lines in a method
+   
 
-### LargeClass
+#### Noncompliant Code:
 
-TODO: Specify description
+```kotlin
+val str = "foo"
+val isFoo = if (str.startsWith("foo") && !str.endsWith("foo") && !str.endsWith("bar") && !str.endsWith("_")) {
+    // ...
+}
+```
 
-#### Configuration options:
+#### Compliant Code:
 
-* `threshold` (default: `150`)
+```kotlin
+val str = "foo"
+val isFoo = if (str.startsWith("foo") && hasCorrectEnding()) {
+    // ...
+}
 
-   maximum size of a class
+fun hasCorrectEnding() = return !str.endsWith("foo") && !str.endsWith("bar") && !str.endsWith("_")
+```
 
 ### ComplexInterface
 
@@ -74,6 +70,84 @@ TODO: Specify description
 * `threshold` (default: `10`)
 
    maximum amount of functions in a class
+
+### LabeledExpression
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+val range = listOf<String>("foo", "bar")
+loop@ for (r in range) {
+    if (r == "bar") break@loop
+    println(r)
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+val range = listOf<String>("foo", "bar")
+for (r in range) {
+    if (r == "bar") break
+    println(r)
+}
+```
+
+### LargeClass
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `threshold` (default: `150`)
+
+   maximum size of a class
+
+### LongMethod
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `threshold` (default: `20`)
+
+   maximum lines in a method
+
+### LongParameterList
+
+Reports functions which have more parameters then a certain threshold (default: 5).
+
+#### Configuration options:
+
+* `threshold` (default: `5`)
+
+   maximum number of parameters
+
+* `ignoreDefaultParameters` (default: `false`)
+
+   ignore parameters that have a default value
+
+### MethodOverloading
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `threshold` (default: `5`)
+
+   
+
+### NestedBlockDepth
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `threshold` (default: `3`)
+
+   maximum nesting depth
 
 ### StringLiteralDuplication
 
@@ -121,26 +195,6 @@ class Foo {
 }
 ```
 
-### MethodOverloading
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `threshold` (default: `5`)
-
-   
-
-### NestedBlockDepth
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `threshold` (default: `3`)
-
-   maximum nesting depth
-
 ### TooManyFunctions
 
 TODO: Specify description
@@ -166,57 +220,3 @@ TODO: Specify description
 * `thresholdInEnums` (default: `10`)
 
    threshold in enums
-
-### ComplexCondition
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `threshold` (default: `3`)
-
-   
-
-#### Noncompliant Code:
-
-```kotlin
-val str = "foo"
-val isFoo = if (str.startsWith("foo") && !str.endsWith("foo") && !str.endsWith("bar") && !str.endsWith("_")) {
-    // ...
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-val str = "foo"
-val isFoo = if (str.startsWith("foo") && hasCorrectEnding()) {
-    // ...
-}
-
-fun hasCorrectEnding() = return !str.endsWith("foo") && !str.endsWith("bar") && !str.endsWith("_")
-```
-
-### LabeledExpression
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-val range = listOf<String>("foo", "bar")
-loop@ for (r in range) {
-    if (r == "bar") break@loop
-    println(r)
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-val range = listOf<String>("foo", "bar")
-for (r in range) {
-    if (r == "bar") break
-    println(r)
-}
-```

--- a/detekt-generator/documentation/potential-bugs.md
+++ b/detekt-generator/documentation/potential-bugs.md
@@ -7,17 +7,17 @@ The potential-bugs rule set provides rules that detect potential bugs.
 1. [DuplicateCaseInWhenExpression](#duplicatecaseinwhenexpression)
 2. [EqualsAlwaysReturnsTrueOrFalse](#equalsalwaysreturnstrueorfalse)
 3. [EqualsWithHashCodeExist](#equalswithhashcodeexist)
-4. [IteratorNotThrowingNoSuchElementException](#iteratornotthrowingnosuchelementexception)
-5. [IteratorHasNextCallsNextMethod](#iteratorhasnextcallsnextmethod)
-6. [UselessPostfixExpression](#uselesspostfixexpression)
-7. [InvalidRange](#invalidrange)
-8. [WrongEqualsTypeParameter](#wrongequalstypeparameter)
-9. [ExplicitGarbageCollectionCall](#explicitgarbagecollectioncall)
-10. [LateinitUsage](#lateinitusage)
-11. [UnconditionalJumpStatementInLoop](#unconditionaljumpstatementinloop)
-12. [UnreachableCode](#unreachablecode)
-13. [UnsafeCallOnNullableType](#unsafecallonnullabletype)
-14. [UnsafeCast](#unsafecast)
+4. [ExplicitGarbageCollectionCall](#explicitgarbagecollectioncall)
+5. [InvalidRange](#invalidrange)
+6. [IteratorHasNextCallsNextMethod](#iteratorhasnextcallsnextmethod)
+7. [IteratorNotThrowingNoSuchElementException](#iteratornotthrowingnosuchelementexception)
+8. [LateinitUsage](#lateinitusage)
+9. [UnconditionalJumpStatementInLoop](#unconditionaljumpstatementinloop)
+10. [UnreachableCode](#unreachablecode)
+11. [UnsafeCallOnNullableType](#unsafecallonnullabletype)
+12. [UnsafeCast](#unsafecast)
+13. [UselessPostfixExpression](#uselesspostfixexpression)
+14. [WrongEqualsTypeParameter](#wrongequalstypeparameter)
 ## Rules in the `potential-bugs` rule set:
 
 ### DuplicateCaseInWhenExpression
@@ -104,78 +104,18 @@ class Foo {
 }
 ```
 
-### IteratorNotThrowingNoSuchElementException
+### ExplicitGarbageCollectionCall
 
-Reports implementations of the Iterator interface which do not throw a NoSuchElementException in the
-implementation of the next() method. When there are no more elements to return an Iterator should throw a
-NoSuchElementException.
-
-See: https://docs.oracle.com/javase/7/docs/api/java/util/Iterator.html#next()
-
-<compliant>
-class MyIterator : Iterator<String> {
-
-    override fun next(): String {
-        if (!this.hasNext()) {
-            throw NoSuchElementException()
-        }
-        // ...
-    }
-}
-</compliant>
-
-### IteratorHasNextCallsNextMethod
-
-Verifies implementations of the Iterator interface.
-The hasNext() method of an Iterator implementation should not have any side effects.
-This rule reports implementations that call the next() method of the Iterator inside the hasNext() method.
+Reports all calls to explicitly trigger the Garbage Collector.
+Code should work independently of the garbage collector and should not require the GC to be triggered in certain
+points in time.
 
 #### Noncompliant Code:
 
 ```kotlin
-class MyIterator : Iterator<String> {
-
-    override fun hasNext(): Boolean {
-        return next() != null
-    }
-}
-```
-
-### UselessPostfixExpression
-
-This rule reports postfix expressions (++, --) which are unused and thus unnecessary.
-This leads to confusion as a reader of the code might think the value will be incremented/decremented.
-However the value is replaced with the original value which might lead to bugs.
-
-#### Noncompliant Code:
-
-```kotlin
-var i = 0
-i = i--
-i = 1 + i++
-i = i++ + 1
-
-fun foo(): Int {
-    var i = 0
-    // ...
-    return i++
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-var i = 0
-i--
-i = i + 2
-i = i + 2
-
-fun foo(): Int {
-    var i = 0
-    // ...
-    i++
-    return i
-}
+System.gc()
+Runtime.getRuntime().gc()
+System.runFinalization()
 ```
 
 ### InvalidRange
@@ -202,47 +142,42 @@ for (i in 2 downTo 2) {}
 val range =  2 until 2)
 ```
 
-### WrongEqualsTypeParameter
+### IteratorHasNextCallsNextMethod
 
-Reports equals() methods which take in a wrongly typed parameter.
-Correct implementations of the equals() method should only take in a parameter of type Any?
-See: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html
-
-#### Noncompliant Code:
-
-```kotlin
-class Foo {
-
-    fun equals(other: String): Boolean {
-        return super.equals(other)
-    }
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-class Foo {
-
-    fun equals(other: Any?): Boolean {
-        return super.equals(other)
-    }
-}
-```
-
-### ExplicitGarbageCollectionCall
-
-Reports all calls to explicitly trigger the Garbage Collector.
-Code should work independently of the garbage collector and should not require the GC to be triggered in certain
-points in time.
+Verifies implementations of the Iterator interface.
+The hasNext() method of an Iterator implementation should not have any side effects.
+This rule reports implementations that call the next() method of the Iterator inside the hasNext() method.
 
 #### Noncompliant Code:
 
 ```kotlin
-System.gc()
-Runtime.getRuntime().gc()
-System.runFinalization()
+class MyIterator : Iterator<String> {
+
+    override fun hasNext(): Boolean {
+        return next() != null
+    }
+}
 ```
+
+### IteratorNotThrowingNoSuchElementException
+
+Reports implementations of the Iterator interface which do not throw a NoSuchElementException in the
+implementation of the next() method. When there are no more elements to return an Iterator should throw a
+NoSuchElementException.
+
+See: https://docs.oracle.com/javase/7/docs/api/java/util/Iterator.html#next()
+
+<compliant>
+class MyIterator : Iterator<String> {
+
+    override fun next(): String {
+        if (!this.hasNext()) {
+            throw NoSuchElementException()
+        }
+        // ...
+    }
+}
+</compliant>
 
 ### LateinitUsage
 
@@ -353,5 +288,70 @@ fun foo(s: Any) {
 ```kotlin
 fun foo(s: Any) {
     println((s as? Int) ?: 0)
+}
+```
+
+### UselessPostfixExpression
+
+This rule reports postfix expressions (++, --) which are unused and thus unnecessary.
+This leads to confusion as a reader of the code might think the value will be incremented/decremented.
+However the value is replaced with the original value which might lead to bugs.
+
+#### Noncompliant Code:
+
+```kotlin
+var i = 0
+i = i--
+i = 1 + i++
+i = i++ + 1
+
+fun foo(): Int {
+    var i = 0
+    // ...
+    return i++
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+var i = 0
+i--
+i = i + 2
+i = i + 2
+
+fun foo(): Int {
+    var i = 0
+    // ...
+    i++
+    return i
+}
+```
+
+### WrongEqualsTypeParameter
+
+Reports equals() methods which take in a wrongly typed parameter.
+Correct implementations of the equals() method should only take in a parameter of type Any?
+See: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html
+
+#### Noncompliant Code:
+
+```kotlin
+class Foo {
+
+    fun equals(other: String): Boolean {
+        return super.equals(other)
+    }
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+class Foo {
+
+    fun equals(other: Any?): Boolean {
+        return super.equals(other)
+    }
 }
 ```

--- a/detekt-generator/documentation/style.md
+++ b/detekt-generator/documentation/style.md
@@ -6,53 +6,63 @@ code style guidelines.
 
 ## Content
 
-1. [CollapsibleIfStatements](#collapsibleifstatements)
-2. [ReturnCount](#returncount)
-3. [ThrowsCount](#throwscount)
-4. [NewLineAtEndOfFile](#newlineatendoffile)
-5. [WildcardImport](#wildcardimport)
-6. [MaxLineLength](#maxlinelength)
-7. [EqualsNullCall](#equalsnullcall)
+1. [ClassNaming](#classnaming)
+2. [CollapsibleIfStatements](#collapsibleifstatements)
+3. [DataClassContainsFunctions](#dataclasscontainsfunctions)
+4. [EnumNaming](#enumnaming)
+5. [EqualsNullCall](#equalsnullcall)
+6. [ExpressionBodySyntax](#expressionbodysyntax)
+7. [ForbiddenClassName](#forbiddenclassname)
 8. [ForbiddenComment](#forbiddencomment)
 9. [ForbiddenImport](#forbiddenimport)
-10. [FunctionOnlyReturningConstant](#functiononlyreturningconstant)
-11. [SpacingBetweenPackageAndImports](#spacingbetweenpackageandimports)
-12. [LoopWithTooManyJumpStatements](#loopwithtoomanyjumpstatements)
-13. [MemberNameEqualsClassName](#membernameequalsclassname)
-14. [VariableNaming](#variablenaming)
-15. [VariableMinLength](#variableminlength)
-16. [VariableMaxLength](#variablemaxlength)
-17. [TopLevelPropertyNaming](#toplevelpropertynaming)
-18. [ObjectPropertyNaming](#objectpropertynaming)
-19. [PackageNaming](#packagenaming)
-20. [ClassNaming](#classnaming)
-21. [EnumNaming](#enumnaming)
-22. [FunctionNaming](#functionnaming)
-23. [FunctionMaxLength](#functionmaxlength)
-24. [FunctionMinLength](#functionminlength)
-25. [ForbiddenClassName](#forbiddenclassname)
-26. [SafeCast](#safecast)
-27. [UnnecessaryAbstractClass](#unnecessaryabstractclass)
-28. [UnnecessaryParentheses](#unnecessaryparentheses)
-29. [UnnecessaryInheritance](#unnecessaryinheritance)
-30. [UtilityClassWithPublicConstructor](#utilityclasswithpublicconstructor)
-31. [OptionalAbstractKeyword](#optionalabstractkeyword)
-32. [OptionalWhenBraces](#optionalwhenbraces)
-33. [OptionalReturnKeyword](#optionalreturnkeyword)
-34. [OptionalUnit](#optionalunit)
-35. [ProtectedMemberInFinalClass](#protectedmemberinfinalclass)
-36. [SerialVersionUIDInSerializableClass](#serialversionuidinserializableclass)
-37. [MagicNumber](#magicnumber)
-38. [ModifierOrder](#modifierorder)
-39. [DataClassContainsFunctions](#dataclasscontainsfunctions)
-40. [UseDataClass](#usedataclass)
-41. [UnusedImports](#unusedimports)
-42. [ExpressionBodySyntax](#expressionbodysyntax)
-43. [NestedClassesVisibility](#nestedclassesvisibility)
-44. [RedundantVisibilityModifierRule](#redundantvisibilitymodifierrule)
-45. [MatchingDeclarationName](#matchingdeclarationname)
-46. [UntilInsteadOfRangeTo](#untilinsteadofrangeto)
+10. [FunctionMaxLength](#functionmaxlength)
+11. [FunctionMinLength](#functionminlength)
+12. [FunctionNaming](#functionnaming)
+13. [FunctionOnlyReturningConstant](#functiononlyreturningconstant)
+14. [LoopWithTooManyJumpStatements](#loopwithtoomanyjumpstatements)
+15. [MagicNumber](#magicnumber)
+16. [MatchingDeclarationName](#matchingdeclarationname)
+17. [MaxLineLength](#maxlinelength)
+18. [MemberNameEqualsClassName](#membernameequalsclassname)
+19. [ModifierOrder](#modifierorder)
+20. [NestedClassesVisibility](#nestedclassesvisibility)
+21. [NewLineAtEndOfFile](#newlineatendoffile)
+22. [ObjectPropertyNaming](#objectpropertynaming)
+23. [OptionalAbstractKeyword](#optionalabstractkeyword)
+24. [OptionalReturnKeyword](#optionalreturnkeyword)
+25. [OptionalUnit](#optionalunit)
+26. [OptionalWhenBraces](#optionalwhenbraces)
+27. [PackageNaming](#packagenaming)
+28. [ProtectedMemberInFinalClass](#protectedmemberinfinalclass)
+29. [RedundantVisibilityModifierRule](#redundantvisibilitymodifierrule)
+30. [ReturnCount](#returncount)
+31. [SafeCast](#safecast)
+32. [SerialVersionUIDInSerializableClass](#serialversionuidinserializableclass)
+33. [SpacingBetweenPackageAndImports](#spacingbetweenpackageandimports)
+34. [ThrowsCount](#throwscount)
+35. [TopLevelPropertyNaming](#toplevelpropertynaming)
+36. [UnnecessaryAbstractClass](#unnecessaryabstractclass)
+37. [UnnecessaryInheritance](#unnecessaryinheritance)
+38. [UnnecessaryParentheses](#unnecessaryparentheses)
+39. [UntilInsteadOfRangeTo](#untilinsteadofrangeto)
+40. [UnusedImports](#unusedimports)
+41. [UseDataClass](#usedataclass)
+42. [UtilityClassWithPublicConstructor](#utilityclasswithpublicconstructor)
+43. [VariableMaxLength](#variablemaxlength)
+44. [VariableMinLength](#variableminlength)
+45. [VariableNaming](#variablenaming)
+46. [WildcardImport](#wildcardimport)
 ## Rules in the `style` rule set:
+
+### ClassNaming
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `classPattern` (default: `'[A-Z$][a-zA-Z0-9$]*'`)
+
+   naming pattern (default: '[A
 
 ### CollapsibleIfStatements
 
@@ -78,141 +88,33 @@ if (i > 0 && i < 5) {
 }
 ```
 
-### ReturnCount
-
-Restrict the number of return methods allowed in methods.
-
-Having many exit points in a function can be confusing and impacts readability of the
-code.
-
-#### Configuration options:
-
-* `max` (default: `2`)
-
-   define the maximum number of return statements allowed per function
-
-* `excludedFunctions` (default: `"equals"`)
-
-   define functions to be ignored by this check
-
-#### Noncompliant Code:
-
-```kotlin
-fun foo(i: Int): String {
-    when (i) {
-        1 -> return "one"
-        2 -> return "two"
-        else -> return "other"
-    }
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-fun foo(i: Int): String {
-    return when (i) {
-        1 -> "one"
-        2 -> "two"
-        else -> "other"
-    }
-}
-```
-
-### ThrowsCount
+### DataClassContainsFunctions
 
 TODO: Specify description
 
 #### Configuration options:
 
-* `max` (default: `2`)
+* `conversionFunctionPrefix` (default: `'to'`)
 
-   maximum amount of throw statements in a method
-
-#### Noncompliant Code:
-
-```kotlin
-fun foo(i: Int) {
-    when (i) {
-        1 -> throw IllegalArgumentException()
-        2 -> throw IllegalArgumentException()
-        3 -> throw IllegalArgumentException()
-    }
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-fun foo(i: Int) {
-    when (i) {
-        1,2,3 -> throw IllegalArgumentException()
-    }
-}
-```
-
-### NewLineAtEndOfFile
-
-TODO: Specify description
-
-### WildcardImport
-
-Wildcard imports should be replaced with imports using fully qualified class names. This helps increase clarity of
-which classes are imported and helps prevent naming conflicts.
-
-Library updates can introduce naming clashes with your own classes which might result in compilation errors.
-
-#### Configuration options:
-
-* `excludeImports` (default: `'java.util.*,kotlinx.android.synthetic.*'`)
-
-   Define a whitelist of package names that should be allowed to be imported
-with wildcard imports.
+   allowed conversion function names
 
 #### Noncompliant Code:
 
 ```kotlin
-package test
-
-import io.gitlab.arturbosch.detekt.*
-
-class DetektElements {
-    val element1 = DetektElement1()
-    val element2 = DetektElement2()
+data class DataClassWithFunctions(val i: Int) {
+    fun foo() { }
 }
 ```
 
-#### Compliant Code:
-
-```kotlin
-package test
-
-import io.gitlab.arturbosch.detekt.DetektElement1
-import io.gitlab.arturbosch.detekt.DetektElement2
-
-class DetektElements {
-    val element1 = DetektElement1()
-    val element2 = DetektElement2()
-}
-```
-
-### MaxLineLength
+### EnumNaming
 
 TODO: Specify description
 
 #### Configuration options:
 
-* `maxLineLength` (default: `120`)
+* `enumEntryPattern` (default: `'^[A-Z$][a-zA-Z_$]*$'`)
 
-   maximum line length
-
-* `excludePackageStatements` (default: `false`)
-
-   if package statements should be ignored
-
-* `excludeImportStatements` (default: `false`)
-
-   if import statements should be ignored
+   naming pattern (default: '^[A
 
 ### EqualsNullCall
 
@@ -229,6 +131,34 @@ fun isNull(str: String) = str.equals(null)
 ```kotlin
 fun isNull(str: String) = str == null
 ```
+
+### ExpressionBodySyntax
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+fun stuff(): Int {
+    return 5
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+fun stuff() = 5
+```
+
+### ForbiddenClassName
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `forbiddenName` (default: `''`)
+
+   forbidden class names
 
 ### ForbiddenComment
 
@@ -266,6 +196,36 @@ import kotlin.jvm.JvmField
 import kotlin.SinceKotlin
 ```
 
+### FunctionMaxLength
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `maximumFunctionNameLength` (default: `30`)
+
+   maximum name length
+
+### FunctionMinLength
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `minimumFunctionNameLength` (default: `3`)
+
+   minimum name length
+
+### FunctionNaming
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `functionPattern` (default: `'^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'`)
+
+   naming pattern (default: '^([a
+
 ### FunctionOnlyReturningConstant
 
 TODO: Specify description
@@ -292,28 +252,6 @@ fun functionReturningConstantString() = "1"
 const val constantString = "1"
 ```
 
-### SpacingBetweenPackageAndImports
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-package foo
-import a.b
-class Bar { }
-```
-
-#### Compliant Code:
-
-```kotlin
-package foo
-
-import a.b
-
-class Bar { }
-```
-
 ### LoopWithTooManyJumpStatements
 
 TODO: Specify description
@@ -333,423 +271,6 @@ for (str in strs) {
         break
     } else {
         continue
-    }
-}
-```
-
-### MemberNameEqualsClassName
-
-This rule reports a member that has the same as the containing class or object.
-This might result in confusion.
-The member should either be renamed or changed to a constructor.
-Factory functions that create an instance of the class are exempt from this rule.
-
-#### Configuration options:
-
-* `ignoreOverriddenFunction` (default: `true`)
-
-   if overridden functions should be ignored
-
-#### Noncompliant Code:
-
-```kotlin
-class MethodNameEqualsClassName {
-
-    fun methodNameEqualsClassName() { }
-}
-
-class PropertyNameEqualsClassName {
-
-    val propertyEqualsClassName = 0
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-class Manager {
-
-    companion object {
-        // factory functions can have the same name as the class
-        fun manager(): Manager {
-            return Manager()
-        }
-    }
-}
-```
-
-### VariableNaming
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `variablePattern` (default: `'[a-z][A-Za-z0-9]*'`)
-
-   naming pattern (default: '[a
-
-* `privateVariablePattern` (default: `'(_)?[a-z][A-Za-z0-9]*'`)
-
-   naming pattern ?[a
-
-### VariableMinLength
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `minimumVariableNameLength` (default: `1`)
-
-   maximum name length
-
-### VariableMaxLength
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `maximumVariableNameLength` (default: `64`)
-
-   maximum name length
-
-### TopLevelPropertyNaming
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `constantPattern` (default: `'[A-Z][_A-Z0-9]*'`)
-
-   naming pattern (default: '[A
-
-* `propertyPattern` (default: `'[a-z][A-Za-z\d]*'`)
-
-   naming pattern (default: '[a
-
-* `privatePropertyPattern` (default: `'(_)?[a-z][A-Za-z0-9]*'`)
-
-   naming pattern ?[a
-
-### ObjectPropertyNaming
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `propertyPattern` (default: `'[A-Za-z][_A-Za-z0-9]*'`)
-
-   naming pattern (default: '[A
-
-### PackageNaming
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `packagePattern` (default: `'^[a-z]+(\.[a-z][a-z0-9]*)*$'`)
-
-   naming pattern (default: '^[a
-
-### ClassNaming
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `classPattern` (default: `'[A-Z$][a-zA-Z0-9$]*'`)
-
-   naming pattern (default: '[A
-
-### EnumNaming
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `enumEntryPattern` (default: `'^[A-Z$][a-zA-Z_$]*$'`)
-
-   naming pattern (default: '^[A
-
-### FunctionNaming
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `functionPattern` (default: `'^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'`)
-
-   naming pattern (default: '^([a
-
-### FunctionMaxLength
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `maximumFunctionNameLength` (default: `30`)
-
-   maximum name length
-
-### FunctionMinLength
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `minimumFunctionNameLength` (default: `3`)
-
-   minimum name length
-
-### ForbiddenClassName
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `forbiddenName` (default: `''`)
-
-   forbidden class names
-
-### SafeCast
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-fun numberMagic(number: Number) {
-    val i = if (number is Int) number else null
-    // ...
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-fun numberMagic(number: Number) {
-    val i = number as? Int
-    // ...
-}
-```
-
-### UnnecessaryAbstractClass
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-abstract class OnlyAbstractMembersInAbstractClass { // violation: no concrete members
-
-    abstract val i: Int
-    abstract fun f()
-}
-
-abstract class OnlyConcreteMembersInAbstractClass { // violation: no abstract members
-
-    val i: Int = 0
-    fun f() { }
-}
-```
-
-### UnnecessaryParentheses
-
-Reports unnecessary parentheses around expressions.
-
-Added in v1.0.0.RC4
-
-#### Noncompliant Code:
-
-```kotlin
-val local = (5 + 3)
-
-if ((local == 8)) { }
-
-fun foo() {
-    function({ input -> println(input) })
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-val local = 5 + 3
-
-if (local == 8) { }
-
-fun foo() {
-    function { input -> println(input) }
-}
-```
-
-### UnnecessaryInheritance
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-class A : Any()
-class B : Object()
-```
-
-### UtilityClassWithPublicConstructor
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-class UtilityClass {
-
-    // public constructor here
-    constructor() {
-        // ...
-    }
-
-    companion object {
-        val i = 0
-    }
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-class UtilityClass {
-
-    private constructor() {
-        // ...
-    }
-
-    companion object {
-        val i = 0
-    }
-}
-```
-
-### OptionalAbstractKeyword
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-abstract interface Foo { // abstract keyword not needed
-
-    abstract fun x() // abstract keyword not needed
-    abstract var y: Int // abstract keyword not needed
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-interface Foo {
-
-    fun x()
-    var y: Int
-}
-```
-
-### OptionalWhenBraces
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-val i = 1
-when (1) {
-    1 -> { println("one") } // unnecessary curly braces since there is only one statement
-    else -> println("else")
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-val i = 1
-when (1) {
-    1 -> println("one")
-    else -> println("else")
-}
-```
-
-### OptionalReturnKeyword
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-val z = if (true) return x else return y
-```
-
-#### Compliant Code:
-
-```kotlin
-val z = if (true) x else y
-```
-
-### OptionalUnit
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-fun foo(): Unit { }
-```
-
-#### Compliant Code:
-
-```kotlin
-fun foo() { }
-```
-
-### ProtectedMemberInFinalClass
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-class ProtectedMemberInFinalClass {
-    protected var i = 0
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-class ProtectedMemberInFinalClass {
-    private var i = 0
-}
-```
-
-### SerialVersionUIDInSerializableClass
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-class IncorrectSerializable : Serializable {
-
-    companion object {
-        val serialVersionUID = 1 // wrong declaration for UID
-    }
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-class CorrectSerializable : Serializable {
-
-    companion object {
-        const val serialVersionUID = 1L
     }
 }
 ```
@@ -825,125 +346,6 @@ class User {
 }
 ```
 
-### ModifierOrder
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-lateinit internal private val str: String
-```
-
-#### Compliant Code:
-
-```kotlin
-private internal lateinit val str: String
-```
-
-### DataClassContainsFunctions
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `conversionFunctionPrefix` (default: `'to'`)
-
-   allowed conversion function names
-
-#### Noncompliant Code:
-
-```kotlin
-data class DataClassWithFunctions(val i: Int) {
-    fun foo() { }
-}
-```
-
-### UseDataClass
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-class DataClassCandidate(val i: Int) {
-
-    val i2: Int = 0
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-data class DataClass(val i: Int, val i2: Int)
-```
-
-### UnusedImports
-
-TODO: Specify description
-
-### ExpressionBodySyntax
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-fun stuff(): Int {
-    return 5
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-fun stuff() = 5
-```
-
-### NestedClassesVisibility
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-internal class NestedClassesVisibility {
-
-    public class NestedPublicClass // should not be public
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-internal class NestedClassesVisibility {
-
-    internal class NestedPublicClass
-}
-```
-
-### RedundantVisibilityModifierRule
-
-TODO: Specify description
-
-#### Noncompliant Code:
-
-```kotlin
-public interface Foo { // public per default
-
-    public fun bar() // public per default
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-interface Foo {
-
-    fun bar()
-}
-```
-
 ### MatchingDeclarationName
 
 "If a Kotlin file contains a single class (potentially with related top-level declarations),
@@ -976,6 +378,471 @@ class Foo { // Foo.kt
 fun Bar.toFoo(): Foo = ...
 ```
 
+### MaxLineLength
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `maxLineLength` (default: `120`)
+
+   maximum line length
+
+* `excludePackageStatements` (default: `false`)
+
+   if package statements should be ignored
+
+* `excludeImportStatements` (default: `false`)
+
+   if import statements should be ignored
+
+### MemberNameEqualsClassName
+
+This rule reports a member that has the same as the containing class or object.
+This might result in confusion.
+The member should either be renamed or changed to a constructor.
+Factory functions that create an instance of the class are exempt from this rule.
+
+#### Configuration options:
+
+* `ignoreOverriddenFunction` (default: `true`)
+
+   if overridden functions should be ignored
+
+#### Noncompliant Code:
+
+```kotlin
+class MethodNameEqualsClassName {
+
+    fun methodNameEqualsClassName() { }
+}
+
+class PropertyNameEqualsClassName {
+
+    val propertyEqualsClassName = 0
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+class Manager {
+
+    companion object {
+        // factory functions can have the same name as the class
+        fun manager(): Manager {
+            return Manager()
+        }
+    }
+}
+```
+
+### ModifierOrder
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+lateinit internal private val str: String
+```
+
+#### Compliant Code:
+
+```kotlin
+private internal lateinit val str: String
+```
+
+### NestedClassesVisibility
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+internal class NestedClassesVisibility {
+
+    public class NestedPublicClass // should not be public
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+internal class NestedClassesVisibility {
+
+    internal class NestedPublicClass
+}
+```
+
+### NewLineAtEndOfFile
+
+TODO: Specify description
+
+### ObjectPropertyNaming
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `propertyPattern` (default: `'[A-Za-z][_A-Za-z0-9]*'`)
+
+   naming pattern (default: '[A
+
+### OptionalAbstractKeyword
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+abstract interface Foo { // abstract keyword not needed
+
+    abstract fun x() // abstract keyword not needed
+    abstract var y: Int // abstract keyword not needed
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+interface Foo {
+
+    fun x()
+    var y: Int
+}
+```
+
+### OptionalReturnKeyword
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+val z = if (true) return x else return y
+```
+
+#### Compliant Code:
+
+```kotlin
+val z = if (true) x else y
+```
+
+### OptionalUnit
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+fun foo(): Unit { }
+```
+
+#### Compliant Code:
+
+```kotlin
+fun foo() { }
+```
+
+### OptionalWhenBraces
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+val i = 1
+when (1) {
+    1 -> { println("one") } // unnecessary curly braces since there is only one statement
+    else -> println("else")
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+val i = 1
+when (1) {
+    1 -> println("one")
+    else -> println("else")
+}
+```
+
+### PackageNaming
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `packagePattern` (default: `'^[a-z]+(\.[a-z][a-z0-9]*)*$'`)
+
+   naming pattern (default: '^[a
+
+### ProtectedMemberInFinalClass
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+class ProtectedMemberInFinalClass {
+    protected var i = 0
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+class ProtectedMemberInFinalClass {
+    private var i = 0
+}
+```
+
+### RedundantVisibilityModifierRule
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+public interface Foo { // public per default
+
+    public fun bar() // public per default
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+interface Foo {
+
+    fun bar()
+}
+```
+
+### ReturnCount
+
+Restrict the number of return methods allowed in methods.
+
+Having many exit points in a function can be confusing and impacts readability of the
+code.
+
+#### Configuration options:
+
+* `max` (default: `2`)
+
+   define the maximum number of return statements allowed per function
+
+* `excludedFunctions` (default: `"equals"`)
+
+   define functions to be ignored by this check
+
+#### Noncompliant Code:
+
+```kotlin
+fun foo(i: Int): String {
+    when (i) {
+        1 -> return "one"
+        2 -> return "two"
+        else -> return "other"
+    }
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+fun foo(i: Int): String {
+    return when (i) {
+        1 -> "one"
+        2 -> "two"
+        else -> "other"
+    }
+}
+```
+
+### SafeCast
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+fun numberMagic(number: Number) {
+    val i = if (number is Int) number else null
+    // ...
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+fun numberMagic(number: Number) {
+    val i = number as? Int
+    // ...
+}
+```
+
+### SerialVersionUIDInSerializableClass
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+class IncorrectSerializable : Serializable {
+
+    companion object {
+        val serialVersionUID = 1 // wrong declaration for UID
+    }
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+class CorrectSerializable : Serializable {
+
+    companion object {
+        const val serialVersionUID = 1L
+    }
+}
+```
+
+### SpacingBetweenPackageAndImports
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+package foo
+import a.b
+class Bar { }
+```
+
+#### Compliant Code:
+
+```kotlin
+package foo
+
+import a.b
+
+class Bar { }
+```
+
+### ThrowsCount
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `max` (default: `2`)
+
+   maximum amount of throw statements in a method
+
+#### Noncompliant Code:
+
+```kotlin
+fun foo(i: Int) {
+    when (i) {
+        1 -> throw IllegalArgumentException()
+        2 -> throw IllegalArgumentException()
+        3 -> throw IllegalArgumentException()
+    }
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+fun foo(i: Int) {
+    when (i) {
+        1,2,3 -> throw IllegalArgumentException()
+    }
+}
+```
+
+### TopLevelPropertyNaming
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `constantPattern` (default: `'[A-Z][_A-Z0-9]*'`)
+
+   naming pattern (default: '[A
+
+* `propertyPattern` (default: `'[a-z][A-Za-z\d]*'`)
+
+   naming pattern (default: '[a
+
+* `privatePropertyPattern` (default: `'(_)?[a-z][A-Za-z0-9]*'`)
+
+   naming pattern ?[a
+
+### UnnecessaryAbstractClass
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+abstract class OnlyAbstractMembersInAbstractClass { // violation: no concrete members
+
+    abstract val i: Int
+    abstract fun f()
+}
+
+abstract class OnlyConcreteMembersInAbstractClass { // violation: no abstract members
+
+    val i: Int = 0
+    fun f() { }
+}
+```
+
+### UnnecessaryInheritance
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+class A : Any()
+class B : Object()
+```
+
+### UnnecessaryParentheses
+
+Reports unnecessary parentheses around expressions.
+
+Added in v1.0.0.RC4
+
+#### Noncompliant Code:
+
+```kotlin
+val local = (5 + 3)
+
+if ((local == 8)) { }
+
+fun foo() {
+    function({ input -> println(input) })
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+val local = 5 + 3
+
+if (local == 8) { }
+
+fun foo() {
+    function { input -> println(input) }
+}
+```
+
 ### UntilInsteadOfRangeTo
 
 Reports calls to '..' operator instead of calls to 'until'.
@@ -994,4 +861,137 @@ val range = 0 .. 10 - 1
 ```kotlin
 for (i in 0 until 10 - 1) {}
 val range = 0 until 10 - 1
+```
+
+### UnusedImports
+
+TODO: Specify description
+
+### UseDataClass
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+class DataClassCandidate(val i: Int) {
+
+    val i2: Int = 0
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+data class DataClass(val i: Int, val i2: Int)
+```
+
+### UtilityClassWithPublicConstructor
+
+TODO: Specify description
+
+#### Noncompliant Code:
+
+```kotlin
+class UtilityClass {
+
+    // public constructor here
+    constructor() {
+        // ...
+    }
+
+    companion object {
+        val i = 0
+    }
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+class UtilityClass {
+
+    private constructor() {
+        // ...
+    }
+
+    companion object {
+        val i = 0
+    }
+}
+```
+
+### VariableMaxLength
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `maximumVariableNameLength` (default: `64`)
+
+   maximum name length
+
+### VariableMinLength
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `minimumVariableNameLength` (default: `1`)
+
+   maximum name length
+
+### VariableNaming
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `variablePattern` (default: `'[a-z][A-Za-z0-9]*'`)
+
+   naming pattern (default: '[a
+
+* `privateVariablePattern` (default: `'(_)?[a-z][A-Za-z0-9]*'`)
+
+   naming pattern ?[a
+
+### WildcardImport
+
+Wildcard imports should be replaced with imports using fully qualified class names. This helps increase clarity of
+which classes are imported and helps prevent naming conflicts.
+
+Library updates can introduce naming clashes with your own classes which might result in compilation errors.
+
+#### Configuration options:
+
+* `excludeImports` (default: `'java.util.*,kotlinx.android.synthetic.*'`)
+
+   Define a whitelist of package names that should be allowed to be imported
+with wildcard imports.
+
+#### Noncompliant Code:
+
+```kotlin
+package test
+
+import io.gitlab.arturbosch.detekt.*
+
+class DetektElements {
+    val element1 = DetektElement1()
+    val element2 = DetektElement2()
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+package test
+
+import io.gitlab.arturbosch.detekt.DetektElement1
+import io.gitlab.arturbosch.detekt.DetektElement2
+
+class DetektElements {
+    val element1 = DetektElement1()
+    val element2 = DetektElement2()
+}
 ```

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DetektCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DetektCollector.kt
@@ -29,6 +29,8 @@ class DetektCollector : Collector<RuleSetPage> {
 			val consolidatedRules = ruleSet.rules.flatMap { ruleName ->
 				multiRules[ruleName] ?: listOf(ruleName)
 			}.mapNotNull { rules.findRuleByName(it) }
+					.sortedBy { rule -> rule.name }
+
 			RuleSetPage(ruleSet, consolidatedRules)
 		}
 	}


### PR DESCRIPTION
Resolves #688 

I'm thinking if it makes sense having a `NamingRuleSetProvider` which groups all the class/object/property/function naming rules together. With this alphabetical sorting they are all placed in different parts of the `style` ruleset config. Before they were grouped together.