### PR TITLE
Change description of TopLevelPropertyNaming rule

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
@@ -25,7 +25,7 @@ class TopLevelPropertyNaming(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName,
 			Severity.Style,
-			"Top level constant names should follow the naming convention set in the projects configuration.",
+			"Top level property names should follow the naming convention set in the projects configuration.",
 			debt = Debt.FIVE_MINS)
 
 	private val constantPattern = Regex(valueOrDefault(CONSTANT_PATTERN, "[A-Z][_A-Z0-9]*"))


### PR DESCRIPTION
Top level declarations don't have to be constants.