### PR TITLE
print test outcome for debugging during the build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
 import com.jfrog.bintray.gradle.BintrayExtension
 import org.codehaus.groovy.tools.shell.util.Logger.io
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.kotlin.dsl.setValue
 import org.jetbrains.dokka.gradle.DokkaTask
 
@@ -95,6 +97,20 @@ subprojects {
 
 	tasks.withType<Test> {
 		useJUnitPlatform()
+		testLogging {
+			// set options for log level LIFECYCLE
+			events = setOf(
+					TestLogEvent.FAILED,
+					TestLogEvent.PASSED,
+					TestLogEvent.SKIPPED,
+					TestLogEvent.STANDARD_OUT
+			)
+			exceptionFormat = TestExceptionFormat.FULL
+			showExceptions = true
+			showCauses = true
+			showStackTraces = true
+
+		}
 	}
 
 	tasks.withType<KotlinCompile> {

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -1,5 +1,7 @@
 import com.gradle.publish.PluginConfig
 import com.jfrog.bintray.gradle.BintrayExtension
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.dokka.gradle.DokkaTask
 import java.util.Date
 
@@ -66,6 +68,19 @@ gradlePlugin {
 
 val test by tasks.getting(Test::class) {
 	useJUnitPlatform()
+	testLogging {
+		// set options for log level LIFECYCLE
+		events = setOf(
+				TestLogEvent.FAILED,
+				TestLogEvent.PASSED,
+				TestLogEvent.SKIPPED,
+				TestLogEvent.STANDARD_OUT
+		)
+		exceptionFormat = TestExceptionFormat.FULL
+		showExceptions = true
+		showCauses = true
+		showStackTraces = true
+	}
 }
 
 pluginBundle {


### PR DESCRIPTION
This will add a lot of verbosity to our build logs that contain tests. However it can be quite helpful when debugging tests from the command line and to see if tests ran at all.