### PR TITLE
Migrate detekt-gradle-plugin/settings.gradle to Gradle DSL

### DIFF
--- a/detekt-gradle-plugin/settings.gradle
+++ b/detekt-gradle-plugin/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'detekt-gradle-plugin'

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = 'detekt-gradle-plugin'


### PR DESCRIPTION
Slightly pointless since it's just a rename without content changes, but it does remove the last file that has a .gradle extension which is exciting.

Fixes #863.