### PR TITLE
Add documentation for style rules

### DIFF
--- a/detekt-generator/documentation/style.md
+++ b/detekt-generator/documentation/style.md
@@ -42,7 +42,7 @@ code style guidelines.
 
 ### CollapsibleIfStatements
 
-This rule detects if statements which can be collapsed. This can reduce nesting and help improve readability.
+This rule detects `if` statements which can be collapsed. This can reduce nesting and help improve readability.
 
 However it should be carefully considered if merging the if statements actually does improve readability or if it
 hides some edge-cases from the reader.
@@ -108,8 +108,8 @@ fun isNull(str: String) = str == null
 
 ### ExpressionBodySyntax
 
-Functions which only contain a `return` statement can be collapsed to an expression body. This shorten and clean up
-the code.
+Functions which only contain a `return` statement can be collapsed to an expression body. This shortens and
+cleans up the code.
 
 #### Noncompliant Code:
 
@@ -289,6 +289,9 @@ class User {
 ### MaxLineLength
 
 This rule reports lines of code which exceed a defined maximum line length.
+
+Long lines might be hard to read on smaller screens or printouts. Additionally having a maximum line length
+in the codebase will help make the code more uniform.
 
 #### Configuration options:
 

--- a/detekt-generator/documentation/style.md
+++ b/detekt-generator/documentation/style.md
@@ -42,7 +42,10 @@ code style guidelines.
 
 ### CollapsibleIfStatements
 
-TODO: Specify description
+This rule detects if statements which can be collapsed. This can reduce nesting and help improve readability.
+
+However it should be carefully considered if merging the if statements actually does improve readability or if it
+hides some edge-cases from the reader.
 
 #### Noncompliant Code:
 
@@ -66,7 +69,11 @@ if (i > 0 && i < 5) {
 
 ### DataClassContainsFunctions
 
-TODO: Specify description
+This rule reports functions inside data classes which have not been whitelisted as a conversion function.
+
+Data classes should mainly be used to store data. This rule assumes that they should not contain any extra functions
+aside functions that help with converting objects from/to one another.
+Data classes will automatically have a generated `equals`, `toString` and `hashCode` function by the compiler.
 
 #### Configuration options:
 
@@ -84,7 +91,8 @@ data class DataClassWithFunctions(val i: Int) {
 
 ### EqualsNullCall
 
-TODO: Specify description
+To compare an object with `null` prefer using `==`. This rule detects and reports instances in the code where the
+`equals()` method is used to compare a value with `null`.
 
 #### Noncompliant Code:
 
@@ -100,7 +108,8 @@ fun isNull(str: String) = str == null
 
 ### ExpressionBodySyntax
 
-TODO: Specify description
+Functions which only contain a `return` statement can be collapsed to an expression body. This shorten and clean up
+the code.
 
 #### Noncompliant Code:
 
@@ -118,7 +127,8 @@ fun stuff() = 5
 
 ### ForbiddenComment
 
-TODO: Specify description
+This rule allows to set a list of comments which are forbidden in the codebase and should only be used during
+development. Offending code comments will then be reported.
 
 #### Configuration options:
 
@@ -135,7 +145,8 @@ fun foo() { }
 
 ### ForbiddenImport
 
-TODO: Specify description
+This rule allows to set a list of forbidden imports. This can be used to discourage the use of unstable, experimental
+or deprecated APIs. Detekt will then report all imports that are forbidden.
 
 #### Configuration options:
 
@@ -154,7 +165,8 @@ import kotlin.SinceKotlin
 
 ### FunctionOnlyReturningConstant
 
-TODO: Specify description
+A function that only returns a single constant can be misleading. Instead prefer to define the constant directly
+as a `const val`.
 
 #### Configuration options:
 
@@ -180,7 +192,8 @@ const val constantString = "1"
 
 ### LoopWithTooManyJumpStatements
 
-TODO: Specify description
+Loops which contain multiple `break` or `continue` statements are hard to read and understand.
+To increase readability they should be refactored into simpler loops.
 
 #### Configuration options:
 
@@ -203,7 +216,8 @@ for (str in strs) {
 
 ### MagicNumber
 
-TODO: Specify description
+This rule detects and reports usages of magic numbers in the code. Prefer defining constants with clear names
+describing what the magic number means.
 
 #### Configuration options:
 
@@ -274,7 +288,7 @@ class User {
 
 ### MaxLineLength
 
-TODO: Specify description
+This rule reports lines of code which exceed a defined maximum line length.
 
 #### Configuration options:
 
@@ -292,7 +306,8 @@ TODO: Specify description
 
 ### ModifierOrder
 
-TODO: Specify description
+This rule reports cases in the code where modifiers are not in the correct order. The default modifier order is
+taken from: http://kotlinlang.org/docs/reference/coding-conventions.html#modifiers
 
 #### Noncompliant Code:
 
@@ -308,7 +323,9 @@ private internal lateinit val str: String
 
 ### NestedClassesVisibility
 
-TODO: Specify description
+Nested classes are often used to implement functionality local to the class it is nested in. Therefore it should
+not be public to other parts of the code.
+Prefer keeping nested classes `private`.
 
 #### Noncompliant Code:
 
@@ -330,11 +347,11 @@ internal class NestedClassesVisibility {
 
 ### NewLineAtEndOfFile
 
-TODO: Specify description
+This rule reports files which do not end with a line separator.
 
 ### OptionalAbstractKeyword
 
-TODO: Specify description
+This rule reports `abstract` modifiers which are unnecessary and can be removed.
 
 #### Noncompliant Code:
 
@@ -358,7 +375,10 @@ interface Foo {
 
 ### OptionalReturnKeyword
 
-TODO: Specify description
+This rule reports optional `return` keywords. Inside conditional expressions the last expression is always returned
+by default.
+
+This makes the return keyword unnecessary and it can be removed safely.
 
 #### Noncompliant Code:
 
@@ -374,7 +394,8 @@ val z = if (true) x else y
 
 ### OptionalUnit
 
-TODO: Specify description
+It is not necessary to define a return type of `Unit` on functions. This rule detects and reports instances where
+the `Unit` return type is specified on functions.
 
 #### Noncompliant Code:
 
@@ -390,7 +411,7 @@ fun foo() { }
 
 ### OptionalWhenBraces
 
-TODO: Specify description
+This rule reports unnecessary braces in when expressions. These optional braces should be removed.
 
 #### Noncompliant Code:
 
@@ -414,7 +435,8 @@ when (1) {
 
 ### ProtectedMemberInFinalClass
 
-TODO: Specify description
+Kotlin classes are `final` by default. Thus classes which are not marked as `open` should not contain any `protected`
+members. Consider using `private` or `internal` modifiers instead.
 
 #### Noncompliant Code:
 
@@ -434,7 +456,7 @@ class ProtectedMemberInFinalClass {
 
 ### RedundantVisibilityModifierRule
 
-TODO: Specify description
+This rule checks for redundant visibility modifiers.
 
 #### Noncompliant Code:
 
@@ -497,7 +519,7 @@ fun foo(i: Int): String {
 
 ### SafeCast
 
-TODO: Specify description
+This rule inspects casts and reports casts which could be replaced with safe casts instead.
 
 #### Noncompliant Code:
 
@@ -519,7 +541,8 @@ fun numberMagic(number: Number) {
 
 ### SerialVersionUIDInSerializableClass
 
-TODO: Specify description
+Classes which implement the `Serializable` interface should also correctly declare a `serialVersionUID`.
+This rule verifies that a `serialVersionUID` was correctly defined.
 
 #### Noncompliant Code:
 
@@ -545,7 +568,8 @@ class CorrectSerializable : Serializable {
 
 ### SpacingBetweenPackageAndImports
 
-TODO: Specify description
+This rule verifies spacing between package and import statements as well as between import statements and class
+declarations.
 
 #### Noncompliant Code:
 
@@ -567,7 +591,8 @@ class Bar { }
 
 ### ThrowsCount
 
-TODO: Specify description
+Functions should have clear `throw` statements. Functions with many `throw` statements can be harder to read and lead
+to confusion. Instead prefer to limit the amount of `throw` statements in a function.
 
 #### Configuration options:
 
@@ -599,7 +624,9 @@ fun foo(i: Int) {
 
 ### UnnecessaryAbstractClass
 
-TODO: Specify description
+This rule inspects `abstract` classes. In case an `abstract class` does not have any concrete members it should be
+refactored into an interfacse. Abstract classes which do not define any `abstract` members should instead be
+refactored into concrete classes.
 
 #### Noncompliant Code:
 
@@ -619,7 +646,8 @@ abstract class OnlyConcreteMembersInAbstractClass { // violation: no abstract me
 
 ### UnnecessaryInheritance
 
-TODO: Specify description
+This rule reports unnecessary super types. Inheriting from `Any` or `Object` is unnecessary and should simply be
+removed.
 
 #### Noncompliant Code:
 
@@ -680,11 +708,14 @@ val range = 0 until 10
 
 ### UnusedImports
 
-TODO: Specify description
+This rule reports unused imports. Unused imports are dead code and should be removed.
 
 ### UseDataClass
 
-TODO: Specify description
+Classes that simply hold data should be refactored into a `data class`. Data classes are specialized to hold data
+and generate `hashCode`, `equals` and `toString` implementations as well.
+
+Read more about `data class`: https://kotlinlang.org/docs/reference/data-classes.html
 
 #### Configuration options:
 
@@ -709,7 +740,7 @@ data class DataClass(val i: Int, val i2: Int)
 
 ### UtilityClassWithPublicConstructor
 
-TODO: Specify description
+A class which only contains utility functions and no concrete implementation can be refactored into an `object`.
 
 #### Noncompliant Code:
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatements.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatements.kt
@@ -13,6 +13,10 @@ import org.jetbrains.kotlin.psi.KtContainerNodeForControlStructureBody
 import org.jetbrains.kotlin.psi.KtIfExpression
 
 /**
+ * This rule detects if statements which can be collapsed. This can reduce nesting and help improve readability.
+ *
+ * However it should be carefully considered if merging the if statements actually does improve readability or if it
+ * hides some edge-cases from the reader.
  *
  * <noncompliant>
  * val i = 1

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatements.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatements.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtContainerNodeForControlStructureBody
 import org.jetbrains.kotlin.psi.KtIfExpression
 
 /**
- * This rule detects if statements which can be collapsed. This can reduce nesting and help improve readability.
+ * This rule detects `if` statements which can be collapsed. This can reduce nesting and help improve readability.
  *
  * However it should be carefully considered if merging the if statements actually does improve readability or if it
  * hides some edge-cases from the reader.

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
@@ -12,6 +12,11 @@ import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
+ * This rule reports functions inside data classes which have not been whitelisted as a conversion function.
+ *
+ * Data classes should mainly be used to store data. This rule assumes that they should not contain any extra functions
+ * aside functions that help with converting objects from/to one another.
+ * Data classes will automatically have a generated `equals`, `toString` and `hashCode` function by the compiler.
  *
  * <noncompliant>
  * data class DataClassWithFunctions(val i: Int) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCall.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCall.kt
@@ -9,6 +9,8 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtCallExpression
 
 /**
+ * To compare an object with `null` prefer using `==`. This rule detects and reports instances in the code where the
+ * `equals()` method is used to compare a value with `null`.
  *
  * <noncompliant>
  * fun isNull(str: String) = str.equals(null)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
@@ -13,6 +13,8 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtReturnExpression
 
 /**
+ * Functions which only contain a `return` statement can be collapsed to an expression body. This shorten and clean up
+ * the code.
  *
  * <noncompliant>
  * fun stuff(): Int {
@@ -25,6 +27,7 @@ import org.jetbrains.kotlin.psi.KtReturnExpression
  * </compliant>
  *
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class ExpressionBodySyntax(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
@@ -13,8 +13,8 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtReturnExpression
 
 /**
- * Functions which only contain a `return` statement can be collapsed to an expression body. This shorten and clean up
- * the code.
+ * Functions which only contain a `return` statement can be collapsed to an expression body. This shortens and
+ * cleans up the code.
  *
  * <noncompliant>
  * fun stuff(): Int {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
@@ -28,6 +28,9 @@ data class KtFileContent(val file: KtFile, val content: Sequence<String>)
 /**
  * This rule reports lines of code which exceed a defined maximum line length.
  *
+ * Long lines might be hard to read on smaller screens or printouts. Additionally having a maximum line length
+ * in the codebase will help make the code more uniform.
+ *
  * @configuration maxLineLength - maximum line length (default: 120)
  * @configuration excludePackageStatements - if package statements should be ignored (default: false)
  * @configuration excludeImportStatements - if import statements should be ignored (default: false)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
@@ -26,6 +26,8 @@ class FileParsingRule(val config: Config = Config.empty) : MultiRule() {
 data class KtFileContent(val file: KtFile, val content: Sequence<String>)
 
 /**
+ * This rule reports lines of code which exceed a defined maximum line length.
+ *
  * @configuration maxLineLength - maximum line length (default: 120)
  * @configuration excludePackageStatements - if package statements should be ignored (default: false)
  * @configuration excludeImportStatements - if import statements should be ignored (default: false)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -10,6 +10,8 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 
 /**
+ * This rule allows to set a list of comments which are forbidden in the codebase and should only be used during
+ * development. Offending code comments will then be reported.
  *
  * <noncompliant>
  * // TODO:,FIXME:,STOPSHIP:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -11,6 +11,8 @@ import io.gitlab.arturbosch.detekt.api.SplitPattern
 import org.jetbrains.kotlin.psi.KtImportList
 
 /**
+ * This rule allows to set a list of forbidden imports. This can be used to discourage the use of unstable, experimental
+ * or deprecated APIs. Detekt will then report all imports that are forbidden.
  *
  * <noncompliant>
  * package foo

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -17,6 +17,8 @@ import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 
 /**
+ * A function that only returns a single constant can be misleading. Instead prefer to define the constant directly
+ * as a `const val`.
  *
  * <noncompliant>
  * fun functionReturningConstantString() = "1"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
@@ -15,6 +15,8 @@ import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtLoopExpression
 
 /**
+ * Loops which contain multiple `break` or `continue` statements are hard to read and understand.
+ * To increase readability they should be refactored into simpler loops.
  *
  * <noncompliant>
  * val strs = listOf("foo, bar")

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -29,6 +29,8 @@ import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 import java.util.Locale
 
 /**
+ * This rule detects and reports usages of magic numbers in the code. Prefer defining constants with clear names
+ * describing what the magic number means.
  *
  * <noncompliant>
  * class User {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
@@ -38,6 +38,8 @@ import org.jetbrains.kotlin.psi.psiUtil.allChildren
 import java.util.Arrays
 
 /**
+ * This rule reports cases in the code where modifiers are not in the correct order. The default modifier order is
+ * taken from: http://kotlinlang.org/docs/reference/coding-conventions.html#modifiers
  *
  * <noncompliant>
  * lateinit internal private val str: String
@@ -46,8 +48,6 @@ import java.util.Arrays
  * <compliant>
  * private internal lateinit val str: String
  * </compliant>
- *
- * Modifier order array taken from http://kotlinlang.org/docs/reference/coding-conventions.html#modifiers
  *
  * @active since v1.0.0
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
@@ -13,6 +13,9 @@ import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtEnumEntry
 
 /**
+ * Nested classes are often used to implement functionality local to the class it is nested in. Therefore it should
+ * not be public to other parts of the code.
+ * Prefer keeping nested classes `private`.
  *
  * <noncompliant>
  * internal class NestedClassesVisibility {
@@ -30,6 +33,7 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
  *
  * @author Ivan Balaksha
  * @author schalkms
+ * @author Marvin Ramin
  */
 class NestedClassesVisibility(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
@@ -10,6 +10,8 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtFile
 
 /**
+ * This rule reports files which do not end with a line separator.
+ *
  * @active since v1.0.0
  * @author Marvin Ramin
  */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeyword.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeyword.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtProperty
 
 /**
+ * This rule reports `abstract` modifiers which are unnecessary and can be removed.
  *
  * <noncompliant>
  * abstract interface Foo { // abstract keyword not needed

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBraces.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBraces.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtWhenExpression
 
 /**
+ * This rule reports unnecessary braces in when expressions. These optional braces should be removed.
  *
  * <noncompliant>
  * val i = 1
@@ -30,6 +31,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  * </compliant>
  *
  * @author schalkms
+ * @author Marvin Ramin
  */
 class OptionalWhenBraces(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
@@ -15,6 +15,8 @@ import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.isProtected
 
 /**
+ * Kotlin classes are `final` by default. Thus classes which are not marked as `open` should not contain any `protected`
+ * members. Consider using `private` or `internal` modifiers instead.
  *
  * <noncompliant>
  * class ProtectedMemberInFinalClass {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtProperty
 
 /**
+ * This rule checks for redundant visibility modifiers.
  *
  * <noncompliant>
  * public interface Foo { // public per default

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.psi.KtIsExpression
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 
 /**
+ * This rule inspects casts and reports casts which could be replaced with safe casts instead.
  *
  * <noncompliant>
  * fun numberMagic(number: Number) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClass.kt
@@ -16,6 +16,8 @@ import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtProperty
 
 /**
+ * Classes which implement the `Serializable` interface should also correctly declare a `serialVersionUID`.
+ * This rule verifies that a `serialVersionUID` was correctly defined.
  *
  * <noncompliant>
  * class IncorrectSerializable : Serializable {
@@ -36,6 +38,7 @@ import org.jetbrains.kotlin.psi.KtProperty
  * </compliant>
  *
  * @author schalkms
+ * @author Marvin Ramin
  */
 class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
@@ -16,6 +16,8 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 /**
+ * This rule verifies spacing between package and import statements as well as between import statements and class
+ * declarations.
  *
  * <noncompliant>
  * package foo

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
@@ -13,6 +13,8 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtThrowExpression
 
 /**
+ * Functions should have clear `throw` statements. Functions with many `throw` statements can be harder to read and lead
+ * to confusion. Instead prefer to limit the amount of `throw` statements in a function.
  *
  * <noncompliant>
  * fun foo(i: Int) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -15,6 +15,9 @@ import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.isAbstract
 
 /**
+ * This rule inspects `abstract` classes. In case an `abstract class` does not have any concrete members it should be
+ * refactored into an interfacse. Abstract classes which do not define any `abstract` members should instead be
+ * refactored into concrete classes.
  *
  * <noncompliant>
  * abstract class OnlyAbstractMembersInAbstractClass { // violation: no concrete members

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritance.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritance.kt
@@ -10,6 +10,8 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
 /**
+ * This rule reports unnecessary super types. Inheriting from `Any` or `Object` is unnecessary and should simply be
+ * removed.
  *
  * <noncompliant>
  * class A : Any()
@@ -18,6 +20,7 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
  *
  * @author schalkms
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class UnnecessaryInheritance(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -16,7 +16,10 @@ import org.jetbrains.kotlin.psi.KtImportList
 import org.jetbrains.kotlin.psi.KtReferenceExpression
 
 /**
+ * This rule reports unused imports. Unused imports are dead code and should be removed.
+ *
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class UnusedImports(config: Config) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -21,6 +21,10 @@ import org.jetbrains.kotlin.psi.psiUtil.isAbstract
 import org.jetbrains.kotlin.psi.psiUtil.isPropertyParameter
 
 /**
+ * Classes that simply hold data should be refactored into a `data class`. Data classes are specialized to hold data
+ * and generate `hashCode`, `equals` and `toString` implementations as well.
+ *
+ * Read more about `data class`: https://kotlinlang.org/docs/reference/data-classes.html
  *
  * <noncompliant>
  * class DataClassCandidate(val i: Int) {
@@ -38,6 +42,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPropertyParameter
  * @author Ivan Balaksha
  * @author Artur Bosch
  * @author schalkms
+ * @author Marvin Ramin
  */
 class UseDataClass(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
@@ -17,7 +17,8 @@ import org.jetbrains.kotlin.psi.KtPrimaryConstructor
 import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 
 /**
- *
+ * A class which only contains utility functions and no concrete implementation can be refactored into an `object`.
+ * 
  * <noncompliant>
  * class UtilityClass {
  *

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalReturnKeyword.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalReturnKeyword.kt
@@ -11,6 +11,10 @@ import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtProperty
 
 /**
+ * This rule reports optional `return` keywords. Inside conditional expressions the last expression is always returned
+ * by default.
+ *
+ * This makes the return keyword unnecessary and it can be removed safely.
  *
  * <noncompliant>
  * val z = if (true) return x else return y
@@ -21,6 +25,7 @@ import org.jetbrains.kotlin.psi.KtProperty
  * </compliant>
  *
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class OptionalReturnKeyword(config: Config) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
@@ -10,6 +10,8 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
+ * It is not necessary to define a return type of `Unit` on functions. This rule detects and reports instances where
+ * the `Unit` return type is specified on functions.
  *
  * <noncompliant>
  * fun foo(): Unit { }
@@ -20,6 +22,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  * </compliant>
  *
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 class OptionalUnit(config: Config = Config.empty) : Rule(config) {
 


### PR DESCRIPTION
Relates to #496 

Together with #701 this should be the last PR to have basic documentation for _all_ rules. After these two PRs no more `TODO:` comments are left in the generated `.md` documentation files.