### PR TITLE
Updated MatchingDeclarationName with typealias

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtTypeAlias
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
 /**
@@ -44,6 +45,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  *
  * @active since v1.0.0
  * @author Artur Bosch
+ * @author schalkms
  */
 class MatchingDeclarationName(config: Config = Config.empty) : Rule(config) {
 
@@ -59,7 +61,9 @@ class MatchingDeclarationName(config: Config = Config.empty) : Rule(config) {
 		if (declarations.size == 1) {
 			val declaration = declarations[0] as? KtClassOrObject
 			val declarationName = declaration?.name ?: return
-			if (declarationName != file.name.removeSuffix(KOTLIN_SUFFIX)) {
+			val filename = file.name.removeSuffix(KOTLIN_SUFFIX)
+			if (declarationName != filename
+					&& file.declarations.filterIsInstance<KtTypeAlias>().all { it.name != filename }) {
 				report(CodeSmell(issue, Entity.from(file), "The file name '${file.name}' " +
 						"does not match the name of the single top-level declaration '$declarationName'."))
 			}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
@@ -77,6 +77,17 @@ internal class MatchingDeclarationNameSpec : Spek({
 			val findings = MatchingDeclarationName().lint(ktFile)
 			assertThat(findings).isEmpty()
 		}
+
+		it("should pass for a class with a typealias") {
+			val code = """
+				typealias Foo = FooImpl
+
+				class FooImpl {}"""
+			val ktFile = compileContentForTest(code)
+			ktFile.name = "Foo.kt"
+			val findings = MatchingDeclarationName().lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
 	}
 
 	given("non-compliant test cases") {
@@ -130,6 +141,17 @@ internal class MatchingDeclarationNameSpec : Spek({
 					ONE, TWO, THREE
 				}
 			' at (1,1) in /E.kt""", trimIndent = true)
+		}
+
+		it("should not pass for a typealias with a different name") {
+			val code = """
+				typealias Bar = FooImpl
+
+				class FooImpl {}"""
+			val ktFile = compileContentForTest(code)
+			ktFile.name = "Foo.kt"
+			val findings = MatchingDeclarationName().lint(ktFile)
+			assertThat(findings).hasSize(1)
 		}
 	}
 })


### PR DESCRIPTION
When a file has a typealias with the same name, it doesn't report
MatchingDeclarationName.

reference #898 