### PR TITLE
KDocStyle MultiRule with EndOfSentenceFormat Rule

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -58,6 +58,9 @@ comments:
     active: false
   CommentOverPrivateProperty:
     active: false
+  EndOfSentenceFormat:
+    active: false
+    endOfSentenceFormat: ([.?!][ \t\n\r\f<])|([.?!]$)
   UndocumentedPublicClass:
     active: false
     searchInNestedClass: true

--- a/detekt-generator/documentation/comments.md
+++ b/detekt-generator/documentation/comments.md
@@ -7,8 +7,9 @@ of the code.
 
 1. [CommentOverPrivateFunction](#commentoverprivatefunction)
 2. [CommentOverPrivateProperty](#commentoverprivateproperty)
-3. [UndocumentedPublicClass](#undocumentedpublicclass)
-4. [UndocumentedPublicFunction](#undocumentedpublicfunction)
+3. [EndOfSentenceFormat](#endofsentenceformat)
+4. [UndocumentedPublicClass](#undocumentedpublicclass)
+5. [UndocumentedPublicFunction](#undocumentedpublicfunction)
 ## Rules in the `comments` rule set:
 
 ### CommentOverPrivateFunction
@@ -32,6 +33,16 @@ why the property exists and what purpose it solves without the comment.
 Instead of simply removing the comment to solve this issue prefer renaming the property to a more self-explanatory
 name. If this property is inside a bigger class it could make senes to refactor and split up the class. This can
 increase readability and make the documentation obsolete.
+
+### EndOfSentenceFormat
+
+This rule validates the end of the first sentence of a KDoc comment. It should end with proper punctuation.
+
+#### Configuration options:
+
+* `endOfSentenceFormat` (default: `([.?!][ \t\n\r\f<])|([.?!]$)`)
+
+   regular expression which should match the end of the first sentence in the KDoc
 
 ### UndocumentedPublicClass
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -68,7 +68,7 @@ class LargeClass(config: Config = Config.empty,
 	}
 
 	/**
-	 * Top level members must be skipped as loc stack can be empty - #64
+	 * Top level members must be skipped as loc stack can be empty. See #64 for more info.
 	 */
 	override fun visitProperty(property: KtProperty) {
 		if (property.isTopLevel) return

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocStyle.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocStyle.kt
@@ -40,15 +40,25 @@ class EndOfSentenceFormat(config: Config = Config.empty) : Rule(config) {
 	private val endOfSentenceFormat =
 			Regex(valueOrDefault(END_OF_SENTENCE_FORMAT, "([.?!][ \\t\\n\\r\\f<])|([.?!]\$)"))
 
+	private val htmlTag = Regex("<.+>")
+
 	fun verify(declaration: KtDeclaration) {
 		declaration.docComment?.let {
 			val text = it.getDefaultSection().getContent()
+			if (text.isEmpty()) {
+				return
+			}
+			if (text.startsWithHtmlTag()) {
+				return
+			}
 			if (!endOfSentenceFormat.containsMatchIn(text)) {
 				report(CodeSmell(issue, Entity.from(declaration), "The first sentence of this KDoc does not" +
 						"end with the correct punctuation."))
 			}
 		}
 	}
+
+	private fun String.startsWithHtmlTag() = startsWith("<") && contains(htmlTag)
 
 	companion object {
 		const val END_OF_SENTENCE_FORMAT = "endOfSentenceFormat"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocStyle.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocStyle.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.psi.KtDeclaration
 
 class KDocStyle(config: Config = Config.empty) : MultiRule() {
 
-	private val endOfSentenceFormat = EndOfSentenceFormat()
+	private val endOfSentenceFormat = EndOfSentenceFormat(config)
 
 	override val rules = listOf(
 			endOfSentenceFormat

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocStyle.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocStyle.kt
@@ -1,0 +1,56 @@
+package io.gitlab.arturbosch.detekt.rules.documentation
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.MultiRule
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtDeclaration
+
+class KDocStyle(config: Config = Config.empty) : MultiRule() {
+
+	private val endOfSentenceFormat = EndOfSentenceFormat()
+
+	override val rules = listOf(
+			endOfSentenceFormat
+	)
+
+	override fun visitDeclaration(dcl: KtDeclaration) {
+		super.visitDeclaration(dcl)
+		endOfSentenceFormat.verify(dcl)
+	}
+}
+
+/**
+ * This rule validates the end of the first sentence of a KDoc comment. It should end with proper punctuation.
+ *
+ * @configuration endOfSentenceFormat - regular expression which should match the end of the first sentence in the KDoc
+ * (default: ([.?!][ \t\n\r\f<])|([.?!]$))
+ *
+ *  @author Marvin Ramin
+ */
+class EndOfSentenceFormat(config: Config = Config.empty) : Rule(config) {
+
+	override val issue = Issue(javaClass.simpleName,
+			Severity.Maintainability,
+			"The first sentence in a KDoc comment should end with correct punctuation.")
+
+	private val endOfSentenceFormat =
+			Regex(valueOrDefault(END_OF_SENTENCE_FORMAT, "([.?!][ \\t\\n\\r\\f<])|([.?!]\$)"))
+
+	fun verify(declaration: KtDeclaration) {
+		declaration.docComment?.let {
+			val text = it.getDefaultSection().getContent()
+			if (!endOfSentenceFormat.containsMatchIn(text)) {
+				report(CodeSmell(issue, Entity.from(declaration), "The first sentence of this KDoc does not" +
+						"end with the correct punctuation."))
+			}
+		}
+	}
+
+	companion object {
+		const val END_OF_SENTENCE_FORMAT = "endOfSentenceFormat"
+	}
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CommentSmellProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CommentSmellProvider.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.rules.documentation.CommentOverPrivateFunction
 import io.gitlab.arturbosch.detekt.rules.documentation.CommentOverPrivateProperty
+import io.gitlab.arturbosch.detekt.rules.documentation.KDocStyle
 import io.gitlab.arturbosch.detekt.rules.documentation.UndocumentedPublicClass
 import io.gitlab.arturbosch.detekt.rules.documentation.UndocumentedPublicFunction
 
@@ -23,6 +24,7 @@ class CommentSmellProvider : RuleSetProvider {
 		return RuleSet(ruleSetId, listOf(
 				CommentOverPrivateFunction(config),
 				CommentOverPrivateProperty(config),
+				KDocStyle(config),
 				UndocumentedPublicClass(config),
 				UndocumentedPublicFunction(config)
 		))

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
@@ -1,0 +1,126 @@
+package io.gitlab.arturbosch.detekt.rules.documentation
+
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
+
+/**
+ * @author Marvin Ramin
+ */
+class EndOfSentenceFormatSpec : SubjectSpek<KDocStyle>({
+	subject { KDocStyle() }
+
+	it("reports invalid KDoc endings on classes") {
+		val code = """
+			/** Some doc */
+			class Test {
+			}
+			"""
+		assertThat(subject.lint(code)).hasSize(1)
+	}
+
+	it("reports invalid KDoc endings on objects") {
+		val code = """
+			/** Some doc */
+			object Test {
+			}
+			"""
+		assertThat(subject.lint(code)).hasSize(1)
+	}
+
+	it("reports invalid KDoc endings on properties") {
+		val code = """
+			class Test {
+			 	/** Some doc */
+				val test = 3
+			}
+			"""
+		assertThat(subject.lint(code)).hasSize(1)
+	}
+
+	it("reports invalid KDoc endings on top-level functions") {
+		val code = """
+			/** Some doc */
+			fun test() = 3
+			"""
+		assertThat(subject.lint(code)).hasSize(1)
+	}
+
+	it("reports invalid KDoc endings on functions") {
+		val code = """
+			class Test {
+			 	/** Some doc */
+				fun test() = 3
+			}
+			"""
+		assertThat(subject.lint(code)).hasSize(1)
+	}
+
+	it("reports invalid KDoc endings") {
+		val code = """
+			class Test {
+			 	/** Some doc-- */
+				fun test() = 3
+			}
+			"""
+		assertThat(subject.lint(code)).hasSize(1)
+	}
+
+	it("reports invalid KDoc endings in block") {
+		val code = """
+			/**
+			 * Something off abc@@
+			 */
+			class Test {
+			}
+			"""
+		assertThat(subject.lint(code)).hasSize(1)
+	}
+
+	it("does not valid first sentence KDoc endings in a multi sentence comment") {
+		val code = """
+			/**
+			 * This sentence is correct.
+			 *
+			 * This sentence doesn't matter
+			 */
+			class Test {
+			}
+			"""
+		assertThat(subject.lint(code)).isEmpty()
+	}
+
+	it("does not report KDoc ending with periods") {
+		val code = """
+			/**
+			 * Something correct.
+			 */
+			class Test {
+			}
+			"""
+		assertThat(subject.lint(code)).isEmpty()
+	}
+
+	it("does not report KDoc ending with questionmarks") {
+		val code = """
+			/**
+			 * Something correct?
+			 */
+			class Test {
+			}
+			"""
+		assertThat(subject.lint(code)).isEmpty()
+	}
+
+	it("does not report KDoc ending with exclamation marks") {
+		val code = """
+			/**
+			 * Something correct!
+			 */
+			class Test {
+			}
+			"""
+		assertThat(subject.lint(code)).isEmpty()
+	}
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
@@ -91,6 +91,54 @@ class EndOfSentenceFormatSpec : SubjectSpek<KDocStyle>({
 		assertThat(subject.lint(code)).isEmpty()
 	}
 
+	it("does not report KDoc which doesn't contain any real sentence") {
+		val code = """
+			/**
+			 * @author Someone
+			 */
+			class Test {
+			}
+			"""
+		assertThat(subject.lint(code)).isEmpty()
+	}
+
+
+	it("does not report KDoc which doesn't contain any real sentence but many tags") {
+		val code = """
+			/**
+			 * @configuration this - just an example (default: 150)
+			 *
+			 * @active since v1.0.0
+			 * @author person1
+			 * @author person2
+			 */
+			class Test {
+			}
+			"""
+		assertThat(subject.lint(code)).isEmpty()
+	}
+
+
+	it("does not report KDoc which doesn't contain any real sentence but html tags") {
+		val code = """
+			/**
+			 *
+			 * <noncompliant>
+			 * fun foo(): Unit { }
+			 * </noncompliant>
+			 *
+			 * <compliant>
+			 * fun foo() { }
+			 * </compliant>
+			 *
+			 * @author someone
+			 */
+			class Test {
+			}
+			"""
+		assertThat(subject.lint(code)).isEmpty()
+	}
+
 	it("does not report KDoc ending with periods") {
 		val code = """
 			/**


### PR DESCRIPTION
Resolves #699 

This PR sets up a `KDocStyle` MultiRule to check different aspects of KDoc in the future. For now I have only implemented the `EndOfSentenceFormat` check to verify the first KDoc sentence ends with proper punctuation.

Any suggestions on how to make the tests better? I kind of dislike calling the `KDocStyle` rule in the test instead of the `EndOfSentenceFormat` rule directly.