### PR TITLE
rename configurations of Gradle Plugin to detekt and detektPlugins

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
@@ -9,8 +9,8 @@ import io.gitlab.arturbosch.detekt.api.RuleSetProvider
  *
  * Note: The formatting rule set is not included in the detekt-cli or gradle plugin.
  *
- * To enable this rule set, add <i>detekt "io.gitlab.arturbosch.detekt:detekt-formatting:$version"</i>
- * to your gradle configuration or reference the `detekt-formatting`-jar with the `--plugins` option
+ * To enable this rule set, add <i>detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:$version"</i>
+ * to your gradle dependencies or reference the `detekt-formatting`-jar with the `--plugins` option
  * in the command line interface.
  *
  * @configuration android - if android style guides should be preferred (default: false)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -82,22 +82,22 @@ class DetektPlugin : Plugin<Project> {
 	private fun determineInput(extension: DetektExtension) = extension.input.filter { it.exists() }
 
 	private fun configurePluginDependencies(project: Project, extension: DetektExtension) {
-		project.configurations.create(CONFIGURATION_DETEKT_INTERNAL) {
+		project.configurations.create(CONFIGURATION_DETEKT_PLUGINS) {
 			isVisible = false
 			isTransitive = true
-			description = "The internal $CONFIGURATION_DETEKT_INTERNAL libraries to be used for this project."
+			description = "The $CONFIGURATION_DETEKT_PLUGINS libraries to be used for this project."
+		}
+
+		project.configurations.create(CONFIGURATION_DETEKT) {
+			isVisible = false
+			isTransitive = true
+			description = "The $CONFIGURATION_DETEKT dependencies to be used for this project."
 
 			@Suppress("USELESS_ELVIS")
 			val version = extension.toolVersion ?: DEFAULT_DETEKT_VERSION
 			defaultDependencies {
 				add(project.dependencies.create("io.gitlab.arturbosch.detekt:detekt-cli:$version"))
 			}
-		}
-
-		project.configurations.create(CONFIGURATION_DETEKT) {
-			isVisible = false
-			isTransitive = true
-			description = "The $CONFIGURATION_DETEKT libraries to be used for this project."
 		}
 	}
 
@@ -111,4 +111,4 @@ class DetektPlugin : Plugin<Project> {
 }
 
 const val CONFIGURATION_DETEKT = "detekt"
-const val CONFIGURATION_DETEKT_INTERNAL = "detektInternal"
+const val CONFIGURATION_DETEKT_PLUGINS = "detektPlugins"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.invoke
 
 import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT
-import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT_INTERNAL
+import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT_PLUGINS
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 
@@ -21,7 +21,7 @@ object DetektInvoker {
 	}
 
 	private fun getConfigurations(project: Project, debug: Boolean = false): FileCollection {
-		val detektConfigurations = setOf(CONFIGURATION_DETEKT_INTERNAL, CONFIGURATION_DETEKT)
+		val detektConfigurations = setOf(CONFIGURATION_DETEKT_PLUGINS, CONFIGURATION_DETEKT)
 		val configurations = project.configurations.filter { detektConfigurations.contains(it.name) }
 
 		val files = project.files(configurations)

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
@@ -257,7 +257,7 @@ internal class DetektTaskKotlinDslTest : Spek({
 		it("can be used without configuration") {
 			val detektConfig = """
 					|dependencies {
-					| detekt("io.gitlab.arturbosch.detekt:detekt-formatting:${VERSION_UNDER_TEST}")
+					| detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:${VERSION_UNDER_TEST}")
 					|}
 				"""
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ which can be easily added to the gradle configuration:
 
 ```gradle
 dependencies {
-    detekt "io.gitlab.arturbosch.detekt:detekt-formatting:[version]"
+    detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:[version]"
 }
 ```
 

--- a/docs/pages/changelog.md
+++ b/docs/pages/changelog.md
@@ -5,6 +5,31 @@ keywords: changelog, release-notes, migration
 permalink: changelog.html
 toc: true
 ---
+
+<!--
+#### Coming up
+
+##### Migration
+
+The configurations in the Detekt Gradle Plugin have changed to align the Plugin further with other
+static analysis plugins. Similar to FindBugs the Detekt Gradle Plugin now defines two configurations:
+`detekt` and `detektPlugins`.
+- `detekt` is now used to define detekt dependencies such as the `detekt-cli`.
+- `detektPlugins` is used to define custom detekt RuleSets and rules such as the `detekt-formatting`
+rules
+
+To define custom detekt extensions or to add the `detekt-formatting` rules you will now have to
+define them as:
+
+```kotlin
+dependencies {
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[version]")
+    detektPlugins("your.custom.detekt.rules:rules:[version]")
+}
+```
+
+-->
+
 #### RC9.2
 
 ##### Migration

--- a/docs/pages/documentation/formatting.md
+++ b/docs/pages/documentation/formatting.md
@@ -10,8 +10,8 @@ This rule set provides rules that address formatting issues.
 
 Note: The formatting rule set is not included in the detekt-cli or gradle plugin.
 
-To enable this rule set, add <i>detekt "io.gitlab.arturbosch.detekt:detekt-formatting:$version"</i>
-to your gradle configuration or reference the `detekt-formatting`-jar with the `--plugins` option
+To enable this rule set, add <i>detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:$version"</i>
+to your gradle dependencies or reference the `detekt-formatting`-jar with the `--plugins` option
 in the command line interface.
 
 ### ChainWrapping


### PR DESCRIPTION
Resolves #1162

This renames the configuraitons of the Gradle Plugin to `detekt` (used for the default `detekt-cli` dependency) and `detektPlugins` (used for custom rules and formatting).