### PR TITLE
Fix typo in KDoc of UnnecessaryAbstractClass

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isAbstract
 
 /**
  * This rule inspects `abstract` classes. In case an `abstract class` does not have any concrete members it should be
- * refactored into an interfacse. Abstract classes which do not define any `abstract` members should instead be
+ * refactored into an interface. Abstract classes which do not define any `abstract` members should instead be
  * refactored into concrete classes.
  *
  * <noncompliant>

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -775,7 +775,7 @@ This rule reports lines that end with a whitespace.
 ### UnnecessaryAbstractClass
 
 This rule inspects `abstract` classes. In case an `abstract class` does not have any concrete members it should be
-refactored into an interfacse. Abstract classes which do not define any `abstract` members should instead be
+refactored into an interface. Abstract classes which do not define any `abstract` members should instead be
 refactored into concrete classes.
 
 **Severity**: Style


### PR DESCRIPTION
`interfacse` -> `interface`