### PR TITLE
Simplify `SingleAssign` by using `lateinit` and add tests for it

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SingleAssign.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SingleAssign.kt
@@ -5,28 +5,17 @@ import kotlin.reflect.KProperty
 /**
  * @author Artur Bosch
  */
-class SingleAssign<T> {
+class SingleAssign<T : Any> {
 
-	private var initialized = false
-	private var _value: Any? = UNINITIALIZED_VALUE
+	private lateinit var _value: T
 
 	operator fun getValue(thisRef: Any?, property: KProperty<*>): T {
-		if (!initialized) {
-			throw IllegalStateException("Property ${property.name} has not been assigned yet!")
-		}
-		@Suppress("UNCHECKED_CAST")
-		return _value as T
+		check(this::_value.isInitialized) { "Property ${property.name} has not been assigned yet!" }
+		return _value
 	}
 
 	operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
-		if (initialized) {
-			throw IllegalStateException("Property ${property.name} has already been assigned!")
-		}
+		check(!this::_value.isInitialized) { "Property ${property.name} has already been assigned!" }
 		_value = value
-		initialized = true
-	}
-
-	companion object {
-		private val UNINITIALIZED_VALUE = Any()
 	}
 }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SingleAssignTest.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SingleAssignTest.kt
@@ -1,0 +1,36 @@
+package io.gitlab.arturbosch.detekt.api
+
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+internal class SingleAssignTest : Spek({
+  describe("value is unset") {
+    var unassigned: Int by SingleAssign()
+    it("should fail when value is retrieved") {
+      assertFailsWith(IllegalStateException::class) {
+        @Suppress("UNUSED_EXPRESSION")
+        unassigned
+      }
+    }
+
+    it("should succeed when value is assigned") {
+      unassigned = 15
+    }
+  }
+
+  describe("value is set") {
+    var assigned: Int by SingleAssign()
+    assigned = 15
+
+    it("should succeed when value is retrieved") {
+      assertEquals(15, assigned)
+    }
+
+    it("should fail when value is assigned") {
+      assertFailsWith<IllegalStateException> { assigned = -1 }
+    }
+  }
+})


### PR DESCRIPTION
Kotlin `1.2` added the ability to check if a `lateinit` variable has been assigned.
This simplifies the implementation.
This also changes the `SingleAssign` to be non-null, which may be changed later.
There are no uses of a nullable `SingleAssign` type previously, so there is no internal breakage.