### PR TITLE
UnusedImports: Add test for inner classes in same package

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
@@ -129,6 +129,21 @@ class UnusedImportsSpec : SubjectSpek<UnusedImports>({
 				assertThat(this[2].entity.signature).contains("import escaped.`foo`")
 			}
 		}
+
+		it("does not report imports in same package when inner") {
+			val lint = subject.lint("""
+            	package test
+
+				import test.Outer.Inner
+
+				class Outer : Something<Inner>() {
+					class Inner { }
+				}"""
+			)
+			with(lint) {
+				assertThat(this).isEmpty()
+			}
+		}
 	}
 
 	given("some import statements with KDoc") {


### PR DESCRIPTION
This makes sure that references to inner classes from outer ones
can be imported without being detected as a smell

I think this tests takes care of @vanniktech's concern

There's no need to change the visitor, as it was already correctly detecting this:

`it.importedFqName?.parent() == currentPackage` is `false` for this type of cases (in the test, that parent would be `test.Outer`, instead of just `test`)