### PR TITLE
Fix issue with wrong report name

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ReportPath.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ReportPath.kt
@@ -14,7 +14,8 @@ data class ReportPath(val kind: String, val path: Path) {
 		private const val NUM_OF_PARTS_UNIX = 2
 		private const val NUM_OF_PARTS_WINDOWS = 3
 		private const val REPORT_PATH_SEPARATOR = ":"
-		private const val ILLEGAL_PARTS_SIZE_ERROR = "Must consist of two parts for Unix OSs or three for Windows (report-id:path)."
+		private const val ILLEGAL_PARTS_SIZE_ERROR =
+				"Must consist of two parts for Unix OSs or three for Windows (report-id:path)."
 
 		fun from(input: String): ReportPath {
 			val parts = input.split(REPORT_PATH_SEPARATOR)

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ReportPath.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ReportPath.kt
@@ -11,10 +11,24 @@ import java.nio.file.Paths
  */
 data class ReportPath(val kind: String, val path: Path) {
 	companion object {
+		private const val NUM_OF_PARTS_UNIX = 2
+		private const val NUM_OF_PARTS_WINDOWS = 3
+		private const val REPORT_PATH_SEPARATOR = ":"
+		private const val ILLEGAL_PARTS_SIZE_ERROR = "Must consist of two parts for Unix OSs or three for Windows (report-id:path)."
+
 		fun from(input: String): ReportPath {
-			val parts = input.split(":")
-			assert(parts.size == 2) { "Must consist of exactly two parts (report-id:path)." }
-			val (kind, path) = parts
+			val parts = input.split(REPORT_PATH_SEPARATOR)
+			val partsSize = parts.size
+
+			require(partsSize == NUM_OF_PARTS_UNIX || partsSize == NUM_OF_PARTS_WINDOWS) { ILLEGAL_PARTS_SIZE_ERROR }
+
+			val kind = parts[0]
+			val path = when (partsSize) {
+				NUM_OF_PARTS_UNIX -> parts[1]
+				NUM_OF_PARTS_WINDOWS -> parts.slice(1 until partsSize).joinToString(REPORT_PATH_SEPARATOR)
+				else -> throw IllegalStateException(ILLEGAL_PARTS_SIZE_ERROR)
+			}
+
 			return ReportPath(defaultMapping(kind), Paths.get(path))
 		}
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/ReportsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/ReportsSpec.kt
@@ -36,6 +36,30 @@ internal class ReportsSpec : Spek({
 			assertThat(reports).hasSize(4)
 		}
 
+		it("it should properly parse XML report entry") {
+			val xmlReport = reports[0]
+			assertThat(xmlReport.kind).isEqualTo(XmlOutputReport::class.java.simpleName)
+			assertThat(xmlReport.path.toString()).isEqualTo("/tmp/path1")
+		}
+
+		it("it should properly parse PLAIN report entry") {
+			val plainReport = reports[1]
+			assertThat(plainReport.kind).isEqualTo(PlainOutputReport::class.java.simpleName)
+			assertThat(plainReport.path.toString()).isEqualTo("/tmp/path2")
+		}
+
+		it("it should properly parse custom report entry") {
+			val customReport = reports[2]
+			assertThat(customReport.kind).isEqualTo(reportUnderTest)
+			assertThat(customReport.path.toString()).isEqualTo("/tmp/path3")
+		}
+
+		it("it should properly parse HTML report entry") {
+			val htmlReport = reports[3]
+			assertThat(htmlReport.kind).isEqualTo(HtmlOutputReport::class.java.simpleName)
+			assertThat(htmlReport.path.toString()).isEqualTo("D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html")
+		}
+
 		val extensions = ReportLocator(ProcessingSettings(listOf())).load()
 		val extensionsIds = extensions.mapTo(HashSet()) { it.id }
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/ReportsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/ReportsSpec.kt
@@ -25,14 +25,15 @@ internal class ReportsSpec : Spek({
 				"--input", "/tmp/must/be/given",
 				"--report", "xml:/tmp/path1",
 				"--report", "plain:/tmp/path2",
-				"--report", "$reportUnderTest:/tmp/path3"
+				"--report", "$reportUnderTest:/tmp/path3",
+				"--report", "html:D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html"
 		)
 		val (cli, _) = parseArguments<CliArgs>(args)
 
 		val reports = cli.reportPaths
 
 		it("should parse multiple report entries") {
-			assertThat(reports).hasSize(3)
+			assertThat(reports).hasSize(4)
 		}
 
 		val extensions = ReportLocator(ProcessingSettings(listOf())).load()

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/ReportsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/ReportsSpec.kt
@@ -11,6 +11,7 @@ import org.assertj.core.api.Condition
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
+import java.nio.file.Paths
 import java.util.function.Predicate
 
 /**
@@ -39,25 +40,25 @@ internal class ReportsSpec : Spek({
 		it("it should properly parse XML report entry") {
 			val xmlReport = reports[0]
 			assertThat(xmlReport.kind).isEqualTo(XmlOutputReport::class.java.simpleName)
-			assertThat(xmlReport.path.toString()).isEqualTo("/tmp/path1")
+			assertThat(xmlReport.path).isEqualTo(Paths.get("/tmp/path1"))
 		}
 
 		it("it should properly parse PLAIN report entry") {
 			val plainReport = reports[1]
 			assertThat(plainReport.kind).isEqualTo(PlainOutputReport::class.java.simpleName)
-			assertThat(plainReport.path.toString()).isEqualTo("/tmp/path2")
+			assertThat(plainReport.path).isEqualTo(Paths.get("/tmp/path2"))
 		}
 
 		it("it should properly parse custom report entry") {
 			val customReport = reports[2]
 			assertThat(customReport.kind).isEqualTo(reportUnderTest)
-			assertThat(customReport.path.toString()).isEqualTo("/tmp/path3")
+			assertThat(customReport.path).isEqualTo(Paths.get("/tmp/path3"))
 		}
 
 		it("it should properly parse HTML report entry") {
 			val htmlReport = reports[3]
 			assertThat(htmlReport.kind).isEqualTo(HtmlOutputReport::class.java.simpleName)
-			assertThat(htmlReport.path.toString()).isEqualTo("D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html")
+			assertThat(htmlReport.path).isEqualTo(Paths.get("D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html"))
 		}
 
 		val extensions = ReportLocator(ProcessingSettings(listOf())).load()


### PR DESCRIPTION
When splitting a report path provided on JCommander, given a Windows path
would cause a false split, that would continue the execution despite the assert check.

This commit fixes this issue by the assumption that an absolute path on Windows
systems, will contain the current disk drive's letter.

Resolves: #1123 - #1141 