### PR TITLE
Don't treat 'input' and 'output' parameters to Gradle as an InputDirectory/OutputDirectory

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCheckTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCheckTask.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.extensions.INPUT_PARAMETER
 import io.gitlab.arturbosch.detekt.extensions.OUTPUT_PARAMETER
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileCollection
-import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
@@ -18,7 +17,6 @@ open class DetektCheckTask : DefaultTask() {
 
 	val input: File?
 
-	@OutputDirectory
 	val output: File?
 
 	private val classpath: FileCollection

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCheckTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCheckTask.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.extensions.INPUT_PARAMETER
 import io.gitlab.arturbosch.detekt.extensions.OUTPUT_PARAMETER
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileCollection
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import java.io.File
@@ -17,7 +16,6 @@ import java.io.File
  */
 open class DetektCheckTask : DefaultTask() {
 
-	@InputDirectory
 	val input: File?
 
 	@OutputDirectory


### PR DESCRIPTION
The current Gradle plugin implementation doesn't follow best practices, so these annotations cause unintended behviour.

Fixes #807 #854 