### PR TITLE
define inputs/outputs for detekt-generator task

### DIFF
--- a/detekt-generator/build.gradle
+++ b/detekt-generator/build.gradle
@@ -13,6 +13,14 @@ configurations {
 
 task generateDocumentation(dependsOn: ":detekt-generator:shadowJar") {
     description "Generates detekt documentation and the default config.yml based on Rule KDoc"
+
+    inputs.files(
+            fileTree("$rootProject.rootDir/detekt-rules/src/main/kotlin"),
+            file("$rootProject.rootDir/detekt-generator/build/libs/detekt-generator-$detektVersion-all.jar"))
+    outputs.files(
+            fileTree("$rootProject.rootDir/detekt-generator/documentation"),
+            file("$rootProject.rootDir/detekt-cli/src/main/resources/default-detekt-config.yml"))
+
     doLast {
         javaexec {
             main = "-jar"


### PR DESCRIPTION
Currently the `generateDocumentation` task runs on every single build. Even if nothing in the codebase has changed.

By defining these `inputs` and `outputs` the `generateDocumentation` will not run during every single build but if the inputs don't change it will report `UP-TO-DATE` and won't run again.