### PR TITLE
Gradle Plugin: Expose a copy of `profiles` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Serj Lotutovici](https://github.com/serj-lotutovici) - Rule improvement: LongParameterList
 - [Dmitry Primshyts](https://github.com/deeprim) - Rule improvement: MagicNumber
 - [Egor Neliuba](https://github.com/egor-n) - Rule improvement: EmptyFunctionBlock, EmptyClassBlock
+- [Said Tahsin Dane](https://github.com/tasomaniac/) - Gradle plugin improvements
 
 ### <a name="mentions">Mentions</a>
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.extensions
 
 import org.gradle.api.Action
 import org.gradle.api.Project
-import java.util.*
 
 /**
  * @author Artur Bosch

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Project
 
 /**
  * @author Artur Bosch
+ * @author Said Tahsin Dane
  */
 open class DetektExtension(open var version: String = SUPPORTED_DETEKT_VERSION,
 						   open var debug: Boolean = DEFAULT_DEBUG_VALUE,

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.extensions
 
 import org.gradle.api.Action
 import org.gradle.api.Project
+import java.util.*
 
 /**
  * @author Artur Bosch
@@ -11,7 +12,8 @@ open class DetektExtension(open var version: String = SUPPORTED_DETEKT_VERSION,
 						   open var profile: String = DEFAULT_PROFILE_NAME,
 						   open var ideaExtension: IdeaExtension = IdeaExtension()) {
 
-	private val profiles: MutableList<ProfileExtension> = mutableListOf()
+	private val _profiles = mutableListOf<ProfileExtension>()
+	val profiles get() = _profiles.toList()
 
 	fun systemOrDefaultProfile() = getSystemProfile() ?: getDefaultProfile()
 	fun ideaFormatArgs() = ideaExtension.formatArgs(this)
@@ -23,7 +25,7 @@ open class DetektExtension(open var version: String = SUPPORTED_DETEKT_VERSION,
 
 	fun profile(name: String, configuration: Action<in ProfileExtension>) {
 		ProfileExtension(name).apply {
-			profiles.add(this)
+			_profiles.add(this)
 			configuration.execute(this)
 		}
 	}


### PR DESCRIPTION
Working on an external tool that integrates detekt, we thought that it would be useful to expose a read-only list of `profiles`

Instead of making the `profiles` just public, introduced a [backing property](https://kotlinlang.org/docs/reference/properties.html#backing-properties) to hold the profiles and another public `profiles` property as a defensive copy of the actual list.

Fixes #705 