### PR TITLE
Add trailing whitespace rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Dmitry Primshyts](https://github.com/deeprim) - Rule improvement: MagicNumber
 - [Egor Neliuba](https://github.com/egor-n) - Rule improvement: EmptyFunctionBlock, EmptyClassBlock
 - [Said Tahsin Dane](https://github.com/tasomaniac/) - Gradle plugin improvements
+- [Misa Torres](https://github.com/misaelmt) - Trailing whitespace rule
 
 ### <a name="mentions">Mentions</a>
 

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -355,6 +355,8 @@ style:
   ThrowsCount:
     active: true
     max: 2
+  TrailingWhitespace:
+    active: false
   UnnecessaryAbstractClass:
     active: false
   UnnecessaryInheritance:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
@@ -13,13 +13,15 @@ import org.jetbrains.kotlin.psi.KtFile
 class FileParsingRule(val config: Config = Config.empty) : MultiRule() {
 
 	private val maxLineLength = MaxLineLength(config)
-	override val rules = listOf<Rule>(maxLineLength)
+	private val trailingWhitespace = TrailingWhitespace(config)
+	override val rules = listOf<Rule>(maxLineLength, trailingWhitespace)
 
 	override fun visitKtFile(file: KtFile) {
 		val lines = file.text.splitToSequence("\n")
 		val fileContents = KtFileContent(file, lines)
 
 		maxLineLength.runIfActive { visit(fileContents) }
+		trailingWhitespace.runIfActive { visit(fileContents) }
 	}
 }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespace.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespace.kt
@@ -1,0 +1,34 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+
+/**
+ * This rule reports lines that end with a whitespace.
+ *
+ * @author Misa Torres
+ */
+class TrailingWhitespace(config: Config = Config.empty) : Rule(config) {
+
+	override val issue = Issue(javaClass.simpleName,
+			Severity.Style,
+			"Checks which lines end with a whitespace.",
+			Debt.FIVE_MINS)
+
+	fun visit(ktFileContent: KtFileContent) {
+		ktFileContent.content.forEachIndexed { index, line ->
+			if (line.isNotEmpty()) {
+				val lastChar = line.last()
+				if (lastChar == ' ' || lastChar == '\t') {
+					report(CodeSmell(issue, Entity.from(ktFileContent.file, line.length - 1),
+							"Line ${index + 1} ends with a whitespace."))
+				}
+			}
+		}
+	}
+}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/Case.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/Case.kt
@@ -71,7 +71,9 @@ enum class Case(val file: String) {
 	UnconditionalJumpStatementInLoopNegative("/cases/UnconditionalJumpStatementInLoopNegative.kt"),
 	UnconditionalJumpStatementInLoopPositive("/cases/UnconditionalJumpStatementInLoopPositive.kt"),
 	NestedClassVisibilityPositive("/cases/NestedClassVisibilityPositive.kt"),
-	NestedClassVisibilityNegative("/cases/NestedClassVisibilityNegative.kt");
+	NestedClassVisibilityNegative("/cases/NestedClassVisibilityNegative.kt"),
+	TrailingWhitespaceNegative("/cases/TrailingWhitespaceNegative.kt"),
+	TrailingWhitespacePositive("/cases/TrailingWhitespacePositive.kt");
 
 	fun path(): Path = Paths.get(resource(file))
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
@@ -1,0 +1,34 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.rules.Case
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileForTest
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+
+class TrailingWhitespaceSpec : Spek({
+
+	given("a kt file that contains lines that end with a whitespace") {
+		it("should flag it") {
+			val rule = TrailingWhitespace()
+			rule.visit(getKtFileContent(Case.TrailingWhitespacePositive))
+			assertThat(rule.findings).hasSize(7)
+		}
+	}
+
+	given("a kt file that does not contain lines that end with a whitespace") {
+		it("should not flag it") {
+			val rule = TrailingWhitespace()
+			rule.visit(getKtFileContent(Case.TrailingWhitespaceNegative))
+			assertThat(rule.findings).hasSize(0)
+		}
+	}
+})
+
+private fun getKtFileContent(case: Case): KtFileContent {
+	val file = compileForTest(case.path())
+	val lines = file.text.splitToSequence("\n")
+	val ktFileContent = KtFileContent(file, lines)
+	return ktFileContent
+}

--- a/detekt-rules/src/test/resources/cases/TrailingWhitespaceNegative.kt
+++ b/detekt-rules/src/test/resources/cases/TrailingWhitespaceNegative.kt
@@ -1,0 +1,8 @@
+package cases
+
+class TrailingWhitespaceNegative {
+
+	fun myFunction() {
+		println("A message")
+	}
+}

--- a/detekt-rules/src/test/resources/cases/TrailingWhitespacePositive.kt
+++ b/detekt-rules/src/test/resources/cases/TrailingWhitespacePositive.kt
@@ -1,0 +1,10 @@
+package cases
+
+ 
+// A comment 
+class TrailingWhitespacePositive { 
+    
+	fun myFunction() { 
+		println("A message")	
+	}  
+}

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -594,6 +594,10 @@ fun foo(i: Int) {
 }
 ```
 
+### TrailingWhitespace
+
+This rule reports lines that end with a whitespace.
+
 ### UnnecessaryAbstractClass
 
 This rule inspects `abstract` classes. In case an `abstract class` does not have any concrete members it should be


### PR DESCRIPTION
I didn't add \<compliant\> and \<noncompliant\> blocks to the KDoc because it's really easy to understand what the rule does and it's hard to see those white spaces at the end of the lines in the KDoc comments.