### PR TITLE
use correct instance of valueOrDefault in FormattingRule

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -33,7 +33,7 @@ abstract class FormattingRule(config: Config) : Rule(config) {
 			Issue(javaClass.simpleName, Severity.Style, description, Debt.FIVE_MINS)
 
 	protected val isAndroid
-		get() = config.valueOrDefault("android", false)
+		get() = valueOrDefault("android", false)
 
 	private var positionByOffset: (offset: Int) -> Pair<Int, Int> by SingleAssign()
 	private var root: KtFile by SingleAssign()


### PR DESCRIPTION
Similar to #1152 I think this rule should use the `ConfigAware#valueOrDefault` method instead of accessing the `config` directly.