### PR TITLE
make detekt-cli tests depend on updated documentation/config

### DIFF
--- a/detekt-cli/build.gradle
+++ b/detekt-cli/build.gradle
@@ -16,3 +16,5 @@ dependencies {
 	testRuntimeOnly "org.junit.platform:junit-platform-console:$junitPlatformVersion"
 	testRuntimeOnly "org.jetbrains.spek:spek-junit-platform-engine:$spekVersion"
 }
+
+test.dependsOn(':detekt-generator:generateDocumentation')


### PR DESCRIPTION
When changing or adding rules currently `./gradlew build` might fail as we have tests in the `detekt-cli` module which verify that the `default-detekt-config.yml` contains all rules. 

A `./gradlew build` will assemble all modules and execute the tests in no particular order. If the `detekt-cli` tests run before the `detekt-generator` has updated the `default-detekt-config.yml` the tests can fail. 

This PR adds a dependency on the `detekt-cli` tests to run after the documentation and config have been updated. Alternatively we can remove the tests that verify the config altogether as we now generate the config. But we can also keep the test around as a kind of "integration test".