### PR TITLE
Additional cli options for printing AST's and running single rules

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Args.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Args.kt
@@ -62,12 +62,20 @@ class Args {
 	var disableDefaultRuleSets: Boolean = false
 
 	@Parameter(names = ["--debug"],
-			description = "Debugs given ktFile by printing its elements.")
+			description = "Prints extra information about configurations and extensions.")
 	var debug: Boolean = false
 
 	@Parameter(names = ["--help", "-h"],
 			help = true, description = "Shows the usage.")
 	var help: Boolean = false
+
+	@Parameter(names = ["--run-rule"],
+			description = "Specify a rule by [RuleSet:Rule] pattern and run it on input.")
+	var runRule: String? = null
+
+	@Parameter(names = ["--print-ast"],
+			description = "Prints the AST for given [input] file. Must be no directory.")
+	var printAst: Boolean = false
 
 	val inputPath: List<Path> by lazy {
 		MultipleExistingPathConverter().convert(input

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.CompositeConfig
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.YamlConfig
 import io.gitlab.arturbosch.detekt.core.PathFilter
-import java.io.File
 import java.nio.file.Path
 
 /**
@@ -55,32 +54,6 @@ private fun parsePathConfig(configPath: String): Config {
 	}
 }
 
-data class FailFastConfig(private val originalConfig: Config, private val defaultConfig: Config) : Config {
-	override fun subConfig(key: String) = FailFastConfig(originalConfig.subConfig(key), defaultConfig.subConfig(key))
-
-	override fun <T : Any> valueOrDefault(key: String, default: T): T {
-		@Suppress("UNCHECKED_CAST")
-		return when (key) {
-			"active" -> originalConfig.valueOrDefault(key, true) as T
-			"maxIssues" -> originalConfig.valueOrDefault(key, 0) as T
-			else -> originalConfig.valueOrDefault(key, defaultConfig.valueOrDefault(key, default))
-		}
-	}
-}
-
 private fun loadDefaultConfig() = YamlConfig.loadResource(ClasspathResourceConverter().convert(DEFAULT_CONFIG))
 
-private const val DEFAULT_CONFIG = "default-detekt-config.yml"
-
-/**
- * @author lummax
- */
-class ConfigExporter : Executable {
-
-	override fun execute() {
-		val defaultConfig = ClasspathResourceConverter().convert(DEFAULT_CONFIG).openStream()
-		defaultConfig.copyTo(File(DEFAULT_CONFIG).outputStream())
-		println("\nSuccessfully copied $DEFAULT_CONFIG to project location.")
-	}
-
-}
+const val DEFAULT_CONFIG = "default-detekt-config.yml"

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/FailFastConfig.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/FailFastConfig.kt
@@ -1,0 +1,19 @@
+package io.gitlab.arturbosch.detekt.cli
+
+import io.gitlab.arturbosch.detekt.api.Config
+
+/**
+ * @author vanniktech
+ */
+data class FailFastConfig(private val originalConfig: Config, private val defaultConfig: Config) : Config {
+	override fun subConfig(key: String) = FailFastConfig(originalConfig.subConfig(key), defaultConfig.subConfig(key))
+
+	override fun <T : Any> valueOrDefault(key: String, default: T): T {
+		@Suppress("UNCHECKED_CAST")
+		return when (key) {
+			"active" -> originalConfig.valueOrDefault(key, true) as T
+			"maxIssues" -> originalConfig.valueOrDefault(key, 0) as T
+			else -> originalConfig.valueOrDefault(key, defaultConfig.valueOrDefault(key, default))
+		}
+	}
+}

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -2,6 +2,9 @@
 
 package io.gitlab.arturbosch.detekt.cli
 
+import io.gitlab.arturbosch.detekt.cli.runners.ConfigExporter
+import io.gitlab.arturbosch.detekt.cli.runners.Runner
+import io.gitlab.arturbosch.detekt.cli.runners.SingleRuleRunner
 import io.gitlab.arturbosch.detekt.core.isFile
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import java.nio.file.Files
@@ -14,6 +17,8 @@ fun main(args: Array<String>) {
 	LOG.active = arguments.debug
 	val executable = when {
 		arguments.generateConfig -> ConfigExporter()
+		arguments.runRule != null -> SingleRuleRunner(arguments)
+		arguments.printAst -> ConfigExporter()
 		else -> Runner(arguments)
 	}
 	executable.execute()

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -2,6 +2,7 @@
 
 package io.gitlab.arturbosch.detekt.cli
 
+import io.gitlab.arturbosch.detekt.cli.runners.AstPrinter
 import io.gitlab.arturbosch.detekt.cli.runners.ConfigExporter
 import io.gitlab.arturbosch.detekt.cli.runners.Runner
 import io.gitlab.arturbosch.detekt.cli.runners.SingleRuleRunner
@@ -18,7 +19,7 @@ fun main(args: Array<String>) {
 	val executable = when {
 		arguments.generateConfig -> ConfigExporter()
 		arguments.runRule != null -> SingleRuleRunner(arguments)
-		arguments.printAst -> ConfigExporter()
+		arguments.printAst -> AstPrinter(arguments)
 		else -> Runner(arguments)
 	}
 	executable.execute()

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinter.kt
@@ -26,19 +26,22 @@ class AstPrinter(private val arguments: Args) : Executable {
 
 		val input = arguments.inputPath[0]
 		val ktFile = KtCompiler().compile(input, input)
-		ElementPrinter.print(ktFile)
+		println(ElementPrinter.dump(ktFile))
 	}
 }
 
-private class ElementPrinter : DetektVisitor() {
+class ElementPrinter : DetektVisitor() {
 
 	companion object {
 		private const val TAB = "\t"
-		internal fun print(file: KtFile) = ElementPrinter().apply {
-			println("0: " + file.javaClass.simpleName)
+		internal fun dump(file: KtFile): String = ElementPrinter().run {
+			sb.appendln("0: " + file.javaClass.simpleName)
 			visitKtFile(file)
+			sb.toString()
 		}
 	}
+
+	private val sb = StringBuilder()
 
 	private val indentation
 		get() = (0..indent).joinToString("") { "  " }
@@ -58,14 +61,14 @@ private class ElementPrinter : DetektVisitor() {
 		val currentLine = element.line
 		if (element.isContainer()) {
 			indent++
-			println(element.dump)
+			sb.appendln(element.dump)
 		} else {
 			if (lastLine == currentLine) {
 				indent++
-				println(element.dump)
+				sb.appendln(element.dump)
 				indent--
 			} else {
-				println(element.dump)
+				sb.appendln(element.dump)
 			}
 		}
 		lastLine = currentLine

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinter.kt
@@ -1,0 +1,82 @@
+package io.gitlab.arturbosch.detekt.cli.runners
+
+import io.gitlab.arturbosch.detekt.api.DetektVisitor
+import io.gitlab.arturbosch.detekt.cli.Args
+import io.gitlab.arturbosch.detekt.core.KtCompiler
+import io.gitlab.arturbosch.detekt.core.isFile
+import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
+import org.jetbrains.kotlin.psi.KtContainerNode
+import org.jetbrains.kotlin.psi.KtDeclarationContainer
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtStatementExpression
+
+/**
+ * @author Artur Bosch
+ */
+class AstPrinter(private val arguments: Args) : Executable {
+
+	override fun execute() {
+		assert(arguments.inputPath.size == 1) {
+			"More than one input path specified. Printing AST is only supported for single files."
+		}
+		assert(arguments.inputPath[0].isFile()) {
+			"Input path must be a kotlin file and not a directory."
+		}
+
+		val input = arguments.inputPath[0]
+		val ktFile = KtCompiler().compile(input, input)
+		ElementPrinter.print(ktFile)
+	}
+}
+
+private class ElementPrinter : DetektVisitor() {
+
+	companion object {
+		private const val TAB = "\t"
+		internal fun print(file: KtFile) = ElementPrinter().apply {
+			println("0: " + file.javaClass.simpleName)
+			visitKtFile(file)
+		}
+	}
+
+	private val indentation
+		get() = (0..indent).joinToString("") { "  " }
+
+	private val KtElement.line
+		get() = DiagnosticUtils.offsetToLineAndColumn(
+				containingFile.viewProvider.document,
+				textRange.startOffset).line
+
+	private val KtElement.dump
+		get() = indentation + line + ": " + javaClass.simpleName
+
+	private var indent: Int = 0
+	private var lastLine = 0
+
+	override fun visitKtElement(element: KtElement) {
+		val currentLine = element.line
+		if (element.isContainer()) {
+			indent++
+			println(element.dump)
+		} else {
+			if (lastLine == currentLine) {
+				indent++
+				println(element.dump)
+				indent--
+			} else {
+				println(element.dump)
+			}
+		}
+		lastLine = currentLine
+		super.visitKtElement(element)
+		if (element.isContainer()) {
+			indent--
+		}
+	}
+
+	private fun KtElement.isContainer() =
+			this is KtStatementExpression
+					|| this is KtDeclarationContainer
+					|| this is KtContainerNode
+}

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporter.kt
@@ -1,0 +1,17 @@
+package io.gitlab.arturbosch.detekt.cli.runners
+
+import io.gitlab.arturbosch.detekt.cli.ClasspathResourceConverter
+import io.gitlab.arturbosch.detekt.cli.DEFAULT_CONFIG
+import java.io.File
+
+/**
+ * @author lummax
+ */
+class ConfigExporter : Executable {
+
+	override fun execute() {
+		val defaultConfig = ClasspathResourceConverter().convert(DEFAULT_CONFIG).openStream()
+		defaultConfig.copyTo(File(DEFAULT_CONFIG).outputStream())
+		println("\nSuccessfully copied $DEFAULT_CONFIG to project location.")
+	}
+}

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Executable.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Executable.kt
@@ -1,0 +1,8 @@
+package io.gitlab.arturbosch.detekt.cli.runners
+
+/**
+ * @author Artur Bosch
+ */
+interface Executable {
+	fun execute()
+}

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -1,12 +1,13 @@
-package io.gitlab.arturbosch.detekt.cli
+package io.gitlab.arturbosch.detekt.cli.runners
 
+import io.gitlab.arturbosch.detekt.cli.Args
+import io.gitlab.arturbosch.detekt.cli.OutputFacade
+import io.gitlab.arturbosch.detekt.cli.createPathFilters
+import io.gitlab.arturbosch.detekt.cli.createPlugins
+import io.gitlab.arturbosch.detekt.cli.loadConfiguration
 import io.gitlab.arturbosch.detekt.core.DetektFacade
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import kotlin.system.measureTimeMillis
-
-interface Executable {
-	fun execute()
-}
 
 /**
  * @author Artur Bosch

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
@@ -1,0 +1,58 @@
+package io.gitlab.arturbosch.detekt.cli.runners
+
+import io.gitlab.arturbosch.detekt.api.BaseRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.cli.Args
+import io.gitlab.arturbosch.detekt.cli.DetektProgressListener
+import io.gitlab.arturbosch.detekt.cli.OutputFacade
+import io.gitlab.arturbosch.detekt.cli.createPathFilters
+import io.gitlab.arturbosch.detekt.cli.createPlugins
+import io.gitlab.arturbosch.detekt.cli.loadConfiguration
+import io.gitlab.arturbosch.detekt.core.DetektFacade
+import io.gitlab.arturbosch.detekt.core.ProcessingSettings
+import io.gitlab.arturbosch.detekt.core.RuleSetLocator
+
+/**
+ * @author Artur Bosch
+ */
+class SingleRuleRunner(private val arguments: Args) : Executable {
+
+	override fun execute() {
+		val (ruleSet, rule) = arguments.runRule?.split(":")
+				?: throw IllegalStateException("Unexpected empty 'runRule' argument.")
+
+		val settings = ProcessingSettings(
+				arguments.inputPath,
+				arguments.loadConfiguration(),
+				arguments.createPathFilters(),
+				arguments.parallel,
+				arguments.disableDefaultRuleSets,
+				arguments.createPlugins())
+
+		val ruleToRun = RuleSetLocator(settings).load()
+				.find { it.ruleSetId == ruleSet }
+				?.buildRuleset(Config.empty)
+				?.rules
+				?.find { it.id == rule }
+				?: throw IllegalArgumentException("There was no rule '$rule' in rule set '$ruleSet'.")
+
+		val provider = FakeRuleSetProvider("$ruleSet-$rule", ruleToRun)
+		val detektion = DetektFacade.create(
+				settings,
+				listOf(provider),
+				listOf(DetektProgressListener())
+		).run()
+		OutputFacade(arguments, detektion, settings).run()
+	}
+}
+
+private class FakeRuleSetProvider(
+		runPattern: String,
+		private val rule: BaseRule) : RuleSetProvider {
+
+	override val ruleSetId: String = runPattern
+
+	override fun instance(config: Config): RuleSet = RuleSet(ruleSetId, listOf(rule))
+}

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinterSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinterSpec.kt
@@ -1,0 +1,43 @@
+package io.gitlab.arturbosch.detekt.cli.runners
+
+import io.gitlab.arturbosch.detekt.test.compileForTest
+import io.gitlab.arturbosch.detekt.test.resource
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.it
+import java.nio.file.Paths
+
+/**
+ * @author Artur Bosch
+ */
+class AstPrinterSpec : Spek({
+
+	it("should print the ast as string") {
+		val case = Paths.get(resource("cases/Poko.kt"))
+		val ktFile = compileForTest(case)
+
+		val dump = ElementPrinter.dump(ktFile)
+
+		assertThat(dump.trimIndent()).isEqualTo(expected)
+	}
+})
+
+private val expected = """0: KtFile
+  1: KtPackageDirective
+    1: KtNameReferenceExpression
+    1: KtImportList
+    3: KtClass
+      3: KtClassBody
+        5: KtProperty
+          5: KtTypeReference
+          5: KtUserType
+          5: KtNameReferenceExpression
+          5: KtStringTemplateExpression
+          5: KtLiteralStringTemplateEntry
+        6: KtNamedFunction
+          6: KtParameterList
+          6: KtStringTemplateExpression
+          6: KtLiteralStringTemplateEntry
+          6: KtSimpleNameStringTemplateEntry
+          6: KtNameReferenceExpression
+""".trimIndent()

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
@@ -1,0 +1,58 @@
+package io.gitlab.arturbosch.detekt.cli.runners
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.ConsoleReport
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Detektion
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.cli.Args
+import io.gitlab.arturbosch.detekt.test.resource
+import org.assertj.core.api.Assertions
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.it
+import java.nio.file.Paths
+
+/**
+ * @author Artur Bosch
+ */
+class SingleRuleRunnerSpec : Spek({
+
+	it("should load and run custom rule") {
+		val case = Paths.get(resource("cases/Poko.kt"))
+
+		val args = Args().apply {
+			val field = this.javaClass.getDeclaredField("input")
+			field.isAccessible = true
+			field.set(this, case.toString())
+			runRule = "test:test"
+		}
+		// assertion is made inside the custom console report
+		SingleRuleRunner(args).execute() // also indirect assertion that test:test exists
+	}
+})
+
+class TestConsoleReport : ConsoleReport() {
+	override fun render(detektion: Detektion): String? {
+		Assertions.assertThat(detektion.findings).hasSize(1)
+		return "I've run!"
+	}
+}
+
+class TestProvider : RuleSetProvider {
+	override val ruleSetId: String = "test"
+	override fun instance(config: Config): RuleSet = RuleSet(ruleSetId, listOf(TestRule()))
+}
+
+class TestRule : Rule() {
+	override val issue = Issue("test", Severity.Minor, "", Debt.FIVE_MINS)
+	override fun visitClass(klass: KtClass) {
+		report(CodeSmell(issue, Entity.from(klass), issue.description))
+	}
+}

--- a/detekt-cli/src/test/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.ConsoleReport
+++ b/detekt-cli/src/test/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.ConsoleReport
@@ -1,0 +1,1 @@
+io.gitlab.arturbosch.detekt.cli.runners.TestConsoleReport

--- a/detekt-cli/src/test/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
+++ b/detekt-cli/src/test/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -1,0 +1,1 @@
+io.gitlab.arturbosch.detekt.cli.runners.TestProvider

--- a/detekt-cli/src/test/resources/cases/Poko.kt
+++ b/detekt-cli/src/test/resources/cases/Poko.kt
@@ -1,0 +1,7 @@
+package cases
+
+class Poko {
+
+	val name: String = "Poko"
+	fun hello() = "Hello, $name"
+}


### PR DESCRIPTION
- flag `--print-ast` helps to debug code while writing new rules
- flag `--run-rule` allows to run single (new) rules on for example our analyzing projects pipeline #846 

Todo:
- tests
- handle MultiRule `ruleSet:rule:subrule`
- handle config properties `ruleSet:rule[config=properties]`