### PR TITLE
Disabled UndocumentedPublicFunction for non-public classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Misa Torres](https://github.com/misaelmt) - Added: TrailingWhitespace and NoTabs rules
 - [R.A. Porter](https://github.com/coyotesqrl) - Updated Readme links to RuleSets
 - [Robbin Voortman](https://github.com/rvoortman) - Rule improvement: MaxLineLength
+- [Mike Gorunov](http://github.com/Miha-x64/) — Rule improvement: UndocumentedPublicFunction
 
 ### Mentions
 


### PR DESCRIPTION
Consider the following sample:
```kt
internal class Whatever {
    fun doSomething() = ...
}
```
Formal visibility modifier of `doSomething` is `public`, but the function effectively-internal.

This PR avoids triggering `UndocumentedPublicFunction` for such declarations.