### PR TITLE
add task inputs/outputs to detektCheck task

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCheckTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCheckTask.kt
@@ -1,18 +1,37 @@
 package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import io.gitlab.arturbosch.detekt.extensions.INPUT_PARAMETER
+import io.gitlab.arturbosch.detekt.extensions.OUTPUT_PARAMETER
 import org.gradle.api.DefaultTask
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import java.io.File
 
 /**
  * @author Artur Bosch
  */
 open class DetektCheckTask : DefaultTask() {
 
+	@InputDirectory
+	val input: File?
+
+	@OutputDirectory
+	val output: File?
+
 	init {
 		description = "Analyze your kotlin code with detekt."
 		group = "verification"
+
+		val detektExtension = project.extensions.getByName("detekt") as DetektExtension
+		val arguments = detektExtension.resolveArguments(project)
+		val inputIndex = arguments.indexOf(INPUT_PARAMETER)
+		input = File(arguments[inputIndex + 1])
+
+		val outputIndex = arguments.indexOf(OUTPUT_PARAMETER)
+		output = File(arguments[outputIndex + 1])
 	}
 
 	@TaskAction

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCheckTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCheckTask.kt
@@ -12,6 +12,7 @@ import java.io.File
 
 /**
  * @author Artur Bosch
+ * @author Marvin Ramin
  */
 open class DetektCheckTask : DefaultTask() {
 


### PR DESCRIPTION
This is a very basic implementation to make the `detektCheck` `UP-TO-DATE` when running on the exact same sources. 

However in the current setup that `detekt` uses for the `detektCheck` task we define `--input` as the root directory of the project, which will have changes after running the task and thus it won't be `UP-TO-DATE`. But if `input` and `output` are set to decent values it works.

Also the implementation is a bit hacky, looking at the list of arguments. This should be improved later.

This should resolve #725 