### PR TITLE
Fixes for .kts files

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -36,6 +36,8 @@ import java.util.ArrayDeque
 class LargeClass(config: Config = Config.empty,
 				 threshold: Int = DEFAULT_ACCEPTED_CLASS_LENGTH) : ThresholdRule(config, threshold) {
 
+	private var containsClassOrObject = false
+
 	override val issue = Issue("LargeClass",
 			Severity.Maintainability,
 			"One class should have one responsibility. Large classes tend to handle many things at once. " +
@@ -48,7 +50,9 @@ class LargeClass(config: Config = Config.empty,
 	}
 
 	private fun addToHead(amount: Int) {
-		locStack.push(locStack.pop() + amount)
+		if (containsClassOrObject) {
+			locStack.push(locStack.pop() + amount)
+		}
 	}
 
 	override fun visitFile(file: PsiFile?) { //TODO
@@ -57,6 +61,7 @@ class LargeClass(config: Config = Config.empty,
 	}
 
 	override fun visitClassOrObject(classOrObject: KtClassOrObject) {
+		containsClassOrObject = true
 		locStack.push(0)
 		classOrObject.getBody()?.let {
 			addToHead(it.declarations.size)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/Case.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/Case.kt
@@ -44,6 +44,7 @@ enum class Case(val file: String) {
 	ComplexInterfacePositive("/cases/ComplexInterfacePositive.kt"),
 	Comments("/cases/Comments.kt"),
 	NestedClasses("/cases/NestedClasses.kt"),
+	NoClasses("/cases/NoClasses.kt"),
 	LongMethodPositive("/cases/LongMethodPositive.kt"),
 	LongMethodNegative("/cases/LongMethodNegative.kt"),
 	FeatureEnvy("/cases/FeatureEnvy.kt"),

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
@@ -19,4 +19,11 @@ class LargeClassSpec : SubjectSpek<LargeClass>({
 			assertEquals(subject.findings.size, 1)
 		}
 	}
+
+	describe("files without classes should not be considered") {
+		it("should not report anything in large files without classes") {
+			subject.lint(Case.NoClasses.path())
+			assertEquals(subject.findings.size, 0)
+		}
+	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
@@ -78,6 +78,16 @@ class SpacingBetweenPackageAndImportsSpec : SubjectSpek<SpacingBetweenPackageAnd
 				"""
 			assertCodeViolation(code, 0)
 		}
+
+		it("has no class") {
+			val code = """
+				package com.my.package
+
+				import android.util.Log
+				import java.util.concurrent.TimeUnit
+				"""
+			assertCodeViolation(code, 0)
+		}
 	}
 })
 

--- a/detekt-rules/src/test/resources/cases/NoClasses.kt
+++ b/detekt-rules/src/test/resources/cases/NoClasses.kt
@@ -1,0 +1,64 @@
+package cases
+
+/**
+ * @author Marvin Ramin
+ */
+const val test = 1
+
+fun test() {
+	println(test)
+	println(test)
+	println(test)
+	println(test)
+	println(test)
+	println(test)
+	println(test)
+	println(test)
+	println(test)
+	println(test)
+	println(test)
+	println(test)
+	println(test)
+	println(test)
+	println(test)
+	println(test)
+	println(test)
+	println(test)
+	println(1)
+	println(1)
+	for (i in 0..500) {
+		println(i)
+		longMethod()
+	}
+}
+
+fun longMethod() {
+	if (true) {
+		if (true) {
+			if (true) {
+				5.run {
+					this.let {
+						listOf(1, 2, 3).map { it * 2 }
+								.groupBy(Int::toString, Int::toString)
+					}
+				}
+			}
+		}
+	}
+
+	try {
+		for (i in 1..5) {
+			when (i) {
+				1 -> print(1)
+			}
+		}
+	} finally {
+
+	}
+}
+
+@Suppress("unused")
+/**
+ * Top level members must be skipped for LargeClass rule
+ */
+val aTopLevelProperty = 0


### PR DESCRIPTION
These two issues came up in #739 and failed the build. 

The `LargeClass` and `SpacingBetweenPackageAndImports` rules were running even though no `class` was defined in the file.