### PR TITLE
Add style rule for mandatory braces for control flow statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [R.A. Porter](https://github.com/coyotesqrl) - Updated Readme links to RuleSets
 - [Robbin Voortman](https://github.com/rvoortman) - Rule improvement: MaxLineLength
 - [Mike Gorunov](http://github.com/Miha-x64/) — Rule improvement: UndocumentedPublicFunction
+- [Joey Kaan](https://github.com/jkaan) - New rule: MandatoryBracesIfStatements
 
 ### Mentions
 

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -411,6 +411,8 @@ style:
     ignoreAnnotation: false
     ignoreNamedArgument: true
     ignoreEnums: false
+  MandatoryBracesIfStatements:
+    active: false
   MaxLineLength:
     active: true
     maxLineLength: 120

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -35,6 +35,7 @@ import io.gitlab.arturbosch.detekt.rules.style.UnusedPrivateMember
 import io.gitlab.arturbosch.detekt.rules.style.UseDataClass
 import io.gitlab.arturbosch.detekt.rules.style.UtilityClassWithPublicConstructor
 import io.gitlab.arturbosch.detekt.rules.style.WildcardImport
+import io.gitlab.arturbosch.detekt.rules.style.optional.MandatoryBracesIfStatements
 import io.gitlab.arturbosch.detekt.rules.style.optional.OptionalUnit
 
 /**
@@ -83,7 +84,8 @@ class StyleGuideProvider : RuleSetProvider {
 				NestedClassesVisibility(config),
 				RedundantVisibilityModifierRule(config),
 				UntilInsteadOfRangeTo(config),
-				MayBeConst(config)
+				MayBeConst(config),
+				MandatoryBracesIfStatements(config)
 		))
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatements.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatements.kt
@@ -32,20 +32,21 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
 class MandatoryBracesIfStatements(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue("MandatoryBracesIfStatements", Severity.Style,
-			"Multi-line if statements detected without braces. " +
-					"The braces can be added to improve readability and prevent possible errors.",
+			"Multi-line if statement was found that does not have braces. " +
+					"These should be added to improve readability.",
 			Debt.FIVE_MINS)
 
 	override fun visitIfExpression(expression: KtIfExpression) {
 		if (isNotBlockExpression(expression) && hasNewLine(expression)) {
 			report(CodeSmell(issue, Entity.from(expression),
-					message = "Multi-line if statements were found that do not have braces. " +
-							"These can be added to improve readability and prevent possible errors."))
+					message = "Multi-line if statement was found that does not have braces. " +
+							"These should be added to improve readability."))
 		}
 
 		if (isNotBlockOrIfExpression(expression) && hasNewLine(expression.elseKeyword)) {
 			report(CodeSmell(issue, Entity.from(expression),
-					message = "Multi-line else statement found that does not have braces."))
+					message = "Multi-line else statement was found that does not have braces." +
+							"These should be added to improve readability"))
 		}
 
 		super.visitIfExpression(expression)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatements.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatements.kt
@@ -1,0 +1,52 @@
+package io.gitlab.arturbosch.detekt.rules.style.optional
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.KtNodeTypes
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.psiUtil.siblings
+
+/**
+ * This rule detects multi-line `if` statements which does have braces.
+ * Adding braces would improve readability and avoid possible errors.
+ *
+ * <noncompliant>
+ * val i = 1
+ * if (i > 0)
+ *    println(i)
+ * </noncompliant>
+ *
+ * <compliant>
+ * val x = if (condition) 5 else 4
+ * </compliant>
+ *
+ * @author jkaan
+ */
+class MandatoryBracesIfStatements(config: Config = Config.empty) : Rule(config) {
+
+	override val issue = Issue("MandatoryBracesIfStatements", Severity.Style,
+			"Multi-line if statements detected without braces. " +
+					"The braces can be added to improve readability and prevent possible errors.",
+			Debt.FIVE_MINS)
+
+	override fun visitIfExpression(expression: KtIfExpression) {
+		if (isNotBlockExpression(expression) && hasNewLine(expression)) {
+			report(CodeSmell(issue, Entity.from(expression), message = ""))
+		}
+		super.visitIfExpression(expression)
+	}
+
+	private fun hasNewLine(expression: KtIfExpression): Boolean =
+			expression.rightParenthesis?.siblings(true, false)
+					?.filter { it is PsiWhiteSpace }
+					?.firstOrNull { (it as PsiWhiteSpace).textContains('\n') } != null
+
+	private fun isNotBlockExpression(expression: KtIfExpression): Boolean =
+			expression.then?.node?.elementType != KtNodeTypes.BLOCK
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatements.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatements.kt
@@ -7,13 +7,13 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
-import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 /**
- * This rule detects multi-line `if` statements which does have braces.
+ * This rule detects multi-line `if` statements which do not have braces.
  * Adding braces would improve readability and avoid possible errors.
  *
  * <noncompliant>
@@ -37,16 +37,18 @@ class MandatoryBracesIfStatements(config: Config = Config.empty) : Rule(config) 
 
 	override fun visitIfExpression(expression: KtIfExpression) {
 		if (isNotBlockExpression(expression) && hasNewLine(expression)) {
-			report(CodeSmell(issue, Entity.from(expression), message = ""))
+			report(CodeSmell(issue, Entity.from(expression),
+					message = "Multi-line if statements were found that do not have braces. " +
+							"These can be added to improve readability and prevent possible errors."))
 		}
 		super.visitIfExpression(expression)
 	}
 
 	private fun hasNewLine(expression: KtIfExpression): Boolean =
 			expression.rightParenthesis?.siblings(true, false)
-					?.filter { it is PsiWhiteSpace }
-					?.firstOrNull { (it as PsiWhiteSpace).textContains('\n') } != null
+					?.filterIsInstance<PsiWhiteSpace>()
+					?.firstOrNull { it.textContains('\n') } != null
 
 	private fun isNotBlockExpression(expression: KtIfExpression): Boolean =
-			expression.then?.node?.elementType != KtNodeTypes.BLOCK
+			expression.then !is KtBlockExpression
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/Case.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/Case.kt
@@ -38,6 +38,8 @@ enum class Case(val file: String) {
 	LabeledExpression("/cases/LabeledExpression.kt"),
 	LoopWithTooManyJumpStatementsNegative("cases/LoopWithTooManyJumpStatementsNegative.kt"),
 	LoopWithTooManyJumpStatementsPositive("cases/LoopWithTooManyJumpStatementsPositive.kt"),
+	MandatoryBracesIfStatementsPositive("cases/MandatoryBracesIfStatementsPositive.kt"),
+	MandatoryBracesIfStatementsNegative("cases/MandatoryBracesIfStatementsNegative.kt"),
 	NamingConventions("/cases/NamingConventions.kt"),
 	NewLineAtEndOfFile("/cases/NewLineAtEndOfFile.kt"),
 	MaxLineLength("/cases/MaxLineLength.kt"),

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementSpec.kt
@@ -16,7 +16,7 @@ class MandatoryBracesIfStatementSpec : SubjectSpek<MandatoryBracesIfStatements>(
 
 		it("reports multi-line if statements should have braces") {
 			val path = Case.MandatoryBracesIfStatementsPositive.path()
-			assertThat(subject.lint(path)).hasSize(1)
+			assertThat(subject.lint(path)).hasSize(4)
 		}
 
 		it("reports non multi-line if statements should have braces") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementSpec.kt
@@ -1,0 +1,27 @@
+package io.gitlab.arturbosch.detekt.rules.style.optional
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.rules.Case
+import io.gitlab.arturbosch.detekt.rules.style.optional.MandatoryBracesIfStatements
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
+
+class MandatoryBracesIfStatementSpec : SubjectSpek<MandatoryBracesIfStatements>({
+	subject { MandatoryBracesIfStatements(Config.empty) }
+
+	given("if statements") {
+
+		it("reports multi-line if statements should have braces") {
+			val path = Case.MandatoryBracesIfStatementsPositive.path()
+			assertThat(subject.lint(path)).hasSize(1)
+		}
+
+		it("reports non multi-line if statements should have braces") {
+			val path = Case.MandatoryBracesIfStatementsNegative.path()
+			assertThat(subject.lint(path)).hasSize(0)
+		}
+	}
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
@@ -2,21 +2,20 @@ package io.gitlab.arturbosch.detekt.rules.style.optional
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.Case
-import io.gitlab.arturbosch.detekt.rules.style.optional.MandatoryBracesIfStatements
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
 
-class MandatoryBracesIfStatementSpec : SubjectSpek<MandatoryBracesIfStatements>({
+class MandatoryBracesIfStatementsSpec : SubjectSpek<MandatoryBracesIfStatements>({
 	subject { MandatoryBracesIfStatements(Config.empty) }
 
 	given("if statements") {
 
 		it("reports multi-line if statements should have braces") {
 			val path = Case.MandatoryBracesIfStatementsPositive.path()
-			assertThat(subject.lint(path)).hasSize(4)
+			assertThat(subject.lint(path)).hasSize(7)
 		}
 
 		it("reports non multi-line if statements should have braces") {

--- a/detekt-rules/src/test/resources/cases/MandatoryBracesIfStatementsNegative.kt
+++ b/detekt-rules/src/test/resources/cases/MandatoryBracesIfStatementsNegative.kt
@@ -14,4 +14,8 @@ fun mandatoryBracesIfStatementNegative() {
 	if (true) println()
 
 	if (true) { println() }
+
+	if (true) println() else println()
+
+	if (true) println() else if (false) println() else println()
 }

--- a/detekt-rules/src/test/resources/cases/MandatoryBracesIfStatementsNegative.kt
+++ b/detekt-rules/src/test/resources/cases/MandatoryBracesIfStatementsNegative.kt
@@ -1,0 +1,17 @@
+package cases
+
+@Suppress("unused", "ConstantConditionIf")
+fun mandatoryBracesIfStatementNegative() {
+	if (true) {
+		println()
+	}
+
+	if (true)
+	{
+		println()
+	}
+
+	if (true) println()
+
+	if (true) { println() }
+}

--- a/detekt-rules/src/test/resources/cases/MandatoryBracesIfStatementsPositive.kt
+++ b/detekt-rules/src/test/resources/cases/MandatoryBracesIfStatementsPositive.kt
@@ -16,4 +16,9 @@ fun mandatoryBracesIfStatementPositive() {
 		println()
 	else
 		println()
+
+	if (true) {
+		println()
+	} else
+		println()
 }

--- a/detekt-rules/src/test/resources/cases/MandatoryBracesIfStatementsPositive.kt
+++ b/detekt-rules/src/test/resources/cases/MandatoryBracesIfStatementsPositive.kt
@@ -1,0 +1,7 @@
+package cases
+
+@Suppress("unused", "ConstantConditionIf")
+fun mandatoryBracesIfStatementPositive() {
+	if (true)
+		println()
+}

--- a/detekt-rules/src/test/resources/cases/MandatoryBracesIfStatementsPositive.kt
+++ b/detekt-rules/src/test/resources/cases/MandatoryBracesIfStatementsPositive.kt
@@ -1,7 +1,19 @@
 package cases
 
-@Suppress("unused", "ConstantConditionIf")
+@Suppress("unused", "ConstantConditionIf", "CascadeIf")
 fun mandatoryBracesIfStatementPositive() {
 	if (true)
+		println()
+
+	if (true)
+		println()
+	else
+		println()
+
+	if (true)
+		println()
+	else if (false)
+		println()
+	else
 		println()
 }

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -294,7 +294,7 @@ class User {
 
 ### MandatoryBracesIfStatements
 
-This rule detects multi-line `if` statements which does not include braces.
+This rule detects multi-line `if` statements which do not have braces.
 Adding braces would improve readability and avoid possible errors.
 
 **Severity**: Style

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -292,6 +292,29 @@ class User {
 }
 ```
 
+### MandatoryBracesIfStatements
+
+This rule detects multi-line `if` statements which does not include braces.
+Adding braces would improve readability and avoid possible errors.
+
+**Severity**: Style
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+val i = 1
+if (i > 0)
+    println(i)
+```
+
+#### Compliant Code:
+
+```kotlin
+val x = if (condition) 5 else 4
+```
+
 ### MaxLineLength
 
 This rule reports lines of code which exceed a defined maximum line length.


### PR DESCRIPTION
This adds the rule that was talked about in #365 