### PR TITLE
fix false positive in UnnecessaryParentheses

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -115,5 +115,53 @@ class UnnecessaryParenthesesSpec : SubjectSpek<UnnecessaryParentheses>({
 			""".trimIndent()
 			assertThat(subject.lint(code)).hasSize(0)
 		}
+
+		it("should not report call to function with two lambda parameters with one as block body") {
+			val code = """
+				class Clazz {
+					fun test(first: (Int) -> Unit, second: (Int) -> Unit) {
+						first(1)
+						second(2)
+					}
+
+					fun call() {
+						test({ println(it) }) { println(it) }
+					}
+				}
+			""".trimIndent()
+			assertThat(subject.lint(code)).hasSize(0)
+		}
+
+		it("should not report call to function with two lambda parameters") {
+			val code = """
+				class Clazz {
+					fun test(first: (Int) -> Unit, second: (Int) -> Unit) {
+						first(1)
+						second(2)
+					}
+
+					fun call() {
+						test({ println(it) }, { println(it) })
+					}
+				}
+			""".trimIndent()
+			assertThat(subject.lint(code)).hasSize(0)
+		}
+
+		it("should not report call to function with multiple lambdas as parameters but also other parameters") {
+			val code = """
+				class Clazz {
+					fun test(text: String, first: () -> Unit, second: () -> Unit) {
+						first()
+						second()
+					}
+
+					fun call() {
+						test("hello", { println(it) }) { println(it) }
+					}
+				}
+			""".trimIndent()
+			assertThat(subject.lint(code)).hasSize(0)
+		}
 	}
 })


### PR DESCRIPTION
Fixes #1051. The 2nd lambda is not part of the `KtParameterList` but another `KtLambdaArgument` attached to the `CallExpression`.

Added a bunch of other tests for similar cases to ensure we handle this case correctly.