### PR TITLE
Change Debt value for TopLevelPropertyNaming, UnusedImports & UnusedPrivateMember.

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -48,6 +48,7 @@ data class Debt(val days: Int = 0, val hours: Int = 0, val mins: Int = 0) {
 		val TWENTY_MINS = Debt(0, 0, 20)
 		val TEN_MINS = Debt(0, 0, 10)
 		val FIVE_MINS = Debt(0, 0, 5)
+		val ONE_MIN = Debt(0, 0, 1)
 	}
 
 	override fun toString(): String {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
@@ -27,7 +27,7 @@ class TopLevelPropertyNaming(config: Config = Config.empty) : Rule(config) {
 	override val issue = Issue(javaClass.simpleName,
 			Severity.Style,
 			"Top level constant names should follow the naming convention set in the projects configuration.",
-			debt = Debt.FIVE_MINS)
+			debt = Debt.ONE_MIN)
 
 	private val constantPattern = Regex(valueOrDefault(CONSTANT_PATTERN, "[A-Z][_A-Z0-9]*"))
 	private val propertyPattern = Regex(valueOrDefault(PROPERTY_PATTERN, "[a-z][A-Za-z0-9]*"))

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -27,7 +27,7 @@ class UnusedImports(config: Config) : Rule(config) {
 			javaClass.simpleName,
 			Severity.Style,
 			"Unused Imports are dead code and should be removed.",
-			Debt.FIVE_MINS)
+			Debt.ONE_MIN)
 
 	private val operatorSet = setOf("unaryPlus", "unaryMinus", "not", "inc", "dec", "plus", "minus", "times", "div",
 			"mod", "rangeTo", "contains", "get", "set", "invoke", "plusAssign", "minusAssign", "timesAssign", "divAssign",

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -31,7 +31,7 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 	override val issue: Issue = Issue("UnusedPrivateMember",
 			Severity.Maintainability,
 			"Private member is unused.",
-			Debt.FIVE_MINS)
+			Debt.ONE_MIN)
 
 	override fun visitClassOrObject(classOrObject: KtClassOrObject) {
 		val propertyVisitor = UnusedPropertyVisitor()


### PR DESCRIPTION
I really like that the `Debt` is shown in the reports now however I feel like the estimates should be closer to how much you actually spend removing the code smell.

Ideally, the overall debt could be a realistic estimate how much time you'd need to spend in a new code base which isn't using Detekt yet.

Probably before 1.0 we should go through all of the issues and do some planning poker :D