### PR TITLE
Change exceptions property to throwable - #109

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -176,7 +176,7 @@ exceptions:
     active: false
   TooGenericExceptionCaught:
     active: true
-    exceptions:
+    exceptionNames:
      - ArrayIndexOutOfBoundsException
      - Error
      - Exception
@@ -187,10 +187,9 @@ exceptions:
      - Throwable
   TooGenericExceptionThrown:
     active: true
-    exceptions:
+    exceptionNames:
      - Error
      - Exception
-     - NullPointerException
      - Throwable
      - RuntimeException
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.psi.KtCatchClause
  * }
  * </compliant>
  *
- * @configuration exceptions - exceptions which are too generic and should not be caught
+ * @configuration exceptionNames - exceptions which are too generic and should not be caught
  * (default: - ArrayIndexOutOfBoundsException
  *			 - Error
  *			 - Exception
@@ -65,7 +65,7 @@ class TooGenericExceptionCaught(config: Config) : Rule(config) {
 	}
 
 	companion object {
-		const val CAUGHT_EXCEPTIONS_PROPERTY = "exceptions"
+		const val CAUGHT_EXCEPTIONS_PROPERTY = "exceptionNames"
 	}
 }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
@@ -30,10 +30,9 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  * }
  * </compliant>
  *
- * @configuration exceptions - exceptions which are too generic and should not be thrown
+ * @configuration exceptionNames - exceptions which are too generic and should not be thrown
  * (default: - Error
  * 			 - Exception
- * 			 - NullPointerException
  *			 - Throwable
  * 			 - RuntimeException)
  *
@@ -60,14 +59,13 @@ class TooGenericExceptionThrown(config: Config) : Rule(config) {
 	}
 
 	companion object {
-		const val THROWN_EXCEPTIONS_PROPERTY = "exceptions"
+		const val THROWN_EXCEPTIONS_PROPERTY = "exceptionNames"
 	}
 }
 
 val thrownExceptionDefaults = listOf(
 		"Error",
 		"Exception",
-		"NullPointerException",
 		"Throwable",
 		"RuntimeException"
 )

--- a/detekt-rules/src/test/resources/deactivated-exceptions.yml
+++ b/detekt-rules/src/test/resources/deactivated-exceptions.yml
@@ -2,9 +2,9 @@ exceptions:
   active: true
   TooGenericExceptionCaught:
     active: true
-    exceptions:
+    exceptionNames:
       -
   TooGenericExceptionThrown:
     active: true
-    exceptions:
+    exceptionNames:
       -

--- a/docs/pages/documentation/exceptions.md
+++ b/docs/pages/documentation/exceptions.md
@@ -292,7 +292,7 @@ exception is too broad it can lead to unintended exceptions being caught.
 
 #### Configuration options:
 
-* `exceptions` (default: `- ArrayIndexOutOfBoundsException
+* `exceptionNames` (default: `- ArrayIndexOutOfBoundsException
 - Error
 - Exception
 - IllegalMonitorStateException
@@ -330,9 +330,8 @@ exceptions to the case that has currently occurred.
 
 #### Configuration options:
 
-* `exceptions` (default: `- Error
+* `exceptionNames` (default: `- Error
 - Exception
-- NullPointerException
 - Throwable
 - RuntimeException`)
 


### PR DESCRIPTION
@andrejp88 suggested to rename the property as it might cause confusion.

For TooGenericExceptionThrown we have:
```
 * @configuration throwable - exceptions which are too generic and should not be thrown
 * (default: - Error
 * 			 - Exception
 * 			 - NullPointerException
 *			 - Throwable
 * 			 - RuntimeException)
```

I'm +1 to remove `NullPointerException` from that list as it is very specific and not generic. What do you think?