### PR TITLE
fix compile erros in the detekt-gradle-plugin project

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCheckTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCheckTask.kt
@@ -46,9 +46,9 @@ open class DetektCheckTask : DefaultTask() {
 		val detektExtension = project.extensions.getByName("detekt") as DetektExtension
 
 		project.javaexec {
-			it.main = "io.gitlab.arturbosch.detekt.cli.Main"
-			it.classpath = classpath
-			it.args(detektExtension.resolveArguments(project))
+			main = "io.gitlab.arturbosch.detekt.cli.Main"
+			classpath = classpath
+			args(detektExtension.resolveArguments(project))
 		}
 	}
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -29,9 +29,9 @@ open class DetektCreateBaselineTask : DefaultTask() {
 		val detektExtension = project.extensions.getByName("detekt") as DetektExtension
 
 		project.javaexec {
-			it.main = "io.gitlab.arturbosch.detekt.cli.Main"
-			it.classpath = classpath
-			it.args(detektExtension.resolveArguments(project).plus(createBaseline))
+			main = "io.gitlab.arturbosch.detekt.cli.Main"
+			classpath = classpath
+			args(detektExtension.resolveArguments(project).plus(createBaseline))
 		}
 	}
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -25,9 +25,9 @@ open class DetektGenerateConfigTask : DefaultTask() {
 	@TaskAction
 	fun generateConfig() {
 		project.javaexec {
-			it.main = "io.gitlab.arturbosch.detekt.cli.Main"
-			it.classpath = classpath
-			it.args("--input", project.projectDir.absolutePath, "--generate-config")
+			main = "io.gitlab.arturbosch.detekt.cli.Main"
+			classpath = classpath
+			args("--input", project.projectDir.absolutePath, "--generate-config")
 		}
 	}
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -13,7 +13,7 @@ class DetektPlugin : Plugin<Project> {
 
 		val profilesContainer = project.container(ProfileExtension::class.java)
 		project.extensions.add(PROFILES_EXTENSION_NAME, profilesContainer)
-		profilesContainer.all { ProfileStorage.add(it) }
+		profilesContainer.forEach { ProfileStorage.add(it) }
 
 		project.extensions.create(DETEKT_EXTENSION_NAME, DetektExtension::class.java)
 		project.task(mapOf(TYPE to DetektCheckTask::class.java), CHECK)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -41,7 +41,7 @@ open class DetektExtension(open var version: String = SUPPORTED_DETEKT_VERSION,
 		.configurations
 		.getByName("detekt")
 		.withDependencies {
-			it.add(
+			add(
 				DefaultExternalModuleDependency(
 					"io.gitlab.arturbosch.detekt", "detekt-cli", version
 				)


### PR DESCRIPTION
While rebasing #771 and trying to check some of the behavior on `master` I couldn't get the project to compile without these changes.