### PR TITLE
remove duplicated `detekt` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,9 @@ plugins {
 }
 
 detekt {
-    detekt {
-        version = "[version]"
-        input = files("src/main/kotlin")
-        filters = ".*/resources/.*,.*/build/.*"
-        config = files("path/to/config.yml")
-    }
+    version = "[version]"
+    input = files("src/main/kotlin")
+    filters = ".*/resources/.*,.*/build/.*"
 }
 ```
 


### PR DESCRIPTION
Accidentally added a duplicate `detekt` closure in the `README.md` in #1095.