### PR TITLE
Fix to work on maven multi-module project 

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Joey Kaan](https://github.com/jkaan) - New rule: MandatoryBracesIfStatements
 - [Dmitriy Samaryan](https://github.com/samarjan92) - Rule fix: SerialVersionUIDInSerializableClass
 - [Mariano Simone](https://github.com/marianosimone) - Rule improvement: UnusedPrivateMember
+- [Shunsuke Maeda](https://github.com/duck8823) - Fix: to work on multi module project using [maven plugin](https://github.com/Ozsie/detekt-maven-plugin)
 
 ### Mentions
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
@@ -3,11 +3,11 @@ package io.gitlab.arturbosch.detekt.cli
 import com.beust.jcommander.JCommander
 import com.beust.jcommander.ParameterException
 
-val jCommander = JCommander()
-
 inline fun <reified T : Args> parseArguments(args: Array<String>): T {
 	val cli = T::class.java.declaredConstructors.firstOrNull()?.newInstance() as? T
 			?: throw IllegalStateException("Could not create Args object for class ${T::class.java}")
+
+	val jCommander = JCommander()
 
 	jCommander.addObject(cli)
 	jCommander.programName = "detekt"
@@ -36,6 +36,6 @@ fun failWithErrorMessages(messages: Iterable<String?>) {
 		println(it)
 	}
 	println()
-	jCommander.usage()
+	JCommander().usage()
 	System.exit(-1)
 }


### PR DESCRIPTION
I tried using [detekt-maven-plugin](https://github.com/Ozsie/detekt-maven-plugin) is introduced by README in this repository.
But, unfortunately, it didn't work in my multi-module project.

I made a sample [here](https://github.com/duck8823/detekt-maven-sample).
The detekt task success first module, but second module occurred error `Can only specify option -i once.`.

I found that jcommander instance is defined as global variable. 
Because the jcommander instance is used multiple times in multi-module project, argument parse error occur!

In this PR, I suggest that jcommander instance define as local variable.