### PR TITLE
#1120/Ignore naming of overridden functions and properties

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -306,6 +306,7 @@ naming:
     active: true
     functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
     excludeClassPattern: '$^'
+    ignoreOverridden: true
   FunctionParameterNaming:
     active: true
     parameterPattern: '[a-z][A-Za-z0-9]*'

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -340,6 +340,7 @@ naming:
     variablePattern: '[a-z][A-Za-z0-9]*'
     privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
+    ignoreOverridden: true
 
 performance:
   active: true

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/KDocTags.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/KDocTags.kt
@@ -32,15 +32,23 @@ fun KDocTag.parseConfigTag(): Configuration {
 	return Configuration(name, description, defaultValue)
 }
 
+private const val EXPECTED_CONFIGURATION_FORMAT =
+		"Expected format: @configuration {paramName} - {paramDescription} (default: {defaultValue})."
+
 fun KDocTag.isValidConfigurationTag(entity: String = "Rule"): Boolean {
 	val content: String = getContent()
-	val valid = content.contains("-") &&
-			content.contains(configurationDefaultValueRegex)
-	if (!valid) {
+	if (!content.contains(" - ")) {
 		throw InvalidDocumentationException(
-				"$entity $name contains an incorrect configuration option tag in the KDoc.")
+				"[${containingFile.name}] $entity '$content' doesn't seem to contain a description.\n" +
+						EXPECTED_CONFIGURATION_FORMAT)
 	}
-	return valid
+	if (!content.contains(configurationDefaultValueRegex)) {
+		val parameterName = content.substringBefore(" - ")
+		throw InvalidDocumentationException(
+				"[${containingFile.name}] $entity '$parameterName' doesn't seem to contain a default value.\n" +
+						EXPECTED_CONFIGURATION_FORMAT)
+	}
+	return true
 }
 
 val configurationDefaultValueRegex = "\\(default: (.+)\\)".toRegex(RegexOption.DOT_MATCHES_ALL)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -37,6 +37,8 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
 	private val ignoreOverridden = valueOrDefault(IGNORE_OVERRIDDEN, true)
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
+		super.visitNamedFunction(function)
+
 		if (function.isOverridden() && ignoreOverridden) {
 			return
 		}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -39,7 +39,7 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		super.visitNamedFunction(function)
 
