### PR TITLE
Make "ComplexMethod" rule also ignore "return when" if configured

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
@@ -37,7 +37,7 @@ class ComplexMethodSpec : Spek({
 
 		it("reports all complex methods") {
 			val subject = ComplexMethod(threshold = 4)
-			assertThat(subject.lint(path)).hasSize(3)
+			assertThat(subject.lint(path)).hasSize(5)
 		}
 	}
 })

--- a/detekt-rules/src/test/resources/cases/ComplexMethods.kt
+++ b/detekt-rules/src/test/resources/cases/ComplexMethods.kt
@@ -21,6 +21,24 @@ fun complexMethodWithSingleWhen2(i: Int) {
 	}
 }
 
+// reports 1 - only if ignoreSingleWhenExpression = false
+fun complexMethodWithSingleWhen3(i: Int): String {
+	return when (i) {
+		1 -> "one"
+		2 -> "two"
+		3 -> "three"
+		else -> ""
+	}
+}
+
+// reports 1 - only if ignoreSingleWhenExpression = false
+fun complexMethodWithSingleWhen4(i: Int) = when (i) {
+	1 -> "one"
+	2 -> "two"
+	3 -> "three"
+	else -> ""
+}
+
 // reports 1
 fun complexMethodWith2Statements(i: Int) {
 	when (i) {


### PR DESCRIPTION
If configured with "ignoreSingleWhenExpression", ComplexMethod should
not only skip "when", but also "return when"

Fixes #1054
