### PR TITLE
Activate rules in failfast.yml part2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,10 +70,6 @@ subprojects {
 		kotlinOptions.allWarningsAsErrors = shouldTreatCompilerWarningsAsErrors()
 	}
 
-	val test by tasks.getting(Test::class) {
-		useJUnitPlatform()
-	}
-
 	bintray {
 		user = System.getenv("BINTRAY_USER") ?: ""
 		key = System.getenv("BINTRAY_API_KEY") ?: ""
@@ -164,7 +160,6 @@ subprojects {
 
 	val kotlinVersion by project
 	val junitEngineVersion by project
-	val junitPlatformVersion by project
 	val assertjVersion by project
 	val spekVersion by project
 	val kotlinImplementation by configurations.creating

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinter.kt
@@ -33,7 +33,6 @@ class AstPrinter(private val arguments: CliArgs) : Executable {
 class ElementPrinter : DetektVisitor() {
 
 	companion object {
-		private const val TAB = "\t"
 		internal fun dump(file: KtFile): String = ElementPrinter().run {
 			sb.appendln("0: " + file.javaClass.simpleName)
 			visitKtFile(file)

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigConstants.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigConstants.kt
@@ -3,11 +3,6 @@ package io.gitlab.arturbosch.detekt.formatting
 /**
  * @author Artur Bosch
  */
-const val KEY_MAX_LINE_LENGTH = "max_line_length"
-const val KEY_INDENT_SIZE = "indent_size"
-const val KEY_CONTINUATION_INDENT_SIZE = "continuation_indent_size"
-const val KEY_INSERT_FINAL_NEWLINE = "insert_final_newline"
-
 const val DEFAULT_INDENT = 4
 const val DEFAULT_CONTINUATION_INDENT = 4
 const val ANDROID_MAX_LINE_LENGTH = 100

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtModifierList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtModifierList.kt
@@ -12,6 +12,8 @@ fun KtModifierListOwner.isOverridden() = hasModifier(KtTokens.OVERRIDE_KEYWORD)
 
 fun KtModifierListOwner.isOpen() = hasModifier(KtTokens.OPEN_KEYWORD)
 
+fun KtModifierListOwner.isOperator() = hasModifier(KtTokens.OPERATOR_KEYWORD)
+
 fun KtModifierListOwner.isPublic(): Boolean {
 	return this.hasModifier(KtTokens.PUBLIC_KEYWORD)
 			|| !(this.hasModifier(KtTokens.PRIVATE_KEYWORD)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
@@ -46,7 +46,7 @@ class ExplicitGarbageCollectionCall(config: Config) : Rule(config) {
 		if (it.textMatches("gc") || it.textMatches("runFinalization")) {
 			it.getReceiverExpression()?.let {
 				when (it.text) {
-					"System", "Runtime.getRuntime()" -> report(CodeSmell(issue, Entity.Companion.from(expression),
+					"System", "Runtime.getRuntime()" -> report(CodeSmell(issue, Entity.from(expression),
 							"An explicit call to the Garbage Collector as in ${it.text} should not be made."))
 				}
 			}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
@@ -72,7 +72,7 @@ class StringLiteralDuplication(
 			report(ThresholdedCodeSmell(issue,
 					main,
 					Metric(type + name, value, threshold),
-					"",
+					issue.description,
 					references))
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -62,7 +62,7 @@ class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
 
 	private fun reportIfUndocumented(element: KtClassOrObject) {
 		if (element.isPublicNotOverridden() && element.notEnumEntry() && element.docComment == null) {
-			report(CodeSmell(issue, Entity.Companion.from(element),
+			report(CodeSmell(issue, Entity.from(element),
 					"${element.nameAsSafeName} is missing required documentation."))
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
  *
  * @author Artur Bosch
  * @author Marvin Ramin
+ * @author schalkms
  */
 class UndocumentedPublicFunction(config: Config = Config.empty) : Rule(config) {
 
@@ -29,21 +30,12 @@ class UndocumentedPublicFunction(config: Config = Config.empty) : Rule(config) {
 		if (function.funKeyword == null && function.isLocal) return
 
 		if (function.docComment == null && function.shouldBeDocumented()) {
-				report(CodeSmell(issue, methodHeaderLocation(function),
+				report(CodeSmell(issue, Entity.from(function),
 						"The function ${function.nameAsSafeName} is missing documentation."))
 		}
 	}
 
-	/**
-	 * A function should be documented when it is not overridden,
-	 * and both the function and a class containing it are public.
-	 */
-	private fun KtNamedFunction.shouldBeDocumented(): Boolean =
-			isContainingClassPublic() && (modifierList == null || isPublicNotOverridden())
+	private fun KtNamedFunction.shouldBeDocumented() = isContainingClassPublic() && isPublicNotOverridden()
 
-	private fun KtNamedFunction.isContainingClassPublic(): Boolean =
-			containingClass().let { it == null || it.isPublic }
-
-	private fun methodHeaderLocation(function: KtNamedFunction) = Entity.from(function)
-
+	private fun KtNamedFunction.isContainingClassPublic() = containingClass().let { it == null || it.isPublic }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
@@ -53,7 +53,7 @@ class NestedClassesVisibility(config: Config = Config.empty) : Rule(config) {
 	private fun checkDeclarations(klass: KtClass) {
 		klass.declarations
 				.filterIsInstance<KtClassOrObject>()
-				.filter { it.isPublic() && it.isNoEnum() }
+				.filter { it.isPublic() && it.isNoEnum() && it.isNoCompanionObj() }
 				.forEach {
 					report(CodeSmell(issue, Entity.from(it),
 						"Nested types are often used for implementing private functionality. " +
@@ -62,4 +62,6 @@ class NestedClassesVisibility(config: Config = Config.empty) : Rule(config) {
 	}
 
 	private fun KtClassOrObject.isNoEnum() = !this.hasModifier(KtTokens.ENUM_KEYWORD) && this !is KtEnumEntry
+
+	private fun KtClassOrObject.isNoCompanionObj() = !this.hasModifier(KtTokens.COMPANION_KEYWORD)
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -11,6 +11,7 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.isAbstract
 import io.gitlab.arturbosch.detekt.rules.isMainFunction
 import io.gitlab.arturbosch.detekt.rules.isOpen
+import io.gitlab.arturbosch.detekt.rules.isOperator
 import io.gitlab.arturbosch.detekt.rules.isOverridden
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClass
@@ -152,8 +153,9 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 			collectFunction(function)
 		}
 		// Overriddable/Overridden functions need to declare parameters, even if they don't use them
-		if (!(function.isAbstract() || function.isOpen() || function.isOverridden())) {
-			collectParameters(function)
+		when {
+			function.isAbstract() || function.isOpen() || function.isOverridden() || function.isOperator() -> { }
+			else -> collectParameters(function)
 		}
 
 		super.visitNamedFunction(function)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -146,15 +146,13 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 	}
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
-		if (function.isMainFunction()) {
-			return
-		}
 		if (function.isPrivate()) {
 			collectFunction(function)
 		}
 		// Overriddable/Overridden functions need to declare parameters, even if they don't use them
 		when {
-			function.isAbstract() || function.isOpen() || function.isOverridden() || function.isOperator() -> { }
+			function.isAbstract() || function.isOpen() || function.isOverridden() || function.isOperator() ||
+					function.isMainFunction()->	{ }
 			else -> collectParameters(function)
 		}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -14,7 +14,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 	given("cases file with different findings") {
 
 		it("positive cases file") {
-			assertThat(subject.lint(Case.UnusedPrivateMemberPositive.path())).hasSize(12)
+			assertThat(subject.lint(Case.UnusedPrivateMemberPositive.path())).hasSize(13)
 		}
 
 		it("negative cases file") {

--- a/detekt-rules/src/test/resources/cases/NestedClassVisibilityNegative.kt
+++ b/detekt-rules/src/test/resources/cases/NestedClassVisibilityNegative.kt
@@ -9,9 +9,14 @@ internal class NestedClassVisibilityNegative {
 
 	private interface PrivateTest
 	internal interface InternalTest
+
+	// should not detect companion object
+	companion object C
 }
 
 private class PrivateClassWithNestedElements {
 
 	class Inner
 }
+
+

--- a/detekt-rules/src/test/resources/cases/UnusedPrivateMemberNegative.kt
+++ b/detekt-rules/src/test/resources/cases/UnusedPrivateMemberNegative.kt
@@ -2,6 +2,8 @@
 
 package cases
 
+import kotlin.reflect.KProperty
+
 /**
  * Many false positives reported in #812 - https://github.com/arturbosch/detekt/issues/812
  * and #840 - https://github.com/arturbosch/detekt/pull/840.
@@ -97,5 +99,13 @@ class Child : Parent() {
 	override fun openFun(arg: Any): Int {
 		println(arg)
 		return 1
+	}
+}
+
+class SingleAssign<String> {
+
+	// ignore unused operator function parameters
+	operator fun getValue(thisRef: Any?, property: KProperty<*>): kotlin.String {
+		return ""
 	}
 }

--- a/detekt-rules/src/test/resources/cases/UnusedPrivateMemberNegative.kt
+++ b/detekt-rules/src/test/resources/cases/UnusedPrivateMemberNegative.kt
@@ -4,10 +4,6 @@ package cases
 
 import kotlin.reflect.KProperty
 
-/**
- * Many false positives reported in #812 - https://github.com/arturbosch/detekt/issues/812
- * and #840 - https://github.com/arturbosch/detekt/pull/840.
- */
 object O { // public
 	const val NUMBER = 5 // public
 }

--- a/detekt-rules/src/test/resources/cases/UnusedPrivateMemberNegative.kt
+++ b/detekt-rules/src/test/resources/cases/UnusedPrivateMemberNegative.kt
@@ -80,7 +80,10 @@ val stuff = object : Iterator<String?> {
 
 fun main(args: Array<String>) {
 	println(stuff.next())
+	calledFromMain()
 }
+
+private fun calledFromMain() { }
 
 abstract class Parent {
 	abstract fun abstractFun(arg: Any)

--- a/detekt-rules/src/test/resources/cases/UnusedPrivateMemberPositive.kt
+++ b/detekt-rules/src/test/resources/cases/UnusedPrivateMemberPositive.kt
@@ -35,3 +35,9 @@ private class ClassWithSecondaryConstructor {
 	// this is actually unused, but clashes with the other constructor
 	constructor(used: Any)
 }
+
+fun main(args: Array<String>) {
+	println("")
+}
+
+private fun unusedAndNotCalledFromMain() { } // unused

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/Resources.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/Resources.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.test
 
 import io.gitlab.arturbosch.detekt.api.YamlConfig
-import java.io.File
 import java.net.URI
 
 internal object Resources
@@ -12,7 +11,5 @@ fun resource(name: String): URI {
 	requireNotNull(resource) { "Make sure the resource '$name' exists!" }
 	return resource.toURI()
 }
-
-fun resourceAsString(name: String): String = File(resource(name)).readText()
 
 fun yamlConfig(resource: String) = YamlConfig.loadResource(Resources::class.java.getResource("/$resource"))

--- a/reports/failfast.yml
+++ b/reports/failfast.yml
@@ -19,10 +19,6 @@ test-pattern: # Configure exclusions for test sources
     - 'SpreadOperator'
     - 'UnsafeCast'
 
-complexity:
-  MethodOverloading:
-    active: true
-
 comments:
   CommentOverPrivateProperty:
     active: true
@@ -30,10 +26,16 @@ comments:
 complexity:
   StringLiteralDuplication:
     active: true
-    threshold: 4
+    threshold: 5
     ignoreAnnotation: true
     excludeStringsWithLessThan5Characters: true
     ignoreStringsRegex: '$^'
+  ComplexInterface:
+    active: true
+    threshold: 10
+    includeStaticDeclarations: false
+  MethodOverloading:
+    active: true
 
 exceptions:
   NotImplementedDeclaration:
@@ -51,6 +53,7 @@ exceptions:
   ThrowingExceptionsWithoutMessageOrCause:
     active: true
   ThrowingNewInstanceOfSameException:
+    active: true
 
 formatting:
   active: true

--- a/reports/failfast.yml
+++ b/reports/failfast.yml
@@ -20,11 +20,11 @@ test-pattern: # Configure exclusions for test sources
     - 'UnsafeCast'
 
 complexity:
-  ComplexInterface:
-    active: true
-    threshold: 10
-    includeStaticDeclarations: false
   MethodOverloading:
+    active: true
+
+comments:
+  CommentOverPrivateProperty:
     active: true
 
 exceptions:
@@ -71,7 +71,6 @@ naming:
     variablePattern: '[a-z][A-Za-z0-9]*'
     privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
-
 
 potential-bugs:
   UnsafeCast:

--- a/reports/failfast.yml
+++ b/reports/failfast.yml
@@ -27,6 +27,14 @@ comments:
   CommentOverPrivateProperty:
     active: true
 
+complexity:
+  StringLiteralDuplication:
+    active: true
+    threshold: 4
+    ignoreAnnotation: true
+    excludeStringsWithLessThan5Characters: true
+    ignoreStringsRegex: '$^'
+
 exceptions:
   NotImplementedDeclaration:
     active: true
@@ -43,7 +51,6 @@ exceptions:
   ThrowingExceptionsWithoutMessageOrCause:
     active: true
   ThrowingNewInstanceOfSameException:
-    active: true
 
 formatting:
   active: true
@@ -78,6 +85,10 @@ potential-bugs:
   UselessPostfixExpression:
     active: true
 
+potential-bugs:
+  UnsafeCast:
+    active: true
+
 style:
   MagicNumber:
     ignoreHashCodeFunction: true
@@ -87,4 +98,9 @@ style:
   SpacingBetweenPackageAndImports:
     active: true
   UtilityClassWithPublicConstructor:
+    active: true
+  VariableNaming:
+    active: true
+    variablePattern: '(_)?[a-z][a-zA-Z0-9]*'
+  SpacingBetweenPackageAndImports:
     active: true


### PR DESCRIPTION
This PR contains some fixes for the `UnusedPrivateMember` rule.