### PR TITLE
Use plugin version as default Detekt version

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -123,6 +123,32 @@ tasks.withType(DokkaTask::class.java) {
 	outputDirectory = "$buildDir/javadoc"
 }
 
+
+val generateDefaultDetektVersionFile by tasks.creating {
+	val defaultDetektVersionFile =
+			File("$buildDir/generated/src/io/gitlab/arturbosch/detekt", "PluginVersion.kt")
+
+	outputs.file(defaultDetektVersionFile)
+
+	doFirst {
+		defaultDetektVersionFile.parentFile.mkdirs()
+		defaultDetektVersionFile.writeText("""
+			package io.gitlab.arturbosch.detekt
+
+			internal const val DEFAULT_DETEKT_VERSION = "${version}"
+			"""
+				.trimIndent()
+		)
+	}
+}
+
+val mainJavaSourceSet: SourceDirectorySet = sourceSets.getByName("main").java
+mainJavaSourceSet.srcDir("$buildDir/generated/src")
+
+tasks.named("compileKotlin").configure {
+	dependsOn(generateDefaultDetektVersionFile)
+}
+
 val javaConvention = the<JavaPluginConvention>()
 val sourcesJar by tasks.creating(Jar::class) {
 	dependsOn("classes")

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -11,9 +11,7 @@ import java.io.File
  */
 class DetektPlugin : Plugin<Project> {
 
-
 	override fun apply(project: Project) {
-
 		val extension = project.extensions.create(DETEKT, DetektExtension::class.java, project)
 
 		configurePluginDependencies(project, extension)
@@ -97,7 +95,6 @@ class DetektPlugin : Plugin<Project> {
 
 
 	companion object {
-		private const val DEFAULT_DETEKT_VERSION = "1.0.0.RC9"
 		private const val DETEKT = "detekt"
 		private const val IDEA_FORMAT = "detektIdeaFormat"
 		private const val IDEA_INSPECT = "detektIdeaInspect"


### PR DESCRIPTION
Removes hardcoded default version in Detekt Gradle Plugin. Closes #1118.