### PR TITLE
UnusedPrivateMember: detect top level declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Mike Gorunov](http://github.com/Miha-x64/) — Rule improvement: UndocumentedPublicFunction
 - [Joey Kaan](https://github.com/jkaan) - New rule: MandatoryBracesIfStatements
 - [Dmitriy Samaryan](https://github.com/samarjan92) - Rule fix: SerialVersionUIDInSerializableClass
+- [Mariano Simone](https://github.com/marianosimone) - Rule improvement: UnusedPrivateMember
 
 ### Mentions
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules
 
 import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtNamedFunction
 
 fun KtFunction.isEqualsFunction() =
 	this.name == "equals" && hasCorrectEqualsParameter() && this.isOverridden()
@@ -10,3 +11,6 @@ fun KtFunction.isHashCodeFunction() =
 
 fun KtFunction.hasCorrectEqualsParameter() =
 		this.valueParameters.firstOrNull()?.typeReference?.text == "Any?"
+
+fun KtNamedFunction.isMainFunction() =
+		this.name == "main" && this.isPublicNotOverridden() && this.isTopLevel

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
@@ -8,7 +8,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.collectByType
-import io.gitlab.arturbosch.detekt.rules.isPublicNotOverridden
+import io.gitlab.arturbosch.detekt.rules.isMainFunction
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtThrowExpression
@@ -34,13 +34,9 @@ class ThrowingExceptionInMain(config: Config = Config.empty) : Rule(config) {
 			"The main method should not throw an exception.", Debt.TWENTY_MINS)
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
-		if (isMainFunction(function) && hasArgsParameter(function.valueParameters) && containsThrowExpression(function)) {
+		if (function.isMainFunction() && hasArgsParameter(function.valueParameters) && containsThrowExpression(function)) {
 			report(CodeSmell(issue, Entity.from(function), issue.description))
 		}
-	}
-
-	private fun isMainFunction(function: KtNamedFunction): Boolean {
-		return function.name == "main" && function.isPublicNotOverridden() && function.isTopLevel
 	}
 
 	private fun hasArgsParameter(parameters: List<KtParameter>): Boolean {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.isMainFunction
 import io.gitlab.arturbosch.detekt.rules.isOverridden
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClass
@@ -51,22 +52,26 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 
 	private val allowedNames = Regex(valueOrDefault(ALLOWED_NAMES_PATTERN, "(_|ignored|expected)"))
 
+	override fun visit(root: KtFile) {
+		super.visit(root)
+
+		val propertyVisitor = UnusedPropertyVisitor(allowedNames)
+		root.accept(propertyVisitor)
+
+		propertyVisitor.getUnusedProperties().forEach {
+			report(CodeSmell(issue, Entity.from(it.value), "Private property ${it.key} is unused."))
+		}
+	}
+
 	override fun visitClassOrObject(classOrObject: KtClassOrObject) {
 		if ((classOrObject as? KtClass)?.isInterface() == true) {
 			return
 		}
 
-		val propertyVisitor = UnusedPropertyVisitor(allowedNames)
-		classOrObject.accept(propertyVisitor)
-
-		propertyVisitor.getUnusedProperties().forEach {
-			report(CodeSmell(issue, Entity.from(it.value), "Private property ${it.key} is unused."))
-		}
-
 		super.visitClassOrObject(classOrObject)
 	}
 
-	class UnusedPropertyVisitor(private val allowedNames: Regex) : DetektVisitor() {
+	private class UnusedPropertyVisitor(private val allowedNames: Regex) : DetektVisitor() {
 
 		private val properties = mutableMapOf<String, KtElement>()
 		private val nameAccesses = mutableSetOf<String>()
@@ -103,17 +108,14 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 		}
 
 		override fun visitProperty(property: KtProperty) {
-			if ((property.isPrivate() && property.isNonNestedMember())
+			if ((property.isPrivate() && property.isMemberOrTopLevel())
 					|| property.isLocal) {
 				checkAllowedNames(property)
 			}
 			super.visitProperty(property)
 		}
 
-		private fun KtProperty.isNonNestedMember() = isMember
-				&& parent // KtClassBody
-				?.parent  // KtClassOrObject
-				?.parent is KtFile
+		private fun KtProperty.isMemberOrTopLevel() = isMember || isTopLevel
 
 		override fun visitReferenceExpression(expression: KtReferenceExpression) {
 			nameAccesses.add(expression.text)
@@ -135,8 +137,14 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 	}
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
-		if (function.isPrivate() && !function.isOverridden()) {
+		if (function.isMainFunction()) {
+			return
+		}
+		if (function.isPrivate()) {
 			collectFunction(function)
+		}
+		// Overridden functions need to declare parameters, even if they don't use them
+		if (!function.isOverridden()) {
 			collectParameters(function)
 		}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -14,7 +14,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 	given("cases file with different findings") {
 
 		it("positive cases file") {
-			assertThat(subject.lint(Case.UnusedPrivateMemberPositive.path())).hasSize(10)
+			assertThat(subject.lint(Case.UnusedPrivateMemberPositive.path())).hasSize(12)
 		}
 
 		it("negative cases file") {
@@ -492,6 +492,77 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 						fun someFunction() = used
 					}
 				}"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+	}
+
+	given("parameters in primary constructors") {
+		it("reports unused private property") {
+			val code = """
+				class Test(private val unused: Any)
+				"""
+			assertThat(subject.lint(code)).hasSize(1)
+		}
+
+		it("reports unused parameter") {
+			val code = """
+				class Test(unused: Any)
+				"""
+			assertThat(subject.lint(code)).hasSize(1)
+		}
+
+		it("does not report used parameter for calling super") {
+			val code = """
+    			class Parent(val ignored: Any)
+				class Test(used: Any) : Parent(used)
+				"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+
+		it("does not report used parameter in init block") {
+			val code = """
+				class Test(used: Any) {
+					init {
+						used.toString()
+					}
+				}
+				"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+
+		it("does not report used parameter to initialize property") {
+			val code = """
+				class Test(used: Any) {
+					val usedString = used.toString()
+				}
+				"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+
+		it("does not report public property") {
+			val code = """
+				class Test(val unused: Any)
+				"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+
+		it("does not report private property used in init block") {
+			val code = """
+				class Test(private val used: Any) {
+					init { used.toString() }
+				}
+				"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+
+		it("does not report private property used in function") {
+			val code = """
+				class Test(private val used: Any) {
+					fun something() {
+						used.toString()
+					}
+				}
+				"""
 			assertThat(subject.lint(code)).isEmpty()
 		}
 	}

--- a/detekt-rules/src/test/resources/cases/UnusedPrivateMemberPositive.kt
+++ b/detekt-rules/src/test/resources/cases/UnusedPrivateMemberPositive.kt
@@ -4,6 +4,7 @@
 class UnusedPrivateMemberPositive {
 	private val unusedField = 5
 	val publicField = 2
+	private val clashingName = 4
 	private fun unusedFunction(unusedParam: Int) {
 		val unusedLocal = 5
 	}
@@ -11,7 +12,11 @@ class UnusedPrivateMemberPositive {
 
 object UnusedPrivateMemberPositiveObject {
 	private const val unusedObjectConst = 2
+	private val unusedField = 5
+	private val clashingName = 5
+	val useForClashingName = clashingName
 	private val unusedObjectField = 4
+
 	object Foo {
 		private val unusedNestedVal = 1
 	}
@@ -22,3 +27,11 @@ private fun unusedTopLevelFunction() = 5
 private val usedTopLevelVal = 1
 private const val unusedTopLevelConst = 1
 private val unusedTopLevelVal = usedTopLevelVal
+
+private class ClassWithSecondaryConstructor {
+	constructor(used: Any, unused: Any) {
+		used.toString()
+	}
+	// this is actually unused, but clashes with the other constructor
+	constructor(used: Any)
+}

--- a/detekt-rules/src/test/resources/cases/UnusedPrivateMemberPositive.kt
+++ b/detekt-rules/src/test/resources/cases/UnusedPrivateMemberPositive.kt
@@ -3,10 +3,22 @@
 // reports 1 violation for every unused* element
 class UnusedPrivateMemberPositive {
 	private val unusedField = 5
-
+	val publicField = 2
 	private fun unusedFunction(unusedParam: Int) {
 		val unusedLocal = 5
 	}
 }
 
+object UnusedPrivateMemberPositiveObject {
+	private const val unusedObjectConst = 2
+	private val unusedObjectField = 4
+	object Foo {
+		private val unusedNestedVal = 1
+	}
+}
+
 private fun unusedTopLevelFunction() = 5
+
+private val usedTopLevelVal = 1
+private const val unusedTopLevelConst = 1
+private val unusedTopLevelVal = usedTopLevelVal


### PR DESCRIPTION
This is one approach to allow `UnusedPrivateMember` to look at top level declarations as well.

Initial discussion in #948