### PR TITLE
Introduce "naming" ruleset

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -188,6 +188,53 @@ exceptions:
      - Throwable
      - RuntimeException
 
+naming:
+  active: true
+  ClassNaming:
+    active: true
+    classPattern: '[A-Z$][a-zA-Z0-9$]*'
+  EnumNaming:
+    active: true
+    enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
+  ForbiddenClassName:
+    active: false
+    forbiddenName: ''
+  FunctionMaxLength:
+    active: false
+    maximumFunctionNameLength: 30
+  FunctionMinLength:
+    active: false
+    minimumFunctionNameLength: 3
+  FunctionNaming:
+    active: true
+    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
+  MatchingDeclarationName:
+    active: true
+  MemberNameEqualsClassName:
+    active: false
+    ignoreOverriddenFunction: true
+  ObjectPropertyNaming:
+    active: true
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+  PackageNaming:
+    active: true
+    packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Z0-9]*'
+    propertyPattern: '[a-z][A-Za-z\d]*'
+    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
+  VariableMaxLength:
+    active: false
+    maximumVariableNameLength: 64
+  VariableMinLength:
+    active: false
+    minimumVariableNameLength: 1
+  VariableNaming:
+    active: true
+    variablePattern: '[a-z][A-Za-z0-9]*'
+    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
+
 performance:
   active: true
   ForEachOnRange:
@@ -232,39 +279,21 @@ potential-bugs:
 
 style:
   active: true
-  ClassNaming:
-    active: true
-    classPattern: '[A-Z$][a-zA-Z0-9$]*'
   CollapsibleIfStatements:
     active: false
   DataClassContainsFunctions:
     active: false
     conversionFunctionPrefix: 'to'
-  EnumNaming:
-    active: true
-    enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
   EqualsNullCall:
     active: false
   ExpressionBodySyntax:
     active: false
-  ForbiddenClassName:
-    active: false
-    forbiddenName: ''
   ForbiddenComment:
     active: true
     values: 'TODO:,FIXME:,STOPSHIP:'
   ForbiddenImport:
     active: false
     imports: ''
-  FunctionMaxLength:
-    active: false
-    maximumFunctionNameLength: 30
-  FunctionMinLength:
-    active: false
-    minimumFunctionNameLength: 3
-  FunctionNaming:
-    active: true
-    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
   FunctionOnlyReturningConstant:
     active: false
     ignoreOverridableFunction: true
@@ -282,25 +311,17 @@ style:
     ignoreAnnotation: false
     ignoreNamedArgument: true
     ignoreEnums: false
-  MatchingDeclarationName:
-    active: true
   MaxLineLength:
     active: true
     maxLineLength: 120
     excludePackageStatements: false
     excludeImportStatements: false
-  MemberNameEqualsClassName:
-    active: false
-    ignoreOverriddenFunction: true
   ModifierOrder:
     active: true
   NestedClassesVisibility:
     active: false
   NewLineAtEndOfFile:
     active: true
-  ObjectPropertyNaming:
-    active: true
-    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
   OptionalAbstractKeyword:
     active: true
   OptionalReturnKeyword:
@@ -309,9 +330,6 @@ style:
     active: false
   OptionalWhenBraces:
     active: false
-  PackageNaming:
-    active: true
-    packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
   ProtectedMemberInFinalClass:
     active: false
   RedundantVisibilityModifierRule:
@@ -329,11 +347,6 @@ style:
   ThrowsCount:
     active: true
     max: 2
-  TopLevelPropertyNaming:
-    active: true
-    constantPattern: '[A-Z][_A-Z0-9]*'
-    propertyPattern: '[a-z][A-Za-z\d]*'
-    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
   UnnecessaryAbstractClass:
     active: false
   UnnecessaryInheritance:
@@ -348,16 +361,6 @@ style:
     active: false
   UtilityClassWithPublicConstructor:
     active: false
-  VariableMaxLength:
-    active: false
-    maximumVariableNameLength: 64
-  VariableMinLength:
-    active: false
-    minimumVariableNameLength: 1
-  VariableNaming:
-    active: true
-    variablePattern: '[a-z][A-Za-z0-9]*'
-    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
   WildcardImport:
     active: true
     excludeImports: 'java.util.*,kotlinx.android.synthetic.*'

