### PR TITLE
Replace Regex with LazyRegex in Rules

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Metric
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.ThresholdRule
@@ -61,7 +62,7 @@ class StringLiteralDuplication(
 
 	private val ignoreAnnotation = valueOrDefault(IGNORE_ANNOTATION, true)
 	private val excludeStringsWithLessThan5Characters = valueOrDefault(EXCLUDE_SHORT_STRING, true)
-	private val ignoreStringsRegex = Regex(valueOrDefault(IGNORE_STRINGS_REGEX, "$^"))
+	private val ignoreStringsRegex by LazyRegex(IGNORE_STRINGS_REGEX, "$^")
 
 	override fun visitKtFile(file: KtFile) {
 		val visitor = StringLiteralVisitor()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.rules.ALLOWED_EXCEPTION_NAME
 import io.gitlab.arturbosch.detekt.rules.identifierName
 import org.jetbrains.kotlin.psi.KtCatchClause
@@ -17,7 +18,7 @@ import org.jetbrains.kotlin.psi.KtCatchClause
  */
 class EmptyCatchBlock(config: Config) : EmptyRule(config = config) {
 
-	private val allowedExceptionNameRegex = Regex(valueOrDefault(ALLOWED_EXCEPTION_NAME_REGEX, ALLOWED_EXCEPTION_NAME))
+	private val allowedExceptionNameRegex by LazyRegex(ALLOWED_EXCEPTION_NAME_REGEX, ALLOWED_EXCEPTION_NAME)
 
 	override fun visitCatchSection(catchClause: KtCatchClause) {
 		super.visitCatchSection(catchClause)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.ALLOWED_EXCEPTION_NAME
@@ -62,8 +63,7 @@ class TooGenericExceptionCaught(config: Config) : Rule(config) {
 	private val exceptions: Set<String> = valueOrDefault(
 			CAUGHT_EXCEPTIONS_PROPERTY, caughtExceptionDefaults).toHashSet()
 
-	private val allowedExceptionNameRegex = Regex(
-			valueOrDefault(ALLOWED_EXCEPTION_NAME_REGEX, ALLOWED_EXCEPTION_NAME))
+	private val allowedExceptionNameRegex by LazyRegex(ALLOWED_EXCEPTION_NAME_REGEX, ALLOWED_EXCEPTION_NAME)
 
 	override fun visitCatchSection(catchClause: KtCatchClause) {
 		catchClause.catchParameter?.let {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.identifierName
@@ -23,7 +24,7 @@ class ClassNaming(config: Config = Config.empty) : Rule(config) {
 			Severity.Style,
 			"A classes name should fit the naming pattern defined in the projects configuration.",
 			debt = Debt.FIVE_MINS)
-	private val classPattern = Regex(valueOrDefault(CLASS_PATTERN, "^[A-Z$][a-zA-Z0-9$]*"))
+	private val classPattern by LazyRegex(CLASS_PATTERN, "^[A-Z$][a-zA-Z0-9$]*")
 
 	override fun visitClassOrObject(classOrObject: KtClassOrObject) {
 		if (!classOrObject.identifierName().matches(classPattern)) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.identifierName
@@ -29,9 +30,9 @@ class ConstructorParameterNaming(config: Config = Config.empty) : Rule(config) {
 			"Constructor parameter names should follow the naming convention set in the projects configuration.",
 			debt = Debt.FIVE_MINS)
 
-	private val parameterPattern = Regex(valueOrDefault(PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*"))
-	private val privateParameterPattern = Regex(valueOrDefault(PRIVATE_PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*"))
-	private val excludeClassPattern = Regex(valueOrDefault(EXCLUDE_CLASS_PATTERN, "$^"))
+	private val parameterPattern by LazyRegex(PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*")
+	private val privateParameterPattern by LazyRegex(PRIVATE_PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*")
+	private val excludeClassPattern by LazyRegex(EXCLUDE_CLASS_PATTERN, "$^")
 
 	override fun visitParameter(parameter: KtParameter) {
 		if (parameter.isContainingExcludedClass(excludeClassPattern)) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.identifierName
@@ -24,7 +25,7 @@ class EnumNaming(config: Config = Config.empty) : Rule(config) {
 			"Enum names should follow the naming convention set in the projects configuration.",
 			debt = Debt.FIVE_MINS)
 
-	private val enumEntryPattern = Regex(valueOrDefault(ENUM_PATTERN, "^[A-Z][_a-zA-Z0-9]*"))
+	private val enumEntryPattern by LazyRegex(ENUM_PATTERN, "^[A-Z][_a-zA-Z0-9]*")
 
 	override fun visitEnumEntry(enumEntry: KtEnumEntry) {
 		if (!enumEntry.identifierName().matches(enumEntryPattern)) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.identifierName
@@ -29,8 +30,8 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
 			debt = Debt.FIVE_MINS,
 			aliases = setOf("FunctionName"))
 
-	private val functionPattern = Regex(valueOrDefault(FUNCTION_PATTERN, "^([a-z$][a-zA-Z$0-9]*)|(`.*`)$"))
-	private val excludeClassPattern = Regex(valueOrDefault(EXCLUDE_CLASS_PATTERN, "$^"))
+	private val functionPattern by LazyRegex(FUNCTION_PATTERN, "^([a-z$][a-zA-Z$0-9]*)|(`.*`)$")
+	private val excludeClassPattern by LazyRegex(EXCLUDE_CLASS_PATTERN, "$^")
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		if (!function.isContainingExcludedClass(excludeClassPattern) &&

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.identifierName
@@ -27,8 +28,8 @@ class FunctionParameterNaming(config: Config = Config.empty) : Rule(config) {
 			"Function parameter names should follow the naming convention set in the projects configuration.",
 			debt = Debt.FIVE_MINS)
 
-	private val parameterPattern = Regex(valueOrDefault(PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*"))
-	private val excludeClassPattern = Regex(valueOrDefault(EXCLUDE_CLASS_PATTERN, "$^"))
+	private val parameterPattern by LazyRegex(PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*")
+	private val excludeClassPattern by LazyRegex(EXCLUDE_CLASS_PATTERN, "$^")
 
 	override fun visitParameter(parameter: KtParameter) {
 		if (parameter.isContainingExcludedClass(excludeClassPattern)) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.hasConstModifier
@@ -29,9 +30,9 @@ class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
 			"Property names inside objects should follow the naming convention set in the projects configuration.",
 			debt = Debt.FIVE_MINS)
 
-	private val constantPattern = Regex(valueOrDefault(CONSTANT_PATTERN, "[A-Za-z][_A-Za-z0-9]*"))
-	private val propertyPattern = Regex(valueOrDefault(PROPERTY_PATTERN, "[A-Za-z][_A-Za-z0-9]*"))
-	private val privatePropertyPattern = Regex(valueOrDefault(PRIVATE_PROPERTY_PATTERN, "(_)?[A-Za-z][A-Za-z0-9]*"))
+	private val constantPattern by LazyRegex(CONSTANT_PATTERN, "[A-Za-z][_A-Za-z0-9]*")
+	private val propertyPattern by LazyRegex(PROPERTY_PATTERN, "[A-Za-z][_A-Za-z0-9]*")
+	private val privatePropertyPattern by LazyRegex(PRIVATE_PROPERTY_PATTERN, "(_)?[A-Za-z][A-Za-z0-9]*")
 
 	override fun visitProperty(property: KtProperty) {
 		if (property.hasConstModifier()) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtPackageDirective
@@ -22,7 +23,7 @@ class PackageNaming(config: Config = Config.empty) : Rule(config) {
 			Severity.Style,
 			"Package names should match the naming convention set in the configuration.",
 			debt = Debt.FIVE_MINS)
-	private val packagePattern = Regex(valueOrDefault(PACKAGE_PATTERN, "^[a-z]+(\\.[a-z][a-z0-9]*)*$"))
+	private val packagePattern by LazyRegex(PACKAGE_PATTERN, "^[a-z]+(\\.[a-z][a-z0-9]*)*$")
 
 	override fun visitPackageDirective(directive: KtPackageDirective) {
 		val name = directive.qualifiedName

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.hasConstModifier
@@ -29,9 +30,9 @@ class TopLevelPropertyNaming(config: Config = Config.empty) : Rule(config) {
 			"Top level property names should follow the naming convention set in the projects configuration.",
 			debt = Debt.FIVE_MINS)
 
-	private val constantPattern = Regex(valueOrDefault(CONSTANT_PATTERN, "[A-Z][_A-Z0-9]*"))
-	private val propertyPattern = Regex(valueOrDefault(PROPERTY_PATTERN, "[A-Za-z][_A-Za-z0-9]*"))
-	private val privatePropertyPattern = Regex(valueOrDefault(PRIVATE_PROPERTY_PATTERN, "(_)?[A-Za-z][A-Za-z0-9]*"))
+	private val constantPattern by LazyRegex(CONSTANT_PATTERN, "[A-Z][_A-Z0-9]*")
+	private val propertyPattern by LazyRegex(PROPERTY_PATTERN, "[A-Za-z][_A-Za-z0-9]*")
+	private val privatePropertyPattern by LazyRegex(PRIVATE_PROPERTY_PATTERN, "(_)?[A-Za-z][A-Za-z0-9]*")
 
 	override fun visitProperty(property: KtProperty) {
 		if (property.hasConstModifier()) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.identifierName
@@ -31,9 +32,9 @@ class VariableNaming(config: Config = Config.empty) : Rule(config) {
 			"Variable names should follow the naming convention set in the projects configuration.",
 			debt = Debt.FIVE_MINS)
 
-	private val variablePattern = Regex(valueOrDefault(VARIABLE_PATTERN, "[a-z][A-Za-z0-9]*"))
-	private val privateVariablePattern = Regex(valueOrDefault(PRIVATE_VARIABLE_PATTERN, "(_)?[a-z][A-Za-z0-9]*"))
-	private val excludeClassPattern = Regex(valueOrDefault(EXCLUDE_CLASS_PATTERN, "$^"))
+	private val variablePattern by LazyRegex(VARIABLE_PATTERN, "[a-z][A-Za-z0-9]*")
+	private val privateVariablePattern by LazyRegex(PRIVATE_VARIABLE_PATTERN, "(_)?[a-z][A-Za-z0-9]*")
+	private val excludeClassPattern by LazyRegex(EXCLUDE_CLASS_PATTERN, "$^")
 
 	override fun visitProperty(property: KtProperty) {
 		if (property.isSingleUnderscore || property.isContainingExcludedClass(excludeClassPattern)) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.isAbstract
@@ -54,7 +55,7 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 			Debt.FIVE_MINS,
 			aliases = setOf("UNUSED_VARIABLE"))
 
-	private val allowedNames = Regex(valueOrDefault(ALLOWED_NAMES_PATTERN, "(_|ignored|expected|serialVersionUID)"))
+	private val allowedNames by LazyRegex(ALLOWED_NAMES_PATTERN, "(_|ignored|expected|serialVersionUID)")
 
 	override fun visit(root: KtFile) {
 		super.visit(root)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
@@ -9,6 +9,8 @@ import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
 import org.jetbrains.spek.subject.dsl.SubjectProviderDsl
+import java.util.regex.PatternSyntaxException
+import kotlin.test.assertFailsWith
 
 class StringLiteralDuplicationSpec : SubjectSpek<StringLiteralDuplication>({
 
@@ -77,6 +79,30 @@ class StringLiteralDuplicationSpec : SubjectSpek<StringLiteralDuplication>({
 			"""
 			val config = TestConfig(mapOf(StringLiteralDuplication.IGNORE_STRINGS_REGEX to "(lorem|ipsum)"))
 			assertFindingWithConfig(code, config, 0)
+		}
+
+		it("should not fail with invalid regex when disabled") {
+			val code = """
+				val str1 = "lorem" + "lorem" + "lorem"
+				val str2 = "ipsum" + "ipsum" + "ipsum"
+			"""
+			val configValues = mapOf(
+					"active" to "false",
+					StringLiteralDuplication.IGNORE_STRINGS_REGEX to "*lorem"
+			)
+			val config = TestConfig(configValues)
+			assertFindingWithConfig(code, config, 0)
+		}
+
+		it("should fail with invalid regex") {
+			val code = """
+				val str1 = "lorem" + "lorem" + "lorem"
+				val str2 = "ipsum" + "ipsum" + "ipsum"
+			"""
+			val config = TestConfig(mapOf(StringLiteralDuplication.IGNORE_STRINGS_REGEX to "*lorem"))
+			assertFailsWith<PatternSyntaxException> {
+				StringLiteralDuplication(config).lint(code)
+			}
 		}
 	}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
@@ -72,6 +72,11 @@ class StringLiteralDuplicationSpec : SubjectSpek<StringLiteralDuplication>({
 
 	given("strings with values to match for the regex") {
 
+		val regexTestingCode = """
+				val str1 = "lorem" + "lorem" + "lorem"
+				val str2 = "ipsum" + "ipsum" + "ipsum"
+			"""
+
 		it("does not report lorem or ipsum according to config in regex") {
 			val code = """
 				val str1 = "lorem" + "lorem" + "lorem"
@@ -82,26 +87,18 @@ class StringLiteralDuplicationSpec : SubjectSpek<StringLiteralDuplication>({
 		}
 
 		it("should not fail with invalid regex when disabled") {
-			val code = """
-				val str1 = "lorem" + "lorem" + "lorem"
-				val str2 = "ipsum" + "ipsum" + "ipsum"
-			"""
 			val configValues = mapOf(
 					"active" to "false",
 					StringLiteralDuplication.IGNORE_STRINGS_REGEX to "*lorem"
 			)
 			val config = TestConfig(configValues)
-			assertFindingWithConfig(code, config, 0)
+			assertFindingWithConfig(regexTestingCode, config, 0)
 		}
 
 		it("should fail with invalid regex") {
-			val code = """
-				val str1 = "lorem" + "lorem" + "lorem"
-				val str2 = "ipsum" + "ipsum" + "ipsum"
-			"""
 			val config = TestConfig(mapOf(StringLiteralDuplication.IGNORE_STRINGS_REGEX to "*lorem"))
 			assertFailsWith<PatternSyntaxException> {
-				StringLiteralDuplication(config).lint(code)
+				StringLiteralDuplication(config).lint(regexTestingCode)
 			}
 		}
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeTest.kt
@@ -18,6 +18,13 @@ class EmptyCodeTest {
 
 	val file = compileForTest(Case.Empty.path())
 
+	private val regexTestingCode = """
+			fun f() {
+				try {
+				} catch (foo: MyException) {
+				}
+			}"""
+
 	@Test
 	fun findsEmptyCatch() {
 		test { EmptyCatchBlock(Config.empty) }
@@ -132,30 +139,18 @@ class EmptyCodeTest {
 
 	@Test
 	fun doesNotFailWithInvalidRegexWhenDisabled() {
-		val code = """
-			fun f() {
-				try {
-				} catch (foo: MyException) {
-				}
-			}"""
 		val configValues = mapOf("active" to "false",
 				EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "*foo")
 		val config = TestConfig(configValues)
-		assertThat(EmptyCatchBlock(config).lint(code)).isEmpty()
+		assertThat(EmptyCatchBlock(config).lint(regexTestingCode)).isEmpty()
 	}
 
 	@Test
 	fun doesFailWithInvalidRegex() {
-		val code = """
-			fun f() {
-				try {
-				} catch (foo: MyException) {
-				}
-			}"""
 		val configValues = mapOf(EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "*foo")
 		val config = TestConfig(configValues)
 		assertFailsWith<PatternSyntaxException> {
-			EmptyCatchBlock(config).lint(code)
+			EmptyCatchBlock(config).lint(regexTestingCode)
 		}
 	}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
@@ -8,6 +8,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
+import java.util.regex.PatternSyntaxException
+import kotlin.test.assertFailsWith
 
 class TooGenericExceptionCaughtSpec : Spek({
 
@@ -40,6 +42,26 @@ class TooGenericExceptionCaughtSpec : Spek({
 			val findings = rule.lint(Case.TooGenericExceptionsOptions.path())
 
 			assertThat(findings).isEmpty()
+		}
+
+		it("should not fail when disabled with invalid regex on allowed exception names") {
+			val configRules = mapOf(
+					"active" to "false",
+					TooGenericExceptionCaught.ALLOWED_EXCEPTION_NAME_REGEX to "*MyException"
+			)
+			val config = TestConfig(configRules)
+			val rule = TooGenericExceptionCaught(config)
+			val findings = rule.lint(Case.TooGenericExceptions.path())
+
+			assertThat(findings).isEmpty()
+		}
+
+		it("should fail with invalid regex on allowed exception names") {
+			val config = TestConfig(mapOf(TooGenericExceptionCaught.ALLOWED_EXCEPTION_NAME_REGEX to "*Foo"))
+			val rule = TooGenericExceptionCaught(config)
+			assertFailsWith<PatternSyntaxException> {
+				rule.lint(Case.TooGenericExceptions.path())
+			}
 		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternTest.kt
@@ -43,6 +43,24 @@ class NamingConventionCustomPatternTest {
 	}
 	private val rule = NamingRules(config)
 
+	private val excludeClassPatternVariableRegexCode = """
+			class Bar {
+				val MYVar = 3
+			}
+
+			object Foo {
+				val MYVar = 3
+			}"""
+
+	private val excludeClassPatternFunctionRegexCode = """
+			class Bar {
+				fun MYFun() {}
+			}
+
+			object Foo {
+				fun MYFun() {}
+			}"""
+
 	@Test
 	fun shouldUseCustomNameForMethodAndClass() {
 		assertThat(rule.lint("""
@@ -101,35 +119,19 @@ class NamingConventionCustomPatternTest {
 
 	@Test
 	fun shouldNotFailWithInvalidRegexWhenDisabledVariableNaming() {
-		val code = """
-			class Bar {
-				val MYVar = 3
-			}
-
-			object Foo {
-				val MYVar = 3
-			}"""
 		val configValues = mapOf(
 				"active" to "false",
 				VariableNaming.EXCLUDE_CLASS_PATTERN to "*Foo"
 		)
 		val config = TestConfig(configValues)
-		assertThat(VariableNaming(config).lint(code)).isEmpty()
+		assertThat(VariableNaming(config).lint(excludeClassPatternVariableRegexCode)).isEmpty()
 	}
 
 	@Test
 	fun shouldFailWithInvalidRegexVariableNaming() {
-		val code = """
-			class Bar {
-				val MYVar = 3
-			}
-
-			object Foo {
-				val MYVar = 3
-			}"""
 		val config = TestConfig(mapOf(VariableNaming.EXCLUDE_CLASS_PATTERN to "*Foo"))
 		assertFailsWith<PatternSyntaxException> {
-			VariableNaming(config).lint(code)
+			VariableNaming(config).lint(excludeClassPatternVariableRegexCode)
 		}
 	}
 
@@ -149,35 +151,19 @@ class NamingConventionCustomPatternTest {
 
 	@Test
 	fun shouldNotFailWithInvalidRegexWhenDisabledFunctionNaming() {
-		val code = """
-			class Bar {
-				fun MYFun() {}
-			}
-
-			object Foo {
-				fun MYFun() {}
-			}"""
 		val configRules = mapOf(
 				"active" to "false",
-				FunctionNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar"
+				FunctionNaming.EXCLUDE_CLASS_PATTERN to "*Foo"
 		)
 		val config = TestConfig(configRules)
-		assertThat(FunctionNaming(config).lint(code)).isEmpty()
+		assertThat(FunctionNaming(config).lint(excludeClassPatternFunctionRegexCode)).isEmpty()
 	}
 
 	@Test
 	fun shouldFailWithInvalidRegexFunctionNaming() {
-		val code = """
-			class Bar {
-				fun MYFun() {}
-			}
-
-			object Foo {
-				fun MYFun() {}
-			}"""
 		val config = TestConfig(mapOf(FunctionNaming.EXCLUDE_CLASS_PATTERN to "*Foo"))
 		assertFailsWith<PatternSyntaxException> {
-			FunctionNaming(config).lint(code)
+			FunctionNaming(config).lint(excludeClassPatternFunctionRegexCode)
 		}
 	}
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -14,6 +14,17 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 
 	subject { UnusedPrivateMember() }
 
+	val regexTestingCode = """
+				class Test {
+					private val used = "This is used"
+					private val unused = "This is not used"
+
+					fun use() {
+						println(used)
+					}
+				}
+				"""
+
 	given("cases file with different findings") {
 
 		it("positive cases file") {
@@ -134,34 +145,14 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 					UnusedPrivateMember.ALLOWED_NAMES_PATTERN to "*foo"
 			)
 			val config = TestConfig(configRules)
-			val code = """
-				class Test {
-					private val used = "This is used"
-					private val unused = "This is not used"
-
-					fun use() {
-						println(used)
-					}
-				}
-				"""
-			assertThat(UnusedPrivateMember(config).lint(code)).isEmpty()
+			assertThat(UnusedPrivateMember(config).lint(regexTestingCode)).isEmpty()
 		}
 
 		it("does fail when enabled with invalid regex") {
 			val configRules = mapOf(UnusedPrivateMember.ALLOWED_NAMES_PATTERN to "*foo")
 			val config = TestConfig(configRules)
-			val code = """
-				class Test {
-					private val used = "This is used"
-					private val unused = "This is not used"
-
-					fun use() {
-						println(used)
-					}
-				}
-				"""
 			assertFailsWith<PatternSyntaxException> {
-				UnusedPrivateMember(config).lint(code)
+				UnusedPrivateMember(config).lint(regexTestingCode)
 			}
 		}
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -1,11 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.rules.Case
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
+import java.util.regex.PatternSyntaxException
+import kotlin.test.assertFailsWith
 
 class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 
@@ -123,6 +126,43 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 				}
 				"""
 			assertThat(subject.lint(code)).hasSize(1)
+		}
+
+		it("does not fail when disabled with invalid regex") {
+			val configRules = mapOf(
+					"active" to "false",
+					UnusedPrivateMember.ALLOWED_NAMES_PATTERN to "*foo"
+			)
+			val config = TestConfig(configRules)
+			val code = """
+				class Test {
+					private val used = "This is used"
+					private val unused = "This is not used"
+
+					fun use() {
+						println(used)
+					}
+				}
+				"""
+			assertThat(UnusedPrivateMember(config).lint(code)).isEmpty()
+		}
+
+		it("does fail when enabled with invalid regex") {
+			val configRules = mapOf(UnusedPrivateMember.ALLOWED_NAMES_PATTERN to "*foo")
+			val config = TestConfig(configRules)
+			val code = """
+				class Test {
+					private val used = "This is used"
+					private val unused = "This is not used"
+
+					fun use() {
+						println(used)
+					}
+				}
+				"""
+			assertFailsWith<PatternSyntaxException> {
+				UnusedPrivateMember(config).lint(code)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR updates any remaining Rules using `Regex`, to use `LazyRegex` instead. I added verifying test steps for the new behaviour for most of them except for Naming rules, which I am not sure that they are covered completely. 

@arturbosch or @schalkms can you let me know if there are more tests for `Naming` rules so that I can cover those I missed?