### PR TITLE
run gradle plugin tests on ./gradlew test execution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,10 @@ tasks.withType<Wrapper> {
 	distributionType = Wrapper.DistributionType.ALL
 }
 
+tasks.withType<Test> {
+	dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":test"))
+}
+
 val detektVersion: String by project
 val usedDetektVersion: String by project
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslTest.kt
@@ -13,6 +13,21 @@ import java.io.File
  */
 internal class DetektTaskGroovyDslTest : Spek({
 
+	val buildGradle = """
+		|import io.gitlab.arturbosch.detekt.DetektPlugin
+		|
+		|plugins {
+		|   id "java-library"
+		|   id "io.gitlab.arturbosch.detekt"
+		|}
+		|
+		|repositories {
+		|	jcenter()
+		|	mavenLocal()
+		|}
+		""".trimMargin()
+	val dslTest = DslBaseTest("build.gradle", buildGradle)
+
 	describe("The Detekt Gradle plugin used in a build.gradle file") {
 		lateinit var rootDir: File
 		beforeEachTest {
@@ -22,7 +37,7 @@ internal class DetektTaskGroovyDslTest : Spek({
 
 			val detektConfig = ""
 
-			writeFiles(rootDir, detektConfig)
+			dslTest.writeFiles(rootDir, detektConfig)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -47,7 +62,7 @@ internal class DetektTaskGroovyDslTest : Spek({
 				|}
 				"""
 
-			writeFiles(rootDir, detektConfig)
+			dslTest.writeFiles(rootDir, detektConfig)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -76,7 +91,7 @@ internal class DetektTaskGroovyDslTest : Spek({
 				|}
 				"""
 
-			writeFiles(rootDir, detektConfig)
+			dslTest.writeFiles(rootDir, detektConfig)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -102,7 +117,7 @@ internal class DetektTaskGroovyDslTest : Spek({
 				|}
 				"""
 
-			writeFiles(rootDir, detektConfig)
+			dslTest.writeFiles(rootDir, detektConfig)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -118,7 +133,7 @@ internal class DetektTaskGroovyDslTest : Spek({
 			assertThat(File(rootDir, "build/detekt-reports/detekt.xml")).exists()
 			assertThat(File(rootDir, "build/detekt-reports/detekt.html")).exists()
 		}
-		it("can change reportsDir but overwrite single report destination") {
+		it("can change reportsDir but overdslTest.write single report destination") {
 
 			val detektConfig = """
 				|detekt {
@@ -129,7 +144,7 @@ internal class DetektTaskGroovyDslTest : Spek({
 				|}
 				"""
 
-			writeFiles(rootDir, detektConfig)
+			dslTest.writeFiles(rootDir, detektConfig)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -154,7 +169,7 @@ internal class DetektTaskGroovyDslTest : Spek({
 				|}
 				"""
 
-			writeFiles(rootDir, detektConfig)
+			dslTest.writeFiles(rootDir, detektConfig)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -182,7 +197,7 @@ internal class DetektTaskGroovyDslTest : Spek({
 				|}
 				"""
 
-			writeFiles(rootDir, detektConfig)
+			dslTest.writeFiles(rootDir, detektConfig)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -204,14 +219,14 @@ internal class DetektTaskGroovyDslTest : Spek({
 					|detekt {
 					| debug = true
 					| input = files(
-					|	 "${customSourceLocation.absolutePath}",
+					|	 "${customSourceLocation.safeAbsolutePath}",
 					|	 "some/location/thatdoesnotexist"
 					| )
 					|}
 				"""
 
-			writeFiles(rootDir, detektConfig, customSourceLocation)
-			writeConfig(rootDir)
+			dslTest.writeFiles(rootDir, detektConfig, customSourceLocation)
+			dslTest.writeConfig(rootDir)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -231,14 +246,14 @@ internal class DetektTaskGroovyDslTest : Spek({
 					|detekt {
 					| debug = true
 					| input = files(
-					|	 "${customSourceLocation.absolutePath}",
-					|	 "${otherCustomSourceLocation.absolutePath}"
+					|	 "${customSourceLocation.safeAbsolutePath}",
+					|	 "${otherCustomSourceLocation.safeAbsolutePath}"
 					| )
 					|}
 				"""
 
-			writeFiles(rootDir, detektConfig, customSourceLocation, otherCustomSourceLocation)
-			writeConfig(rootDir)
+			dslTest.writeFiles(rootDir, detektConfig, customSourceLocation, otherCustomSourceLocation)
+			dslTest.writeConfig(rootDir)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -259,7 +274,7 @@ internal class DetektTaskGroovyDslTest : Spek({
 					|	description = "Runs a failfast detekt build."
 					|
 					|	input = files("src/main/java")
-					|	config = files("${configFile.absolutePath}")
+					|	config = files("${configFile.safeAbsolutePath}")
 					|	debug = true
 					|	reports {
 					|		xml {
@@ -270,8 +285,8 @@ internal class DetektTaskGroovyDslTest : Spek({
 					|}
 				"""
 
-			writeFiles(rootDir, detektConfig)
-			writeConfig(rootDir, failFast = true)
+			dslTest.writeFiles(rootDir, detektConfig)
+			dslTest.writeConfig(rootDir, failfast = true)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -289,52 +304,3 @@ internal class DetektTaskGroovyDslTest : Spek({
 		}
 	}
 })
-
-// build.gradle
-private fun buildFileContent(detektConfiguration: String) = """
-	|import io.gitlab.arturbosch.detekt.DetektPlugin
-	|
-	|plugins {
-	|   id "java-library"
-	|   id "io.gitlab.arturbosch.detekt"
-	|}
-	|
-	|repositories {
-	|	jcenter()
-	|	mavenLocal()
-	|}
-	|
-	|$detektConfiguration
-	""".trimMargin()
-
-// settings.gradle
-private const val settingsFileContent = """include ":custom""""
-
-// src/main/kotlin/MyClass.kt
-private val ktFileContent = """
-	|internal class MyClass
-	|
-	""".trimMargin()
-
-private fun writeFiles(root: File, detektConfiguration: String, srcDir: String = "src/main/java") {
-	File(root, "build.gradle").writeText(buildFileContent(detektConfiguration))
-	File(root, "settings.gradle").writeText(settingsFileContent)
-	File(root, srcDir).mkdirs()
-	File(root, "$srcDir/MyClass.kt").writeText(ktFileContent)
-}
-
-private fun writeFiles(root: File, detektConfiguration: String, vararg srcDir: File) {
-	File(root, "build.gradle").writeText(buildFileContent(detektConfiguration))
-	File(root, "settings.gradle").writeText(settingsFileContent)
-	srcDir.forEach {
-		it.mkdirs()
-		File(it, "/MyClass.kt").writeText(ktFileContent)
-	}
-}
-
-private fun writeConfig(root: File, failFast: Boolean = false) {
-	File(root, "config.yml").writeText("""
-		|autoCorrect: true
-		|failFast: $failFast
-		""".trimMargin())
-}

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
@@ -13,6 +13,21 @@ import java.io.File
  */
 internal class DetektTaskKotlinDslTest : Spek({
 
+	val buildGradle = """
+		|import io.gitlab.arturbosch.detekt.detekt
+		|
+		|plugins {
+		|   `java-library`
+		|	id("io.gitlab.arturbosch.detekt")
+		|}
+		|
+		|repositories {
+		|	jcenter()
+		|	mavenLocal()
+		|}
+		""".trimMargin()
+	val dslTest = DslBaseTest("build.gradle.kts", buildGradle)
+
 	describe("The Detekt Gradle plugin used in a build.gradle.kts file") {
 		lateinit var rootDir: File
 		beforeEachTest {
@@ -22,8 +37,8 @@ internal class DetektTaskKotlinDslTest : Spek({
 
 			val detektConfig = ""
 
-			writeFiles(rootDir, detektConfig)
-			writeConfig(rootDir)
+			dslTest.writeFiles(rootDir, detektConfig)
+			dslTest.writeConfig(rootDir)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -42,8 +57,8 @@ internal class DetektTaskKotlinDslTest : Spek({
 			val detektConfig = ""
 
 			val srcDir = File(rootDir, "src/main/kotlin")
-			writeFiles(rootDir, detektConfig, srcDir)
-			writeConfig(rootDir)
+			dslTest.writeFiles(rootDir, detektConfig, srcDir)
+			dslTest.writeConfig(rootDir)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -65,8 +80,8 @@ internal class DetektTaskKotlinDslTest : Spek({
 					|}
 				"""
 
-			writeFiles(rootDir, detektConfig)
-			writeConfig(rootDir)
+			dslTest.writeFiles(rootDir, detektConfig)
+			dslTest.writeConfig(rootDir)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -89,12 +104,12 @@ internal class DetektTaskKotlinDslTest : Spek({
 
 			val detektConfig = """
 					|detekt {
-					|	config = files("${configPath.absolutePath}")
+					|	config = files("${configPath.safeAbsolutePath}")
 					|}
 				"""
 
-			writeFiles(rootDir, detektConfig)
-			writeConfig(rootDir)
+			dslTest.writeFiles(rootDir, detektConfig)
+			dslTest.writeConfig(rootDir)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -117,15 +132,15 @@ internal class DetektTaskKotlinDslTest : Spek({
 					|	parallel = true
 					|	disableDefaultRuleSets = true
 					|	toolVersion = "$VERSION_UNDER_TEST"
-					|	config = files("${configFile.absolutePath}")
-					|	baseline = file("${baselineFile.absolutePath}")
+					|	config = files("${configFile.safeAbsolutePath}")
+					|	baseline = file("${baselineFile.safeAbsolutePath}")
 					|	filters = ".*/resources/.*, .*/build/.*"
 					|}
 				"""
 
-			writeFiles(rootDir, detektConfig)
-			writeConfig(rootDir)
-			writeBaseline(rootDir)
+			dslTest.writeFiles(rootDir, detektConfig)
+			dslTest.writeConfig(rootDir)
+			dslTest.writeBaseline(rootDir)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -148,7 +163,7 @@ internal class DetektTaskKotlinDslTest : Spek({
 					|	description = "Runs a failfast detekt build."
 					|
 					|	input = files("src/main/java")
-					|	config = files("${configFile.absolutePath}")
+					|	config = files("${configFile.safeAbsolutePath}")
 					|	debug = true
 					|	reports {
 					|		xml {
@@ -159,9 +174,9 @@ internal class DetektTaskKotlinDslTest : Spek({
 					|}
 				"""
 
-			writeFiles(rootDir, detektConfig)
-			writeConfig(rootDir, failfast = true)
-			writeBaseline(rootDir)
+			dslTest.writeFiles(rootDir, detektConfig)
+			dslTest.writeConfig(rootDir, failfast = true)
+			dslTest.writeBaseline(rootDir)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -189,9 +204,9 @@ internal class DetektTaskKotlinDslTest : Spek({
 					|}
 				"""
 
-			writeFiles(rootDir, detektConfig)
-			writeConfig(rootDir)
-			writeBaseline(rootDir)
+			dslTest.writeFiles(rootDir, detektConfig)
+			dslTest.writeConfig(rootDir)
+			dslTest.writeBaseline(rootDir)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -215,9 +230,9 @@ internal class DetektTaskKotlinDslTest : Spek({
 					|}
 				"""
 
-			writeFiles(rootDir, detektConfig)
-			writeConfig(rootDir)
-			writeBaseline(rootDir)
+			dslTest.writeFiles(rootDir, detektConfig)
+			dslTest.writeConfig(rootDir)
+			dslTest.writeBaseline(rootDir)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -238,13 +253,13 @@ internal class DetektTaskKotlinDslTest : Spek({
 			val detektConfig = """
 					|detekt {
 					| debug = true
-					| input = files("${customSourceLocation.absolutePath}")
+					| input = files("${customSourceLocation.safeAbsolutePath}")
 					|}
 				"""
 
-			writeFiles(rootDir, detektConfig, customSourceLocation)
-			writeConfig(rootDir)
-			writeBaseline(rootDir)
+			dslTest.writeFiles(rootDir, detektConfig, customSourceLocation)
+			dslTest.writeConfig(rootDir)
+			dslTest.writeBaseline(rootDir)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -265,8 +280,8 @@ internal class DetektTaskKotlinDslTest : Spek({
 					|}
 				"""
 
-			writeFiles(rootDir, detektConfig)
-			writeConfig(rootDir)
+			dslTest.writeFiles(rootDir, detektConfig)
+			dslTest.writeConfig(rootDir)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -282,47 +297,3 @@ internal class DetektTaskKotlinDslTest : Spek({
 	}
 })
 
-// build.gradle.kts
-private fun getBuildFileContent(detektConfig: String) = """
-	|import io.gitlab.arturbosch.detekt.detekt
-	|
-	|plugins {
-	|   `java-library`
-	|	id("io.gitlab.arturbosch.detekt")
-	|}
-	|
-	|repositories {
-	|	jcenter()
-	|	mavenLocal()
-	|}
-	|
-	|$detektConfig
-	""".trimMargin()
-
-
-// src/main/kotlin/MyClass.kt
-private val ktFileContent = """
-	|internal class MyClass
-	|
-	""".trimMargin()
-
-private fun writeFiles(root: File, detektConfig: String, sourceDir: File = File(root, "src/main/java")) {
-	File(root, "build.gradle.kts").writeText(getBuildFileContent(detektConfig))
-	sourceDir.mkdirs()
-	File(sourceDir, "/MyClass.kt").writeText(ktFileContent)
-}
-
-private fun writeConfig(root: File, failfast: Boolean = false) {
-	File(root, "config.yml").writeText("""
-		|autoCorrect: true
-		|failFast: $failfast
-		""".trimMargin())
-}
-
-private fun writeBaseline(root: File) {
-	File(root, "baseline.xml").writeText("""
-		|<some>
-		|	<xml/>
-		|</some>
-		""".trimMargin())
-}

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslBaseTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslBaseTest.kt
@@ -1,0 +1,56 @@
+package io.gitlab.arturbosch.detekt
+
+import java.io.File
+
+class DslBaseTest(private val buildGradleFileName: String, private val buildGradleFile: String) {
+
+	private fun getBuildFileContent(customConfig: String): String {
+		return """
+    	|$buildGradleFile
+		|
+    	|$customConfig
+		""".trimMargin()
+	}
+
+	private val ktFileContent = """
+	|internal class MyClass
+	|
+	""".trimMargin()
+
+	// settings.gradle
+	private val settingsFileContent = """include ":custom""""
+
+	fun writeConfig(root: File, failfast: Boolean = false) {
+		File(root, "config.yml").writeText("""
+		|autoCorrect: true
+		|failFast: $failfast
+		""".trimMargin())
+	}
+
+	fun writeBaseline(root: File) {
+		File(root, "baseline.xml").writeText("""
+		|<some>
+		|	<xml/>
+		|</some>
+		""".trimMargin())
+	}
+
+	fun writeFiles(root: File, detektConfiguration: String, srcDir: File = File(root, "src/main/java")) {
+		File(root, buildGradleFileName).writeText(getBuildFileContent(detektConfiguration))
+		File(root, "settings.gradle").writeText(settingsFileContent)
+		srcDir.mkdirs()
+		File(srcDir, "MyClass.kt").writeText(ktFileContent)
+	}
+
+	fun writeFiles(root: File, detektConfiguration: String, vararg srcDir: File) {
+		File(root, buildGradleFileName).writeText(getBuildFileContent(detektConfiguration))
+		File(root, "settings.gradle").writeText(settingsFileContent)
+		srcDir.forEach {
+			it.mkdirs()
+			File(it, "MyClass.kt").writeText(ktFileContent)
+		}
+	}
+}
+
+val File.safeAbsolutePath
+	get() = absolutePath.replace("\\", "\\\\")


### PR DESCRIPTION
Resolves #1146 

This ensures that tests of the Gradle Plugin run when executing `./gradlew test`

This means also when running `./gradlew build` the Gradle Plugin's tests will be executed. As there are currently test failures this PR should be red until we merge a PR to fix the failures.

See #1148 for the fixes to the tests.