### PR TITLE
Refactor UnusedImports rule

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -3,16 +3,18 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.isPartOf
-import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocTag
 import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtImportList
+import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtReferenceExpression
 
 /**
@@ -29,67 +31,70 @@ class UnusedImports(config: Config) : Rule(config) {
 			"Unused Imports are dead code and should be removed.",
 			Debt.FIVE_MINS)
 
-	private val operatorSet = setOf("unaryPlus", "unaryMinus", "not", "inc", "dec", "plus", "minus", "times", "div",
-			"mod", "rangeTo", "contains", "get", "set", "invoke", "plusAssign", "minusAssign", "timesAssign", "divAssign",
-			"modAssign", "equals", "compareTo", "iterator", "getValue", "setValue")
+	companion object {
+		private val operatorSet = setOf("unaryPlus", "unaryMinus", "not", "inc", "dec", "plus", "minus", "times", "div",
+				"mod", "rangeTo", "contains", "get", "set", "invoke", "plusAssign", "minusAssign", "timesAssign", "divAssign",
+				"modAssign", "equals", "compareTo", "iterator", "getValue", "setValue")
 
-	private var imports = mutableListOf<Pair<String, KtImportDirective>>()
-	private val kotlinDocReferencesRegExp = Regex("\\[([^]]+)](?!\\[)")
-
-	override fun visitFile(file: PsiFile?) {
-		imports.clear()
-		super.visitFile(file)
-		imports.forEach { report(CodeSmell(issue, Entity.from(it.second), "The import ${it.first} is " +
-				"unused.")) }
+		private val kotlinDocReferencesRegExp = Regex("\\[([^]]+)](?!\\[)")
 	}
 
-	override fun visitImportList(importList: KtImportList) {
-		imports = importList.imports.filter { it.isValidImport }
-				.filter { it.identifier()?.contains("*")?.not() == true }
-				.filter { it.identifier() != null }
-				.filter { !operatorSet.contains(it.identifier()) }
-				.map { it.identifier()!! to it }
-				.toMutableList()
-		super.visitImportList(importList)
+	override fun visit(root: KtFile) {
+		with(UnusedImportsVisitor()) {
+			root.accept(this)
+			unusedImports().forEach {
+				report(CodeSmell(issue, Entity.from(it), "The import '${it.importedFqName}' is unused."))
+			}
+		}
+		super.visit(root)
 	}
 
-	override fun visitReferenceExpression(expression: KtReferenceExpression) {
-		if (expression.isPartOf(KtImportDirective::class)) return
+	private class UnusedImportsVisitor : DetektVisitor() {
+		private var imports: List<KtImportDirective>? = null
+		private val namedReferences = mutableSetOf<String>()
 
-		val reference = expression.text.trim('`')
-		imports.find { it.first == reference }?.let {
-			imports.remove(it)
+		fun unusedImports(): List<KtImportDirective> {
+			return imports
+					?.filter { it.identifier() !in namedReferences }
+					.orEmpty()
 		}
 
-		super.visitReferenceExpression(expression)
-	}
-
-	override fun visitDeclaration(dcl: KtDeclaration) {
-		val kdoc = dcl.docComment?.getDefaultSection()
-
-		kdoc?.children
-				?.filter { it is KDocTag }
-				?.map { it.text }
-				?.forEach { handleKDoc(it) }
-
-		kdoc?.getContent()?.let {
-			handleKDoc(it)
+		override fun visitImportList(importList: KtImportList) {
+			imports = importList.imports.filter { it.isValidImport }
+					.filter { it.identifier()?.contains("*")?.not() == true }
+					.filter { it.identifier() != null }
+					.filter { !operatorSet.contains(it.identifier()) }
+			super.visitImportList(importList)
 		}
-		super.visitDeclaration(dcl)
-	}
 
-	private fun handleKDoc(content: String) {
-		kotlinDocReferencesRegExp.findAll(content, 0)
-				.map { it.groupValues[1] }
-				.forEach { checkImports(it) }
-	}
+		override fun visitReferenceExpression(expression: KtReferenceExpression) {
+			expression
+					.takeIf { !it.isPartOf(KtImportDirective::class) && !it.isPartOf(KtPackageDirective::class) }
+					?.takeIf { it.children.isEmpty() }
+					?.run { namedReferences.add(text.trim('`')) }
+			super.visitReferenceExpression(expression)
+		}
 
-	private fun checkImports(it: String) {
-		imports.removeIf { pair ->
-			val identifier = pair.second.identifier()
-			identifier != null && it.startsWith(identifier)
+		override fun visitDeclaration(dcl: KtDeclaration) {
+			val kdoc = dcl.docComment?.getDefaultSection()
+
+			kdoc?.children
+					?.filter { it is KDocTag }
+					?.map { it.text }
+					?.forEach { handleKDoc(it) }
+
+			kdoc?.getContent()?.let {
+				handleKDoc(it)
+			}
+			super.visitDeclaration(dcl)
+		}
+
+		private fun handleKDoc(content: String) {
+			kotlinDocReferencesRegExp.findAll(content, 0)
+					.map { it.groupValues[1] }
+					.forEach { namedReferences.add(it.split(".")[0]) }
 		}
 	}
-
-	private fun KtImportDirective.identifier() = this.importPath?.importedName?.identifier
 }
+
+private fun KtImportDirective.identifier() = this.importPath?.importedName?.identifier

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
@@ -26,7 +26,7 @@ class UnusedImportsSpec : SubjectSpek<UnusedImports>({
 					} success {
 					}
             	}"""
-			)).hasSize(0)
+			)).isEmpty()
 		}
 
 		it("does not report imports in documentation") {
@@ -51,7 +51,7 @@ class UnusedImportsSpec : SubjectSpek<UnusedImports>({
 		}
 
 		it("should ignore import for link") {
-			assertThat(subject.lint("""
+			val lint = subject.lint("""
 				import tasks.success
 				import tasks.failure
 				import tasks.undefined
@@ -65,7 +65,11 @@ class UnusedImportsSpec : SubjectSpek<UnusedImports>({
 				}
 				}
             """
-			)).hasSize(1)
+			)
+			with(lint) {
+				assertThat(this).hasSize(1)
+				assertThat(this[0].entity.signature).endsWith("import tasks.undefined")
+			}
 		}
 
 		it("does not report KDoc references with method calls") {
@@ -82,11 +86,11 @@ class UnusedImportsSpec : SubjectSpek<UnusedImports>({
 						TODO()
 					}
 				}"""
-			assertThat(subject.lint(code)).hasSize(0)
+			assertThat(subject.lint(code)).isEmpty()
 		}
 
 		it("reports imports with different cases") {
-			assertThat(subject.lint("""
+			val lint = subject.lint("""
             	import p.a
             	import p.B6 // positive
             	import p.B as B12 // positive
@@ -103,7 +107,13 @@ class UnusedImportsSpec : SubjectSpek<UnusedImports>({
             	    fn(B2.NAME)
             	    `when`()
             	}"""
-			)).hasSize(3)
+			)
+			with(lint) {
+				assertThat(this).hasSize(3)
+				assertThat(this[0].entity.signature).contains("import p.B6")
+				assertThat(this[1].entity.signature).contains("import p.B as B12")
+				assertThat(this[2].entity.signature).contains("import escaped.`foo`")
+			}
 		}
 	}
 
@@ -125,7 +135,7 @@ class UnusedImportsSpec : SubjectSpek<UnusedImports>({
 					TODO()
 				}"""
 
-			assertThat(subject.lint(code)).hasSize(0)
+			assertThat(subject.lint(code)).isEmpty()
 		}
 	}
 })


### PR DESCRIPTION
1. Make tests a bit more robust (by actually verifying what the
smells are)
2. Implement the rule with an internal visitor, so there's no state
in the rule itself (which needed to be reset for each file, preventing
it for being a candidate for parallel excecution)
3. Only look at KtReferenceExpressions that are not imports, package
directives nor have children. For example:

`foo(a, b)`

actually gets visited for `foo(a(b), c)`, `foo`, `a(b)`, `a`, `b`, and
`c`, but we only care about `foo`, `a`, `b`, and `c`