### PR TITLE
#1131 complex method should be less strict with simple when entries

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -42,8 +42,11 @@ open class ThresholdedCodeSmell(
 		entity: Entity,
 		val metric: Metric,
 		message: String,
-		references: List<Entity> = emptyList()) : CodeSmell(
-		issue, entity, message, metrics = listOf(metric), references = references) {
+		references: List<Entity> = emptyList()
+) : CodeSmell(
+		issue, entity, message, metrics = listOf(metric), references = references
+) {
+
 	val value: Int
 		get() = metric.value
 	val threshold: Int

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -77,6 +77,7 @@ complexity:
     active: true
     threshold: 10
     ignoreSingleWhenExpression: false
+    simpleWhenEntryWeight: 0.5
   LabeledExpression:
     active: false
   LargeClass:

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/DetektYmlConfigTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/DetektYmlConfigTest.kt
@@ -75,7 +75,7 @@ class DetektYmlConfigTest {
 
 	private fun loadConfig(): Config {
 		val workingDirectory = Paths.get(".").toAbsolutePath().normalize().toString()
-		val file = File(workingDirectory + "/src/main/resources/$CONFIG_FILE")
+		val file = File("$workingDirectory/src/main/resources/$CONFIG_FILE")
 		val url = file.toURI().toURL()
 		return YamlConfig.loadResource(url)
 	}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/ComplexityVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/ComplexityVisitorTest.kt
@@ -31,6 +31,6 @@ internal class ComplexityVisitorTest {
 
 		val mcc = calcComplexity(path)
 
-		assertThat(mcc).isEqualTo(56)
+		assertThat(mcc).isEqualTo(54)
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  * @configuration threshold - MCC threshold for a method (default: 10)
  * @configuration ignoreSingleWhenExpression - Ignores a complex method if it only contains a single when expression.
  * (default: false)
- * @configuration simpleWhenEntriesWeight - The weight used for simple (braceless) when entries. (default: 0.5)
+ * @configuration simpleWhenEntryWeight - The weight used for simple (braceless) when entries. (default: 0.5)
  *
  * @active since v1.0.0
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  * @configuration threshold - MCC threshold for a method (default: 10)
  * @configuration ignoreSingleWhenExpression - Ignores a complex method if it only contains a single when expression.
  * (default: false)
+ * @configuration simpleWhenEntriesWeight - The weight used for simple (braceless) when entries. (default: 0.5)
  *
  * @active since v1.0.0
  * @author Artur Bosch
@@ -38,12 +39,13 @@ class ComplexMethod(config: Config = Config.empty,
 			Debt.TWENTY_MINS)
 
 	private val ignoreSingleWhenExpression = valueOrDefault(IGNORE_SINGLE_WHEN_EXPRESSION, false)
+	private val simpleWhenEntriesWeight = valueOrDefault(SIMPLE_WHEN_ENTRY_WEIGHT, 0.5)
 
 	override fun visitNamedFunction(function: KtNamedFunction) {
 		if (hasSingleWhenExpression(function.bodyExpression)) {
 			return
 		}
-		val visitor = McCabeVisitor()
+		val visitor = McCabeVisitor(simpleWhenEntriesWeight)
 		visitor.visitNamedFunction(function)
 		val mcc = visitor.mcc
 		if (mcc >= threshold) {
@@ -73,5 +75,6 @@ class ComplexMethod(config: Config = Config.empty,
 	companion object {
 		const val DEFAULT_ACCEPTED_METHOD_COMPLEXITY = 10
 		const val IGNORE_SINGLE_WHEN_EXPRESSION = "ignoreSingleWhenExpression"
+		const val SIMPLE_WHEN_ENTRY_WEIGHT = "simpleWhenEntryWeight"
 	}
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
@@ -1,10 +1,11 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
-import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
+import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.isThresholded
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
@@ -19,9 +20,13 @@ class ComplexMethodSpec : Spek({
 		it("finds one complex method") {
 			val subject = ComplexMethod()
 			subject.lint(Case.ComplexClass.path())
-			assertThat(subject.findings).hasSize(1)
-			assertThat((subject.findings[0] as ThresholdedCodeSmell).value).isEqualTo(20)
-			assertThat((subject.findings[0] as ThresholdedCodeSmell).threshold).isEqualTo(10)
+
+			assertThat(subject.findings).hasSourceLocations(SourceLocation(3, 1))
+
+			assertThat(subject.findings.first())
+					.isThresholded()
+					.withValue(19)
+					.withThreshold(10)
 		}
 	}
 
@@ -30,14 +35,56 @@ class ComplexMethodSpec : Spek({
 		val path = Case.ComplexMethods.path()
 
 		it("does not report complex methods with a single when expression") {
-			val config = TestConfig(mapOf(ComplexMethod.IGNORE_SINGLE_WHEN_EXPRESSION to "true"))
+			val config = TestConfig(mapOf(
+					ComplexMethod.SIMPLE_WHEN_ENTRY_WEIGHT to "1.0",
+					ComplexMethod.IGNORE_SINGLE_WHEN_EXPRESSION to "true"))
 			val subject = ComplexMethod(config, threshold = 4)
-			assertThat(subject.lint(path)).hasSize(1)
+
+			assertThat(subject.lint(path)).hasSourceLocations(SourceLocation(42, 1))
 		}
 
 		it("reports all complex methods") {
-			val subject = ComplexMethod(threshold = 4)
-			assertThat(subject.lint(path)).hasSize(5)
+			val config = TestConfig(mapOf(ComplexMethod.SIMPLE_WHEN_ENTRY_WEIGHT to "1.0"))
+			val subject = ComplexMethod(config, threshold = 4)
+
+			assertThat(subject.lint(path)).hasSourceLocations(
+					SourceLocation(5, 1),
+					SourceLocation(14, 1),
+					SourceLocation(24, 1),
+					SourceLocation(34, 1),
+					SourceLocation(42, 1)
+			)
+		}
+
+		it("does not trip for a reasonable amount of simple when entries") {
+			val config = TestConfig(mapOf(ComplexMethod.SIMPLE_WHEN_ENTRY_WEIGHT to "0.5"))
+			val subject = ComplexMethod(config)
+			val code = """
+				internal fun Map<String, Any>.asBundle(): Bundle {
+					val bundle = Bundle(size)
+
+					for ((key, value) in this) {
+						val transformedKey = key.asFcmId()
+
+						when (value) {
+							is Int -> bundle.putInt(transformedKey, value)
+							is String -> bundle.putString(transformedKey, value)
+							is Float -> bundle.putFloat(transformedKey, value)
+							is Double -> bundle.putDouble(transformedKey, value)
+							is Byte -> bundle.putByte(transformedKey, value)
+							is Short -> bundle.putShort(transformedKey, value)
+							is Long -> bundle.putLong(transformedKey, value)
+							is Boolean -> bundle.putBoolean(transformedKey, value)
+							else -> throw IllegalArgumentException("Unexpected type value")
+						}
+					}
+
+					return bundle
+				}
+			""".trimIndent()
+
+			val findings = subject.lint(code)
+			assertThat(findings).isEmpty()
 		}
 	}
 })

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -1,11 +1,14 @@
 package io.gitlab.arturbosch.detekt.test
 
 import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.SourceLocation
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.api.AbstractListAssert
 import org.assertj.core.internal.Objects
 
 fun assertThat(findings: List<Finding>) = FindingsAssert(findings)
+
+fun assertThat(finding: Finding) = FindingAssert(finding)
 
 class FindingsAssert(actual: List<Finding>) :
 		AbstractListAssert<FindingsAssert, List<Finding>,
@@ -20,18 +23,32 @@ class FindingsAssert(actual: List<Finding>) :
 
 	fun hasLocationStrings(vararg expected: String, trimIndent: Boolean = false) {
 		isNotNull
-		val locationStrings = actual.map { it.locationAsString }
+
+		val locationStrings = actual.asSequence().map { it.locationAsString }
 		if (trimIndent) {
-			areEqual(locationStrings.map { it.trimIndent() }, expected.map { it.trimIndent() })
+			areEqual(locationStrings.map { it.trimIndent() }.toList(), expected.map { it.trimIndent() })
 		} else {
-			areEqual(locationStrings, expected.toList())
+			areEqual(locationStrings.toList(), expected.toList())
 		}
 	}
 
-	private fun areEqual(actualLocationStrings: List<String>, expectedLocationStrings: List<String>) {
+	fun hasSourceLocations(vararg expected: SourceLocation) {
+		isNotNull
+
+		val actualSources = actual.asSequence()
+				.map { it.location.source }
+				.sortedWith(compareBy({ it.line }, { it.column }))
+
+		val expectedSources = expected.asSequence()
+				.sortedWith(compareBy({ it.line }, { it.column }))
+
+		areEqual(actualSources.toList(), expectedSources.toList())
+	}
+
+	private fun <T> areEqual(actual: List<T>, expected: List<T>) {
 		Objects.instance()
-				.assertEqual(writableAssertionInfo, actualLocationStrings, expectedLocationStrings.toList())
+				.assertEqual(writableAssertionInfo, actual, expected)
 	}
 }
 
-class FindingAssert(actual: Finding?) : AbstractAssert<FindingAssert, Finding>(actual, FindingAssert::class.java)
+class FindingAssert(val actual: Finding?) : AbstractAssert<FindingAssert, Finding>(actual, FindingAssert::class.java)

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.internal.Objects
 
-
 fun assertThat(thresholdedCodeSmell: ThresholdedCodeSmell) = ThresholdedCodeSmellAssert(thresholdedCodeSmell)
 
 fun FindingAssert.isThresholded(): ThresholdedCodeSmellAssert {

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssertions.kt
@@ -1,0 +1,39 @@
+package io.gitlab.arturbosch.detekt.test
+
+import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
+import org.assertj.core.api.AbstractAssert
+import org.assertj.core.internal.Objects
+
+
+fun assertThat(thresholdedCodeSmell: ThresholdedCodeSmell) = ThresholdedCodeSmellAssert(thresholdedCodeSmell)
+
+fun FindingAssert.isThresholded(): ThresholdedCodeSmellAssert {
+	isNotNull
+	assert(actual is ThresholdedCodeSmell) { "The finding '$actual' is not a ThresholdedCodeSmell" }
+	return ThresholdedCodeSmellAssert(actual as ThresholdedCodeSmell?)
+}
+
+class ThresholdedCodeSmellAssert(actual: ThresholdedCodeSmell?) :
+		AbstractAssert<ThresholdedCodeSmellAssert, ThresholdedCodeSmell>(
+				actual, ThresholdedCodeSmellAssert::class.java) {
+
+	fun withValue(expected: Int) = hasValue(expected).let { this }
+
+	private val objects = Objects.instance()
+
+	fun hasValue(expected: Int) {
+		isNotNull
+
+		val smell = actual as ThresholdedCodeSmell
+		objects.assertEqual(writableAssertionInfo, smell.value, expected)
+	}
+
+	fun withThreshold(expected: Int) = hasThreshold(expected).let { this }
+
+	fun hasThreshold(expected: Int) {
+		isNotNull
+
+		val smell = actual as ThresholdedCodeSmell
+		objects.assertEqual(writableAssertionInfo, smell.threshold, expected)
+	}
+}

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -87,6 +87,10 @@ Smaller methods can also be named much clearer which leads to improved readabili
 
    Ignores a complex method if it only contains a single when expression.
 
+* `simpleWhenEntryWeight` (default: `0.5`)
+
+   The weight used for simple (braceless) when entries.
+
 ### LabeledExpression
 
 This rule reports labeled expressions. Expressions with labels generally increase complexity and worsen the


### PR DESCRIPTION
This fixes #1131 by weighing simple `when` entries to `0.5` (was `1.0`) by default, and allowing users to customise the weight if they want to.

This requires the McCabe visitor to internally keep a floating-point sum of the complexities, but we still emit an integer value to keep backwards compatibility (and for simplicity).

This PR also improves `ComplexMethod`'s tests, and adds better facilities to test `Finding`s and `ThresholdedCodeSmell`s.