### PR TITLE
Reworked UnconditionalJumpStatementInLoop

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.psi.KtContinueExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtLoopExpression
 import org.jetbrains.kotlin.psi.KtReturnExpression
-import org.jetbrains.kotlin.psi.KtThrowExpression
 
 /**
  * Reports loops which contain jump statements that jump regardless of any conditions.
@@ -52,6 +51,5 @@ class UnconditionalJumpStatementInLoop(config: Config = Config.empty) : Rule(con
 			isJumpStatement(body) || body?.children?.any { isJumpStatement(it) } == true
 
 	private fun isJumpStatement(element: PsiElement?) =
-			element is KtReturnExpression || element is KtBreakExpression ||
-					element is KtContinueExpression || element is KtThrowExpression
+			element is KtReturnExpression || element is KtBreakExpression || element is KtContinueExpression
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
@@ -14,7 +14,7 @@ class UnconditionalJumpStatementInLoopSpec : SubjectSpek<UnconditionalJumpStatem
 
 		it("reports unconditional jumps") {
 			val path = Case.UnconditionalJumpStatementInLoopPositive.path()
-			assertThat(subject.lint(path)).hasSize(6)
+			assertThat(subject.lint(path)).hasSize(8)
 		}
 
 		it("does not report conditional jumps") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
@@ -14,7 +14,7 @@ class UnconditionalJumpStatementInLoopSpec : SubjectSpek<UnconditionalJumpStatem
 
 		it("reports unconditional jumps") {
 			val path = Case.UnconditionalJumpStatementInLoopPositive.path()
-			assertThat(subject.lint(path)).hasSize(7)
+			assertThat(subject.lint(path)).hasSize(6)
 		}
 
 		it("does not report conditional jumps") {

--- a/detekt-rules/src/test/resources/cases/UnconditionalJumpStatementInLoopPositive.kt
+++ b/detekt-rules/src/test/resources/cases/UnconditionalJumpStatementInLoopPositive.kt
@@ -12,6 +12,17 @@ fun unconditionalJumpStatementsInLoop() { // reports 5 - 1 for every jump statem
 	} while (true)
 }
 
+fun unconditionalJumpStatementsInLoop2() {
+	for (i in 1..2) {
+		break // reports 1 - dead code
+		print("")
+	}
+	for (i in 1..2) {
+		print("")
+		break // reports 1
+	}
+}
+
 fun unconditionalJumpStatementInNestedLoop() { // reports 1
 	for (i in 1..2) {
 		for (j in 1..2) {

--- a/detekt-rules/src/test/resources/cases/UnconditionalJumpStatementInLoopPositive.kt
+++ b/detekt-rules/src/test/resources/cases/UnconditionalJumpStatementInLoopPositive.kt
@@ -2,11 +2,10 @@
 
 package cases
 
-fun unconditionalJumpStatementsInLoop() { // reports 6
+fun unconditionalJumpStatementsInLoop() { // reports 5 - 1 for every jump statement
 	for (i in 1..2) break
 	for (i in 1..2) continue
 	for (i in 1..2) return
-	for (i in 1..2) throw IllegalStateException()
 	while (true) break
 	do {
 		break


### PR DESCRIPTION
This rule should flag jump statements in loop more conservatively.