### PR TITLE
Use native junitPlatform from gradle 4.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,6 @@ import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.extensions.ProfileExtension
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.junit.platform.console.options.Details
-import org.junit.platform.gradle.plugin.JUnitPlatformExtension
 import java.util.*
 
 buildscript {
@@ -15,11 +13,9 @@ buildscript {
 	}
 
 	val kotlinVersion by project
-	val junitPlatformVersion by project
 
 	dependencies {
 		classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-		classpath("org.junit.platform:junit-platform-gradle-plugin:$junitPlatformVersion")
 	}
 }
 
@@ -53,7 +49,6 @@ allprojects {
 subprojects {
 
 	apply {
-		plugin("org.junit.platform.gradle.plugin")
 		plugin("java-library")
 		plugin("kotlin")
 		plugin("com.jfrog.bintray")
@@ -74,13 +69,8 @@ subprojects {
 		kotlinOptions.allWarningsAsErrors = shouldTreatCompilerWarningsAsErrors()
 	}
 
-	configure<JUnitPlatformExtension> {
-		details = Details.TREE
-		filters {
-			engines {
-				include = listOf("spek", "junit-jupiter")
-			}
-		}
+	val test by tasks.getting(Test::class) {
+		useJUnitPlatform()
 	}
 
 	bintray {
@@ -178,7 +168,6 @@ subprojects {
 	val spekVersion by project
 	val kotlinImplementation by configurations.creating
 	val kotlinTest by configurations.creating
-	val junitPlatform = configurations["junitPlatform"]
 
 	dependencies {
 		kotlinImplementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinVersion")
@@ -191,9 +180,6 @@ subprojects {
 		kotlinTest("org.jetbrains.spek:spek-subject-extension:$spekVersion")
 		kotlinTest("org.junit.jupiter:junit-jupiter-engine:$junitEngineVersion")
 		kotlinTest("org.reflections:reflections:0.9.11")
-		junitPlatform("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-		junitPlatform("org.junit.platform:junit-platform-console:$junitPlatformVersion")
-		junitPlatform("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
 	}
 
 	the<JavaPluginConvention>().sourceSets {

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -11,6 +11,5 @@ dependencies {
 	testImplementation(project(":detekt-test"))
 
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-	testRuntimeOnly("org.junit.platform:junit-platform-console:$junitPlatformVersion")
 	testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
 }

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -19,7 +19,6 @@ dependencies {
 
 	testImplementation(project(":detekt-test"))
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-	testRuntimeOnly("org.junit.platform:junit-platform-console:$junitPlatformVersion")
 	testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
 }
 

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -10,6 +10,5 @@ dependencies {
 	testImplementation(project(":detekt-rules"))
 	testImplementation(project(":detekt-test"))
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-	testRuntimeOnly("org.junit.platform:junit-platform-console:$junitPlatformVersion")
 	testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
 }

--- a/detekt-formatting/build.gradle
+++ b/detekt-formatting/build.gradle
@@ -18,7 +18,6 @@ dependencies {
 	testCompile project(':detekt-api')
 	testCompile project(':detekt-test')
 	testRuntime "org.junit.platform:junit-platform-launcher:$junitPlatformVersion"
-	testRuntime "org.junit.platform:junit-platform-console:$junitPlatformVersion"
 	testRuntime "org.jetbrains.spek:spek-junit-platform-engine:$spekVersion"
 }
 

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -95,6 +95,5 @@ dependencies {
 
     testImplementation(project(":detekt-test"))
     testRuntime("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntime("org.junit.platform:junit-platform-console:$junitPlatformVersion")
     testRuntime("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
 }

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
 
 	testImplementation(project(":detekt-test"))
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-	testRuntimeOnly("org.junit.platform:junit-platform-console:$junitPlatformVersion")
 	testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
 }
 

--- a/detekt-sample-extensions/build.gradle.kts
+++ b/detekt-sample-extensions/build.gradle.kts
@@ -39,6 +39,5 @@ dependencies {
 	testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitEngineVersion")
 
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-	testRuntimeOnly("org.junit.platform:junit-platform-console:$junitPlatformVersion")
 	testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
 }

--- a/detekt-test/build.gradle.kts
+++ b/detekt-test/build.gradle.kts
@@ -11,6 +11,5 @@ dependencies {
 	implementation("org.assertj:assertj-core:$assertjVersion")
 
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-	testRuntimeOnly("org.junit.platform:junit-platform-console:$junitPlatformVersion")
 	testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
 }

--- a/detekt-watch-service/build.gradle.kts
+++ b/detekt-watch-service/build.gradle.kts
@@ -15,6 +15,5 @@ dependencies {
 	implementation(project(":detekt-core"))
 	testImplementation(project(":detekt-test"))
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-	testRuntimeOnly("org.junit.platform:junit-platform-console:$junitPlatformVersion")
 	testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
 }


### PR DESCRIPTION
The 2nd part of  #936.
This pr makes use of native junitPlatform from gradle 4.6 in projects other than detekt-gradle-plugin project.