### PR TITLE
update kotlin to v1.2.70

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -212,7 +212,7 @@ subprojects {
 		}
 	}
 
-	val kotlinVersion: String  by project
+	val kotlinVersion: String by project
 	val junitEngineVersion: String by project
 	val assertjVersion: String by project
 	val spekVersion: String by project

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 	`java-gradle-plugin`
 	id("com.gradle.plugin-publish") version "0.9.10"
 	id("com.jfrog.bintray") version "1.8.4"
-	kotlin("jvm") version "1.2.70"
+	kotlin("jvm") version "1.2.71"
 	`kotlin-dsl`
 	id("org.jetbrains.dokka") version "0.9.17"
 }

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 	`java-gradle-plugin`
 	id("com.gradle.plugin-publish") version "0.9.10"
 	id("com.jfrog.bintray") version "1.8.4"
-	kotlin("jvm") version "1.2.61"
+	kotlin("jvm") version "1.2.70"
 	`kotlin-dsl`
 	id("org.jetbrains.dokka") version "0.9.17"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 detektVersion=1.0.0.RC9.2
 usedDetektVersion=1.0.0.RC9.2
 ktlintVersion=0.28.0
-kotlinVersion=1.2.61
+kotlinVersion=1.2.71
 spekVersion=1.2.1
 junitPlatformVersion=1.2.0
 junitEngineVersion=5.2.0


### PR DESCRIPTION
Release notes: https://blog.jetbrains.com/kotlin/2018/09/kotlin-1-2-70-is-out/

Currently does not seem to compile because of version conflicts of the Kotlin Plugin in the Kotlin-DSL