### PR TITLE
Lazy regex evaluation on Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Scott Kennedy](https://github.com/scottkennedy) - Minor fixes
 - [Mickele Moriconi](https://github.com/mickele) - Added: ConstructorParameterNaming and FunctionParameterNaming rules
 - [Lukasz Jazgar](https://github.com/ljazgar) - Fixed configuring formatting rules
+- [Pavlos-Petros Tournaris](https://github.com/pavlospt) - Lazy evaluation of Regex in Rules
 
 ### Mentions
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/LazyRegex.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/LazyRegex.kt
@@ -1,6 +1,5 @@
-package io.gitlab.arturbosch.detekt.api.internal
+package io.gitlab.arturbosch.detekt.api
 
-import io.gitlab.arturbosch.detekt.api.Rule
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/LazyRegex.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/LazyRegex.kt
@@ -1,0 +1,21 @@
+package io.gitlab.arturbosch.detekt.api.internal
+
+import io.gitlab.arturbosch.detekt.api.Rule
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+class LazyRegex(
+		private val key: String,
+		private val default: String
+) : ReadOnlyProperty<Rule, Regex> {
+
+	private var lazyRegexValue: Regex? = null
+
+	override fun getValue(thisRef: Rule, property: KProperty<*>): Regex {
+		return lazyRegexValue ?: createRegex(thisRef).also { lazyRegexValue = it }
+	}
+
+	private fun createRegex(rule: Rule): Regex {
+		return Regex(rule.config.valueOrDefault(key = key, default = default))
+	}
+}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/LazyRegex.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/LazyRegex.kt
@@ -4,6 +4,14 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
+/**
+ * LazyRegex class provides a lazy evaluation of a Regex pattern for usages inside Rules.
+ * It computes the value once when reaching the point of its usage and returns the same
+ * value when requested again.
+ *
+ * @author Pavlos-Petros Tournaris
+ */
+
 class LazyRegex(
 		private val key: String,
 		private val default: String

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/LazyRegex.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/LazyRegex.kt
@@ -9,6 +9,8 @@ import kotlin.reflect.KProperty
  * It computes the value once when reaching the point of its usage and returns the same
  * value when requested again.
  *
+ * `key` & `default` are used to retrieve a value from config.
+ *
  * @author Pavlos-Petros Tournaris
  */
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SplitPattern
+import io.gitlab.arturbosch.detekt.api.internal.LazyRegex
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtProperty
@@ -45,7 +46,7 @@ class LateinitUsage(config: Config = Config.empty) : Rule(config) {
 
 	private val excludeAnnotatedProperties = SplitPattern(valueOrDefault(EXCLUDE_ANNOTATED_PROPERTIES, ""))
 
-	private val ignoreOnClassesPattern = Regex(valueOrDefault(IGNORE_ON_CLASSES_PATTERN, ""))
+	private val ignoreOnClassesPattern by LazyRegex(key = IGNORE_ON_CLASSES_PATTERN, default = "")
 
 	private var properties = mutableListOf<KtProperty>()
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -9,7 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SplitPattern
-import io.gitlab.arturbosch.detekt.api.internal.LazyRegex
+import io.gitlab.arturbosch.detekt.api.LazyRegex
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtProperty

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
@@ -6,6 +6,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
+import java.util.regex.PatternSyntaxException
+import kotlin.test.assertFailsWith
 
 class LateinitUsageSpec : Spek({
 
@@ -64,6 +66,18 @@ class LateinitUsageSpec : Spek({
 
 		it("should not report lateinit properties when ignoreOnClassesPattern does match") {
 			val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.IGNORE_ON_CLASSES_PATTERN to "[\\w]+Test"))).lint(code)
+			assertThat(findings).hasSize(0)
+		}
+
+		it("should fail when enabled with faulty regex pattern") {
+			assertFailsWith<PatternSyntaxException> {
+				LateinitUsage(TestConfig(mapOf(LateinitUsage.IGNORE_ON_CLASSES_PATTERN to "*Test"))).lint(code)
+			}
+		}
+
+		it("should not fail when disabled with faulty regex pattern") {
+			val configValues = mapOf("active" to "false", LateinitUsage.IGNORE_ON_CLASSES_PATTERN to "*Test")
+			val findings = LateinitUsage(TestConfig(configValues)).lint(code)
 			assertThat(findings).hasSize(0)
 		}
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
@@ -31,27 +31,27 @@ class LateinitUsageSpec : Spek({
 
 		it("should not report lateinit properties annotated @JvmField") {
 			val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.EXCLUDE_ANNOTATED_PROPERTIES to "JvmField"))).lint(code)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should not report lateinit properties annotated @JvmField with trailing whitespace") {
 			val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.EXCLUDE_ANNOTATED_PROPERTIES to " JvmField "))).lint(code)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should not report lateinit properties matching kotlin.*") {
 			val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.EXCLUDE_ANNOTATED_PROPERTIES to "kotlin.*"))).lint(code)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should not report lateinit properties matching kotlin.jvm.") {
 			val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.EXCLUDE_ANNOTATED_PROPERTIES to "kotlin.jvm."))).lint(code)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should not report lateinit properties matching kotlin.jvm.*") {
 			val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.EXCLUDE_ANNOTATED_PROPERTIES to "kotlin.jvm.*"))).lint(code)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should not exclude lateinit properties not matching the exclude pattern") {
@@ -66,7 +66,7 @@ class LateinitUsageSpec : Spek({
 
 		it("should not report lateinit properties when ignoreOnClassesPattern does match") {
 			val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.IGNORE_ON_CLASSES_PATTERN to "[\\w]+Test"))).lint(code)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 
 		it("should fail when enabled with faulty regex pattern") {
@@ -78,7 +78,7 @@ class LateinitUsageSpec : Spek({
 		it("should not fail when disabled with faulty regex pattern") {
 			val configValues = mapOf("active" to "false", LateinitUsage.IGNORE_ON_CLASSES_PATTERN to "*Test")
 			val findings = LateinitUsage(TestConfig(configValues)).lint(code)
-			assertThat(findings).hasSize(0)
+			assertThat(findings).isEmpty()
 		}
 	}
 })


### PR DESCRIPTION
This PR resolves the eager Regex evaluation discussed in #1064 

1) Introduces `LazyRegex` class that evaluates a `Regex` needed inside a rule, only when it is requested and only once.
2) Makes use of `LazyRegex` in `LateinitUsage` rule.
3) Adds 2 extra test steps asserting the discussed behaviour.

@arturbosch I would be more than happy to migrate the rest of the `Regex` usages inside `Rule`s (if any) once you think this is a proper solution! 
