### PR TITLE
re-add useJUnitPlatform

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,10 @@ subprojects {
 		}
 	}
 
+	tasks.withType<Test> {
+		useJUnitPlatform()
+	}
+
 	tasks.withType<KotlinCompile> {
 		kotlinOptions.jvmTarget = "1.8"
 		// https://youtrack.jetbrains.com/issue/KT-24946


### PR DESCRIPTION
fixes #1029 
It looks like this one was introduced in this https://github.com/arturbosch/detekt/commit/aea9aa46187919f2ddd4c089eeaa7f2c49e423ab commit.
Let's re-add `useJUnitPlatform` in order to get junit platform based tests executed via gradle.