### PR TITLE
Fix issue when multiple input files are specified

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -28,7 +28,7 @@ internal object GenerateConfigArgument : CliArgument() {
 }
 
 internal data class InputArgument(val fileCollection: FileCollection) : CliArgument() {
-	override fun toArgument() = listOf(INPUT_PARAMETER, fileCollection.asPath)
+	override fun toArgument() = listOf(INPUT_PARAMETER, fileCollection.joinToString(",") { it.absolutePath })
 }
 
 internal data class FiltersArgument(val filters: String?) : CliArgument() {
@@ -53,8 +53,7 @@ internal data class HtmlReportArgument(val file: File?) : CliArgument() {
 
 internal data class ConfigArgument(val config: FileCollection?) : CliArgument() {
 	override fun toArgument() = config?.let { configPaths ->
-		listOf(CONFIG_PARAMETER,
-				configPaths.joinToString(",") { it.absolutePath })
+		listOf(CONFIG_PARAMETER, configPaths.joinToString(",") { it.absolutePath })
 	} ?: emptyList()
 }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslTest.kt
@@ -203,10 +203,10 @@ internal class DetektTaskGroovyDslTest : Spek({
 			val detektConfig = """
 					|detekt {
 					| debug = true
-					|	input = files(
-					|		"$customSourceLocation",
-					|		"some/location/thatdoesnotexist"
-					|	)
+					| input = files(
+					|	 "$customSourceLocation",
+					|	 "some/location/thatdoesnotexist"
+					| )
 					|}
 				"""
 
@@ -230,10 +230,10 @@ internal class DetektTaskGroovyDslTest : Spek({
 			val detektConfig = """
 					|detekt {
 					| debug = true
-					|	input = files(
-					|		"$customSourceLocation",
-					|		"$otherCustomSourceLocation"
-					|	)
+					| input = files(
+					|	 "$customSourceLocation",
+					|	 "$otherCustomSourceLocation"
+					| )
 					|}
 				"""
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslTest.kt
@@ -202,6 +202,7 @@ internal class DetektTaskGroovyDslTest : Spek({
 			val customSourceLocation = "gensrc/kotlin"
 			val detektConfig = """
 					|detekt {
+					| debug = true
 					|	input = files(
 					|		"$customSourceLocation",
 					|		"some/location/thatdoesnotexist"
@@ -220,7 +221,34 @@ internal class DetektTaskGroovyDslTest : Spek({
 					.build()
 
 			assertThat(result.output).contains("number of classes: 1")
-			assertThat(result.output).contains("--input $rootDir/$customSourceLocation")
+			assertThat(result.output).contains("--input, /private$rootDir/$customSourceLocation")
+			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+		}
+		it("can configure multiple input directories") {
+			val customSourceLocation = "gensrc/kotlin"
+			val otherCustomSourceLocation = "gensrc/foo"
+			val detektConfig = """
+					|detekt {
+					| debug = true
+					|	input = files(
+					|		"$customSourceLocation",
+					|		"$otherCustomSourceLocation"
+					|	)
+					|}
+				"""
+
+			writeFiles(rootDir, detektConfig, customSourceLocation, otherCustomSourceLocation)
+			writeConfig(rootDir)
+
+			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
+			val result = GradleRunner.create()
+					.withProjectDir(rootDir)
+					.withArguments("--project-cache-dir", createTempDir(prefix = "cache").absolutePath, "check", "--stacktrace", "--info")
+					.withPluginClasspath()
+					.build()
+
+			assertThat(result.output).contains("number of classes: 2")
+			assertThat(result.output).contains("--input, /private$rootDir/$customSourceLocation,/private$rootDir/$otherCustomSourceLocation")
 			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 		}
 		it("can configure a new custom detekt task") {
@@ -292,6 +320,15 @@ private fun writeFiles(root: File, detektConfiguration: String, srcDir: String =
 	File(root, "settings.gradle").writeText(settingsFileContent)
 	File(root, srcDir).mkdirs()
 	File(root, "$srcDir/MyClass.kt").writeText(ktFileContent)
+}
+
+private fun writeFiles(root: File, detektConfiguration: String, vararg srcDir: String) {
+	File(root, "build.gradle").writeText(buildFileContent(detektConfiguration))
+	File(root, "settings.gradle").writeText(settingsFileContent)
+	srcDir.forEach {
+		File(root, it).mkdirs()
+		File(root, "$it/MyClass.kt").writeText(ktFileContent)
+	}
 }
 
 private fun writeConfig(root: File, failFast: Boolean = false) {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
@@ -231,6 +231,7 @@ internal class DetektTaskKotlinDslTest : Spek({
 			val customSourceLocation = "gensrc/kotlin"
 			val detektConfig = """
 					|detekt {
+					| debug = true
 					|	input = files("$customSourceLocation")
 					|}
 				"""
@@ -247,7 +248,7 @@ internal class DetektTaskKotlinDslTest : Spek({
 					.build()
 
 			assertThat(result.output).contains("number of classes: 1")
-			assertThat(result.output).contains("--input $rootDir/$customSourceLocation")
+			assertThat(result.output).contains("--input, /private$rootDir/$customSourceLocation")
 			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 		}
 	}

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
@@ -232,7 +232,7 @@ internal class DetektTaskKotlinDslTest : Spek({
 			val detektConfig = """
 					|detekt {
 					| debug = true
-					|	input = files("$customSourceLocation")
+					| input = files("$customSourceLocation")
 					|}
 				"""
 


### PR DESCRIPTION
After Gradle plugin rework, there was a removal of `:` as path separator which caused inputs not being properly split by `DetektInputPathConverter`.

Commit removing `:`: https://github.com/arturbosch/detekt/commit/3b0f992bda34a25cd34bbc237d637f13d9845a1b#diff-fffb30c13416dcda612424cc7a5e3034

The above commit conflicted with the way FileCollection.asPath returns the path of specified files,
because it concatenates the absolute paths with `:`.

Updating InputArgument#toArgument to join files absolute paths with `,` fixes the issue.