### PR TITLE
New rule: VarCouldBeVal

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -476,6 +476,8 @@ style:
     excludeAnnotatedClasses: ""
   UtilityClassWithPublicConstructor:
     active: false
+  VarCouldBeVal:
+    active: false
   WildcardImport:
     active: true
     excludeImports: 'java.util.*,kotlinx.android.synthetic.*'

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -34,6 +34,7 @@ import io.gitlab.arturbosch.detekt.rules.style.UnusedImports
 import io.gitlab.arturbosch.detekt.rules.style.UnusedPrivateMember
 import io.gitlab.arturbosch.detekt.rules.style.UseDataClass
 import io.gitlab.arturbosch.detekt.rules.style.UtilityClassWithPublicConstructor
+import io.gitlab.arturbosch.detekt.rules.style.VarCouldBeVal
 import io.gitlab.arturbosch.detekt.rules.style.WildcardImport
 import io.gitlab.arturbosch.detekt.rules.style.optional.MandatoryBracesIfStatements
 import io.gitlab.arturbosch.detekt.rules.style.optional.OptionalUnit
@@ -87,7 +88,8 @@ class StyleGuideProvider : RuleSetProvider {
 				UntilInsteadOfRangeTo(config),
 				MayBeConst(config),
 				PreferToOverPairSyntax(config),
-				MandatoryBracesIfStatements(config)
+				MandatoryBracesIfStatements(config),
+				VarCouldBeVal(config)
 		))
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
@@ -1,0 +1,111 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.DetektVisitor
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtUnaryExpression
+
+private val unaryAssignmentOperators = setOf(KtTokens.MINUSMINUS, KtTokens.PLUSPLUS)
+
+/**
+ * Reports var declarations (locally-scoped variables) that could be val, as they are not re-assigned.
+ * Val declarations are assign-once (read-only), which makes understanding the current state easier.
+ *
+ * <noncompliant>
+ * fun example() {
+ *     var i = 1 // violation: this variable is never re-assigned
+ *     val j = i + 1
+ * }
+ * </noncompliant>
+ *
+ * <compliant>
+ * fun example() {
+ *     val i = 1
+ *     val j = i + 1
+ * }
+ * </compliant>
+ *
+ * @author marianosimone
+ */
+class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
+
+	override val issue: Issue = Issue("VarCouldBeVal",
+			Severity.Maintainability,
+			"Var declaration could be val.",
+			Debt.FIVE_MINS,
+			aliases = setOf("CanBeVal"))
+
+	override fun visitNamedFunction(function: KtNamedFunction) {
+		val assignmentVisitor = AssignmentVisitor()
+		function.accept(assignmentVisitor)
+
+		assignmentVisitor.getNonReAssignedDeclarations().forEach {
+			report(CodeSmell(issue, Entity.from(it), "Variable '${it.nameAsSafeName.identifier}' could be val."))
+		}
+		super.visitNamedFunction(function)
+	}
+
+	private class AssignmentVisitor : DetektVisitor() {
+
+		private val declarations = mutableSetOf<KtNamedDeclaration>()
+		// an easy way to find declarations when walking up the contexts of an assignment
+		private val contextsByDeclarationName = mutableMapOf<String, MutableSet<PsiElement>>()
+		private val assignments = mutableMapOf<String, MutableSet<PsiElement>>()
+
+		fun getNonReAssignedDeclarations(): List<KtNamedDeclaration> {
+			return declarations.filter { declaration ->
+				assignments[declaration.nameAsSafeName.identifier]
+						?.let { declaration.parent !in it }
+						?: true
+			}
+		}
+
+		override fun visitProperty(property: KtProperty) {
+			if (property.isVar) {
+				declarations.add(property)
+				val contextsForName = contextsByDeclarationName.getOrPut(property.nameAsSafeName.identifier) { mutableSetOf() }
+				contextsForName.add(property.parent)
+			}
+			super.visitProperty(property)
+		}
+
+		override fun visitUnaryExpression(expression: KtUnaryExpression) {
+			if (expression.operationToken in unaryAssignmentOperators) {
+				expression.baseExpression?.run {
+					visitAssignment(text, expression.parent)
+				}
+			}
+			super.visitUnaryExpression(expression)
+		}
+
+		override fun visitBinaryExpression(expression: KtBinaryExpression) {
+			if (expression.operationToken in KtTokens.ALL_ASSIGNMENTS) {
+				visitAssignment(expression.firstChild.text, expression.parent)
+			}
+			super.visitBinaryExpression(expression)
+		}
+
+		private fun visitAssignment(assignedName: String, context: PsiElement) {
+			val potentialContexts = contextsByDeclarationName[assignedName]
+			if (potentialContexts != null) {
+				val actualContextChain = generateSequence(context) { it.parent }
+				val actualContext = actualContextChain.firstOrNull { it in potentialContexts }
+				if (actualContext != null) {
+					val nameAssignments = assignments.getOrPut(assignedName) { mutableSetOf() }
+					nameAssignments.add(actualContext)
+				}
+			}
+		}
+	}
+}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -1,0 +1,125 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
+
+class VarCouldBeValSpec : SubjectSpek<VarCouldBeVal>({
+
+	subject { VarCouldBeVal() }
+
+	given("local declarations in functions") {
+
+		it("does not report variables that are re-assigned") {
+			val code = """
+    		fun test() {
+				var a = 1
+				a = 2
+			}
+			"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+
+		it("does not report variables that are re-assigned with assignment operator") {
+			val code = """
+			fun test() {
+				var a = 1
+				a += 2
+			}
+			"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+
+		it("does not report variables that are re-assigned with assignment operator") {
+			val code = """
+    		fun test() {
+				var a = 1
+				a += 2
+			}
+			"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+
+		it("does not report variables that are re-assigned with postfix operators") {
+			val code = """
+			fun test() {
+				var a = 1
+				a++
+			}
+			"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+
+		it("does not report variables that are re-assigned with infix operators") {
+			val code = """
+			fun test() {
+				var a = 1
+				--a
+			}
+			"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+
+		it("does not report variables that are re-assigned inside scope functions") {
+			val code = """
+			fun test() {
+				var a = 1
+				a.also {
+					a = 2
+				}
+			}
+			"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+
+		it("reports variables that are not re-assigned, but used in expressions") {
+			val code = """
+			fun test() {
+				var a = 1
+				val b = a + 2
+			}
+			"""
+			val lint = subject.lint(code)
+
+			assertThat(lint).hasSize(1)
+			with(lint[0]) {
+				assertThat(entity.name).isEqualTo("a")
+			}
+		}
+
+		it("reports variables that are not re-assigned, but used in function calls") {
+			val code = """
+			fun test() {
+				var a = 1
+				something(a)
+			}
+			"""
+			val lint = subject.lint(code)
+
+			assertThat(lint).hasSize(1)
+			with(lint[0]) {
+				assertThat(entity.name).isEqualTo("a")
+			}
+		}
+
+		it("reports variables that are not re-assigned, but shadowed by one that is") {
+			val code = """
+			fun test() {
+				var shadowed = 1
+				fun nestedFunction() {
+					var shadowed = 2
+					shadowed = 3
+				}
+			}
+			"""
+			val lint = subject.lint(code)
+
+			assertThat(lint).hasSize(1)
+			with(lint[0].entity) {
+				assertThat(ktElement?.text).isEqualTo("var shadowed = 1")
+			}
+		}
+	}
+})

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -968,6 +968,33 @@ class UtilityClass {
 }
 ```
 
+### VarCouldBeVal
+
+Reports var declarations (locally-scoped variables) that could be val, as they are not re-assigned.
+Val declarations are assign-once (read-only), which makes understanding the current state easier.
+
+**Severity**: Maintainability
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+fun example() {
+    var i = 1 // violation: this variable is never re-assigned
+    val j = i + 1
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+fun example() {
+    val i = 1
+    val j = i + 1
+}
+```
+
 ### WildcardImport
 
 Wildcard imports should be replaced with imports using fully qualified class names. This helps increase clarity of


### PR DESCRIPTION
This is a first implementation of a rule, as requested in #657 

Note that, for now, it only looks at locally-scoped variables inside functions. I want to make it more useful than this (think, private top-level variables, properties in classes, etc.), but given that this is my first rule, I wanted to create a quick PR to get some feedback and see if I'm going down the right path.
