### PR TITLE
#520 Add "Unnecessary let" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Dmitriy Samaryan](https://github.com/samarjan92) - Rule fix: SerialVersionUIDInSerializableClass
 - [Mariano Simone](https://github.com/marianosimone) - Rule improvement: UnusedPrivateMember
 - [Shunsuke Maeda](https://github.com/duck8823) - Fix: to work on multi module project using [maven plugin](https://github.com/Ozsie/detekt-maven-plugin)
+- [Mikhail Levchenko](https://github.com/mishkun) - New rule: Unnecessary let
 - [Scott Kennedy](https://github.com/scottkennedy) - Minor fixes
 - [Mickele Moriconi](https://github.com/mickele) - Added: ConstructorParameterNaming and FunctionParameterNaming rules
 - [Lukasz Jazgar](https://github.com/ljazgar) - Fixed configuring formatting rules

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -469,6 +469,8 @@ style:
     excludeAnnotatedClasses: "dagger.Module"
   UnnecessaryInheritance:
     active: false
+  UnnecessaryLet:
+    active: false
   UnnecessaryParentheses:
     active: false
   UntilInsteadOfRangeTo:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -29,6 +29,7 @@ import io.gitlab.arturbosch.detekt.rules.style.SpacingBetweenPackageAndImports
 import io.gitlab.arturbosch.detekt.rules.style.ThrowsCount
 import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryAbstractClass
 import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryInheritance
+import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryLet
 import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryParentheses
 import io.gitlab.arturbosch.detekt.rules.style.UntilInsteadOfRangeTo
 import io.gitlab.arturbosch.detekt.rules.style.UnusedImports
@@ -87,6 +88,7 @@ class StyleGuideProvider : RuleSetProvider {
 				NestedClassesVisibility(config),
 				RedundantVisibilityModifierRule(config),
 				UntilInsteadOfRangeTo(config),
+				UnnecessaryLet(config),
 				MayBeConst(config),
 				PreferToOverPairSyntax(config),
 				MandatoryBracesIfStatements(config),

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -41,28 +41,28 @@ class UnnecessaryLet(config: Config) : Rule(config) {
 
 	override fun visitCallExpression(expression: KtCallExpression) {
 		super.visitCallExpression(expression)
-		if (expression.isLetExpr()) {
-			val lambdaExpr = expression.firstLambdaArg
-			val lambdaParameter = lambdaExpr?.firstParameter
-			val lambdaBody = lambdaExpr?.bodyExpression
-			// we need to check lambdas with only one statement
-			if (lambdaBody?.children?.size == 1) {
-				// only dot qualified expressions can be unnecessary
-				val firstExpr = lambdaBody.firstChild as? KtDotQualifiedExpression
-				val exprReceiver = firstExpr?.receiverExpression
+		if (!expression.isLetExpr()) return
+		
+		val lambdaExpr = expression.firstLambdaArg
+		val lambdaParameter = lambdaExpr?.firstParameter
+		val lambdaBody = lambdaExpr?.bodyExpression
+		// we need to check lambdas with only one statement
+		if (lambdaBody?.children?.size == 1) {
+            // only dot qualified expressions can be unnecessary
+            val firstExpr = lambdaBody.firstChild as? KtDotQualifiedExpression
+            val exprReceiver = firstExpr?.receiverExpression
 
-				if (exprReceiver != null) {
-					val isLetWithImplicitParam = lambdaParameter == null && exprReceiver.textMatches(IT_LITERAL)
-					val isLetWithExplicitParam = lambdaParameter != null && lambdaParameter.textMatches(exprReceiver)
-					if (isLetWithExplicitParam || isLetWithImplicitParam) {
-						report(CodeSmell(
-								issue, Entity.from(expression),
-								"let expression can be omitted"
-						))
-					}
-				}
-			}
-		}
+            if (exprReceiver != null) {
+                val isLetWithImplicitParam = lambdaParameter == null && exprReceiver.textMatches(IT_LITERAL)
+                val isLetWithExplicitParam = lambdaParameter != null && lambdaParameter.textMatches(exprReceiver)
+                if (isLetWithExplicitParam || isLetWithImplicitParam) {
+                    report(CodeSmell(
+                            issue, Entity.from(expression),
+                            "let expression can be omitted"
+                    ))
+                }
+            }
+        }
 	}
 
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtLambdaExpression
@@ -41,28 +42,29 @@ class UnnecessaryLet(config: Config) : Rule(config) {
 
 	override fun visitCallExpression(expression: KtCallExpression) {
 		super.visitCallExpression(expression)
+
 		if (!expression.isLetExpr()) return
-		
+
 		val lambdaExpr = expression.firstLambdaArg
 		val lambdaParameter = lambdaExpr?.firstParameter
 		val lambdaBody = lambdaExpr?.bodyExpression
-		// we need to check lambdas with only one statement
-		if (lambdaBody?.children?.size == 1) {
-            // only dot qualified expressions can be unnecessary
-            val firstExpr = lambdaBody.firstChild as? KtDotQualifiedExpression
-            val exprReceiver = firstExpr?.receiverExpression
 
-            if (exprReceiver != null) {
-                val isLetWithImplicitParam = lambdaParameter == null && exprReceiver.textMatches(IT_LITERAL)
-                val isLetWithExplicitParam = lambdaParameter != null && lambdaParameter.textMatches(exprReceiver)
-                if (isLetWithExplicitParam || isLetWithImplicitParam) {
-                    report(CodeSmell(
-                            issue, Entity.from(expression),
-                            "let expression can be omitted"
-                    ))
-                }
-            }
-        }
+		if (lambdaBody.hasOnlyOneStatement()) {
+			// only dot qualified expressions can be unnecessary
+			val firstExpr = lambdaBody.firstChild as? KtDotQualifiedExpression
+			val exprReceiver = firstExpr?.receiverExpression
+
+			if (exprReceiver != null) {
+				val isLetWithImplicitParam = lambdaParameter == null && exprReceiver.textMatches(IT_LITERAL)
+				val isLetWithExplicitParam = lambdaParameter != null && lambdaParameter.textMatches(exprReceiver)
+				if (isLetWithExplicitParam || isLetWithImplicitParam) {
+					report(CodeSmell(
+							issue, Entity.from(expression),
+							"let expression can be omitted"
+					))
+				}
+			}
+		}
 	}
 
 }
@@ -76,3 +78,5 @@ private fun KtCallExpression.isLetExpr() = calleeExpression?.textMatches(LET_LIT
 private val KtCallExpression.firstLambdaArg get() = lambdaArguments.firstOrNull()?.getLambdaExpression()
 
 private val KtLambdaExpression.firstParameter get() = valueParameters.firstOrNull()
+
+private fun KtBlockExpression?.hasOnlyOneStatement() = this?.children?.size == 1

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -12,11 +12,25 @@ import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 
 /**
- * Unnecessary `let` TODO
+ * `let` expressions are used extensively in our code for null-checking and chaining functions,
+ * but sometimes their usage should be replaced with a ordinary method/extension function call
+ * to reduce visual complexity
  *
  * <noncompliant>
- * TODO add example
+ * a.let { it.plus(1) } // can be replaced with `a.plus(1)`
+ * a?.let { it.plus(1) } // can be replaced with `a?.plus(1)`
+ * a.let { that -> that.plus(1) } // can be replaced with `a.plus(1)`
+ * a?.let { that -> that.plus(1) } // can be replaced with `a?.plus(1)`
+ * a?.let { that -> that.plus(1) }?.let { it.plus(1) } // can be replaced with `a?.plus(1)?.plus(1)`
  * </noncompliant>
+ *
+ * <compliant>
+ * a?.let { print(it) }
+ * a.let { print(it) }
+ * a?.let { msg -> print(msg) }
+ * a.let { msg -> print(msg) }
+ * a?.let { 1.plus(it) } ?.let { msg -> print(msg) }
+ * </compliant>
  *
  * @author mishkun
  */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -1,10 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.*
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.*
-import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
-import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForReceiver
+import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 /**
  * @author mishkun

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -1,0 +1,32 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.*
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
+import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForReceiver
+
+/**
+ * @author mishkun
+ */
+class UnnecessaryLet : Rule() {
+	override val issue = Issue(javaClass.simpleName, Severity.Style,
+			"The `let` usage is unnecessary", Debt.FIVE_MINS)
+
+	// catches the `let { it.foo() }` and `let { it.baz }` cases
+	private val letItRegex = """let\s*\{\s*it\??\.\w+(?:\(.*\))?\s*}""".toRegex()
+	// catches the `let { a -> a.foo() }` and `let { a -> a.baz }` cases
+	private val letParamRegex = """let\s*\{\s*(\w*)\s*->\s*\1\??\.\w*(?:\(.*\))?\s*}""".toRegex()
+
+	override fun visitCallExpression(expression: KtCallExpression) {
+		val isLetIt = expression.text matches letItRegex
+		val isLetParam = expression.text matches letParamRegex
+		if	(isLetIt || isLetParam){
+			report(CodeSmell(
+					issue, Entity.from(expression.parent ?: expression),
+					"let expression can be omitted"
+			))
+		}
+	}
+
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -17,11 +17,12 @@ class UnnecessaryLet : Rule() {
 	private val letParamRegex = """let\s*\{\s*(\w*)\s*->\s*\1\??\.\w*(?:\(.*\))?\s*}""".toRegex()
 
 	override fun visitCallExpression(expression: KtCallExpression) {
+		super.visitCallExpression(expression)
 		val isLetIt = expression.text matches letItRegex
 		val isLetParam = expression.text matches letParamRegex
 		if	(isLetIt || isLetParam){
 			report(CodeSmell(
-					issue, Entity.from(expression.parent ?: expression),
+					issue, Entity.from(expression),
 					"let expression can be omitted"
 			))
 		}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -51,7 +51,7 @@ class UnnecessaryLet(config: Config) : Rule(config) {
 
 		if (lambdaBody.hasOnlyOneStatement()) {
 			// only dot qualified expressions can be unnecessary
-			val firstExpr = lambdaBody.firstChild as? KtDotQualifiedExpression
+			val firstExpr = lambdaBody?.firstChild as? KtDotQualifiedExpression
 			val exprReceiver = firstExpr?.receiverExpression
 
 			if (exprReceiver != null) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -1,13 +1,25 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.*
-import org.jetbrains.kotlin.psi.*
-import org.jetbrains.kotlin.psi.psiUtil.siblings
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
 
 /**
+ * Unnecessary `let` TODO
+ *
+ * <noncompliant>
+ * TODO add example
+ * </noncompliant>
+ *
  * @author mishkun
  */
-class UnnecessaryLet : Rule() {
+class UnnecessaryLet(config: Config) : Rule(config) {
+
 	override val issue = Issue(javaClass.simpleName, Severity.Style,
 			"The `let` usage is unnecessary", Debt.FIVE_MINS)
 
@@ -20,12 +32,11 @@ class UnnecessaryLet : Rule() {
 		super.visitCallExpression(expression)
 		val isLetIt = expression.text matches letItRegex
 		val isLetParam = expression.text matches letParamRegex
-		if	(isLetIt || isLetParam){
+		if	(isLetIt || isLetParam) {
 			report(CodeSmell(
 					issue, Entity.from(expression),
 					"let expression can be omitted"
 			))
 		}
 	}
-
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -15,12 +15,10 @@ class UnnecessaryLetSpec : SubjectSpek<UnnecessaryLet>({
 			val findings = subject.lint("""
 				fun f() {
 					val a : Int? = null
-					val b = a.let { it.plus(3) }.let { a -> a.minus(1) }
-					val c = b
-					b.let { it?.plus(c) }
-					a?.let { it.plus(b) }
+					a?.let { it.plus(1) }
+					a.let { that -> that.plus(1) }
 				}""")
-			assertThat(findings).hasSize(4)
+			assertThat(findings).hasSize(2)
 		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -1,24 +1,26 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
 
 class UnnecessaryLetSpec : SubjectSpek<UnnecessaryLet>({
-	subject { UnnecessaryLet() }
+	subject { UnnecessaryLet(Config.empty) }
 
-	describe("check lets"){
-		it("has unnecessary lets"){
+	describe("check lets") {
+		it("has unnecessary lets") {
 			val findings = subject.lint("""
-				val a : Int? = null
-				val b = a.let { it.plus(3) }.let { a -> a.minus(1) }
-				val c = b
-				b.let { it?.plus(c) }
-				a?.let { it.plus(b) }""")
-			Assertions.assertThat(findings).hasSize(4)
+				fun f() {
+					val a : Int? = null
+					val b = a.let { it.plus(3) }.let { a -> a.minus(1) }
+					val c = b
+					b.let { it?.plus(c) }
+					a?.let { it.plus(b) }
+				}""")
+			assertThat(findings).hasSize(4)
 		}
 	}
 })
-

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -13,12 +13,11 @@ class UnnecessaryLetSpec : SubjectSpek<UnnecessaryLet>({
 		it("has unnecessary lets"){
 			val findings = subject.lint("""
 				val a : Int? = null
-				val b = a.let { it.plus(3) }
+				val b = a.let { it.plus(3) }.let { a -> a.minus(1) }
 				val c = b
 				b.let { it?.plus(c) }
 				a?.let { it.plus(b) }""")
-			println(findings.joinToString { it.message })
-			Assertions.assertThat(findings).hasSize(1)
+			Assertions.assertThat(findings).hasSize(4)
 		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -23,7 +23,7 @@ class UnnecessaryLetSpec : SubjectSpek<UnnecessaryLet>({
 				}""")
 			assertThat(findings).hasSize(6)
 		}
-		it("does not report lets used for function calls"){
+		it("does not report lets used for function calls") {
 			val findings = subject.lint("""
 				fun f() {
 					val a : Int? = null
@@ -35,7 +35,7 @@ class UnnecessaryLetSpec : SubjectSpek<UnnecessaryLet>({
 				}""")
 			assertThat(findings).hasSize(0)
 		}
-		it("does not report lets with lambda body containing more than one statement"){
+		it("does not report lets with lambda body containing more than one statement") {
 			val findings = subject.lint("""
 				fun f() {
 					val a : Int? = null

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -3,22 +3,55 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
 
 class UnnecessaryLetSpec : SubjectSpek<UnnecessaryLet>({
 	subject { UnnecessaryLet(Config.empty) }
 
-	describe("check lets") {
-		it("has unnecessary lets") {
+	given("some code using let expressions extensively") {
+		it("reports unnecessary lets that can be changed to ordinary method call") {
 			val findings = subject.lint("""
 				fun f() {
 					val a : Int? = null
+					a.let { it.plus(1) }
 					a?.let { it.plus(1) }
 					a.let { that -> that.plus(1) }
+					a?.let { that -> that.plus(1) }
+					a?.let { that -> that.plus(1) }?.let { it.plus(1) }
 				}""")
-			assertThat(findings).hasSize(2)
+			assertThat(findings).hasSize(6)
+		}
+		it("does not report lets used for function calls"){
+			val findings = subject.lint("""
+				fun f() {
+					val a : Int? = null
+					a.let { print(it) }
+					a?.let { print(it) }
+					a.let { that -> print(that) }
+					a?.let { that -> 1.plus(that) }
+					a?.let { that -> 1.plus(that) }?.let { print(it) }
+				}""")
+			assertThat(findings).hasSize(0)
+		}
+		it("does not report lets with lambda body containing more than one statement"){
+			val findings = subject.lint("""
+				fun f() {
+					val a : Int? = null
+					a.let { it.plus(1)
+                            it.plus(2) }
+					a?.let { it.plus(1)
+                             it.plus(2) }
+					a.let { that -> that.plus(1)
+                                    that.plus(2)  }
+					a?.let { that -> that.plus(1)
+                                     that.plus(2)  }
+					a?.let { that -> 1.plus(that) }
+                     ?.let { it.plus(1)
+                             it.plus(2) }
+				}""")
+			assertThat(findings).hasSize(0)
 		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -1,0 +1,25 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
+
+class UnnecessaryLetSpec : SubjectSpek<UnnecessaryLet>({
+	subject { UnnecessaryLet() }
+
+	describe("check lets"){
+		it("has unnecessary lets"){
+			val findings = subject.lint("""
+				val a : Int? = null
+				val b = a.let { it.plus(3) }
+				val c = b
+				b.let { it?.plus(c) }
+				a?.let { it.plus(b) }""")
+			println(findings.joinToString { it.message })
+			Assertions.assertThat(findings).hasSize(1)
+		}
+	}
+})
+

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -856,6 +856,20 @@ class A : Any()
 class B : Object()
 ```
 
+### UnnecessaryLet
+
+Unnecessary `let` TODO
+
+**Severity**: Style
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+TODO add example
+```
+
 ### UnnecessaryParentheses
 
 This rule reports unnecessary parentheses around expressions.

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -858,7 +858,9 @@ class B : Object()
 
 ### UnnecessaryLet
 
-Unnecessary `let` TODO
+`let` expressions are used extensively in our code for null-checking and chaining functions,
+but sometimes their usage should be replaced with a ordinary method/extension function call
+to reduce visual complexity
 
 **Severity**: Style
 
@@ -867,7 +869,21 @@ Unnecessary `let` TODO
 #### Noncompliant Code:
 
 ```kotlin
-TODO add example
+a.let { it.plus(1) } // can be replaced with `a.plus(1)`
+a?.let { it.plus(1) } // can be replaced with `a?.plus(1)`
+a.let { that -> that.plus(1) } // can be replaced with `a.plus(1)`
+a?.let { that -> that.plus(1) } // can be replaced with `a?.plus(1)`
+a?.let { that -> that.plus(1) }?.let { it.plus(1) } // can be replaced with `a?.plus(1)?.plus(1)`
+```
+
+#### Compliant Code:
+
+```kotlin
+a?.let { print(it) }
+a.let { print(it) }
+a?.let { msg -> print(msg) }
+a.let { msg -> print(msg) }
+a?.let { 1.plus(it) } ?.let { msg -> print(msg) }
 ```
 
 ### UnnecessaryParentheses


### PR DESCRIPTION
This pull request is intended to resolve #520. But I'm struggling to hit `let`'s which return value is not used.

For example, the test code
```
val a : Int? = null
val b = a.let { it.plus(3) } // #let1
val c = b.let { a -> a.minus(1) } // #let2
b.let { it?.plus(c) } // let3
a?.let { it.plus(b) } // let4
```
when linted, the rule finds only *let1* and *let2* but never visits *let3* and *let4*, even though it visits their lambda arguments. Looks like it doesn't count as expressions statements, which values never used. What am I doing wrong?