### PR TITLE
Use correct accessor method for config in LazyRegex

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/LazyRegex.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/LazyRegex.kt
@@ -25,6 +25,6 @@ class LazyRegex(
 	}
 
 	private fun createRegex(rule: Rule): Regex {
-		return Regex(rule.config.valueOrDefault(key = key, default = default))
+		return Regex(rule.valueOrDefault(key = key, default = default))
 	}
 }


### PR DESCRIPTION
This PR fixes #1122 and similar issues reported on Slack.

`LazyRegex` was directly accessing the config. However instead it should only access the methods defined by `ConfigAware`. 

`ConfigAware`, which is a base class of `Rule` ensures that the config works on the correct `subConfig`. Using `config` directly however operates on the entire config of the whole `RuleSet`.

As this is a really easy mistake to make, which is quite hard to debug, we should make it harder to directly access the `config` in a `Rule` class to prevent similar issues in the future.