### PR TITLE
UnusedPrivateMember: do not report unused parameters in abstract/open functions

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtModifierList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtModifierList.kt
@@ -6,6 +6,8 @@ import org.jetbrains.kotlin.psi.KtModifierListOwner
 fun KtModifierListOwner.isPublicNotOverridden() =
 		isPublic() && !isOverridden()
 
+fun KtModifierListOwner.isAbstract() = hasModifier(KtTokens.ABSTRACT_KEYWORD)
+
 fun KtModifierListOwner.isOverridden() = hasModifier(KtTokens.OVERRIDE_KEYWORD)
 
 fun KtModifierListOwner.isOpen() = hasModifier(KtTokens.OPEN_KEYWORD)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -8,12 +8,13 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.isAbstract
 import io.gitlab.arturbosch.detekt.rules.isMainFunction
+import io.gitlab.arturbosch.detekt.rules.isOpen
 import io.gitlab.arturbosch.detekt.rules.isOverridden
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
-import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
@@ -150,8 +151,8 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 		if (function.isPrivate()) {
 			collectFunction(function)
 		}
-		// Overridden functions need to declare parameters, even if they don't use them
-		if (!function.isOverridden()) {
+		// Overriddable/Overridden functions need to declare parameters, even if they don't use them
+		if (!(function.isAbstract() || function.isOpen() || function.isOverridden())) {
 			collectParameters(function)
 		}
 

--- a/detekt-rules/src/test/resources/cases/UnusedPrivateMemberNegative.kt
+++ b/detekt-rules/src/test/resources/cases/UnusedPrivateMemberNegative.kt
@@ -83,3 +83,19 @@ val stuff = object : Iterator<String?> {
 fun main(args: Array<String>) {
 	println(stuff.next())
 }
+
+abstract class Parent {
+	abstract fun abstractFun(arg: Any)
+	open fun openFun(arg: Any): Int = 0
+}
+
+class Child : Parent() {
+	override fun abstractFun(arg: Any) {
+		println(arg)
+	}
+
+	override fun openFun(arg: Any): Int {
+		println(arg)
+		return 1
+	}
+}


### PR DESCRIPTION
Fixes #972