-		if (function.isOverridden() && ignoreOverridden) {
+		if (ignoreOverridden && function.isOverridden()) {
 			return
 		}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.identifierName
+import io.gitlab.arturbosch.detekt.rules.isOverridden
 import io.gitlab.arturbosch.detekt.rules.naming.util.isContainingExcludedClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
@@ -17,6 +18,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  *
  * @configuration functionPattern - naming pattern (default: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$')
  * @configuration excludeClassPattern - ignores functions in classes which match this regex (default: '$^')
+ * @configuration ignoreOverridden - ignores functions that have the override modifier
  *
  * @active since v1.0.0
  * @author Marvin Ramin
@@ -32,8 +34,13 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
 
 	private val functionPattern by LazyRegex(FUNCTION_PATTERN, "^([a-z$][a-zA-Z$0-9]*)|(`.*`)$")
 	private val excludeClassPattern by LazyRegex(EXCLUDE_CLASS_PATTERN, "$^")
+	private val ignoreOverridden = valueOrDefault(IGNORE_OVERRIDDEN, true)
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
+		if (function.isOverridden() && ignoreOverridden) {
+			return
+		}
+
 		if (!function.isContainingExcludedClass(excludeClassPattern) &&
 				!function.identifierName().matches(functionPattern)) {
 			report(CodeSmell(
@@ -46,5 +53,6 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
 	companion object {
 		const val FUNCTION_PATTERN = "functionPattern"
 		const val EXCLUDE_CLASS_PATTERN = "excludeClassPattern"
+		const val IGNORE_OVERRIDDEN = "ignoreOverridden"
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  *
  * @configuration functionPattern - naming pattern (default: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$')
  * @configuration excludeClassPattern - ignores functions in classes which match this regex (default: '$^')
- * @configuration ignoreOverridden - ignores functions that have the override modifier
+ * @configuration ignoreOverridden - ignores functions that have the override modifier (default: true)
  *
  * @active since v1.0.0
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRules.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRules.kt
@@ -63,7 +63,7 @@ class NamingRules(config: Config = Config.empty) : MultiRule() {
 		}
 		declaration.nameIdentifier?.parent?.javaClass?.let {
 			when (declaration) {
-				is KtProperty -> handleVariable(declaration)
+				is KtProperty -> handleProperty(declaration)
 				is KtNamedFunction -> handleFunction(declaration)
 				is KtEnumEntry -> enumEntryNamingRule.runIfActive { visitEnumEntry(declaration) }
 				is KtClassOrObject -> handleClassOrObject(declaration)
@@ -84,7 +84,7 @@ class NamingRules(config: Config = Config.empty) : MultiRule() {
 		functionMinNameLengthRule.runIfActive { visitNamedFunction(declaration) }
 	}
 
-	private fun handleVariable(declaration: KtProperty) {
+	private fun handleProperty(declaration: KtProperty) {
 		variableMaxNameLengthRule.runIfActive { visitProperty(declaration) }
 		variableMinNameLengthRule.runIfActive { visitProperty(declaration) }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
  * @configuration variablePattern - naming pattern (default: '[a-z][A-Za-z0-9]*')
  * @configuration privateVariablePattern - naming pattern (default: '(_)?[a-z][A-Za-z0-9]*')
  * @configuration excludeClassPattern - ignores variables in classes which match this regex (default: '$^')
+ * @configuration ignoreOverridden - ignores member properties that have the override modifier (default: true)
  *
  * @active since v1.0.0
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
@@ -44,7 +44,7 @@ class VariableNaming(config: Config = Config.empty) : Rule(config) {
 			return
 		}
 
-		if (property.isOverridden() && ignoreOverridden) {
+		if (ignoreOverridden && property.isOverridden()) {
 			return
 		}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.identifierName
+import io.gitlab.arturbosch.detekt.rules.isOverridden
 import io.gitlab.arturbosch.detekt.rules.naming.util.isContainingExcludedClass
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
@@ -35,9 +36,14 @@ class VariableNaming(config: Config = Config.empty) : Rule(config) {
 	private val variablePattern by LazyRegex(VARIABLE_PATTERN, "[a-z][A-Za-z0-9]*")
 	private val privateVariablePattern by LazyRegex(PRIVATE_VARIABLE_PATTERN, "(_)?[a-z][A-Za-z0-9]*")
 	private val excludeClassPattern by LazyRegex(EXCLUDE_CLASS_PATTERN, "$^")
+	private val ignoreOverridden = valueOrDefault(IGNORE_OVERRIDDEN, true)
 
 	override fun visitProperty(property: KtProperty) {
 		if (property.isSingleUnderscore || property.isContainingExcludedClass(excludeClassPattern)) {
+			return
+		}
+
+		if (property.isOverridden() && ignoreOverridden) {
 			return
 		}
 
@@ -63,5 +69,6 @@ class VariableNaming(config: Config = Config.empty) : Rule(config) {
 		const val VARIABLE_PATTERN = "variablePattern"
 		const val PRIVATE_VARIABLE_PATTERN = "privateVariablePattern"
 		const val EXCLUDE_CLASS_PATTERN = "excludeClassPattern"
+		const val IGNORE_OVERRIDDEN = "ignoreOverridden"
 	}
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -29,11 +29,33 @@ class FunctionNamingSpec : Spek({
 		assertThat(FunctionNaming(config).lint(code)).isEmpty()
 	}
 
+	it("flags functions inside functions") {
+		val code = """
+			override fun shouldNotBeFlagged() {
+				fun SHOULD_BE_FLAGGED() { }
+			}
+		"""
+		assertThat(FunctionNaming().lint(code)).hasLocationStrings(
+				"'fun SHOULD_BE_FLAGGED() { }' at (2,2) in /foo.bar"
+		)
+	}
+
 	it("ignores overridden functions by default") {
 		val code = """
 			override fun SHOULD_NOT_BE_FLAGGED() = TODO()
 		"""
 		assertThat(FunctionNaming().lint(code)).isEmpty()
+	}
+
+	it("flags functions with bad names inside overridden functions by default") {
+		val code = """
+			override fun SHOULD_NOT_BE_FLAGGED() {
+				fun SHOULD_BE_FLAGGED() {}
+			}
+		"""
+		assertThat(FunctionNaming().lint(code)).hasLocationStrings(
+				"'fun SHOULD_BE_FLAGGED() {}' at (2,2) in /foo.bar"
+		)
 	}
 
 	it("doesn't ignore overridden functions if ignoreOverridden is false") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -1,22 +1,48 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
 
 /**
  * @author Artur Bosch
  */
-class FunctionNamingSpec : SubjectSpek<FunctionNaming>({
-
-	subject { FunctionNaming() }
+class FunctionNamingSpec : Spek({
 
 	it("allows FunctionName as alias for suppressing") {
 		val code = """
 			@Suppress("FunctionName")
 			fun MY_FUN() = TODO()
 		"""
-		assertThat(subject.lint(code)).isEmpty()
+		assertThat(FunctionNaming().lint(code)).isEmpty()
+	}
+
+	it("ignores functions in classes matching excludeClassPattern") {
+		val code = """
+			class WhateverTest {
+				fun SHOULD_NOT_BE_FLAGGED() = TODO()
+			}
+		"""
+		val config = TestConfig(mapOf("excludeClassPattern" to ".*Test$"))
+		assertThat(FunctionNaming(config).lint(code)).isEmpty()
+	}
+
+	it("ignores overridden functions by default") {
+		val code = """
+			override fun SHOULD_NOT_BE_FLAGGED() = TODO()
+		"""
+		assertThat(FunctionNaming().lint(code)).isEmpty()
+	}
+
+	it("doesn't ignore overridden functions if ignoreOverridden is false") {
+		val code = """
+			override fun SHOULD_BE_FLAGGED() = TODO()
+		"""
+		val config = TestConfig(mapOf("ignoreOverridden" to "false"))
+		assertThat(FunctionNaming(config).lint(code)).hasLocationStrings(
+				"'override fun SHOULD_BE_FLAGGED() = TODO()' at (1,1) in /foo.bar"
+		)
 	}
 })

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -20,11 +20,11 @@ class FindingsAssert(actual: List<Finding>) :
 
 	fun hasLocationStrings(vararg expected: String, trimIndent: Boolean = false) {
 		isNotNull
-		val locationStrings = actual.map { it.locationAsString }
+		val locationStrings = actual.map { it.locationAsString }.sorted()
 		if (trimIndent) {
-			areEqual(locationStrings.map { it.trimIndent() }, expected.map { it.trimIndent() })
+			areEqual(locationStrings.map { it.trimIndent() }, expected.map { it.trimIndent() }.sorted())
 		} else {
-			areEqual(locationStrings, expected.toList())
+			areEqual(locationStrings, expected.toList().sorted())
 		}
 	}
 

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -122,6 +122,10 @@ Reports when function names which do not follow the specified naming convention 
 
    ignores functions in classes which match this regex
 
+* `ignoreOverridden` (default: `true`)
+
+   ignores functions that have the override modifier
+
 ### FunctionParameterNaming
 
 Reports function parameter names which do not follow the specified naming convention are used.
@@ -328,3 +332,7 @@ Reports when variable names which do not follow the specified naming convention 
 * `excludeClassPattern` (default: `'$^'`)
 
    ignores variables in classes which match this regex
+
+* `ignoreOverridden` (default: `true`)
+
+   ignores member properties that have the override modifier


### PR DESCRIPTION
FIxes #1120 as discussed on that issue: by default we ignore naming of functions and member properties which have the `override` modifier.