### PR TITLE
Fix Gradle Plugin Tests

### DIFF
--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslTest.kt
@@ -221,7 +221,7 @@ internal class DetektTaskGroovyDslTest : Spek({
 					.build()
 
 			assertThat(result.output).contains("number of classes: 1")
-			assertThat(result.output).contains("--input, /private$rootDir/$customSourceLocation")
+			assertThat(result.output).contains("--input, $rootDir/$customSourceLocation")
 			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 		}
 		it("can configure multiple input directories") {
@@ -248,7 +248,7 @@ internal class DetektTaskGroovyDslTest : Spek({
 					.build()
 
 			assertThat(result.output).contains("number of classes: 2")
-			assertThat(result.output).contains("--input, /private$rootDir/$customSourceLocation,/private$rootDir/$otherCustomSourceLocation")
+			assertThat(result.output).contains("--input, $rootDir/$customSourceLocation,$rootDir/$otherCustomSourceLocation")
 			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 		}
 		it("can configure a new custom detekt task") {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
@@ -248,7 +248,7 @@ internal class DetektTaskKotlinDslTest : Spek({
 					.build()
 
 			assertThat(result.output).contains("number of classes: 1")
-			assertThat(result.output).contains("--input, /private$rootDir/$customSourceLocation")
+			assertThat(result.output).contains("--input, $rootDir/$customSourceLocation")
 			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 		}
 	}


### PR DESCRIPTION
Three tests which were testing for the correct `--input` path were failing.

As the Gradle Plugin tests don't seem to run on CI at the moment (see #1146) I have a follow up PR to enable the tests on CI.