### PR TITLE
Fixed #1039 - Indentation and MaximumLineLength configuration paramet…

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Mariano Simone](https://github.com/marianosimone) - Rule improvement: UnusedPrivateMember
 - [Shunsuke Maeda](https://github.com/duck8823) - Fix: to work on multi module project using [maven plugin](https://github.com/Ozsie/detekt-maven-plugin)
 - [Scott Kennedy](https://github.com/scottkennedy) - Minor fixes
+- [Lukasz Jazgar](https://github.com/ljazgar) - Fixed configuring formatting rules
 
 ### Mentions
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigMerge.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigMerge.kt
@@ -1,0 +1,29 @@
+package io.gitlab.arturbosch.detekt.formatting
+
+import com.github.shyiko.ktlint.core.EditorConfig
+
+/**
+ * Creates new EditorConfig by merging existing EditorConfig with properties values passed by parameters.
+ * Values of properties passed by parameters are more important than properties in sourceEditorConfig.
+ *
+ * @author Lukasz Jazgar
+ */
+fun EditorConfig.Companion.merge(sourceEditorConfig: EditorConfig?,
+																 indentSize: Int? = null,
+																 continuationIndentSize: Int? = null,
+																 maxLineLength: Int? = null,
+																 insertFinalNewline: Boolean? = null): EditorConfig =
+	EditorConfig.fromMap(
+		HashMap<String, String>().also {
+			copyProperty(it, "indent_size", indentSize, sourceEditorConfig)
+			copyProperty(it, "continuation_indent_size", continuationIndentSize, sourceEditorConfig)
+			copyProperty(it, "max_line_length", maxLineLength, sourceEditorConfig)
+			copyProperty(it, "insert_final_newline", insertFinalNewline, sourceEditorConfig)
+		}
+	)
+
+private fun copyProperty(map: MutableMap<String, String>, property: String, value: Any?,
+												 sourceEditorConfig: EditorConfig?) {
+	val newValue: String? = value?.toString() ?: sourceEditorConfig?.get(property)
+	newValue?.let { map[property] = it }
+}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigMerge.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigMerge.kt
@@ -8,11 +8,13 @@ import com.github.shyiko.ktlint.core.EditorConfig
  *
  * @author Lukasz Jazgar
  */
-fun EditorConfig.Companion.merge(sourceEditorConfig: EditorConfig?,
-																 indentSize: Int? = null,
-																 continuationIndentSize: Int? = null,
-																 maxLineLength: Int? = null,
-																 insertFinalNewline: Boolean? = null): EditorConfig =
+fun EditorConfig.Companion.merge(
+		sourceEditorConfig: EditorConfig?,
+		indentSize: Int? = null,
+		continuationIndentSize: Int? = null,
+		maxLineLength: Int? = null,
+		insertFinalNewline: Boolean? = null
+): EditorConfig =
 	EditorConfig.fromMap(
 		HashMap<String, String>().also {
 			copyProperty(it, "indent_size", indentSize, sourceEditorConfig)
@@ -22,8 +24,12 @@ fun EditorConfig.Companion.merge(sourceEditorConfig: EditorConfig?,
 		}
 	)
 
-private fun copyProperty(map: MutableMap<String, String>, property: String, value: Any?,
-												 sourceEditorConfig: EditorConfig?) {
+private fun copyProperty(
+		map: MutableMap<String, String>,
+		property: String,
+		value: Any?,
+		sourceEditorConfig: EditorConfig?
+) {
 	val newValue: String? = value?.toString() ?: sourceEditorConfig?.get(property)
 	newValue?.let { map[property] = it }
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.formatting
 
+import com.github.shyiko.ktlint.core.EditorConfig
 import com.github.shyiko.ktlint.core.KtLint
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
@@ -44,7 +45,13 @@ abstract class FormattingRule(config: Config) : Rule(config) {
 			val offsetDueToLineBreakNormalization = calculateLineBreakOffset(root.text)
 			return@let { offset: Int -> it(offset + offsetDueToLineBreakNormalization(offset)) }
 		}
+		editorConfigUpdater()?.let { updateFunc ->
+			val oldEditorConfig = root.node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)
+			root.node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY, updateFunc(oldEditorConfig))
+		}
 	}
+
+	open fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? = null
 
 	fun apply(node: ASTNode) {
 		if (ruleShouldOnlyRunOnFileNode(node)) {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
@@ -1,13 +1,12 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.github.shyiko.ktlint.core.EditorConfig
-import com.github.shyiko.ktlint.core.KtLint
 import com.github.shyiko.ktlint.ruleset.standard.IndentationRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_CONTINUATION_INDENT
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_INDENT
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
-import org.jetbrains.kotlin.psi.KtFile
+import io.gitlab.arturbosch.detekt.formatting.merge
 
 /**
  * See <a href="https://ktlint.github.io/#rule-indentation">ktlint-website</a> for documentation.
@@ -27,12 +26,10 @@ class Indentation(config: Config) : FormattingRule(config) {
 	private val indentSize = valueOrDefault(INDENT_SIZE, DEFAULT_INDENT)
 	private val continuationIndentSize = valueOrDefault(CONTINUATION_INDENT_SIZE, DEFAULT_CONTINUATION_INDENT)
 
-	override fun visit(root: KtFile) {
-		super.visit(root)
-		root.node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY,
-				EditorConfig.fromMap(mapOf(
-						INDENT_SIZE to indentSize.toString(),
-						CONTINUATION_INDENT_SIZE to continuationIndentSize.toString())))
+	override fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? = {
+		EditorConfig.merge(it,
+			indentSize = indentSize,
+			continuationIndentSize = continuationIndentSize)
 	}
 }
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MaximumLineLength.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MaximumLineLength.kt
@@ -1,13 +1,12 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.github.shyiko.ktlint.core.EditorConfig
-import com.github.shyiko.ktlint.core.KtLint
 import com.github.shyiko.ktlint.ruleset.standard.MaxLineLengthRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.ANDROID_MAX_LINE_LENGTH
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_IDEA_LINE_LENGTH
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
-import org.jetbrains.kotlin.psi.KtFile
+import io.gitlab.arturbosch.detekt.formatting.merge
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
@@ -27,10 +26,9 @@ class MaximumLineLength(config: Config) : FormattingRule(config) {
 			else DEFAULT_IDEA_LINE_LENGTH
 	private val maxLineLength: Int = valueOrDefault(MAX_LINE_LENGTH, defaultMaxLineLength)
 
-	override fun visit(root: KtFile) {
-		super.visit(root)
-		root.node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY,
-				EditorConfig.fromMap(mapOf(MAX_LINE_LENGTH to maxLineLength.toString())))
+	override fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? = {
+		EditorConfig.merge(it,
+			maxLineLength = maxLineLength)
 	}
 }
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
@@ -1,12 +1,11 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.github.shyiko.ktlint.core.EditorConfig
-import com.github.shyiko.ktlint.core.KtLint
 import com.github.shyiko.ktlint.ruleset.standard.ParameterListWrappingRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_INDENT
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
-import org.jetbrains.kotlin.psi.KtFile
+import io.gitlab.arturbosch.detekt.formatting.merge
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
@@ -24,10 +23,9 @@ class ParameterListWrapping(config: Config) : FormattingRule(config) {
 
 	private val indentSize = valueOrDefault(INDENT_SIZE, DEFAULT_INDENT)
 
-	override fun visit(root: KtFile) {
-		super.visit(root)
-		root.node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY,
-				EditorConfig.fromMap(mapOf(INDENT_SIZE to indentSize.toString())))
+	override fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? = {
+		EditorConfig.merge(it,
+			indentSize = indentSize)
 	}
 }
 


### PR DESCRIPTION
…ers are now properly passed to KTLint rules.

Names of properties of EditorConfig passed to KTLint rules are now correct.
Different formatting rules doesn't overwrite EditorConfig any more.
