### PR TITLE
1125/Allow spaces in CLI filters param

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -19,7 +19,7 @@ class CliArgs : Args {
 	private var input: String? = null
 
 	@Parameter(names = ["--filters", "-f"],
-			description = "Path filters defined through regex with separator ';' (\".*test.*\").")
+			description = "Path filters defined through regex with separator ';' or ',' (\".*test.*\").")
 	var filters: String? = null // Using a converter for List<PathFilter> resulted in a ClassCastException
 
 	@Parameter(names = ["--config", "-c"],

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -14,6 +14,7 @@ fun CliArgs.createPathFilters(): List<PathFilter> = filters.letIfNonEmpty {
 	split(SEPARATOR_COMMA, SEPARATOR_SEMICOLON)
 			.asSequence()
 			.map { it.trim() }
+			.filter { it.isNotEmpty() }
 			.map(::PathFilter)
 			.toList()
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -11,7 +11,11 @@ import java.nio.file.Path
  */
 
 fun CliArgs.createPathFilters(): List<PathFilter> = filters.letIfNonEmpty {
-	split(SEPARATOR_COMMA, SEPARATOR_SEMICOLON).map(::PathFilter)
+	split(SEPARATOR_COMMA, SEPARATOR_SEMICOLON)
+			.asSequence()
+			.map { it.trim() }
+			.map(::PathFilter)
+			.toList()
 }
 
 fun CliArgs.createPlugins(): List<Path> = plugins.letIfNonEmpty {

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigurationsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigurationsSpec.kt
@@ -140,6 +140,11 @@ internal class ConfigurationsSpec : Spek({
 			)
 		}
 
+		it("should ignore empty and blank filters") {
+			val filters = CliArgs().apply { filters = " ,,.*/three" }.createPathFilters()
+			assertThat(filters).containsExactly(PathFilter(".*/three"))
+		}
+
 		it("should fail on invalid filters values") {
 			assertFails { CliArgs().apply { filters = "*." }.createPathFilters() }
 			assertFails { CliArgs().apply { filters = "(ahel" }.createPathFilters() }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigurationsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigurationsSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.cli
 
+import io.gitlab.arturbosch.detekt.core.PathFilter
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
@@ -75,6 +76,73 @@ internal class ConfigurationsSpec : Spek({
 			assertFails { CliArgs().apply { configResource = "," }.loadConfiguration() }
 			assertFails { CliArgs().apply { configResource = "sfsjfsdkfsd" }.loadConfiguration() }
 			assertFails { CliArgs().apply { configResource = "./i.do.not.exist.yml" }.loadConfiguration() }
+		}
+	}
+
+	describe("parse different filter settings") {
+
+		it("should load single filter") {
+			val filters = CliArgs().apply { filters = ".*/one/.*" }.createPathFilters()
+			assertThat(filters).containsExactly(PathFilter(".*/one/.*"))
+		}
+
+		it("should load multiple comma-separated filters with no spaces around commas") {
+			val filters = CliArgs().apply { filters = ".*/one/.*,.*/two/.*,.*/three" }.createPathFilters()
+			assertThat(filters).containsExactly(
+					PathFilter(".*/one/.*"),
+					PathFilter(".*/two/.*"),
+					PathFilter(".*/three")
+			)
+		}
+
+		it("should load multiple semicolon-separated filters with no spaces around semicolons") {
+			val filters = CliArgs().apply { filters = ".*/one/.*;.*/two/.*;.*/three" }.createPathFilters()
+			assertThat(filters).containsExactly(
+					PathFilter(".*/one/.*"),
+					PathFilter(".*/two/.*"),
+					PathFilter(".*/three")
+			)
+		}
+
+		it("should load multiple comma-separated filters with spaces around commas") {
+			val filters = CliArgs().apply { filters = ".*/one/.* ,.*/two/.*, .*/three" }.createPathFilters()
+			assertThat(filters).containsExactly(
+					PathFilter(".*/one/.*"),
+					PathFilter(".*/two/.*"),
+					PathFilter(".*/three")
+			)
+		}
+
+		it("should load multiple semicolon-separated filters with spaces around semicolons") {
+			val filters = CliArgs().apply { filters = ".*/one/.* ;.*/two/.*; .*/three" }.createPathFilters()
+			assertThat(filters).containsExactly(
+					PathFilter(".*/one/.*"),
+					PathFilter(".*/two/.*"),
+					PathFilter(".*/three")
+			)
+		}
+
+		it("should load multiple mixed-separated filters with no spaces around separators") {
+			val filters = CliArgs().apply { filters = ".*/one/.*,.*/two/.*;.*/three" }.createPathFilters()
+			assertThat(filters).containsExactly(
+					PathFilter(".*/one/.*"),
+					PathFilter(".*/two/.*"),
+					PathFilter(".*/three")
+			)
+		}
+
+		it("should load multiple mixed-separated filters with spaces around separators") {
+			val filters = CliArgs().apply { filters = ".*/one/.* ,.*/two/.*; .*/three" }.createPathFilters()
+			assertThat(filters).containsExactly(
+					PathFilter(".*/one/.*"),
+					PathFilter(".*/two/.*"),
+					PathFilter(".*/three")
+			)
+		}
+
+		it("should fail on invalid filters values") {
+			assertFails { CliArgs().apply { filters = "*." }.createPathFilters() }
+			assertFails { CliArgs().apply { filters = "(ahel" }.createPathFilters() }
 		}
 	}
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/PathFilter.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/PathFilter.kt
@@ -15,8 +15,12 @@ class PathFilter(pattern: String) {
 	private val regex: Regex
 
 	init {
+		if (pattern.isBlank()) {
+			throw IllegalArgumentException("Empty patterns aren't acceptable")
+		}
+
 		try {
-			val independentPattern = if (IS_WINDOWS) pattern.replace("/", "\\\\") else pattern
+			val independentPattern = if (IS_WINDOWS) pattern.replace('/', '\\') else pattern
 			regex = Regex(independentPattern)
 		} catch (exception: PatternSyntaxException) {
 			throw IllegalArgumentException("Provided regex is not valid: $pattern")

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/PathFilter.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/PathFilter.kt
@@ -20,7 +20,7 @@ class PathFilter(pattern: String) {
 		}
 
 		try {
-			val independentPattern = if (IS_WINDOWS) pattern.replace('/', '\\') else pattern
+			val independentPattern = if (IS_WINDOWS) pattern.replace("/", "\\\\") else pattern
 			regex = Regex(independentPattern)
 		} catch (exception: PatternSyntaxException) {
 			throw IllegalArgumentException("Provided regex is not valid: $pattern")

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/PathFilter.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/PathFilter.kt
@@ -24,4 +24,24 @@ class PathFilter(pattern: String) {
 	}
 
 	fun matches(path: Path): Boolean = path.toAbsolutePath().toString().matches(regex)
+
+	override fun equals(other: Any?): Boolean {
+		if (this === other) return true
+		if (other !is PathFilter) return false
+
+		// We compare the patterns — there is no meaningful way to compare equality for regexes,
+		// but we control the creation of the regexes and we can say that all else is equal, so
+		// that's good enough in this case.
+		if (regex.pattern != other.regex.pattern) return false
+
+		return true
+	}
+
+	override fun hashCode(): Int {
+		return regex.hashCode()
+	}
+
+	override fun toString(): String {
+		return "PathFilter(regex=$regex)"
+	}
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/PathFilterSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/PathFilterSpec.kt
@@ -1,0 +1,34 @@
+package io.gitlab.arturbosch.detekt.core
+
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.junit.jupiter.api.assertThrows
+import java.nio.file.Paths
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class PathFilterSpec : Spek({
+
+	given("an invalid regex pattern") {
+		it("throws an IllegalArgumentException") {
+			assertThrows<IllegalArgumentException> { PathFilter("*.") }
+		}
+	}
+
+	given("a single regex pattern") {
+		val pathFilter = PathFilter(".*/build/.*")
+
+		it("matches a corresponding path") {
+			val path = Paths.get("/tmp/whatever/detekt/build/should/match")
+
+			assertTrue { pathFilter.matches(path) }
+		}
+
+		it("does not match an unrelated path") {
+			val path = Paths.get("/tmp/whatever/detekt/this/should/NOT/match")
+
+			assertFalse { pathFilter.matches(path) }
+		}
+	}
+})

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/PathFilterSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/PathFilterSpec.kt
@@ -16,6 +16,18 @@ internal class PathFilterSpec : Spek({
 		}
 	}
 
+	given("an empty pattern") {
+		it("throws an IllegalArgumentException") {
+			assertThrows<IllegalArgumentException> { PathFilter("") }
+		}
+	}
+
+	given("an blank pattern") {
+		it("throws an IllegalArgumentException") {
+			assertThrows<IllegalArgumentException> { PathFilter("    ") }
+		}
+	}
+
 	given("a single regex pattern") {
 		val pathFilter = PathFilter(".*/build/.*")
 


### PR DESCRIPTION
This PR fixes an issue with the filters being passed to the CLI where spaces around separators were not trimmed correctly, making some filters ineffective. A bunch of tests have been added to avoid future problems, around `PathFilter` and for `Configurations#createPathFilters()`.

This fixes #1125 