--- a/detekt-generator/documentation/naming.md
+++ b/detekt-generator/documentation/naming.md
@@ -1,0 +1,226 @@
+# naming
+
+The naming ruleset contains rules which assert the naming of different parts of the codebase.
+
+## Content
+
+1. [ClassNaming](#classnaming)
+2. [EnumNaming](#enumnaming)
+3. [ForbiddenClassName](#forbiddenclassname)
+4. [FunctionMaxLength](#functionmaxlength)
+5. [FunctionMinLength](#functionminlength)
+6. [FunctionNaming](#functionnaming)
+7. [MatchingDeclarationName](#matchingdeclarationname)
+8. [MemberNameEqualsClassName](#membernameequalsclassname)
+9. [ObjectPropertyNaming](#objectpropertynaming)
+10. [PackageNaming](#packagenaming)
+11. [TopLevelPropertyNaming](#toplevelpropertynaming)
+12. [VariableMaxLength](#variablemaxlength)
+13. [VariableMinLength](#variableminlength)
+14. [VariableNaming](#variablenaming)
+## Rules in the `naming` rule set:
+
+### ClassNaming
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `classPattern` (default: `'[A-Z$][a-zA-Z0-9$]*'`)
+
+   naming pattern (default: '[A
+
+### EnumNaming
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `enumEntryPattern` (default: `'^[A-Z$][a-zA-Z_$]*$'`)
+
+   naming pattern (default: '^[A
+
+### ForbiddenClassName
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `forbiddenName` (default: `''`)
+
+   forbidden class names
+
+### FunctionMaxLength
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `maximumFunctionNameLength` (default: `30`)
+
+   maximum name length
+
+### FunctionMinLength
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `minimumFunctionNameLength` (default: `3`)
+
+   minimum name length
+
+### FunctionNaming
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `functionPattern` (default: `'^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'`)
+
+   naming pattern (default: '^([a
+
+### MatchingDeclarationName
+
+"If a Kotlin file contains a single class (potentially with related top-level declarations),
+its name should be the same as the name of the class, with the .kt extension appended.
+If a file contains multiple classes, or only top-level declarations,
+choose a name describing what the file contains, and name the file accordingly.
+Use camel humps with an uppercase first letter (e.g. ProcessDeclarations.kt).
+
+The name of the file should describe what the code in the file does.
+Therefore, you should avoid using meaningless words such as "Util" in file names." - Official Kotlin Style Guide
+
+More information at: http://kotlinlang.org/docs/reference/coding-conventions.html
+
+#### Noncompliant Code:
+
+```kotlin
+class Foo // FooUtils.kt
+
+fun Bar.toFoo(): Foo = ...
+fun Foo.toBar(): Bar = ...
+```
+
+#### Compliant Code:
+
+```kotlin
+class Foo { // Foo.kt
+    fun stuff() = 42
+}
+
+fun Bar.toFoo(): Foo = ...
+```
+
+### MemberNameEqualsClassName
+
+This rule reports a member that has the same as the containing class or object.
+This might result in confusion.
+The member should either be renamed or changed to a constructor.
+Factory functions that create an instance of the class are exempt from this rule.
+
+#### Configuration options:
+
+* `ignoreOverriddenFunction` (default: `true`)
+
+   if overridden functions should be ignored
+
+#### Noncompliant Code:
+
+```kotlin
+class MethodNameEqualsClassName {
+
+    fun methodNameEqualsClassName() { }
+}
+
+class PropertyNameEqualsClassName {
+
+    val propertyEqualsClassName = 0
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+class Manager {
+
+    companion object {
+        // factory functions can have the same name as the class
+        fun manager(): Manager {
+            return Manager()
+        }
+    }
+}
+```
+
+### ObjectPropertyNaming
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `propertyPattern` (default: `'[A-Za-z][_A-Za-z0-9]*'`)
+
+   naming pattern (default: '[A
+
+### PackageNaming
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `packagePattern` (default: `'^[a-z]+(\.[a-z][a-z0-9]*)*$'`)
+
+   naming pattern (default: '^[a
+
+### TopLevelPropertyNaming
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `constantPattern` (default: `'[A-Z][_A-Z0-9]*'`)
+
+   naming pattern (default: '[A
+
+* `propertyPattern` (default: `'[a-z][A-Za-z\d]*'`)
+
+   naming pattern (default: '[a
+
+* `privatePropertyPattern` (default: `'(_)?[a-z][A-Za-z0-9]*'`)
+
+   naming pattern ?[a
+
+### VariableMaxLength
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `maximumVariableNameLength` (default: `64`)
+
+   maximum name length
+
+### VariableMinLength
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `minimumVariableNameLength` (default: `1`)
+
+   maximum name length
+
+### VariableNaming
+
+TODO: Specify description
+
+#### Configuration options:
+
+* `variablePattern` (default: `'[a-z][A-Za-z0-9]*'`)
+
+   naming pattern (default: '[a
+
+* `privateVariablePattern` (default: `'(_)?[a-z][A-Za-z0-9]*'`)
+
+   naming pattern ?[a

--- a/detekt-generator/documentation/style.md
+++ b/detekt-generator/documentation/style.md
@@ -6,63 +6,39 @@ code style guidelines.
 
 ## Content
 
-1. [ClassNaming](#classnaming)
-2. [CollapsibleIfStatements](#collapsibleifstatements)
-3. [DataClassContainsFunctions](#dataclasscontainsfunctions)
-4. [EnumNaming](#enumnaming)
-5. [EqualsNullCall](#equalsnullcall)
-6. [ExpressionBodySyntax](#expressionbodysyntax)
-7. [ForbiddenClassName](#forbiddenclassname)
-8. [ForbiddenComment](#forbiddencomment)
-9. [ForbiddenImport](#forbiddenimport)
-10. [FunctionMaxLength](#functionmaxlength)
-11. [FunctionMinLength](#functionminlength)
-12. [FunctionNaming](#functionnaming)
-13. [FunctionOnlyReturningConstant](#functiononlyreturningconstant)
-14. [LoopWithTooManyJumpStatements](#loopwithtoomanyjumpstatements)
-15. [MagicNumber](#magicnumber)
-16. [MatchingDeclarationName](#matchingdeclarationname)
-17. [MaxLineLength](#maxlinelength)
-18. [MemberNameEqualsClassName](#membernameequalsclassname)
-19. [ModifierOrder](#modifierorder)
-20. [NestedClassesVisibility](#nestedclassesvisibility)
-21. [NewLineAtEndOfFile](#newlineatendoffile)
-22. [ObjectPropertyNaming](#objectpropertynaming)
-23. [OptionalAbstractKeyword](#optionalabstractkeyword)
-24. [OptionalReturnKeyword](#optionalreturnkeyword)
-25. [OptionalUnit](#optionalunit)
-26. [OptionalWhenBraces](#optionalwhenbraces)
-27. [PackageNaming](#packagenaming)
-28. [ProtectedMemberInFinalClass](#protectedmemberinfinalclass)
-29. [RedundantVisibilityModifierRule](#redundantvisibilitymodifierrule)
-30. [ReturnCount](#returncount)
-31. [SafeCast](#safecast)
-32. [SerialVersionUIDInSerializableClass](#serialversionuidinserializableclass)
-33. [SpacingBetweenPackageAndImports](#spacingbetweenpackageandimports)
-34. [ThrowsCount](#throwscount)
-35. [TopLevelPropertyNaming](#toplevelpropertynaming)
-36. [UnnecessaryAbstractClass](#unnecessaryabstractclass)
-37. [UnnecessaryInheritance](#unnecessaryinheritance)
-38. [UnnecessaryParentheses](#unnecessaryparentheses)
-39. [UntilInsteadOfRangeTo](#untilinsteadofrangeto)
-40. [UnusedImports](#unusedimports)
-41. [UseDataClass](#usedataclass)
-42. [UtilityClassWithPublicConstructor](#utilityclasswithpublicconstructor)
-43. [VariableMaxLength](#variablemaxlength)
-44. [VariableMinLength](#variableminlength)
-45. [VariableNaming](#variablenaming)
-46. [WildcardImport](#wildcardimport)
+1. [CollapsibleIfStatements](#collapsibleifstatements)
+2. [DataClassContainsFunctions](#dataclasscontainsfunctions)
+3. [EqualsNullCall](#equalsnullcall)
+4. [ExpressionBodySyntax](#expressionbodysyntax)
+5. [ForbiddenComment](#forbiddencomment)
+6. [ForbiddenImport](#forbiddenimport)
+7. [FunctionOnlyReturningConstant](#functiononlyreturningconstant)
+8. [LoopWithTooManyJumpStatements](#loopwithtoomanyjumpstatements)
+9. [MagicNumber](#magicnumber)
+10. [MaxLineLength](#maxlinelength)
+11. [ModifierOrder](#modifierorder)
+12. [NestedClassesVisibility](#nestedclassesvisibility)
+13. [NewLineAtEndOfFile](#newlineatendoffile)
+14. [OptionalAbstractKeyword](#optionalabstractkeyword)
+15. [OptionalReturnKeyword](#optionalreturnkeyword)
+16. [OptionalUnit](#optionalunit)
+17. [OptionalWhenBraces](#optionalwhenbraces)
+18. [ProtectedMemberInFinalClass](#protectedmemberinfinalclass)
+19. [RedundantVisibilityModifierRule](#redundantvisibilitymodifierrule)
+20. [ReturnCount](#returncount)
+21. [SafeCast](#safecast)
+22. [SerialVersionUIDInSerializableClass](#serialversionuidinserializableclass)
+23. [SpacingBetweenPackageAndImports](#spacingbetweenpackageandimports)
+24. [ThrowsCount](#throwscount)
+25. [UnnecessaryAbstractClass](#unnecessaryabstractclass)
+26. [UnnecessaryInheritance](#unnecessaryinheritance)
+27. [UnnecessaryParentheses](#unnecessaryparentheses)
+28. [UntilInsteadOfRangeTo](#untilinsteadofrangeto)
+29. [UnusedImports](#unusedimports)
+30. [UseDataClass](#usedataclass)
+31. [UtilityClassWithPublicConstructor](#utilityclasswithpublicconstructor)
+32. [WildcardImport](#wildcardimport)
 ## Rules in the `style` rule set:
-
-### ClassNaming
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `classPattern` (default: `'[A-Z$][a-zA-Z0-9$]*'`)
-
-   naming pattern (default: '[A
 
 ### CollapsibleIfStatements
 
@@ -106,16 +82,6 @@ data class DataClassWithFunctions(val i: Int) {
 }
 ```
 
-### EnumNaming
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `enumEntryPattern` (default: `'^[A-Z$][a-zA-Z_$]*$'`)
-
-   naming pattern (default: '^[A
-
 ### EqualsNullCall
 
 TODO: Specify description
@@ -149,16 +115,6 @@ fun stuff(): Int {
 ```kotlin
 fun stuff() = 5
 ```
-
-### ForbiddenClassName
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `forbiddenName` (default: `''`)
-
-   forbidden class names
 
 ### ForbiddenComment
 
@@ -195,36 +151,6 @@ package foo
 import kotlin.jvm.JvmField
 import kotlin.SinceKotlin
 ```
-
-### FunctionMaxLength
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `maximumFunctionNameLength` (default: `30`)
-
-   maximum name length
-
-### FunctionMinLength
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `minimumFunctionNameLength` (default: `3`)
-
-   minimum name length
-
-### FunctionNaming
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `functionPattern` (default: `'^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'`)
-
-   naming pattern (default: '^([a
 
 ### FunctionOnlyReturningConstant
 
@@ -346,38 +272,6 @@ class User {
 }
 ```
 
-### MatchingDeclarationName
-
-"If a Kotlin file contains a single class (potentially with related top-level declarations),
-its name should be the same as the name of the class, with the .kt extension appended.
-If a file contains multiple classes, or only top-level declarations,
-choose a name describing what the file contains, and name the file accordingly.
-Use camel humps with an uppercase first letter (e.g. ProcessDeclarations.kt).
-
-The name of the file should describe what the code in the file does.
-Therefore, you should avoid using meaningless words such as "Util" in file names." - Official Kotlin Style Guide
-
-More information at: http://kotlinlang.org/docs/reference/coding-conventions.html
-
-#### Noncompliant Code:
-
-```kotlin
-class Foo // FooUtils.kt
-
-fun Bar.toFoo(): Foo = ...
-fun Foo.toBar(): Bar = ...
-```
-
-#### Compliant Code:
-
-```kotlin
-class Foo { // Foo.kt
-    fun stuff() = 42
-}
-
-fun Bar.toFoo(): Foo = ...
-```
-
 ### MaxLineLength
 
 TODO: Specify description
@@ -395,47 +289,6 @@ TODO: Specify description
 * `excludeImportStatements` (default: `false`)
 
    if import statements should be ignored
-
-### MemberNameEqualsClassName
-
-This rule reports a member that has the same as the containing class or object.
-This might result in confusion.
-The member should either be renamed or changed to a constructor.
-Factory functions that create an instance of the class are exempt from this rule.
-
-#### Configuration options:
-
-* `ignoreOverriddenFunction` (default: `true`)
-
-   if overridden functions should be ignored
-
-#### Noncompliant Code:
-
-```kotlin
-class MethodNameEqualsClassName {
-
-    fun methodNameEqualsClassName() { }
-}
-
-class PropertyNameEqualsClassName {
-
-    val propertyEqualsClassName = 0
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-class Manager {
-
-    companion object {
-        // factory functions can have the same name as the class
-        fun manager(): Manager {
-            return Manager()
-        }
-    }
-}
-```
 
 ### ModifierOrder
 
@@ -478,16 +331,6 @@ internal class NestedClassesVisibility {
 ### NewLineAtEndOfFile
 
 TODO: Specify description
-
-### ObjectPropertyNaming
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `propertyPattern` (default: `'[A-Za-z][_A-Za-z0-9]*'`)
-
-   naming pattern (default: '[A
 
 ### OptionalAbstractKeyword
 
@@ -568,16 +411,6 @@ when (1) {
     else -> println("else")
 }
 ```
-
-### PackageNaming
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `packagePattern` (default: `'^[a-z]+(\.[a-z][a-z0-9]*)*$'`)
-
-   naming pattern (default: '^[a
 
 ### ProtectedMemberInFinalClass
 
@@ -764,24 +597,6 @@ fun foo(i: Int) {
 }
 ```
 
-### TopLevelPropertyNaming
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `constantPattern` (default: `'[A-Z][_A-Z0-9]*'`)
-
-   naming pattern (default: '[A
-
-* `propertyPattern` (default: `'[a-z][A-Za-z\d]*'`)
-
-   naming pattern (default: '[a
-
-* `privatePropertyPattern` (default: `'(_)?[a-z][A-Za-z0-9]*'`)
-
-   naming pattern ?[a
-
 ### UnnecessaryAbstractClass
 
 TODO: Specify description
@@ -920,40 +735,6 @@ class UtilityClass {
     }
 }
 ```
-
-### VariableMaxLength
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `maximumVariableNameLength` (default: `64`)
-
-   maximum name length
-
-### VariableMinLength
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `minimumVariableNameLength` (default: `1`)
-
-   maximum name length
-
-### VariableNaming
-
-TODO: Specify description
-
-#### Configuration options:
-
-* `variablePattern` (default: `'[a-z][A-Za-z0-9]*'`)
-
-   naming pattern (default: '[a
-
-* `privateVariablePattern` (default: `'(_)?[a-z][A-Za-z0-9]*'`)
-
-   naming pattern ?[a
 
 ### WildcardImport
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLength.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLength.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRules.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRules.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.MultiRule

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLength.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLength.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/NamingProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/NamingProvider.kt
@@ -1,0 +1,28 @@
+package io.gitlab.arturbosch.detekt.rules.providers
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.rules.style.MatchingDeclarationName
+import io.gitlab.arturbosch.detekt.rules.style.MemberNameEqualsClassName
+import io.gitlab.arturbosch.detekt.rules.style.naming.NamingRules
+
+/**
+ * The naming ruleset contains rules which assert the naming of different parts of the codebase.
+ *
+ * @active since v1.0.0
+ * @author Marvin Ramin
+ */
+class NamingProvider : RuleSetProvider {
+
+	override val ruleSetId: String = "naming"
+
+	override fun instance(config: Config): RuleSet {
+		return RuleSet(ruleSetId, listOf(
+				MatchingDeclarationName(config),
+				MemberNameEqualsClassName(config),
+				NamingRules(config)
+		))
+	}
+
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/NamingProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/NamingProvider.kt
@@ -3,9 +3,9 @@ package io.gitlab.arturbosch.detekt.rules.providers
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import io.gitlab.arturbosch.detekt.rules.style.MatchingDeclarationName
-import io.gitlab.arturbosch.detekt.rules.style.MemberNameEqualsClassName
-import io.gitlab.arturbosch.detekt.rules.style.naming.NamingRules
+import io.gitlab.arturbosch.detekt.rules.naming.MatchingDeclarationName
+import io.gitlab.arturbosch.detekt.rules.naming.MemberNameEqualsClassName
+import io.gitlab.arturbosch.detekt.rules.naming.NamingRules
 
 /**
  * The naming ruleset contains rules which assert the naming of different parts of the codebase.

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -13,8 +13,6 @@ import io.gitlab.arturbosch.detekt.rules.style.ForbiddenImport
 import io.gitlab.arturbosch.detekt.rules.style.FunctionOnlyReturningConstant
 import io.gitlab.arturbosch.detekt.rules.style.LoopWithTooManyJumpStatements
 import io.gitlab.arturbosch.detekt.rules.style.MagicNumber
-import io.gitlab.arturbosch.detekt.rules.style.MatchingDeclarationName
-import io.gitlab.arturbosch.detekt.rules.style.MemberNameEqualsClassName
 import io.gitlab.arturbosch.detekt.rules.style.ModifierOrder
 import io.gitlab.arturbosch.detekt.rules.style.NestedClassesVisibility
 import io.gitlab.arturbosch.detekt.rules.style.NewLineAtEndOfFile
@@ -35,7 +33,6 @@ import io.gitlab.arturbosch.detekt.rules.style.UnusedImports
 import io.gitlab.arturbosch.detekt.rules.style.UseDataClass
 import io.gitlab.arturbosch.detekt.rules.style.UtilityClassWithPublicConstructor
 import io.gitlab.arturbosch.detekt.rules.style.WildcardImport
-import io.gitlab.arturbosch.detekt.rules.style.naming.NamingRules
 import io.gitlab.arturbosch.detekt.rules.style.optional.OptionalReturnKeyword
 import io.gitlab.arturbosch.detekt.rules.style.optional.OptionalUnit
 
@@ -65,8 +62,6 @@ class StyleGuideProvider : RuleSetProvider {
 				FunctionOnlyReturningConstant(config),
 				SpacingBetweenPackageAndImports(config),
 				LoopWithTooManyJumpStatements(config),
-				MemberNameEqualsClassName(config),
-				NamingRules(config),
 				SafeCast(config),
 				UnnecessaryAbstractClass(config),
 				UnnecessaryParentheses(config),
@@ -86,7 +81,6 @@ class StyleGuideProvider : RuleSetProvider {
 				ExpressionBodySyntax(config),
 				NestedClassesVisibility(config),
 				RedundantVisibilityModifierRule(config),
-				MatchingDeclarationName(config),
 				UntilInsteadOfRangeTo(config)
 		))
 	}

--- a/detekt-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
+++ b/detekt-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -5,3 +5,4 @@ io.gitlab.arturbosch.detekt.rules.providers.EmptyCodeProvider
 io.gitlab.arturbosch.detekt.rules.providers.PerformanceProvider
 io.gitlab.arturbosch.detekt.rules.providers.PotentialBugProvider
 io.gitlab.arturbosch.detekt.rules.providers.ExceptionsProvider
+io.gitlab.arturbosch.detekt.rules.providers.NamingProvider

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RuleProviderTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RuleProviderTest.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.rules.providers.CommentSmellProvider
 import io.gitlab.arturbosch.detekt.rules.providers.ComplexityProvider
 import io.gitlab.arturbosch.detekt.rules.providers.EmptyCodeProvider
 import io.gitlab.arturbosch.detekt.rules.providers.ExceptionsProvider
+import io.gitlab.arturbosch.detekt.rules.providers.NamingProvider
 import io.gitlab.arturbosch.detekt.rules.providers.PerformanceProvider
 import io.gitlab.arturbosch.detekt.rules.providers.PotentialBugProvider
 import io.gitlab.arturbosch.detekt.rules.providers.StyleGuideProvider
@@ -51,6 +52,15 @@ class RuleProviderTest {
 		RuleProviderAssert(
 				ExceptionsProvider(),
 				"io.gitlab.arturbosch.detekt.rules.exceptions",
+				Rule::class.java)
+				.assert()
+	}
+
+	@Test
+	fun namingProvider() {
+		RuleProviderAssert(
+				NamingProvider(),
+				"io.gitlab.arturbosch.detekt.rules.naming",
 				Rule::class.java)
 				.assert()
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
@@ -1,5 +1,6 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.rules.naming.NamingRules
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -1,5 +1,6 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.rules.naming.NamingRules
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions
 import org.jetbrains.spek.api.Spek

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenNameSpec.kt
@@ -1,7 +1,5 @@
-package io.gitlab.arturbosch.detekt.rules.style
+package io.gitlab.arturbosch.detekt.rules.naming
 
-import io.gitlab.arturbosch.detekt.rules.style.naming.ForbiddenClassName
-import io.gitlab.arturbosch.detekt.rules.style.naming.NamingRules
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
-import io.gitlab.arturbosch.detekt.rules.naming.MatchingDeclarationName
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
@@ -1,5 +1,6 @@
-package io.gitlab.arturbosch.detekt.rules.style
+package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.rules.naming.MatchingDeclarationName
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.Case

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternTest.kt
@@ -1,14 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.rules.naming.ClassNaming
-import io.gitlab.arturbosch.detekt.rules.naming.EnumNaming
-import io.gitlab.arturbosch.detekt.rules.naming.FunctionMaxLength
-import io.gitlab.arturbosch.detekt.rules.naming.FunctionNaming
-import io.gitlab.arturbosch.detekt.rules.naming.NamingRules
-import io.gitlab.arturbosch.detekt.rules.naming.PackageNaming
-import io.gitlab.arturbosch.detekt.rules.naming.TopLevelPropertyNaming
-import io.gitlab.arturbosch.detekt.rules.naming.VariableNaming
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternTest.kt
@@ -1,6 +1,14 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.rules.naming.ClassNaming
+import io.gitlab.arturbosch.detekt.rules.naming.EnumNaming
+import io.gitlab.arturbosch.detekt.rules.naming.FunctionMaxLength
+import io.gitlab.arturbosch.detekt.rules.naming.FunctionNaming
+import io.gitlab.arturbosch.detekt.rules.naming.NamingRules
+import io.gitlab.arturbosch.detekt.rules.naming.PackageNaming
+import io.gitlab.arturbosch.detekt.rules.naming.TopLevelPropertyNaming
+import io.gitlab.arturbosch.detekt.rules.naming.VariableNaming
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
-import io.gitlab.arturbosch.detekt.rules.naming.NamingRules
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions
 import org.jetbrains.spek.api.dsl.it

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
@@ -1,5 +1,6 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.rules.naming.NamingRules
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions
 import org.jetbrains.spek.api.dsl.it

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
@@ -1,5 +1,7 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.rules.naming.NamingRules
+import io.gitlab.arturbosch.detekt.rules.naming.PackageNaming
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.it

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
@@ -1,7 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
-import io.gitlab.arturbosch.detekt.rules.naming.NamingRules
-import io.gitlab.arturbosch.detekt.rules.naming.PackageNaming
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.it

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PropertyNamingSpec.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules.style.naming
+package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint


### PR DESCRIPTION
This PR adds the naming ruleset as discussed in #689 

After #689 is merged I'll re-generate the documentation and config of this PR to get it sorted correctly.

The naming ruleset contains:
- Naming Rules (min/max length, naming regex rules, forbidden name)
- `MatchingDeclarationName`
- `MemberNameEqualsClassName`