### PR TITLE
add messages to all CodeSmells

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -37,7 +37,7 @@ class ComplexMethod(config: Config = Config.empty,
 			report(ThresholdedCodeSmell(issue,
 					Entity.from(function),
 					Metric("MCC", mcc, threshold),
-					message = ""))
+					"The function ${function.nameAsSafeName} appears to be too complex."))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.psi.KtExpressionWithLabel
  * </compliant>
  *
  * @author Ivan Balaksha
+ * @author Marvin Ramin
  */
 class LabeledExpression(config: Config = Config.empty) : Rule(config) {
 	override val issue: Issue = Issue("LabeledExpression",
@@ -38,7 +39,7 @@ class LabeledExpression(config: Config = Config.empty) : Rule(config) {
 	override fun visitExpressionWithLabel(expression: KtExpressionWithLabel) {
 		super.visitExpressionWithLabel(expression)
 		expression.getLabelName()?.let {
-			report(CodeSmell(issue, Entity.from(expression), message = ""))
+			report(CodeSmell(issue, Entity.from(expression), issue.description))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -39,7 +39,8 @@ class LongMethod(config: Config = Config.empty,
 					ThresholdedCodeSmell(issue,
 							Entity.from(function),
 							Metric("SIZE", size, threshold),
-							message = ""))
+							"The function ${function.nameAsSafeName} is too long. The maximum length is " +
+									"$threshold."))
 		}
 		super.visitNamedFunction(function)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -35,21 +35,23 @@ class LongParameterList(config: Config = Config.empty,
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		if (function.hasModifier(KtTokens.OVERRIDE_KEYWORD)) return
-		function.valueParameterList?.checkThreshold()
+		val parameterList = function.valueParameterList
+		val parameters = parameterList?.parameterCount()
+
+		if (parameters != null && parameters > threshold) {
+			report(ThresholdedCodeSmell(issue,
+					Entity.from(parameterList),
+					Metric("SIZE", parameters, threshold),
+					"The function ${function.nameAsSafeName} has too many parameters. The current threshold" +
+							" is set to $threshold."))
+		}
 	}
 
-	private fun KtParameterList.checkThreshold() {
-		val size = if (ignoreDefaultParameters) {
+	private fun KtParameterList.parameterCount(): Int {
+		return if (ignoreDefaultParameters) {
 			parameters.filter { !it.hasDefaultValue() }.size
 		} else {
 			parameters.size
-		}
-
-		if (size > threshold) {
-			report(ThresholdedCodeSmell(issue,
-					Entity.from(this),
-					Metric("SIZE", size, threshold),
-					message = ""))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
@@ -34,7 +34,8 @@ class CommentOverPrivateFunction(config: Config = Config.empty) : Rule(config) {
 		val modifierList = function.modifierList
 		if (modifierList != null && function.docComment != null) {
 			if (modifierList.hasModifier(KtTokens.PRIVATE_KEYWORD)) {
-				report(CodeSmell(issue, Entity.from(function.docComment!!), message = ""))
+				report(CodeSmell(issue, Entity.from(function.docComment!!), "The function ${function.nameAsSafeName} " +
+						"has a comment. Prefer renaming the function giving it a more self-explanatory name."))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
@@ -32,7 +32,7 @@ class CommentOverPrivateProperty(config: Config = Config.empty) : Rule(config) {
 		val modifierList = property.modifierList
 		if (modifierList != null && property.docComment != null) {
 			if (modifierList.hasModifier(KtTokens.PRIVATE_KEYWORD)) {
-				report(CodeSmell(issue, Entity.from(property.docComment!!), message = ""))
+				report(CodeSmell(issue, Entity.from(property.docComment!!), issue.description))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -60,7 +60,8 @@ class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
 
 	private fun reportIfUndocumented(element: KtClassOrObject) {
 		if (element.isPublicNotOverridden() && element.notEnumEntry() && element.docComment == null) {
-			report(CodeSmell(issue, Entity.Companion.from(element), message = ""))
+			report(CodeSmell(issue, Entity.Companion.from(element),
+					"${element.nameAsSafeName} is missing required documentation."))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
@@ -28,11 +28,13 @@ class UndocumentedPublicFunction(config: Config = Config.empty) : Rule(config) {
 		val modifierList = function.modifierList
 		if (function.docComment == null) {
 			if (modifierList == null) {
-				report(CodeSmell(issue, methodHeaderLocation(function), message = ""))
+				report(CodeSmell(issue, methodHeaderLocation(function), "The function ${function.nameAsSafeName}" +
+						" is missing documentation."))
 			}
 			if (modifierList != null) {
 				if (function.isPublicNotOverridden()) {
-					report(CodeSmell(issue, methodHeaderLocation(function), message = ""))
+					report(CodeSmell(issue, methodHeaderLocation(function), "The function ${function.nameAsSafeName}" +
+							" is missing documentation."))
 				}
 			}
 		}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
@@ -43,7 +43,7 @@ class ExceptionRaisedInUnexpectedLocation(config: Config = Config.empty) : Rule(
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		if (isPotentialMethod(function) && hasThrowExpression(function.bodyExpression)) {
-			report(CodeSmell(issue, Entity.from(function), message = ""))
+			report(CodeSmell(issue, Entity.from(function), issue.description))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForException.kt
@@ -48,11 +48,11 @@ class InstanceOfCheckForException(config: Config = Config.empty) : Rule(config) 
 
 	override fun visitCatchSection(catchClause: KtCatchClause) {
 		catchClause.catchBody?.collectByType<KtIsExpression>()?.forEach {
-			report(CodeSmell(issue, Entity.from(it), message = ""))
+			report(CodeSmell(issue, Entity.from(it), issue.description))
 		}
 		catchClause.catchBody?.collectByType<KtBinaryExpressionWithTypeRHS>()?.forEach {
 			if (KtPsiUtil.isUnsafeCast(it)) {
-				report(CodeSmell(issue, Entity.from(it), message = ""))
+				report(CodeSmell(issue, Entity.from(it), issue.description))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclaration.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclaration.kt
@@ -40,7 +40,7 @@ class NotImplementedDeclaration(config: Config = Config.empty) : Rule(config) {
 	override fun visitThrowExpression(expression: KtThrowExpression) {
 		val calleeExpression = expression.thrownExpression?.getCalleeExpressionIfAny()
 		if (calleeExpression?.text == "NotImplementedError") {
-			report(CodeSmell(issue, Entity.from(expression), message = ""))
+			report(CodeSmell(issue, Entity.from(expression), issue.description))
 		}
 	}
 
@@ -48,7 +48,7 @@ class NotImplementedDeclaration(config: Config = Config.empty) : Rule(config) {
 		if (expression.calleeExpression?.text == "TODO") {
 			val size = expression.valueArguments.size
 			if (size == 0 || size == 1) {
-				report(CodeSmell(issue, Entity.from(expression), message = ""))
+				report(CodeSmell(issue, Entity.from(expression), issue.description))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTrace.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTrace.kt
@@ -58,14 +58,14 @@ class PrintStackTrace(config: Config = Config.empty) : Rule(config) {
 		val callNameExpression = expression.getCallNameExpression()
 		if (callNameExpression?.text == "dumpStack"
 				&& callNameExpression.getReceiverExpression()?.text == "Thread") {
-			report(CodeSmell(issue, Entity.from(expression), message = ""))
+			report(CodeSmell(issue, Entity.from(expression), issue.description))
 		}
 	}
 
 	override fun visitCatchSection(catchClause: KtCatchClause) {
 		catchClause.catchBody?.collectByType<KtNameReferenceExpression>()?.forEach {
 			if (it.text == catchClause.catchParameter?.name && hasPrintStacktraceCallExpression(it)) {
-				report(CodeSmell(issue, Entity.from(it), message = ""))
+				report(CodeSmell(issue, Entity.from(it), issue.description))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtException.kt
@@ -48,7 +48,7 @@ class RethrowCaughtException(config: Config = Config.empty) : Rule(config) {
 			it.thrownExpression?.text == catchClause.catchParameter?.name
 		}
 		if (throwExpression != null) {
-			report(CodeSmell(issue, Entity.from(throwExpression), message = ""))
+			report(CodeSmell(issue, Entity.from(throwExpression), issue.description))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
@@ -39,7 +39,7 @@ class ReturnFromFinally(config: Config = Config.empty) : Rule(config) {
 		val innerFunctions = finallySection.finalExpression.collectByType<KtNamedFunction>()
 		returnExpressions.forEach {
 			if (isNotInInnerFunction(it, innerFunctions)) {
-				report(CodeSmell(issue, Entity.from(it), message = ""))
+				report(CodeSmell(issue, Entity.from(it), issue.description))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -45,7 +45,7 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
 
 	override fun visitCatchSection(catchClause: KtCatchClause) {
 		if (isExceptionSwallowed(catchClause) == true) {
-			report(CodeSmell(issue, Entity.from(catchClause), message = ""))
+			report(CodeSmell(issue, Entity.from(catchClause), issue.description))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinally.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinally.kt
@@ -35,7 +35,7 @@ class ThrowingExceptionFromFinally(config: Config = Config.empty) : Rule(config)
 	override fun visitFinallySection(finallySection: KtFinallySection) {
 		val throwExpressions = finallySection.finalExpression.collectByType<KtThrowExpression>()
 		throwExpressions.forEach {
-			report(CodeSmell(issue, Entity.from(it), message = ""))
+			report(CodeSmell(issue, Entity.from(it), issue.description))
 		}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
@@ -34,7 +34,7 @@ class ThrowingExceptionInMain(config: Config = Config.empty) : Rule(config) {
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		if (isMainFunction(function) && hasArgsParameter(function.valueParameters) && containsThrowExpression(function)) {
-			report(CodeSmell(issue, Entity.from(function), message = ""))
+			report(CodeSmell(issue, Entity.from(function), issue.description))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
@@ -53,7 +53,7 @@ class ThrowingExceptionsWithoutMessageOrCause(config: Config = Config.empty) : R
 	override fun visitCallExpression(expression: KtCallExpression) {
 		val calleeExpressionText = expression.calleeExpression?.text
 		if (exceptions.contains(calleeExpressionText) && expression.valueArguments.isEmpty()) {
-			report(CodeSmell(issue, Entity.from(expression), message = ""))
+			report(CodeSmell(issue, Entity.from(expression), issue.description))
 		}
 		super.visitCallExpression(expression)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameException.kt
@@ -54,7 +54,7 @@ class ThrowingNewInstanceOfSameException(config: Config = Config.empty) : Rule(c
 					&& hasSameExceptionParameter(thrownExpression.valueArguments, parameterName)
 		}
 		if (throwExpression != null) {
-			report(CodeSmell(issue, Entity.from(throwExpression), message = ""))
+			report(CodeSmell(issue, Entity.from(throwExpression), issue.description))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
@@ -59,7 +59,7 @@ class TooGenericExceptionCaught(config: Config) : Rule(config) {
 		catchClause.catchParameter?.let {
 			val text = it.typeReference?.text
 			if (text != null && text in exceptions)
-				report(CodeSmell(issue, Entity.from(it), message = ""))
+				report(CodeSmell(issue, Entity.from(it), issue.description))
 		}
 		super.visitCatchSection(catchClause)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
@@ -53,7 +53,8 @@ class TooGenericExceptionThrown(config: Config) : Rule(config) {
 
 	override fun visitThrowExpression(expression: KtThrowExpression) {
 		expression.thrownExpression?.text?.substringBefore("(")?.let {
-			if (it in exceptions) report(CodeSmell(issue, Entity.from(expression), message = ""))
+			if (it in exceptions) report(CodeSmell(issue, Entity.from(expression), "$it is a too generic " +
+					"Exception. Prefer throwing specific exceptions that indicate a specific error case."))
 		}
 		super.visitThrowExpression(expression)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
@@ -51,7 +51,7 @@ class ForEachOnRange(config: Config = Config.empty) : Rule(config) {
 
 			it.getReceiverExpression()?.text?.let {
 				if (it matches rangeRegex) {
-					report(CodeSmell(issue, Entity.from(expression), message = ""))
+					report(CodeSmell(issue, Entity.from(expression), issue.description))
 				}
 			}
 		}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
@@ -37,7 +37,7 @@ class SpreadOperator(config: Config = Config.empty) : Rule(config) {
 		super.visitValueArgumentList(list)
 		list.arguments.filter { it.getSpreadElement() != null }
 				.forEach {
-					report(CodeSmell(issue, Entity.from(list), message = ""))
+					report(CodeSmell(issue, Entity.from(list), issue.description))
 				}
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiation.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiation.kt
@@ -38,7 +38,7 @@ class UnnecessaryTemporaryInstantiation(config: Config = Config.empty) : Rule(co
 	override fun visitCallExpression(expression: KtCallExpression) {
 		if (isPrimitiveWrapperType(expression.calleeExpression)
 				&& isToStringMethod(expression.nextSibling?.nextSibling)) {
-			report(CodeSmell(issue, Entity.from(expression), message = ""))
+			report(CodeSmell(issue, Entity.from(expression), issue.description))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCall.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCall.kt
@@ -30,7 +30,7 @@ class EqualsNullCall(config: Config = Config.empty) : Rule(config) {
 
 	override fun visitCallExpression(expression: KtCallExpression) {
 		if (expression.calleeExpression?.text == "equals" && hasNullParameter(expression)) {
-			report(CodeSmell(issue, Entity.from(expression), message = ""))
+			report(CodeSmell(issue, Entity.from(expression), issue.description))
 		} else {
 			super.visitCallExpression(expression)
 		}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
@@ -42,7 +42,7 @@ class ExpressionBodySyntax(config: Config = Config.empty) : Rule(config) {
 		if (function.bodyExpression != null) {
 			val body = function.bodyExpression!!
 			body.singleReturnStatement()?.let { returnStmt ->
-				report(CodeSmell(issue, Entity.from(returnStmt), message = ""))
+				report(CodeSmell(issue, Entity.from(returnStmt), issue.description))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
@@ -61,7 +61,7 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 		lines.forEach { line ->
 			offset += line.length
 			if (!isValidLine(line)) {
-				report(CodeSmell(issue, Entity.from(file, offset), message = ""))
+				report(CodeSmell(issue, Entity.from(file, offset), issue.description))
 			}
 
 			offset += 1 /* '\n' */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -43,7 +43,8 @@ class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
 
 		values.forEach {
 			if (text.contains(it, ignoreCase = true)) {
-				report(CodeSmell(issue, Entity.from(comment), message = ""))
+				report(CodeSmell(issue, Entity.from(comment), "This comment contains text that has been " +
+						"defined as forbidden in detekt."))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -41,7 +41,8 @@ class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
 				.imports
 				.filterNot { it.isAllUnder }
 				.filter { forbiddenImports.contains(it.importedFqName?.asString() ?: "") }
-				.forEach { report(CodeSmell(issue, Entity.from(it), message = "")) }
+				.forEach { report(CodeSmell(issue, Entity.from(it), "The import " +
+						"${it.importedFqName!!.asString()} has been forbidden in the Detekt config.")) }
 	}
 
 	companion object {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -45,7 +45,8 @@ class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		if (checkOverridableFunction(function) && isNotExcluded(function) && isReturningAConstant(function)) {
-			report(CodeSmell(issue, Entity.from(function), message = ""))
+			report(CodeSmell(issue, Entity.from(function),
+					"${function.nameAsSafeName} is returning a constant. Prefer declaring a constant instead."))
 		}
 		super.visitNamedFunction(function)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
@@ -44,7 +44,7 @@ class LoopWithTooManyJumpStatements(config: Config = Config.empty) : Rule(config
 
 	override fun visitLoopExpression(loopExpression: KtLoopExpression) {
 		if (countBreakAndReturnStatements(loopExpression.body) > maxJumpCount) {
-			report(CodeSmell(issue, Entity.from(loopExpression), message = ""))
+			report(CodeSmell(issue, Entity.from(loopExpression), issue.description))
 		}
 		super.visitLoopExpression(loopExpression)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -117,7 +117,8 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
 		val number = parseAsDoubleOrNull(rawNumber) ?: return
 		if (!ignoredNumbers.contains(number)) {
-			report(CodeSmell(issue, Entity.from(expression), message = ""))
+			report(CodeSmell(issue, Entity.from(expression), "This expression contains a magic number." +
+					" Consider defining it to a well named constant."))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
@@ -25,7 +25,8 @@ class NewLineAtEndOfFile(config: Config = Config.empty) : Rule(config) {
 	override fun visitKtFile(file: KtFile) {
 		val text = file.text
 		if (text.isNotEmpty() && text.last() != '\n') {
-			report(CodeSmell(issue, Entity.from(file, text.length - 1), message = ""))
+			report(CodeSmell(issue, Entity.from(file, text.length - 1),
+					"The file ${file.name} is not ending with a new line."))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBraces.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBraces.kt
@@ -35,14 +35,16 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  */
 class OptionalWhenBraces(config: Config = Config.empty) : Rule(config) {
 
-	override val issue: Issue = Issue(javaClass.simpleName, Severity.Style,
-			"Optional braces in when expression", Debt.FIVE_MINS)
+	override val issue: Issue = Issue(javaClass.simpleName,
+			Severity.Style,
+			"Optional braces in when expression",
+			Debt.FIVE_MINS)
 
 	override fun visitWhenExpression(expression: KtWhenExpression) {
 		for (entry in expression.entries) {
 			val blockExpression = entry.expression as? KtBlockExpression
 			if (hasOneStatement(blockExpression) && hasOptionalBrace(blockExpression)) {
-				report(CodeSmell(issue, Entity.from(entry), message = ""))
+				report(CodeSmell(issue, Entity.from(entry), issue.description))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
@@ -64,7 +64,7 @@ class ProtectedMemberInFinalClass(config: Config = Config.empty) : Rule(config) 
 
 		override fun visitDeclaration(dcl: KtDeclaration) {
 			if (dcl.isProtected() && !dcl.isOverridden()) {
-				report(CodeSmell(issue, Entity.from(dcl), message = ""))
+				report(CodeSmell(issue, Entity.from(dcl), issue.description))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
@@ -68,6 +68,6 @@ class SafeCast(config: Config = Config.empty) : Rule(config) {
 	}
 
 	private fun addReport(expression: KtIfExpression) {
-		report(CodeSmell(issue, Entity.from(expression), message = ""))
+		report(CodeSmell(issue, Entity.from(expression), "This cast should be replaced with a safe cast: as?"))
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClass.kt
@@ -53,7 +53,8 @@ class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(
 		if (!klass.isInterface() && isImplementingSerializable(klass)) {
 			val companionObject = klass.companionObject()
 			if (companionObject == null || !hasCorrectSerialVersionUUID(companionObject)) {
-				report(CodeSmell(issue, Entity.from(klass), message = ""))
+				report(CodeSmell(issue, Entity.from(klass), "The class ${klass.nameAsSafeName} implements" +
+						"the Serializable interface and should thus define a serialVersionUID."))
 			}
 		}
 		super.visitClass(klass)
@@ -63,7 +64,8 @@ class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(
 		if (!declaration.isCompanion()
 				&& isImplementingSerializable(declaration)
 				&& !hasCorrectSerialVersionUUID(declaration)) {
-			report(CodeSmell(issue, Entity.from(declaration), message = ""))
+			report(CodeSmell(issue, Entity.from(declaration),"The object ${declaration.nameAsSafeName} " +
+					"implements the Serializable interface and should thus define a serialVersionUID."))
 		}
 		super.visitObjectDeclaration(declaration)
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
@@ -53,7 +53,8 @@ class ThrowsCount(config: Config = Config.empty) : Rule(config) {
 		if (!function.hasModifier(KtTokens.OVERRIDE_KEYWORD)) {
 			val count = function.collectByType<KtThrowExpression>().count()
 			if (count > max) {
-				report(CodeSmell(issue, Entity.from(function), message = ""))
+				report(CodeSmell(issue, Entity.from(function), "Too many throw statements in the function" +
+						" ${function.nameAsSafeName}. The maximum number of allowed throw statements is $max."))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -39,7 +39,8 @@ class UnusedImports(config: Config) : Rule(config) {
 	override fun visitFile(file: PsiFile?) {
 		imports.clear()
 		super.visitFile(file)
-		imports.forEach { report(CodeSmell(issue, Entity.from(it.second), message = "")) }
+		imports.forEach { report(CodeSmell(issue, Entity.from(it.second), "The import ${it.first} is" +
+				"unused.")) }
 	}
 
 	override fun visitImportList(importList: KtImportList) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -76,7 +76,8 @@ class UseDataClass(config: Config = Config.empty) : Rule(config) {
 			val containsPropertyOrPropertyParameters = properties.isNotEmpty() || propertyParameters.isNotEmpty()
 
 			if (containsFunctions && containsPropertyOrPropertyParameters) {
-				report(CodeSmell(issue, Entity.from(klass), message = ""))
+				report(CodeSmell(issue, Entity.from(klass), "The class ${klass.nameAsSafeName} defines no" +
+						"functionality and only holds data. Consider converting it to a data class."))
 			}
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
@@ -62,7 +62,8 @@ class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(co
 		if (!klass.isInterface() && !klass.hasDelegates() && hasPublicConstructor(klass)) {
 			val declarations = klass.getBody()?.declarations
 			if (hasOnlyUtilityClassMembers(declarations)) {
-				report(CodeSmell(issue, Entity.from(klass), message = ""))
+				report(CodeSmell(issue, Entity.from(klass), "The class ${klass.nameAsSafeName} only contains" +
+						"utility functions. Consider defining it as an object."))
 			}
 		}
 		super.visitClass(klass)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -68,7 +68,8 @@ class WildcardImport(config: Config = Config.empty) : Rule(config) {
 			if (excludedImports.contains(import)) {
 				return
 			}
-			report(CodeSmell(issue, Entity.from(importDirective), message = ""))
+				report(CodeSmell(issue, Entity.from(importDirective), "${importDirective.importPath!!.pathStr} " +
+						"is a wildcard import. Replace it with fully qualified imports."))
 		}
 	}
 


### PR DESCRIPTION
This adds the remaining messages to all `CodeSmell` instances. After this PR there are no more `message = ""` remaining.

Related to #347 (maybe we can even close it after this one?)
Also related to #496 