### PR TITLE
Splitted test cases for NamingRulesSpec

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -222,6 +222,7 @@ naming:
   ObjectPropertyNaming:
     active: true
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    constantPattern: '[A-Za-z][_A-Za-z0-9]*'
   PackageNaming:
     active: true
     packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtVariableDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 
@@ -28,6 +29,11 @@ fun KtClassOrObject.isObjectOfAnonymousClass() =
 fun KtCallExpression.isUsedForNesting(): Boolean = when (getCallNameExpression()?.text) {
 	"run", "let", "apply", "with", "use", "forEach" -> true
 	else -> false
+}
+
+fun KtVariableDeclaration.hasConstModifier(): Boolean {
+	val modifierList = this.modifierList
+	return modifierList != null && modifierList.hasModifier(KtTokens.CONST_KEYWORD)
 }
 
 fun KtBlockExpression.hasCommentInside(): Boolean {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
@@ -27,7 +27,7 @@ class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
 	private val propertyPattern = Regex(valueOrDefault(PROPERTY_PATTERN, "[A-Za-z][_A-Za-z\\d]*"))
 
 	override fun visitProperty(property: KtProperty) {
-		if (doesntMatchPattern((property))) {
+		if (doesNotMatchPattern((property))) {
 			report(CodeSmell(
 					issue,
 					Entity.from(property),
@@ -35,7 +35,8 @@ class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
 		}
 	}
 
-	fun doesntMatchPattern(element: KtVariableDeclaration) = !element.identifierName().matches(propertyPattern)
+	private fun doesNotMatchPattern(element: KtVariableDeclaration) =
+			!element.identifierName().matches(propertyPattern)
 
 	companion object {
 		const val PROPERTY_PATTERN = "propertyPattern"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.hasConstModifier
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtVariableDeclaration
 
@@ -14,8 +15,10 @@ import org.jetbrains.kotlin.psi.KtVariableDeclaration
  * Reports when property names inside objects which do not follow the specified naming convention are used.
  *
  * @configuration propertyPattern - naming pattern (default: '[A-Za-z][_A-Za-z0-9]*')
+ * @configuration constantPattern - naming pattern (default: '[A-Za-z][_A-Za-z0-9]*')
  * @active since v1.0.0
  * @author Marvin Ramin
+ * @author schalkms
  */
 class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
 
@@ -25,9 +28,18 @@ class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
 			debt = Debt.FIVE_MINS)
 
 	private val propertyPattern = Regex(valueOrDefault(PROPERTY_PATTERN, "[A-Za-z][_A-Za-z\\d]*"))
+	private val constantPattern = Regex(valueOrDefault(CONSTANT_PATTERN, "[A-Za-z][_A-Za-z\\d]*"))
 
 	override fun visitProperty(property: KtProperty) {
-		if (doesNotMatchPattern(property)) {
+		if (property.hasConstModifier()) {
+			reportIfNotMatching(property, constantPattern)
+		} else {
+			reportIfNotMatching(property, propertyPattern)
+		}
+	}
+
+	private fun reportIfNotMatching(property: KtProperty, pattern: Regex) {
+		if (doesNotMatchPattern(property, pattern)) {
 			report(CodeSmell(
 					issue,
 					Entity.from(property),
@@ -35,10 +47,11 @@ class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
 		}
 	}
 
-	private fun doesNotMatchPattern(element: KtVariableDeclaration) =
-			!element.identifierName().matches(propertyPattern)
+	private fun doesNotMatchPattern(element: KtVariableDeclaration, pattern: Regex) =
+			!element.identifierName().matches(pattern)
 
 	companion object {
 		const val PROPERTY_PATTERN = "propertyPattern"
+		const val CONSTANT_PATTERN = "constantPattern"
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
@@ -27,7 +27,7 @@ class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
 	private val propertyPattern = Regex(valueOrDefault(PROPERTY_PATTERN, "[A-Za-z][_A-Za-z\\d]*"))
 
 	override fun visitProperty(property: KtProperty) {
-		if (doesNotMatchPattern((property))) {
+		if (doesNotMatchPattern(property)) {
 			report(CodeSmell(
 					issue,
 					Entity.from(property),

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
@@ -7,9 +7,8 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
-import org.jetbrains.kotlin.lexer.KtTokens
+import io.gitlab.arturbosch.detekt.rules.hasConstModifier
 import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.psi.KtVariableDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
 /**
@@ -66,11 +65,6 @@ class TopLevelPropertyNaming(config: Config = Config.empty) : Rule(config) {
 						message = "Top level property names should match the pattern: $propertyPattern"))
 			}
 		}
-	}
-
-	private fun KtVariableDeclaration.hasConstModifier(): Boolean {
-		val modifierList = this.modifierList
-		return modifierList != null && modifierList.hasModifier(KtTokens.CONST_KEYWORD)
 	}
 
 	companion object {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
@@ -1,0 +1,63 @@
+package io.gitlab.arturbosch.detekt.rules.naming
+
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
+
+class NamingRulesSpec : SubjectSpek<NamingRules>({
+
+	subject { NamingRules() }
+
+	describe("properties in classes") {
+
+		it("should detect all positive cases") {
+			val code = """
+				class C {
+					private val _FIELD = 5
+					val FIELD get() = _field
+					val camel_Case_Property = 5
+					const val MY_CONST = 7
+					const val MYCONST = 7
+				}
+			"""
+			val findings = subject.lint(code)
+			assertThat(findings).hasSize(5)
+		}
+
+		it("checks all negative cases") {
+			val code = """
+				class C {
+					private val _field = 5
+					val field get() = _field
+					val camelCaseProperty = 5
+					const val myConst = 7
+
+					data class D(val i: Int, val j: Int)
+					fun doStuff() {
+						val (_, holyGrail) = D(5, 4)
+						emptyMap<String, String>().forEach { _, v -> println(v) }
+					}
+					val doable: (Int) -> Unit = { _ -> Unit }
+				}
+			"""
+			val findings = subject.lint(code)
+			assertThat(findings).isEmpty()
+		}
+	}
+
+	describe("naming like in constants is allowed for destructuring and lambdas") {
+		it("should not detect any") {
+			val code = """
+				data class D(val i: Int, val j: Int)
+				fun doStuff() {
+					val (_, HOLY_GRAIL) = D(5, 4)
+					emptyMap<String, String>().forEach { _, V -> println(v) }
+				}
+			"""
+			val findings = subject.lint(code)
+			assertThat(findings).isEmpty()
+		}
+	}
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -1,0 +1,73 @@
+package io.gitlab.arturbosch.detekt.rules.naming
+
+import io.gitlab.arturbosch.detekt.test.compileContentForTest
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
+
+class ObjectPropertyNamingSpec : SubjectSpek<ObjectPropertyNaming>({
+
+	subject { ObjectPropertyNaming() }
+
+	describe("constants in object declarations") {
+		val code = compileContentForTest("""
+			object O {
+				const val MY_NAME_8 = "Artur"
+				const val MYNAME = "Artur"
+				const val MyNAME = "Artur"
+				const val name = "Artur"
+				const val nAme = "Artur"
+				const val _nAme = "Artur" // invalid
+				const val serialVersionUID = 42L
+			}
+		""")
+
+		it("should detect one constant not matching [A-Za-z][_A-Za-z\\d]*") {
+			val findings = subject.lint(code)
+			assertThat(findings).hasSize(1)
+		}
+	}
+
+	describe("constants in companion object") {
+		val code = compileContentForTest("""
+			class C {
+				companion object {
+					const val MY_NAME_8 = "Artur"
+					const val MYNAME = "Artur"
+					const val MyNAME = "Artur"
+					const val name = "Artur"
+					const val nAme = "Artur"
+					const val _nAme = "Artur" // invalid
+					const val serialVersionUID = 42L
+				}
+			}
+		""")
+
+		it("should detect one constant not matching [A-Za-z][_A-Za-z\\d]*") {
+			val findings = subject.lint(code)
+			assertThat(findings).hasSize(1)
+		}
+	}
+
+	describe("variables in objects") {
+		val code = compileContentForTest("""
+			object O {
+				val MY_NAME = "Artur"
+				val MYNAME = "Artur"
+				val MyNAME = "Artur"
+				val name = "Artur"
+				val nAme8 = "Artur"
+				val _nAme = "Artur" // invalid
+				private val _name = "Artur" // invalid
+				val serialVersionUID = 42L
+			}
+		""")
+
+		it("should detect two object properties not matching [A-Za-z][_A-Za-z\\d]*") {
+			val findings = subject.lint(code)
+			assertThat(findings).hasSize(2)
+		}
+	}
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
@@ -68,6 +69,22 @@ class ObjectPropertyNamingSpec : SubjectSpek<ObjectPropertyNaming>({
 		it("should detect two object properties not matching [A-Za-z][_A-Za-z\\d]*") {
 			val findings = subject.lint(code)
 			assertThat(findings).hasSize(2)
+		}
+	}
+
+	describe("variables and constants in objects with custom config") {
+		val code = compileContentForTest("""
+			object O {
+				val _name = "Artur"
+				val NAME = "Artur" // invalid
+				const val MYNAME = "Artur"
+				const val myname = "Artur" // invalid
+			}
+		""")
+
+		it("should detect invalid variables and constants in object") {
+			val config = TestConfig(mapOf(ObjectPropertyNaming.CONSTANT_PATTERN to "[A-Z][_A-Z0-9]*"))
+			assertThat(ObjectPropertyNaming(config).lint(code)).hasSize(2)
 		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
@@ -23,7 +23,7 @@ class TopLevelPropertyNamingSpec : SubjectSpek<TopLevelPropertyNaming>({
 		""")
 
 		it("should detect five constants not matching [A-Z][_A-Z\\d]*") {
-			val findings = TopLevelPropertyNaming().lint(code)
+			val findings = subject.lint(code)
 			assertThat(findings).hasSize(5)
 		}
 	}
@@ -41,7 +41,7 @@ class TopLevelPropertyNamingSpec : SubjectSpek<TopLevelPropertyNaming>({
             val serialVersionUID = 42L
 		""")
 
-		val findings = TopLevelPropertyNaming().lint(code)
+		val findings = subject.lint(code)
 
 		it("should detect four top level variables not matching [a-z][A-Za-z\\d]*") {
 			assertThat(findings).hasSize(5)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
@@ -7,9 +7,9 @@ import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
 
-class TopLevelPropertyNamingSpec : SubjectSpek<NamingRules>({
+class TopLevelPropertyNamingSpec : SubjectSpek<TopLevelPropertyNaming>({
 
-	subject { NamingRules() }
+	subject { TopLevelPropertyNaming() }
 
 	describe("constants on top level") {
 		val code = compileContentForTest("""
@@ -41,7 +41,7 @@ class TopLevelPropertyNamingSpec : SubjectSpek<NamingRules>({
             val serialVersionUID = 42L
 		""")
 
-		val findings = subject.lint(code)
+		val findings = TopLevelPropertyNaming().lint(code)
 
 		it("should detect four top level variables not matching [a-z][A-Za-z\\d]*") {
 			assertThat(findings).hasSize(5)
@@ -49,117 +49,6 @@ class TopLevelPropertyNamingSpec : SubjectSpek<NamingRules>({
 
 		it("should allow underscores in private property") {
 			assertThat(findings.find { it.name == "_name" }).isNull()
-		}
-	}
-
-	describe("constants in object declarations") {
-		val code = compileContentForTest("""
-			object O {
-				const val MY_NAME_8 = "Artur"
-				const val MYNAME = "Artur"
-				const val MyNAME = "Artur"
-				const val name = "Artur"
-				const val nAme = "Artur"
-				const val _nAme = "Artur" // invalid
-				const val serialVersionUID = 42L
-			}
-		""")
-
-		it("should detect one constant not matching [A-Za-z][_A-Za-z\\d]*") {
-			val findings = subject.lint(code)
-			assertThat(findings).hasSize(1)
-		}
-	}
-
-	describe("constants in companion object") {
-		val code = compileContentForTest("""
-			class C {
-				companion object {
-					const val MY_NAME_8 = "Artur"
-					const val MYNAME = "Artur"
-					const val MyNAME = "Artur"
-					const val name = "Artur"
-					const val nAme = "Artur"
-					const val _nAme = "Artur" // invalid
-					const val serialVersionUID = 42L
-				}
-			}
-		""")
-
-		it("should detect one constant not matching [A-Za-z][_A-Za-z\\d]*") {
-			val findings = subject.lint(code)
-			assertThat(findings).hasSize(1)
-		}
-	}
-
-	describe("variables in objects") {
-		val code = compileContentForTest("""
-			object O {
-				val MY_NAME = "Artur"
-				val MYNAME = "Artur"
-				val MyNAME = "Artur"
-				val name = "Artur"
-				val nAme8 = "Artur"
-				val _nAme = "Artur" // invalid
-				private val _name = "Artur" // invalid
-				val serialVersionUID = 42L
-			}
-		""")
-
-		it("should detect two object properties not matching [A-Za-z][_A-Za-z\\d]*") {
-			val findings = subject.lint(code)
-			assertThat(findings).hasSize(2)
-		}
-	}
-
-	describe("properties in classes") {
-
-		it("should detect all positive cases") {
-			val code = """
-				class C {
-					private val _FIELD = 5
-					val FIELD get() = _field
-					val camel_Case_Property = 5
-					const val MY_CONST = 7
-					const val MYCONST = 7
-				}
-			"""
-			val findings = subject.lint(code)
-			assertThat(findings).hasSize(5)
-		}
-
-		it("checks all negative cases") {
-			val code = """
-				class C {
-					private val _field = 5
-					val field get() = _field
-					val camelCaseProperty = 5
-					const val myConst = 7
-
-					data class D(val i: Int, val j: Int)
-					fun doStuff() {
-						val (_, holyGrail) = D(5, 4)
-						emptyMap<String, String>().forEach { _, v -> println(v) }
-					}
-					val doable: (Int) -> Unit = { _ -> Unit }
-				}
-			"""
-			val findings = subject.lint(code)
-			assertThat(findings).isEmpty()
-		}
-	}
-
-	describe("naming like in constants is allowed for destructuring and lambdas") {
-		it("should not detect any") {
-			val code = """
-				data class D(val i: Int, val j: Int)
-				fun doStuff() {
-					val (_, HOLY_GRAIL) = D(5, 4)
-					emptyMap<String, String>().forEach { _, V -> println(v) }
-				}
-			"""
-			val findings = subject.lint(code)
-			assertThat(findings).isEmpty()
 		}
 	}
 })

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -193,6 +193,10 @@ Reports when property names inside objects which do not follow the specified nam
 
    naming pattern
 
+* `constantPattern` (default: `'[A-Za-z][_A-Za-z0-9]*'`)
+
+   naming pattern
+
 ### PackageNaming
 
 Reports when package names which do not follow the specified naming convention are used.


### PR DESCRIPTION
As described in #844 we mixed up test cases for two separate rules and this commit fixes it.