### PR TITLE
Remove useTabs from sample Maven config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,6 @@ dependencies {
                                 <arg value="${basedir}/src"/>
                                 <arg value="-f"/>
                                 <arg value=".*test.*"/>
-                                <arg value="--useTabs"/>
                             </java>
                         </target>
                     </configuration>


### PR DESCRIPTION
The presence of this property causes a project set up with the sample configuration to fail with:
detekt:
   [detekt] Was passed main parameter '--useTabs' but no main parameter was defined in your arg class
   [detekt] 
   [detekt] Usage: detekt [options]
   [detekt]   Options:
It looks like this property was removed in #326