### PR TITLE
Do not write deprecated build fail properties to default config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ Export the default config with the `--generate-config` flag or copy and modify t
 
 #### Override defaults ([via `failFast` option](https://github.com/arturbosch/detekt/issues/179))
 
-Set `failFast: true` in your detekt.yml configuration file.  As a result, every rule will be enabled and `warningThreshold` and `errorThreshold` will be set to 0.  Weights can then be ignored and left untouched.
+Set `failFast: true` in your detekt.yml configuration file.  As a result, every rule will be enabled and `maxIssues` will be set to 0.  Weights can then be ignored and left untouched.
 
 To adjust, for example, the maxLineLength value, use this configuration file:
 ```
@@ -443,8 +443,7 @@ _detekt_ supports the Java (`@SuppressWarnings`) and Kotlin (`@Suppress`) style 
 _detekt_ now can throw a BuildFailure(Exception) and let the build fail with following config parameters:
 ```yaml
 build:
-  warningThreshold: 5 // Five weighted findings 
-  failThreshold: 10 // Ten weighted smells to fail the build
+  maxIssues: 10 // Ten weighted smells to fail the build
   weights:
     complexity: 2 // Whole complexity rule should add two for each finding.
     LongParameterList: 1 // The specific rule should not add two.

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -62,7 +62,7 @@ data class FailFastConfig(private val originalConfig: Config, private val defaul
 		@Suppress("UNCHECKED_CAST")
 		return when (key) {
 			"active" -> originalConfig.valueOrDefault(key, true) as T
-			"warningThreshold", "failThreshold" -> originalConfig.valueOrDefault(key, 0) as T
+			"maxIssues" -> originalConfig.valueOrDefault(key, 0) as T
 			else -> originalConfig.valueOrDefault(key, defaultConfig.valueOrDefault(key, default))
 		}
 	}

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -20,8 +20,6 @@ test-pattern: # Configure exclusions for test sources
     - 'TooManyFunctions'
 
 build:
-  warningThreshold: 5
-  failThreshold: 10
   maxIssues: 10
   weights:
     # complexity: 2

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigurationsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigurationsSpec.kt
@@ -85,12 +85,8 @@ internal class ConfigurationsSpec : Spek({
 			assertThat(config.subConfig("comments").subConfig("UndocumentedPublicClass").valueOrDefault("active", false)).isEqualTo(true)
 		}
 
-		it("should override warningThreshold to 0 by default") {
-			assertThat(config.subConfig("build").valueOrDefault("warningThreshold", -1)).isEqualTo(0)
-		}
-
-		it("should override failThreshold to 0 by default") {
-			assertThat(config.subConfig("build").valueOrDefault("failThreshold", -1)).isEqualTo(0)
+		it("should override maxIssues to 0 by default") {
+			assertThat(config.subConfig("build").valueOrDefault("maxIssues", -1)).isEqualTo(0)
 		}
 
 		it("should keep config from default") {
@@ -109,12 +105,8 @@ internal class ConfigurationsSpec : Spek({
 			assertThat(config.subConfig("comments").subConfig("CommentOverPrivateMethod").valueOrDefault("active", true)).isEqualTo(false)
 		}
 
-		it("should override warningThreshold when specified") {
-			assertThat(config.subConfig("build").valueOrDefault("warningThreshold", -1)).isEqualTo(1)
-		}
-
-		it("should override failThreshold when specified") {
-			assertThat(config.subConfig("build").valueOrDefault("failThreshold", -1)).isEqualTo(1)
+		it("should override maxIssues when specified") {
+			assertThat(config.subConfig("build").valueOrDefault("maxIssues", -1)).isEqualTo(1)
 		}
 	}
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/BuildFailureReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/BuildFailureReportSpec.kt
@@ -55,6 +55,11 @@ internal class BuildFailureReportSpec : SubjectSpek<BuildFailureReport>({
 				assertFails { subject.render(detektion) }
 			}
 
+			it("should throw a build failure error when maxIssues met") {
+				subject.init(TestConfig(mapOf("maxIssues" to "-2")))
+				assertFails { subject.render(detektion) }
+			}
+
 			it("should throw a build failure error even if warning threshold is also met") {
 				subject.init(TestConfig(mapOf("failThreshold" to "-2", "warningThreshold" to "-2")))
 				assertFails { subject.render(detektion) }

--- a/detekt-cli/src/test/resources/configs/fail-fast-override.yml
+++ b/detekt-cli/src/test/resources/configs/fail-fast-override.yml
@@ -3,6 +3,7 @@ failFast: true
 build:
   warningThreshold: 1
   failThreshold: 1
+  maxIssues: 1
 
 style:
   MaxLineLength:

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -80,8 +80,6 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
 	private fun defaultBuildConfiguration(): String {
 		return """
 			build:
-			  warningThreshold: 5
-			  failThreshold: 10
 			  maxIssues: 10
 			  weights:
 			    # complexity: 2

--- a/docs/pages/configurations.md
+++ b/docs/pages/configurations.md
@@ -97,7 +97,7 @@ processors:
 #### failfast property
 
 Set `failFast: true` in your detekt.yml configuration file.  
-As a result, every rule will be enabled and `warningThreshold` and `errorThreshold` will be set to 0.  
+As a result, every rule will be enabled and `maxIssues` will be set to 0.  
 Weights can then be ignored and left untouched.  
 
 

--- a/docs/pages/failonbuild.md
+++ b/docs/pages/failonbuild.md
@@ -13,8 +13,7 @@ For this the following code must be inside the detekt config:
 
 ```yaml
 build:
-  warningThreshold: 5 // print a warning when five weighted issues are found
-  failThreshold: 10 // break the build if ten weighted issues are found
+  maxIssues: 10 // break the build if ten weighted issues are found
   weights:
     complexity: 2 // every rule of the complexity rule set should count as if two issues were found...
     LongParameterList: 1 // ...with the exception of the LongParameterList rule.


### PR DESCRIPTION
- Closes#811
- for 1.0.GA we need to remove all the code for `warningThreshold` and `failThreshold`

