### PR TITLE
use debug flag for printing outputs in gradle plugin

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaFormatTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaFormatTask.kt
@@ -40,6 +40,6 @@ open class DetektIdeaFormatTask : DefaultTask() {
 	fun format() {
 		if (debugOrDefault) println("$ideaExtension")
 
-		startProcess(ideaExtension.formatArgs(input.asPath))
+		startProcess(ideaExtension.formatArgs(input.asPath), debugOrDefault)
 	}
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaInspectionTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaInspectionTask.kt
@@ -41,6 +41,6 @@ open class DetektIdeaInspectionTask : DefaultTask() {
 		if (debugOrDefault) println("Running inspection task in debug mode")
 
 		if (debugOrDefault) println("$ideaExtension")
-		ProcessExecutor.startProcess(ideaExtension.inspectArgs(input.asPath))
+		ProcessExecutor.startProcess(ideaExtension.inspectArgs(input.asPath), debugOrDefault)
 	}
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/ProcessExecutor.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/ProcessExecutor.kt
@@ -10,12 +10,12 @@ import java.io.InputStreamReader
  * @author Marvin Ramin
  */
 object ProcessExecutor {
-	fun startProcess(args: Array<String>) {
+	fun startProcess(args: Array<String>, debug: Boolean = false) {
 		val process = Runtime.getRuntime().exec(args)
 
 		BufferedReader(InputStreamReader(BufferedInputStream(process.inputStream))).use {
 			val inputs = it.readLines().joinToString("\n")
-			println(inputs)
+			if (debug) println(inputs)
 		}
 
 		BufferedReader(InputStreamReader(BufferedInputStream(process.errorStream))).use {


### PR DESCRIPTION
There was one rogue `println(..)` in the Gradle Plugin that did not respect the `debug` configuration.