### PR TITLE
Refactor ObjectPropertyNaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Dmitriy Samaryan](https://github.com/samarjan92) - Rule fix: SerialVersionUIDInSerializableClass
 - [Mariano Simone](https://github.com/marianosimone) - Rule improvement: UnusedPrivateMember
 - [Shunsuke Maeda](https://github.com/duck8823) - Fix: to work on multi module project using [maven plugin](https://github.com/Ozsie/detekt-maven-plugin)
+- [Scott Kennedy](https://github.com/scottkennedy) - Minor fixes
 
 ### Mentions
 

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -314,8 +314,9 @@ naming:
     ignoreOverriddenFunction: true
   ObjectPropertyNaming:
     active: true
-    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     constantPattern: '[A-Za-z][_A-Za-z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '(_)?[A-Za-z][A-Za-z0-9]*'
   PackageNaming:
     active: true
     packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
@@ -57,13 +57,11 @@ class TopLevelPropertyNaming(config: Config = Config.empty) : Rule(config) {
 						Entity.from(property),
 						message = "Private top level property names should match the pattern: $privatePropertyPattern"))
 			}
-		} else {
-			if (!property.identifierName().matches(propertyPattern)) {
-				report(CodeSmell(
-						issue,
-						Entity.from(property),
-						message = "Top level property names should match the pattern: $propertyPattern"))
-			}
+		} else if (!property.identifierName().matches(propertyPattern)) {
+			report(CodeSmell(
+					issue,
+					Entity.from(property),
+					message = "Top level property names should match the pattern: $propertyPattern"))
 		}
 	}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -78,6 +78,7 @@ class ObjectPropertyNamingSpec : SubjectSpek<ObjectPropertyNaming>({
 					val name = "Artur"
 					val nAme8 = "Artur"
 					val serialVersionUID = 42L
+					private val _name = "Artur"
 				}
 			""")
 			assertThat(subject.lint(code)).hasSize(0)
@@ -87,10 +88,9 @@ class ObjectPropertyNamingSpec : SubjectSpek<ObjectPropertyNaming>({
 			val code = compileContentForTest("""
 				object O {
 					val _nAme = "Artur"
-					private val _name = "Artur"
 				}
 			""")
-			assertThat(subject.lint(code)).hasSize(2)
+			assertThat(subject.lint(code)).hasSize(1)
 		}
 	}
 

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -191,11 +191,15 @@ Reports when property names inside objects which do not follow the specified nam
 
 #### Configuration options:
 
+* `constantPattern` (default: `'[A-Za-z][_A-Za-z0-9]*'`)
+
+   naming pattern
+
 * `propertyPattern` (default: `'[A-Za-z][_A-Za-z0-9]*'`)
 
    naming pattern
 
-* `constantPattern` (default: `'[A-Za-z][_A-Za-z0-9]*'`)
+* `privatePropertyPattern` (default: `'(_)?[A-Za-z][A-Za-z0-9]*'`)
 
    naming pattern
 


### PR DESCRIPTION
This adds a privatePropertyPattern and much more closely matches the
code in TopLevelPropertyNaming.  They may be able to share a base class (or be merged into one) in the future.
