### PR TITLE
Add MayBeConst rule

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -320,6 +320,8 @@ style:
     maxLineLength: 120
     excludePackageStatements: false
     excludeImportStatements: false
+  MayBeConst:
+    active: false
   ModifierOrder:
     active: true
   NestedClassesVisibility:

--- a/detekt-generator/documentation/style.md
+++ b/detekt-generator/documentation/style.md
@@ -16,29 +16,30 @@ code style guidelines.
 8. [LoopWithTooManyJumpStatements](#loopwithtoomanyjumpstatements)
 9. [MagicNumber](#magicnumber)
 10. [MaxLineLength](#maxlinelength)
-11. [ModifierOrder](#modifierorder)
-12. [NestedClassesVisibility](#nestedclassesvisibility)
-13. [NewLineAtEndOfFile](#newlineatendoffile)
-14. [OptionalAbstractKeyword](#optionalabstractkeyword)
-15. [OptionalReturnKeyword](#optionalreturnkeyword)
-16. [OptionalUnit](#optionalunit)
-17. [OptionalWhenBraces](#optionalwhenbraces)
-18. [ProtectedMemberInFinalClass](#protectedmemberinfinalclass)
-19. [RedundantVisibilityModifierRule](#redundantvisibilitymodifierrule)
-20. [ReturnCount](#returncount)
-21. [SafeCast](#safecast)
-22. [SerialVersionUIDInSerializableClass](#serialversionuidinserializableclass)
-23. [SpacingBetweenPackageAndImports](#spacingbetweenpackageandimports)
-24. [ThrowsCount](#throwscount)
-25. [UnnecessaryAbstractClass](#unnecessaryabstractclass)
-26. [UnnecessaryInheritance](#unnecessaryinheritance)
-27. [UnnecessaryParentheses](#unnecessaryparentheses)
-28. [UntilInsteadOfRangeTo](#untilinsteadofrangeto)
-29. [UnusedImports](#unusedimports)
-30. [UnusedPrivateMember](#unusedprivatemember)
-31. [UseDataClass](#usedataclass)
-32. [UtilityClassWithPublicConstructor](#utilityclasswithpublicconstructor)
-33. [WildcardImport](#wildcardimport)
+11. [MayBeConst](#maybeconst)
+12. [ModifierOrder](#modifierorder)
+13. [NestedClassesVisibility](#nestedclassesvisibility)
+14. [NewLineAtEndOfFile](#newlineatendoffile)
+15. [OptionalAbstractKeyword](#optionalabstractkeyword)
+16. [OptionalReturnKeyword](#optionalreturnkeyword)
+17. [OptionalUnit](#optionalunit)
+18. [OptionalWhenBraces](#optionalwhenbraces)
+19. [ProtectedMemberInFinalClass](#protectedmemberinfinalclass)
+20. [RedundantVisibilityModifierRule](#redundantvisibilitymodifierrule)
+21. [ReturnCount](#returncount)
+22. [SafeCast](#safecast)
+23. [SerialVersionUIDInSerializableClass](#serialversionuidinserializableclass)
+24. [SpacingBetweenPackageAndImports](#spacingbetweenpackageandimports)
+25. [ThrowsCount](#throwscount)
+26. [UnnecessaryAbstractClass](#unnecessaryabstractclass)
+27. [UnnecessaryInheritance](#unnecessaryinheritance)
+28. [UnnecessaryParentheses](#unnecessaryparentheses)
+29. [UntilInsteadOfRangeTo](#untilinsteadofrangeto)
+30. [UnusedImports](#unusedimports)
+31. [UnusedPrivateMember](#unusedprivatemember)
+32. [UseDataClass](#usedataclass)
+33. [UtilityClassWithPublicConstructor](#utilityclasswithpublicconstructor)
+34. [WildcardImport](#wildcardimport)
 ## Rules in the `style` rule set:
 
 ### CollapsibleIfStatements
@@ -307,6 +308,24 @@ in the codebase will help make the code more uniform.
 * `excludeImportStatements` (default: `false`)
 
    if import statements should be ignored
+
+### MayBeConst
+
+This rule identifies and reports properties (`val`) that may be `const val` instead.
+Using `const val` can lead to better performance of the resulting bytecode as well as better interoperability with
+Java.
+
+#### Noncompliant Code:
+
+```kotlin
+val myConstant = "abc"
+```
+
+#### Compliant Code:
+
+```kotlin
+const val MY_CONSTANT = "abc"
+```
 
 ### ModifierOrder
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtModifierList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtModifierList.kt
@@ -17,4 +17,6 @@ fun KtModifierListOwner.isPublic(): Boolean {
 			|| this.hasModifier(KtTokens.INTERNAL_KEYWORD))
 }
 
+fun KtModifierListOwner.isConstant() = hasModifier(KtTokens.CONST_KEYWORD)
+
 fun KtModifierListOwner.isInternal() = hasModifier(KtTokens.INTERNAL_KEYWORD)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -13,6 +13,7 @@ import io.gitlab.arturbosch.detekt.rules.style.ForbiddenImport
 import io.gitlab.arturbosch.detekt.rules.style.FunctionOnlyReturningConstant
 import io.gitlab.arturbosch.detekt.rules.style.LoopWithTooManyJumpStatements
 import io.gitlab.arturbosch.detekt.rules.style.MagicNumber
+import io.gitlab.arturbosch.detekt.rules.style.MayBeConst
 import io.gitlab.arturbosch.detekt.rules.style.ModifierOrder
 import io.gitlab.arturbosch.detekt.rules.style.NestedClassesVisibility
 import io.gitlab.arturbosch.detekt.rules.style.NewLineAtEndOfFile
@@ -83,7 +84,8 @@ class StyleGuideProvider : RuleSetProvider {
 				ExpressionBodySyntax(config),
 				NestedClassesVisibility(config),
 				RedundantVisibilityModifierRule(config),
-				UntilInsteadOfRangeTo(config)
+				UntilInsteadOfRangeTo(config),
+				MayBeConst(config)
 		))
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConst.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConst.kt
@@ -1,0 +1,76 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.isConstant
+import io.gitlab.arturbosch.detekt.rules.isOverridden
+import org.jetbrains.kotlin.KtNodeTypes
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
+
+/**
+ * This rule identifies and reports properties (`val`) that may be `const val` instead.
+ * Using `const val` can lead to better performance of the resulting bytecode as well as better interoperability with
+ * Java.
+ *
+ * <noncompliant>
+ * val myConstant = "abc"
+ * </noncompliant>
+ *
+ * <compliant>
+ * const val MY_CONSTANT = "abc"
+ * </compliant>
+ *
+ * @author Marvin Ramin
+ */
+class MayBeConst(config: Config = Config.empty) : Rule(config) {
+
+	override val issue = Issue(javaClass.simpleName,
+			Severity.Style,
+			"Reports vals that can be const val instead.",
+			Debt.FIVE_MINS)
+
+	override fun visitProperty(property: KtProperty) {
+		super.visitProperty(property)
+
+		if (property.canBeConst()) {
+			report(CodeSmell(issue, Entity.from(property), "${property.nameAsSafeName} can be a `const val`."))
+		}
+	}
+
+	private fun KtProperty.canBeConst(): Boolean {
+		if (isLocal
+				|| isVar
+				|| getter != null
+				|| isConstant()
+				|| isOverridden()) {
+			return false
+		}
+
+		if (!isTopLevel && containingClassOrObject !is KtObjectDeclaration) return false
+
+		val isJvmField = annotationEntries.any { it.text == "@JvmField" }
+		if (annotationEntries.isNotEmpty() && !isJvmField) return false
+
+		val initializer = initializer ?: return false
+
+		return initializer.isConstantExpression()
+	}
+
+	private fun KtExpression.isConstantExpression(): Boolean {
+		return this is KtStringTemplateExpression
+				|| node.elementType == KtNodeTypes.BOOLEAN_CONSTANT
+				|| node.elementType == KtNodeTypes.INTEGER_CONSTANT
+				|| node.elementType == KtNodeTypes.CHARACTER_CONSTANT
+				|| node.elementType == KtNodeTypes.FLOAT_CONSTANT
+	}
+
+}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
@@ -1,0 +1,185 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
+
+class MayBeConstSpec : SubjectSpek<MayBeConst>({
+
+	subject { MayBeConst() }
+
+	given("some valid constants") {
+		it("is a valid constant") {
+			val code = """const val X = 42"""
+			subject.lint(code)
+			assertThat(subject.findings).isEmpty()
+		}
+
+
+		it("is const vals in object") {
+			val code = """
+				object Test {
+					const val TEST = "Test"
+				}
+				"""
+			subject.lint(code)
+			assertThat(subject.findings).isEmpty()
+		}
+
+		it("isconst vals in companion objects") {
+			val code = """
+				class Test {
+					companion object {
+						const val B = 1
+					}
+				}
+				"""
+			subject.lint(code)
+			assertThat(subject.findings).isEmpty()
+		}
+
+		it("does not report const vals that use other const vals") {
+			val code = """
+				const val a = 0
+
+				class Test {
+					companion object {
+						@JvmField
+						const val B = a + 1
+					}
+				}
+				"""
+			subject.lint(code)
+			assertThat(subject.findings).isEmpty()
+		}
+
+	}
+
+	given("some vals that could be constants") {
+		it("is a simple val") {
+			val code = """
+				val x = 1
+				"""
+			subject.lint(code)
+			assertThat(subject.findings).hasSize(1)
+		}
+
+		it("is a simple JvmField val") {
+			val code = """
+				@JvmField val x = 1
+				"""
+			subject.lint(code)
+			assertThat(subject.findings).hasSize(1)
+		}
+
+		it("is a field in an object") {
+			val code = """
+				object Test {
+    				@JvmField val test = "Test"
+				}
+				"""
+			subject.lint(code)
+			assertThat(subject.findings).hasSize(1)
+		}
+
+		it("reports vals in companion objects") {
+			val code = """
+				class Test {
+					companion object {
+						val b = 1
+					}
+				}
+				"""
+			subject.lint(code)
+			assertThat(subject.findings).hasSize(1)
+		}
+	}
+
+	given("vals that can be constants but detekt doesn't handle yet") {
+		it("is a constant expression") {
+			val code = """
+				const val one = 1
+				val two = one * 2 // this is an expression that detekt doesn't support yet
+				"""
+			subject.lint(code)
+			assertThat(subject.findings).isEmpty() // should be 1
+		}
+
+		it("reports vals that use other const vals") {
+			val code = """
+				const val a = 0
+
+				class Test {
+					companion object {
+						@JvmField
+						val b = a + 1 // this is an expression that detekt doesn't support yet
+					}
+				}
+				"""
+			subject.lint(code)
+			assertThat(subject.findings).isEmpty() // should be 1
+		}
+	}
+
+	given("vals that cannot be constants") {
+		it("does not report arrays") {
+			val code = "val arr = arrayOf(\"a\", \"b\")"
+			subject.lint(code)
+			assertThat(subject.findings).isEmpty()
+		}
+
+		it("is a var") {
+			val code = "var test = 1"
+			subject.lint(code)
+			assertThat(subject.findings).isEmpty()
+		}
+
+		it("has a getter") {
+			val code = "val withGetter get() = 42"
+			subject.lint(code)
+			assertThat(subject.findings).isEmpty()
+		}
+
+		it("is initialized to null") {
+			val code = "val test = null"
+			subject.lint(code)
+			assertThat(subject.findings).isEmpty()
+		}
+
+		it("is a JvmField in a class") {
+			val code = """
+				class Test {
+					@JvmField val a = 3
+				}
+			""".trimMargin()
+			subject.lint(code)
+			assertThat(subject.findings).isEmpty()
+		}
+
+		it("has some annotation") {
+			val code = """
+				annotation class A
+
+				@A val a = 55
+			""".trimMargin()
+			subject.lint(code)
+			assertThat(subject.findings).isEmpty()
+		}
+
+		it("overrides something") {
+			val code = """
+				interface Base {
+					val property: Int
+				}
+
+				object Derived : Base {
+					override val property = 1
+				}
+			""".trimMargin()
+			subject.lint(code)
+			assertThat(subject.findings).isEmpty()
+		}
+	}
+})


### PR DESCRIPTION
This resolves #731 (kind of)

This rule checks the most obvious cases where `val`s can be `const val`. There are more cases where expressions are used to initialize the `val`. However with type resolution this could be easily detected if they could be constants. Without type resolution it might be possible but I'm not sure if that is time well spent.