### PR TITLE
Prevent overwriting of defaultDependency detekt-cli by additional detekt dependencies

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -82,10 +82,10 @@ class DetektPlugin : Plugin<Project> {
 	private fun determineInput(extension: DetektExtension) = extension.input.filter { it.exists() }
 
 	private fun configurePluginDependencies(project: Project, extension: DetektExtension) {
-		project.configurations.create(CONFIGURATION_DETEKT_PLUGIN) {
+		project.configurations.create(CONFIGURATION_DETEKT_INTERNAL) {
 			isVisible = false
 			isTransitive = true
-			description = "The internal $CONFIGURATION_DETEKT_PLUGIN libraries to be used for this project."
+			description = "The internal $CONFIGURATION_DETEKT_INTERNAL libraries to be used for this project."
 
 			@Suppress("USELESS_ELVIS")
 			val version = extension.toolVersion ?: DEFAULT_DETEKT_VERSION
@@ -111,4 +111,4 @@ class DetektPlugin : Plugin<Project> {
 }
 
 const val CONFIGURATION_DETEKT = "detekt"
-const val CONFIGURATION_DETEKT_PLUGIN = "detektPlugins"
+const val CONFIGURATION_DETEKT_INTERNAL = "detektInternal"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -81,17 +81,20 @@ class DetektPlugin : Plugin<Project> {
 
 	private fun determineInput(extension: DetektExtension) = extension.input.filter { it.exists() }
 
-	private fun configurePluginDependencies(project: Project, extension: DetektExtension) =
-			project.configurations.create(DETEKT) {
-				isVisible = false
-				isTransitive = true
-				description = "The $DETEKT libraries to be used for this project."
-				defaultDependencies {
-					@Suppress("USELESS_ELVIS")
-					val version = extension.toolVersion ?: DEFAULT_DETEKT_VERSION
-					add(project.dependencies.create("io.gitlab.arturbosch.detekt:detekt-cli:$version"))
-				}
-			}
+	private fun configurePluginDependencies(project: Project, extension: DetektExtension) {
+		project.configurations.create(DETEKT) {
+			isVisible = false
+			isTransitive = true
+			description = "The $DETEKT libraries to be used for this project."
+
+			@Suppress("USELESS_ELVIS")
+			val version = extension.toolVersion ?: DEFAULT_DETEKT_VERSION
+			dependencies.add(project.dependencies.add(
+					"detekt",
+					"io.gitlab.arturbosch.detekt:detekt-cli:$version")
+			)
+		}
+	}
 
 
 	companion object {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -82,20 +82,24 @@ class DetektPlugin : Plugin<Project> {
 	private fun determineInput(extension: DetektExtension) = extension.input.filter { it.exists() }
 
 	private fun configurePluginDependencies(project: Project, extension: DetektExtension) {
-		project.configurations.create(DETEKT) {
+		project.configurations.create(CONFIGURATION_DETEKT_PLUGIN) {
 			isVisible = false
 			isTransitive = true
-			description = "The $DETEKT libraries to be used for this project."
+			description = "The internal $CONFIGURATION_DETEKT_PLUGIN libraries to be used for this project."
 
 			@Suppress("USELESS_ELVIS")
 			val version = extension.toolVersion ?: DEFAULT_DETEKT_VERSION
-			dependencies.add(project.dependencies.add(
-					"detekt",
-					"io.gitlab.arturbosch.detekt:detekt-cli:$version")
-			)
+			defaultDependencies {
+				add(project.dependencies.create("io.gitlab.arturbosch.detekt:detekt-cli:$version"))
+			}
+		}
+
+		project.configurations.create(CONFIGURATION_DETEKT) {
+			isVisible = false
+			isTransitive = true
+			description = "The $CONFIGURATION_DETEKT libraries to be used for this project."
 		}
 	}
-
 
 	companion object {
 		private const val DETEKT = "detekt"
@@ -105,3 +109,6 @@ class DetektPlugin : Plugin<Project> {
 		private const val BASELINE = "detektBaseline"
 	}
 }
+
+const val CONFIGURATION_DETEKT = "detekt"
+const val CONFIGURATION_DETEKT_PLUGIN = "detektPlugins"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -1,19 +1,33 @@
 package io.gitlab.arturbosch.detekt.invoke
 
+import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT
+import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT_PLUGIN
 import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
 
 /**
  * @author Marvin Ramin
  */
 object DetektInvoker {
 	internal fun invokeCli(project: Project, arguments: List<CliArgument>, debug: Boolean = false) {
-		val args = arguments.map(CliArgument::toArgument).flatten()
+		val cliArguments = arguments.map(CliArgument::toArgument).flatten()
 
-		if (debug) println(args)
+		if (debug) println(cliArguments)
 		project.javaexec {
-			main = "io.gitlab.arturbosch.detekt.cli.Main"
-			classpath(project.configurations.getAt("detekt"))
-			args(args)
+			main = DETEKT_MAIN
+			classpath = getConfigurations(project, debug)
+			args = cliArguments
 		}
 	}
+
+	private fun getConfigurations(project: Project, debug: Boolean = false): FileCollection {
+		val detektConfigurations = setOf(CONFIGURATION_DETEKT_PLUGIN, CONFIGURATION_DETEKT)
+		val configurations = project.configurations.filter { detektConfigurations.contains(it.name) }
+
+		val files = project.files(configurations)
+		if (debug) files.forEach { println(it) }
+		return files
+	}
 }
+
+private const val DETEKT_MAIN = "io.gitlab.arturbosch.detekt.cli.Main"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.invoke
 
 import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT
-import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT_PLUGIN
+import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT_INTERNAL
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 
@@ -21,7 +21,7 @@ object DetektInvoker {
 	}
 
 	private fun getConfigurations(project: Project, debug: Boolean = false): FileCollection {
-		val detektConfigurations = setOf(CONFIGURATION_DETEKT_PLUGIN, CONFIGURATION_DETEKT)
+		val detektConfigurations = setOf(CONFIGURATION_DETEKT_INTERNAL, CONFIGURATION_DETEKT)
 		val configurations = project.configurations.filter { detektConfigurations.contains(it.name) }
 
 		val files = project.files(configurations)

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
@@ -203,6 +203,7 @@ internal class DetektTaskKotlinDslTest : Spek({
 			assertThat(File(rootDir, "build/xml/detekt.xml")).exists()
 			assertThat(File(rootDir, "build/html/detekt.html")).exists()
 		}
+
 		it("can configure reports base directory") {
 			val detektConfig = """
 					|detekt {
@@ -227,6 +228,7 @@ internal class DetektTaskKotlinDslTest : Spek({
 			assertThat(File(rootDir, "build/my-reports/detekt.xml")).exists()
 			assertThat(File(rootDir, "build/my-reports/detekt.html")).exists()
 		}
+
 		it("can configure the input directory") {
 			val customSourceLocation = "gensrc/kotlin"
 			val detektConfig = """
@@ -249,6 +251,32 @@ internal class DetektTaskKotlinDslTest : Spek({
 
 			assertThat(result.output).contains("number of classes: 1")
 			assertThat(result.output).contains("--input, /private$rootDir/$customSourceLocation")
+			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+		}
+
+		it("can add an additional detekt dependency") {
+			val customSourceLocation = "gensrc/kotlin"
+			val detektConfig = """
+					|detekt {
+					| debug = true
+					|}
+					|
+					|dependencies {
+					| detekt("io.gitlab.arturbosch.detekt:detekt-formatting:${VERSION_UNDER_TEST}")
+					|}
+				"""
+
+			writeFiles(rootDir, detektConfig, customSourceLocation)
+			writeConfig(rootDir)
+			writeBaseline(rootDir)
+
+			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
+			val result = GradleRunner.create()
+					.withProjectDir(rootDir)
+					.withArguments("--project-cache-dir", createTempDir(prefix = "cache").absolutePath, "check", "--stacktrace", "--info")
+					.withPluginClasspath()
+					.build()
+
 			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 		}
 	}

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
@@ -254,21 +254,15 @@ internal class DetektTaskKotlinDslTest : Spek({
 			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 		}
 
-		it("can add an additional detekt dependency") {
-			val customSourceLocation = "gensrc/kotlin"
+		it("can be used without configuration") {
 			val detektConfig = """
-					|detekt {
-					| debug = true
-					|}
-					|
 					|dependencies {
 					| detekt("io.gitlab.arturbosch.detekt:detekt-formatting:${VERSION_UNDER_TEST}")
 					|}
 				"""
 
-			writeFiles(rootDir, detektConfig, customSourceLocation)
+			writeFiles(rootDir, detektConfig)
 			writeConfig(rootDir)
-			writeBaseline(rootDir)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -277,6 +271,8 @@ internal class DetektTaskKotlinDslTest : Spek({
 					.withPluginClasspath()
 					.build()
 
+			assertThat(result.output).contains("number of classes: 1")
+			assertThat(result.output).contains("Ruleset: comments")
 			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 		}
 	}


### PR DESCRIPTION
When including an additional dependency in the `detekt` configuration it would overwrite the `defaultdependency` we define in `DetektPlugin`. This behavior is also described in the Gradle documentation: https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/Configuration.html#defaultDependencies-org.gradle.api.Action-
> Execute the given action if the configuration has no defined dependencies when it first participates in dependency resolution.

In case of an extra `detekt` dependency the default dependency the `DetektPlugin` defines is omitted.

However we _require_ `detekt-cli` to be able to run detekt at all. To prevent the overwriting we simply define `detekt-cli` as a regular dependency in the `DetektPlugin`.

The added test fails with the `master` version of `DetektPlugin` and passes with the changes.

fixes #1143