### PR TITLE
Add no tabs rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Dmitry Primshyts](https://github.com/deeprim) - Rule improvement: MagicNumber
 - [Egor Neliuba](https://github.com/egor-n) - Rule improvement: EmptyFunctionBlock, EmptyClassBlock
 - [Said Tahsin Dane](https://github.com/tasomaniac/) - Gradle plugin improvements
-- [Misa Torres](https://github.com/misaelmt) - Trailing whitespace rule
+- [Misa Torres](https://github.com/misaelmt) - Added: TrailingWhitespace and NoTabs rules
 
 ### <a name="mentions">Mentions</a>
 

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -332,6 +332,8 @@ style:
     active: false
   NewLineAtEndOfFile:
     active: true
+  NoTabs:
+    active: false
   OptionalAbstractKeyword:
     active: true
   OptionalUnit:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
@@ -14,7 +14,8 @@ class FileParsingRule(val config: Config = Config.empty) : MultiRule() {
 
 	private val maxLineLength = MaxLineLength(config)
 	private val trailingWhitespace = TrailingWhitespace(config)
-	override val rules = listOf<Rule>(maxLineLength, trailingWhitespace)
+	private val noTabs = NoTabs(config)
+	override val rules = listOf(maxLineLength, trailingWhitespace, noTabs)
 
 	override fun visitKtFile(file: KtFile) {
 		val lines = file.text.splitToSequence("\n")
@@ -22,6 +23,7 @@ class FileParsingRule(val config: Config = Config.empty) : MultiRule() {
 
 		maxLineLength.runIfActive { visit(fileContents) }
 		trailingWhitespace.runIfActive { visit(fileContents) }
+		noTabs.runIfActive { visit(fileContents) }
 	}
 }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabs.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabs.kt
@@ -1,0 +1,35 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+
+/**
+ * This rule reports if tabs are used in Kotlin files.
+ * According to
+ * [Google's Kotlin style guide](https://android.github.io/kotlin-guides/style.html#whitespace-characters)
+ * the only whitespace chars that are allowed in a source file are the line terminator sequence
+ * and the ASCII horizontal space character (0x20).
+ *
+ * @author Misa Torres
+ */
+class NoTabs(config: Config = Config.empty) : Rule(config) {
+
+	override val issue = Issue(javaClass.simpleName,
+			Severity.Style,
+			"Checks if tabs are used in Kotlin files.",
+			Debt.FIVE_MINS)
+
+	fun visit(ktFileContent: KtFileContent) {
+		ktFileContent.content.forEachIndexed { index, line ->
+			if (line.contains('\t')) {
+				report(CodeSmell(issue, Entity.from(ktFileContent.file),
+						"Line ${index + 1} uses the tab character."))
+			}
+		}
+	}
+}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/Case.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/Case.kt
@@ -1,5 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules
 
+import io.gitlab.arturbosch.detekt.rules.style.KtFileContent
+import io.gitlab.arturbosch.detekt.test.compileForTest
 import io.gitlab.arturbosch.detekt.test.resource
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -73,7 +75,16 @@ enum class Case(val file: String) {
 	NestedClassVisibilityPositive("/cases/NestedClassVisibilityPositive.kt"),
 	NestedClassVisibilityNegative("/cases/NestedClassVisibilityNegative.kt"),
 	TrailingWhitespaceNegative("/cases/TrailingWhitespaceNegative.kt"),
-	TrailingWhitespacePositive("/cases/TrailingWhitespacePositive.kt");
+	TrailingWhitespacePositive("/cases/TrailingWhitespacePositive.kt"),
+	NoTabsNegative("/cases/NoTabsNegative.kt"),
+	NoTabsPositive("/cases/NoTabsPositive.kt");
 
 	fun path(): Path = Paths.get(resource(file))
+
+	fun getKtFileContent(): KtFileContent {
+		val file = compileForTest(path())
+		val lines = file.text.splitToSequence("\n")
+		val ktFileContent = KtFileContent(file, lines)
+		return ktFileContent
+	}
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RunRuleSetWithRuleFiltersSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RunRuleSetWithRuleFiltersSpec.kt
@@ -54,7 +54,7 @@ class RunRuleSetWithRuleFiltersSpec : Spek({
 
 		it("should filter all rules") {
 			val ruleSet = RuleSet("Test", listOf(FileParsingRule(), OptionalUnit()))
-			assertThat(ruleSet.accept(emptyFile, setOf("MaxLineLength", "OptionalUnit"))).isEmpty()
+			assertThat(ruleSet.accept(emptyFile, setOf("MaxLineLength", "NoTabs", "OptionalUnit"))).isEmpty()
 		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabsSpec.kt
@@ -1,0 +1,26 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.rules.Case
+import io.gitlab.arturbosch.detekt.test.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+
+class NoTabsSpec : Spek({
+
+	given("a line that contains a tab") {
+		it("should flag it") {
+			val rule = NoTabs()
+			rule.visit(Case.NoTabsPositive.getKtFileContent())
+			assertThat(rule.findings).hasSize(3)
+		}
+	}
+
+	given("a line that does not contain a tab") {
+		it("should not flag it") {
+			val rule = NoTabs()
+			rule.visit(Case.NoTabsNegative.getKtFileContent())
+			assertThat(rule.findings).hasSize(0)
+		}
+	}
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
@@ -12,7 +11,7 @@ class TrailingWhitespaceSpec : Spek({
 	given("a kt file that contains lines that end with a whitespace") {
 		it("should flag it") {
 			val rule = TrailingWhitespace()
-			rule.visit(getKtFileContent(Case.TrailingWhitespacePositive))
+			rule.visit(Case.TrailingWhitespacePositive.getKtFileContent())
 			assertThat(rule.findings).hasSize(7)
 		}
 	}
@@ -20,15 +19,8 @@ class TrailingWhitespaceSpec : Spek({
 	given("a kt file that does not contain lines that end with a whitespace") {
 		it("should not flag it") {
 			val rule = TrailingWhitespace()
-			rule.visit(getKtFileContent(Case.TrailingWhitespaceNegative))
+			rule.visit(Case.TrailingWhitespaceNegative.getKtFileContent())
 			assertThat(rule.findings).hasSize(0)
 		}
 	}
 })
-
-private fun getKtFileContent(case: Case): KtFileContent {
-	val file = compileForTest(case.path())
-	val lines = file.text.splitToSequence("\n")
-	val ktFileContent = KtFileContent(file, lines)
-	return ktFileContent
-}

--- a/detekt-rules/src/test/resources/cases/NoTabsNegative.kt
+++ b/detekt-rules/src/test/resources/cases/NoTabsNegative.kt
@@ -1,0 +1,8 @@
+package cases
+
+class NoTabsNegative {
+
+  fun methodOk() {
+    println("A message")
+  }
+}

--- a/detekt-rules/src/test/resources/cases/NoTabsPositive.kt
+++ b/detekt-rules/src/test/resources/cases/NoTabsPositive.kt
@@ -1,0 +1,9 @@
+package cases
+
+class NoTabsPositive {
+
+	fun methodOk() {
+		println("A message")
+
+	}
+}

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -340,6 +340,14 @@ internal class NestedClassesVisibility {
 
 This rule reports files which do not end with a line separator.
 
+### NoTabs
+
+This rule reports if tabs are used in Kotlin files.
+According to
+[Google's Kotlin style guide](https://android.github.io/kotlin-guides/style.html#whitespace-characters)
+the only whitespace chars that are allowed in a source file are the line terminator sequence
+and the ASCII horizontal space character (0x20).
+
 ### OptionalAbstractKeyword
 
 This rule reports `abstract` modifiers which are unnecessary and can be removed.


### PR DESCRIPTION
I didn't add <compliant> and <noncompliant> blocks to the KDoc because it's really easy to understand what the rule does and it's hard to see those tabs in the KDoc comments.