### PR TITLE
Added option to exclude comments from MaxLineLength

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [ ![Download](https://api.bintray.com/packages/arturbosch/code-analysis/detekt/images/download.svg) ](https://bintray.com/arturbosch/code-analysis/detekt/_latestVersion)
 [![gradle plugin](https://img.shields.io/badge/gradle_plugin-1.0.0.RC6.4-blue.svg?style=flat-square)](https://plugins.gradle.org/plugin/io.gitlab.arturbosch.detekt)
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-40-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-41-orange.svg?style=flat-square)](#contributors)
 [![Awesome Kotlin Badge](https://kotlin.link/awesome-kotlin.svg)](https://github.com/KotlinBy/awesome-kotlin)
 
 Meet _detekt_, a static code analysis tool for the _Kotlin_ programming language.
@@ -647,6 +647,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Said Tahsin Dane](https://github.com/tasomaniac/) - Gradle plugin improvements
 - [Misa Torres](https://github.com/misaelmt) - Added: TrailingWhitespace and NoTabs rules
 - [R.A. Porter](https://github.com/coyotesqrl) - Updated Readme links to RuleSets
+- [Robbin Voortman](https://github.com/rvoortman) - Rule improvement: MaxLineLength
 
 ### <a name="mentions">Mentions</a>
 

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -323,6 +323,7 @@ style:
     maxLineLength: 120
     excludePackageStatements: false
     excludeImportStatements: false
+    excludeCommentStatements: false
   MayBeConst:
     active: false
   ModifierOrder:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -38,8 +38,10 @@ data class KtFileContent(val file: KtFile, val content: Sequence<String>)
  * @configuration maxLineLength - maximum line length (default: 120)
  * @configuration excludePackageStatements - if package statements should be ignored (default: false)
  * @configuration excludeImportStatements - if import statements should be ignored (default: false)
+ * @configuration excludeCommentStatements - if comment statements should be ignored (default: false)
  *
  * @active since v1.0.0
+ * @author Robbin Voortman
  * @author Marvin Ramin
  * @author Artur Bosch
  */
@@ -56,6 +58,8 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 			= valueOrDefault(MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS, MaxLineLength.DEFAULT_VALUE_PACKAGE_EXCLUDE)
 	private val excludeImportStatements: Boolean
 			= valueOrDefault(MaxLineLength.EXCLUDE_IMPORT_STATEMENTS, MaxLineLength.DEFAULT_VALUE_IMPORTS_EXCLUDE)
+	private val excludeCommentStatements: Boolean
+			= valueOrDefault(MaxLineLength.EXCLUDE_COMMENT_STATEMENTS, MaxLineLength.DEFAULT_VALUE_COMMENT_EXCLUDE)
 
 	fun visit(element: KtFileContent) {
 		var offset = 0
@@ -75,7 +79,8 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 	private fun isValidLine(line: String): Boolean {
 		return (line.length <= maxLineLength
 				|| containsIgnoredPackageStatement(line)
-				|| containsIgnoredImportStatement(line))
+				|| containsIgnoredImportStatement(line)
+				|| containsIgnoredCommentStatement(line))
 	}
 
 	private fun containsIgnoredPackageStatement(line: String): Boolean {
@@ -92,6 +97,13 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 		return false
 	}
 
+	private fun containsIgnoredCommentStatement(line: String): Boolean {
+		if (excludeCommentStatements) {
+			return line.contains("//") || line.contains("/*") || line.trimStart().startsWith("*")
+		}
+		return false
+	}
+
 	companion object {
 		const val MAX_LINE_LENGTH = "maxLineLength"
 		const val DEFAULT_IDEA_LINE_LENGTH = 120
@@ -101,6 +113,8 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 
 		const val EXCLUDE_IMPORT_STATEMENTS = "excludeImportStatements"
 		const val DEFAULT_VALUE_IMPORTS_EXCLUDE = false
+
+		const val EXCLUDE_COMMENT_STATEMENTS = "excludeCommentStatements"
+		const val DEFAULT_VALUE_COMMENT_EXCLUDE = false
 	}
 }
-

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -77,10 +77,13 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 	}
 
 	private fun isValidLine(line: String): Boolean {
-		return (line.length <= maxLineLength
-				|| containsIgnoredPackageStatement(line)
-				|| containsIgnoredImportStatement(line)
-				|| containsIgnoredCommentStatement(line))
+		return (line.length <= maxLineLength || isIgnoredStatement(line))
+	}
+
+	private fun isIgnoredStatement(line: String): Boolean {
+		return containsIgnoredPackageStatement(line) ||
+				containsIgnoredImportStatement(line) ||
+				containsIgnoredCommentStatement(line)
 	}
 
 	private fun containsIgnoredPackageStatement(line: String): Boolean {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -87,26 +87,23 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 	}
 
 	private fun containsIgnoredPackageStatement(line: String): Boolean {
-		if (excludePackageStatements) {
-			return line.trimStart().startsWith("package ")
-		}
-		return false
+		if (!excludePackageStatements) return false
+
+		return line.trimStart().startsWith("package ")
 	}
 
 	private fun containsIgnoredImportStatement(line: String): Boolean {
-		if (excludeImportStatements) {
-			return line.trimStart().startsWith("import ")
-		}
-		return false
+		if(!excludeImportStatements) return false
+
+		return line.trimStart().startsWith("import ")
 	}
 
 	private fun containsIgnoredCommentStatement(line: String): Boolean {
-		if (excludeCommentStatements) {
-			return  line.trimStart().startsWith("//") ||
-					line.trimStart().startsWith("/*") ||
-					line.trimStart().startsWith("*")
-		}
-		return false
+		if (!excludeCommentStatements) return false
+
+		return  line.trimStart().startsWith("//") ||
+				line.trimStart().startsWith("/*") ||
+				line.trimStart().startsWith("*")
 	}
 
 	companion object {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -99,7 +99,9 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 
 	private fun containsIgnoredCommentStatement(line: String): Boolean {
 		if (excludeCommentStatements) {
-			return line.contains("//") || line.contains("/*") || line.trimStart().startsWith("*")
+			return  line.trimStart().startsWith("//") ||
+					line.trimStart().startsWith("/*") ||
+					line.trimStart().startsWith("*")
 		}
 		return false
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/Case.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/Case.kt
@@ -41,6 +41,7 @@ enum class Case(val file: String) {
 	NamingConventions("/cases/NamingConventions.kt"),
 	NewLineAtEndOfFile("/cases/NewLineAtEndOfFile.kt"),
 	MaxLineLength("/cases/MaxLineLength.kt"),
+	MaxLineLengthWithLongComments("/cases/MaxLineLengthWithLongComments.kt"),
 	MemberNameEqualsClassNameNegative("/cases/MemberNameEqualsClassNameNegative.kt"),
 	MemberNameEqualsClassNamePositive("/cases/MemberNameEqualsClassNamePositive.kt"),
 	OverloadedMethods("/cases/OverloadedMethods.kt"),

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -18,7 +18,7 @@ class MaxLineLengthSpec : Spek({
 
 		it("should report no errors when maxLineLength is set to 200") {
 			val rule = MaxLineLength(TestConfig(mapOf("maxLineLength" to "200")))
-
+ 
 			rule.visit(fileContent)
 			assertThat(rule.findings).isEmpty()
 		}
@@ -27,7 +27,7 @@ class MaxLineLengthSpec : Spek({
 			val rule = MaxLineLength()
 
 			rule.visit(fileContent)
-			assertThat(rule.findings).hasSize(3)
+			assertThat(rule.findings).hasSize(6)
 		}
 	}
 
@@ -94,6 +94,56 @@ class MaxLineLengthSpec : Spek({
 
 			rule.visit(fileContent)
 			assertThat(rule.findings).isEmpty()
+		}
+	}
+	given("a kt file with a long package name, long import statements, a long line and long comments") {
+		val code = """
+			package anIncrediblyLongAndComplexPackageNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
+
+			import anIncrediblyLongAndComplexImportNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
+
+			class Test {
+				fun anIncrediblyLongAndComplexMethodNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot() {}
+			}
+			// anIncrediblyLongAndComplexCommentThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
+			/* anIncrediblyLongAndComplexCommentThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot */
+			/*
+			* anIncrediblyLongAndComplexCommentThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
+			*/
+		""".trim()
+		val file = compileContentForTest(code)
+		val lines = file.text.splitToSequence("\n")
+		val fileContent = KtFileContent(file, lines)
+
+		it("should report the package statement, import statements, line and comments by default") {
+			val rule = MaxLineLength(TestConfig(mapOf(
+					"maxLineLength" to "60"
+			)))
+
+			rule.visit(fileContent)
+			assertThat(rule.findings).hasSize(6)
+		}
+
+		it("should report the package statement, import statements, line and comments if they're enabled") {
+			val rule = MaxLineLength(TestConfig(mapOf(
+					"maxLineLength" to "60",
+					"excludePackageStatements" to "false",
+					"excludeImportStatements" to "false",
+					"excludeCommentStatements" to "false"
+			)))
+
+			rule.visit(fileContent)
+			assertThat(rule.findings).hasSize(6)
+		}
+
+		it("should not report comments if they're disabled") {
+			val rule = MaxLineLength(TestConfig(mapOf(
+					"maxLineLength" to "60",
+					"excludeCommentStatements" to "true"
+			)))
+
+			rule.visit(fileContent)
+			assertThat(rule.findings).hasSize(3)
 		}
 	}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -27,7 +27,7 @@ class MaxLineLengthSpec : Spek({
 			val rule = MaxLineLength()
 
 			rule.visit(fileContent)
-			assertThat(rule.findings).hasSize(6)
+			assertThat(rule.findings).hasSize(3)
 		}
 	}
 
@@ -97,21 +97,7 @@ class MaxLineLengthSpec : Spek({
 		}
 	}
 	given("a kt file with a long package name, long import statements, a long line and long comments") {
-		val code = """
-			package anIncrediblyLongAndComplexPackageNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
-
-			import anIncrediblyLongAndComplexImportNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
-
-			class Test {
-				fun anIncrediblyLongAndComplexMethodNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot() {}
-			}
-			// anIncrediblyLongAndComplexCommentThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
-			/* anIncrediblyLongAndComplexCommentThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot */
-			/*
-			* anIncrediblyLongAndComplexCommentThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
-			*/
-		""".trim()
-		val file = compileContentForTest(code)
+		val file = compileForTest(Case.MaxLineLengthWithLongComments.path())
 		val lines = file.text.splitToSequence("\n")
 		val fileContent = KtFileContent(file, lines)
 
@@ -121,7 +107,7 @@ class MaxLineLengthSpec : Spek({
 			)))
 
 			rule.visit(fileContent)
-			assertThat(rule.findings).hasSize(6)
+			assertThat(rule.findings).hasSize(8)
 		}
 
 		it("should report the package statement, import statements, line and comments if they're enabled") {
@@ -133,7 +119,7 @@ class MaxLineLengthSpec : Spek({
 			)))
 
 			rule.visit(fileContent)
-			assertThat(rule.findings).hasSize(6)
+			assertThat(rule.findings).hasSize(8)
 		}
 
 		it("should not report comments if they're disabled") {
@@ -143,7 +129,7 @@ class MaxLineLengthSpec : Spek({
 			)))
 
 			rule.visit(fileContent)
-			assertThat(rule.findings).hasSize(3)
+			assertThat(rule.findings).hasSize(5)
 		}
 	}
 

--- a/detekt-rules/src/test/resources/cases/MaxLineLength.kt
+++ b/detekt-rules/src/test/resources/cases/MaxLineLength.kt
@@ -2,7 +2,12 @@ package cases
 
 @Suppress("unused")
 class MaxLineLength {
+	// Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+	/* Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. */
 
+	/*
+	* Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+	*/
 	companion object {
 		val LOREM_IPSUM = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
 	}

--- a/detekt-rules/src/test/resources/cases/MaxLineLengthWithLongComments.kt
+++ b/detekt-rules/src/test/resources/cases/MaxLineLengthWithLongComments.kt
@@ -1,7 +1,13 @@
 package cases
 
 @Suppress("unused")
-class MaxLineLength {
+class MaxLineLengthWithLongComments {
+	// Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+	/* Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. */
+
+	/*
+	* Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+	*/
 	companion object {
 		val LOREM_IPSUM = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
 	}
@@ -15,17 +21,10 @@ class MaxLineLength {
 			println("It's indeed a very long String")
 		}
 
-		val hello = anIncrediblyLongAndComplexMethodNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot()
 		val loremIpsum = getLoremIpsum()
 
-		println(hello)
 		println(loremIpsum)
 
 	}
-
-	fun anIncrediblyLongAndComplexMethodNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot(): String {
-		return "Hello"
-	}
-
 	fun getLoremIpsum() = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
 }

--- a/docs/pages/changelog.md
+++ b/docs/pages/changelog.md
@@ -11,7 +11,7 @@ toc: true
 - NoSuchElementException when running from build.gradle.kts - [#793](https://github.com/arturbosch/detekt/issues/793)
 - No files analysed if path contains test - [#792](https://github.com/arturbosch/detekt/issues/792)
 - Does detekt include copy/paste detector ? - [#789](https://github.com/arturbosch/detekt/issues/789)
-- @Suppress("MaxLineLength") at file-level doesn't work - [#788](https://github.com/arturbosch/detekt/issues/788)
+- @Suppress("MaxLineLenth") at file-level doesn't work - [#788](https://github.com/arturbosch/detekt/issues/788)
 - Update test dependencies and publish versions - [#787](https://github.com/arturbosch/detekt/pull/787)
 - Bitrise step to run detekt - [#785](https://github.com/arturbosch/detekt/issues/785)
 - Add no tabs rule - [#782](https://github.com/arturbosch/detekt/pull/782)

--- a/docs/pages/changelog.md
+++ b/docs/pages/changelog.md
@@ -11,7 +11,7 @@ toc: true
 - NoSuchElementException when running from build.gradle.kts - [#793](https://github.com/arturbosch/detekt/issues/793)
 - No files analysed if path contains test - [#792](https://github.com/arturbosch/detekt/issues/792)
 - Does detekt include copy/paste detector ? - [#789](https://github.com/arturbosch/detekt/issues/789)
-- @Suppress("MaxLineLenth") at file-level doesn't work - [#788](https://github.com/arturbosch/detekt/issues/788)
+- @Suppress("MaxLineLength") at file-level doesn't work - [#788](https://github.com/arturbosch/detekt/issues/788)
 - Update test dependencies and publish versions - [#787](https://github.com/arturbosch/detekt/pull/787)
 - Bitrise step to run detekt - [#785](https://github.com/arturbosch/detekt/issues/785)
 - Add no tabs rule - [#782](https://github.com/arturbosch/detekt/pull/782)

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -317,6 +317,10 @@ in the codebase will help make the code more uniform.
 
    if import statements should be ignored
 
+* `excludeCommentStatements` (default: `false`)
+
+   if comment statements should be ignored
+
 ### MayBeConst
 
 This rule identifies and reports properties (`val`) that may be `const val` instead.


### PR DESCRIPTION
This will add an option to exclude comments from the MaxLineLength rule.

Fixes #718 
