### PR TITLE
don't report method as complex if it returns a single objectexpression

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
@@ -40,4 +40,59 @@ class ComplexMethodSpec : Spek({
 			assertThat(subject.lint(path)).hasSize(5)
 		}
 	}
+
+	given("a method returning a complex abstract class implementation") {
+		val subject = ComplexMethod()
+		val code = """
+			fun f(): List<Any> {
+				return object : List<Any> {
+					override val size: Int get() = TODO("not implemented")
+
+					override fun contains(element: Any): Boolean {
+						TODO("not implemented")
+					}
+
+					override fun containsAll(elements: Collection<Any>): Boolean {
+						TODO("not implemented")
+					}
+
+					override fun get(index: Int): Any {
+						TODO("not implemented")
+					}
+
+					override fun indexOf(element: Any): Int {
+						TODO("not implemented")
+					}
+
+					override fun isEmpty(): Boolean {
+						TODO("not implemented")
+					}
+
+					override fun iterator(): Iterator<Any> {
+						TODO("not implemented")
+					}
+
+					override fun lastIndexOf(element: Any): Int {
+						TODO("not implemented")
+					}
+
+					override fun listIterator(): ListIterator<Any> {
+						TODO("not implemented")
+					}
+
+					override fun listIterator(index: Int): ListIterator<Any> {
+						TODO("not implemented")
+					}
+
+					override fun subList(fromIndex: Int, toIndex: Int): List<Any> {
+						TODO("not implemented")
+					}
+				}
+			}
+			""".trimIndent()
+		it("does not report it") {
+			subject.lint(code)
+			assertThat(subject.findings).isEmpty()
+		}
+	}
 })


### PR DESCRIPTION
Fixes #1037. 

If a method only returns an object expression we don't report it as a complex method.. Not sure if this is the best way.