### PR TITLE
OptionalUnit update

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
@@ -16,12 +16,17 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  * the `Unit` return type is specified on functions.
  *
  * <noncompliant>
- * fun foo(): Unit { }
+ * fun foo(): Unit {
+ *     return Unit 
+ * }
  * fun foo() = Unit
  * </noncompliant>
  *
  * <compliant>
  * fun foo() { }
+ *
+ * // overridden no-op functions are allowed
+ * override fun foo() = Unit
  * </compliant>
  *
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
@@ -53,10 +53,9 @@ class OptionalUnit(config: Config = Config.empty) : Rule(config) {
 
 	private fun checkFunctionWithExplicitReturnType(function: KtNamedFunction) {
 		val typeReference = function.typeReference
-		typeReference?.typeElement?.text?.let {
-			if (it == "Unit") {
-				report(CodeSmell(issue, Entity.from(typeReference), createMessage(function)))
-			}
+		val typeElementText = typeReference?.typeElement?.text
+		if (typeElementText == "Unit") {
+			report(CodeSmell(issue, Entity.from(typeReference), createMessage(function)))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  *
  * <noncompliant>
  * fun foo(): Unit { }
+ * fun foo() = Unit
  * </noncompliant>
  *
  * <compliant>

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -16,11 +16,12 @@ class OptionalUnitSpec : Spek({
 		it("should detect one finding") {
 			val findings = OptionalUnit().lint("""
 				fun returnsUnit1(): Unit {
+					fun returnsUnitNested(): Unit {}
 				}
 
 				fun returnsUnit2() = Unit
 			""")
-			assertThat(findings).hasSize(2)
+			assertThat(findings).hasSize(3)
 		}
 
 		it("should not report Unit reference") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -12,12 +12,24 @@ import org.jetbrains.spek.api.dsl.it
 class OptionalUnitSpec : Spek({
 
 	describe("running specified rule") {
+
 		it("should detect one finding") {
 			val findings = OptionalUnit().lint("""
-				fun returnsUnit(): Unit {
+				fun returnsUnit1(): Unit {
+				}
+
+				fun returnsUnit2() = Unit
+			""")
+			assertThat(findings).hasSize(2)
+		}
+
+		it("should not report Unit reference") {
+			val findings = OptionalUnit().lint("""
+				fun returnsNothing() {
+					Unit
 				}
 			""")
-			assertThat(findings).hasSize(1)
+			assertThat(findings).isEmpty()
 		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -18,7 +18,10 @@ class OptionalUnitSpec : SubjectSpek<OptionalUnit>({
 		it("should detect one finding") {
 			val findings = subject.lint("""
 				fun returnsUnit1(): Unit {
-					fun returnsUnitNested(): Unit {}
+					fun returnsUnitNested(): Unit {
+						return Unit
+					}
+					return Unit
 				}
 
 				fun returnsUnit2() = Unit
@@ -31,6 +34,13 @@ class OptionalUnitSpec : SubjectSpek<OptionalUnit>({
 				fun returnsNothing() {
 					Unit
 				}
+			""")
+			assertThat(findings).isEmpty()
+		}
+
+		it("should not report Unit return type in overridden function") {
+			val findings = subject.lint("""
+				override fun returnsUnit2() = Unit
 			""")
 			assertThat(findings).isEmpty()
 		}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -1,20 +1,22 @@
 package io.gitlab.arturbosch.detekt.rules.style.optional
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
 
 /**
  * @author Artur Bosch
  */
-class OptionalUnitSpec : Spek({
+class OptionalUnitSpec : SubjectSpek<OptionalUnit>({
+	subject { OptionalUnit(Config.empty) }
 
 	describe("running specified rule") {
 
 		it("should detect one finding") {
-			val findings = OptionalUnit().lint("""
+			val findings = subject.lint("""
 				fun returnsUnit1(): Unit {
 					fun returnsUnitNested(): Unit {}
 				}
@@ -25,7 +27,7 @@ class OptionalUnitSpec : Spek({
 		}
 
 		it("should not report Unit reference") {
-			val findings = OptionalUnit().lint("""
+			val findings = subject.lint("""
 				fun returnsNothing() {
 					Unit
 				}

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -489,6 +489,7 @@ the `Unit` return type is specified on functions.
 
 ```kotlin
 fun foo(): Unit { }
+fun foo() = Unit
 ```
 
 #### Compliant Code:

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -488,7 +488,9 @@ the `Unit` return type is specified on functions.
 #### Noncompliant Code:
 
 ```kotlin
-fun foo(): Unit { }
+fun foo(): Unit {
+    return Unit 
+}
 fun foo() = Unit
 ```
 
@@ -496,6 +498,9 @@ fun foo() = Unit
 
 ```kotlin
 fun foo() { }
+
+// overridden no-op functions are allowed
+override fun foo() = Unit
 ```
 
 ### OptionalWhenBraces


### PR DESCRIPTION
The `OptionalUnit` rule doesn't flag a overridden no-op function which returns Unit.

@vanniktech 
At least the `OptionalUnit` does not flag the code mentioned in #1012 
Please take a look at this PR and review it if you have time.
