### PR TITLE
TooManyFunctions : Add option to ignore private functions

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -116,6 +116,7 @@ complexity:
     thresholdInObjects: 11
     thresholdInEnums: 11
     ignoreDeprecated: false
+    ignorePrivate: false
 
 empty-blocks:
   active: true

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
-import com.sun.tools.javac.code.Flags.DEPRECATED
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -68,7 +68,7 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
 	}
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
-		if (function.isTopLevel && ignoresDeprecatedFunction(function) && ignoresPrivateFunction(function)) {
+		if (function.isTopLevel && !isIgnoredFunction(function)) {
 			amountOfTopLevelFunctions++
 		}
 	}
@@ -119,22 +119,17 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
 
 	private fun calcFunctions(classOrObject: KtClassOrObject): Int = classOrObject.getBody()?.declarations
 			?.filterIsInstance<KtNamedFunction>()
-			?.filter { ignoresDeprecatedFunction(it) }
-			?.filter { ignoresPrivateFunction(it) }
+			?.filter { !isIgnoredFunction(it) }
 			?.size ?: 0
 
-	private fun ignoresDeprecatedFunction(function: KtNamedFunction): Boolean {
+	private fun isIgnoredFunction(function: KtNamedFunction): Boolean {
 		if (ignoreDeprecated) {
-			return !function.annotationEntries.any { it.typeReferenceName == DEPRECATED }
+			return function.annotationEntries.any { it.typeReferenceName == DEPRECATED }
 		}
-		return true
-	}
-
-	private fun ignoresPrivateFunction(function: KtNamedFunction): Boolean {
 		if (ignorePrivate) {
-			return !function.isPrivate()
+			return function.isPrivate()
 		}
-		return true
+		return false
 	}
 
 	companion object {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
+import com.sun.tools.javac.code.Flags.DEPRECATED
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
@@ -122,14 +123,10 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
 			?.filter { !isIgnoredFunction(it) }
 			?.size ?: 0
 
-	private fun isIgnoredFunction(function: KtNamedFunction): Boolean {
-		if (ignoreDeprecated) {
-			return function.annotationEntries.any { it.typeReferenceName == DEPRECATED }
-		}
-		if (ignorePrivate) {
-			return function.isPrivate()
-		}
-		return false
+	private fun isIgnoredFunction(function: KtNamedFunction): Boolean = when {
+			ignoreDeprecated -> function.annotationEntries.any { it.typeReferenceName == DEPRECATED }
+			ignorePrivate -> function.isPrivate()
+			else -> false
 	}
 
 	companion object {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
@@ -137,5 +137,31 @@ class TooManyFunctionsSpec : Spek({
 				assertThat(configuredRule.lint(code)).isEmpty()
 			}
 		}
+
+		describe("different private functions") {
+
+			val code = """
+				private fun f() {
+				}
+
+				class A {
+					private fun f() {
+					}
+				}
+				"""
+
+			it("finds all private functions per default") {
+				assertThat(rule.lint(code)).hasSize(2)
+			}
+
+			it("finds no private functions") {
+				val configuredRule = TooManyFunctions(TestConfig(mapOf(
+					TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
+					TooManyFunctions.THRESHOLD_IN_FILES to "1",
+					TooManyFunctions.IGNORE_PRIVATE to "true"
+				)))
+				assertThat(configuredRule.lint(code)).isEmpty()
+			}
+		}
 	}
 })

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -292,3 +292,7 @@ which clearly belongs together in separate parts of the code.
 * `ignoreDeprecated` (default: `false`)
 
    ignore deprecated functions
+
+* `ignorePrivate` (default: `false`)
+
+   ignore private functions


### PR DESCRIPTION
> Too many functions inside a/an file/class/object/interface always indicate a violation of the single responsibility principle. Maybe the file/class/object/interface wants to manage to many things at once. Extract functionality which clearly belongs together.

While I agree with the general principle that a class with too many functions may violate SRP. I think that this only applies to functions that **expose functionality outside the class** as private functions just lets us organise the code in a cleaner way.

Having private functions count toward the "TooManyFunctions" threshold may deter us from extracting private functions to split big public functions and thus make code less readable.

That's why I suggest adding a _ignorePrivate_ flag to this rule.