### PR TITLE
Migrate all assertions to AssertJ

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -223,7 +223,6 @@ subprojects {
 		kotlinImplementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinVersion")
 		kotlinImplementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
 		kotlinTest("org.junit.jupiter:junit-jupiter-api:$junitEngineVersion")
-		kotlinTest("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
 		kotlinTest("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
 		kotlinTest("org.assertj:assertj-core:$assertjVersion")
 		kotlinTest("org.jetbrains.spek:spek-api:$spekVersion")

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigSpec.kt
@@ -1,12 +1,12 @@
 package io.gitlab.arturbosch.detekt.api
 
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.assertj.core.api.Assertions.fail
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import java.nio.file.Paths
-import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
-import kotlin.test.fail
 
 /**
  * @author Artur Bosch
@@ -20,11 +20,11 @@ class ConfigSpec : Spek({
 		it("should create a sub config") {
 			try {
 				val subConfig = config.subConfig("style")
-				assertTrue { subConfig.valueOrDefault("WildcardImport", mapOf<String, Any>()).isNotEmpty() }
-				assertTrue { subConfig.valueOrDefault("WildcardImport", mapOf<String, Any>())["active"].toString() == "true" }
-				assertTrue { subConfig.valueOrDefault("WildcardImport", mapOf<String, Any>())["active"] as Boolean }
-				assertTrue { subConfig.valueOrDefault("NotFound", mapOf<String, Any>()).isEmpty() }
-				assertTrue { subConfig.valueOrDefault("NotFound", "") == "" }
+				assertThat(subConfig.valueOrDefault("WildcardImport", mapOf<String, Any>())).isNotEmpty
+				assertThat(subConfig.valueOrDefault("WildcardImport", mapOf<String, Any>())["active"].toString()).isEqualTo("true")
+				assertThat(subConfig.valueOrDefault("WildcardImport", mapOf<String, Any>())["active"] as Boolean).isTrue()
+				assertThat(subConfig.valueOrDefault("NotFound", mapOf<String, Any>())).isEmpty()
+				assertThat(subConfig.valueOrDefault("NotFound", "")).isEmpty()
 			} catch (ignored: Config.InvalidConfigurationError) {
 				fail("Creating a sub config should work for test resources config!")
 			}
@@ -34,15 +34,15 @@ class ConfigSpec : Spek({
 			try {
 				val subConfig = config.subConfig("style")
 				val subSubConfig = subConfig.subConfig("WildcardImport")
-				assertTrue { subSubConfig.valueOrDefault("active", false) }
-				assertTrue { subSubConfig.valueOrDefault("NotFound", true) }
+				assertThat(subSubConfig.valueOrDefault("active", false)).isTrue()
+				assertThat(subSubConfig.valueOrDefault("NotFound", true)).isTrue()
 			} catch (ignored: Config.InvalidConfigurationError) {
 				fail("Creating a sub config should work for test resources config!")
 			}
 		}
 
 		it("tests wrong sub config conversion") {
-			assertFailsWith<ClassCastException> {
+			assertThatExceptionOfType(ClassCastException::class.java).isThrownBy {
 				@Suppress("UNUSED_VARIABLE")
 				val ignored = config.valueOrDefault("style", "")
 			}

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/DebtSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/DebtSpec.kt
@@ -1,10 +1,10 @@
 package io.gitlab.arturbosch.detekt.api
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
-import kotlin.test.assertFails
 
 /**
  * @author Artur Bosch
@@ -13,11 +13,11 @@ class DebtSpec : Spek({
 
 	describe("creating issues with custom debt values") {
 		it("should fail on negative values") {
-			assertFails { Debt(-1, -1, -1) }
+			assertThatIllegalArgumentException().isThrownBy { Debt(-1, -1, -1) }
 		}
 
 		it("should fail if all values are less than zero ") {
-			assertFails { Debt(0, 0, 0) }
+			assertThatIllegalArgumentException().isThrownBy { Debt(0, 0, 0) }
 		}
 
 		it("should print 20min, 10min and 5min") {

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/MetricSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/MetricSpec.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.api
 
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.it
-import kotlin.test.assertEquals
-import kotlin.test.assertFails
 
 /**
  * @author Artur Bosch
@@ -12,12 +12,12 @@ class MetricSpec : Spek({
 
 	it("should convert double values to int") {
 		val metric = Metric("LOC", 0.33, 0.10, 100)
-		assertEquals(0.33, metric.doubleValue())
-		assertEquals(0.10, metric.doubleThreshold())
+		assertThat(metric.doubleValue()).isEqualTo(0.33)
+		assertThat(metric.doubleThreshold()).isEqualTo(0.10)
 	}
 
 	it("should throw error if double value is asked for int metric") {
-		assertFails {
+		assertThatIllegalStateException().isThrownBy {
 			Metric("LOC", 100, 50).doubleValue()
 		}
 	}

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SingleAssignTest.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SingleAssignTest.kt
@@ -1,16 +1,16 @@
 package io.gitlab.arturbosch.detekt.api
 
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
 internal class SingleAssignTest : Spek({
   describe("value is unset") {
     var unassigned: Int by SingleAssign()
     it("should fail when value is retrieved") {
-      assertFailsWith(IllegalStateException::class) {
+      assertThatIllegalStateException().isThrownBy {
         @Suppress("UNUSED_EXPRESSION")
         unassigned
       }
@@ -26,11 +26,11 @@ internal class SingleAssignTest : Spek({
     assigned = 15
 
     it("should succeed when value is retrieved") {
-      assertEquals(15, assigned)
+      assertThat(assigned).isEqualTo(15)
     }
 
     it("should fail when value is assigned") {
-      assertFailsWith<IllegalStateException> { assigned = -1 }
+	  assertThatIllegalStateException().isThrownBy { assigned = -1 }
     }
   }
 })

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SuppressibleSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SuppressibleSpec.kt
@@ -1,13 +1,12 @@
 package io.gitlab.arturbosch.detekt.api
 
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 /**
  * @author Marvin Ramin
@@ -17,79 +16,79 @@ internal class SuppressibleSpec : Spek({
 	given("a Test rule") {
 
 		it("should not be suppressed by a @Deprecated annotation") {
-			assertFalse { checkSuppression("Deprecated", "This should no longer be used") }
+			assertThat(checkSuppression("Deprecated", "This should no longer be used")).isFalse()
 		}
 
 		it("should not be suppressed by a @Suppress annotation for another rule") {
-			assertFalse { checkSuppression("Suppress", "NotATest") }
+			assertThat(checkSuppression("Suppress", "NotATest")).isFalse()
 		}
 
 		it("should not be suppressed by a @SuppressWarnings annotation for another rule") {
-			assertFalse { checkSuppression("SuppressWarnings", "NotATest") }
+			assertThat(checkSuppression("SuppressWarnings", "NotATest")).isFalse()
 		}
 
 		it("should be suppressed by a @Suppress annotation for the rule") {
-			assertTrue { checkSuppression("Suppress", "Test") }
+			assertThat(checkSuppression("Suppress", "Test")).isTrue()
 		}
 
 		it("should be suppressed by a @SuppressWarnings annotation for the rule") {
-			assertTrue { checkSuppression("SuppressWarnings", "Test") }
+			assertThat(checkSuppression("SuppressWarnings", "Test")).isTrue()
 		}
 
 		it("should be suppressed by a @SuppressWarnings annotation for 'all' rules") {
-			assertTrue { checkSuppression("Suppress", "all") }
+			assertThat(checkSuppression("Suppress", "all")).isTrue()
 		}
 
 		it("should be suppressed by a @SuppressWarnings annotation for 'ALL' rules") {
-			assertTrue { checkSuppression("SuppressWarnings", "ALL") }
+			assertThat(checkSuppression("SuppressWarnings", "ALL")).isTrue()
 		}
 
 		it("should not be suppressed by a @Suppress annotation with a Checkstyle prefix") {
-			assertFalse { checkSuppression("Suppress", "Checkstyle:Test") }
+			assertThat(checkSuppression("Suppress", "Checkstyle:Test")).isFalse()
 		}
 
 		it("should not be suppressed by a @SuppressWarnings annotation with a Checkstyle prefix") {
-			assertFalse { checkSuppression("SuppressWarnings", "Checkstyle:Test") }
+			assertThat(checkSuppression("SuppressWarnings", "Checkstyle:Test")).isFalse()
 		}
 
 		it("should be suppressed by a @Suppress annotation with a 'Detekt' prefix") {
-			assertTrue { checkSuppression("Suppress", "Detekt:Test") }
+			assertThat(checkSuppression("Suppress", "Detekt:Test")).isTrue()
 		}
 
 		it("should be suppressed by a @SuppressWarnings annotation with a 'Detekt' prefix") {
-			assertTrue { checkSuppression("SuppressWarnings", "Detekt:Test") }
+			assertThat(checkSuppression("SuppressWarnings", "Detekt:Test")).isTrue()
 		}
 
 		it("should be suppressed by a @Suppress annotation with a 'detekt' prefix") {
-			assertTrue { checkSuppression("Suppress", "detekt:Test") }
+			assertThat(checkSuppression("Suppress", "detekt:Test")).isTrue()
 		}
 
 		it("should be suppressed by a @SuppressWarnings annotation with a 'detekt' prefix") {
-			assertTrue { checkSuppression("SuppressWarnings", "detekt:Test") }
+			assertThat(checkSuppression("SuppressWarnings", "detekt:Test")).isTrue()
 		}
 
 		it("should be suppressed by a @Suppress annotation with a 'detekt' prefix with a dot") {
-			assertTrue { checkSuppression("Suppress", "detekt.Test") }
+			assertThat(checkSuppression("Suppress", "detekt.Test")).isTrue()
 		}
 
 		it("should be suppressed by a @SuppressWarnings annotation with a 'detekt' prefix with a dot") {
-			assertTrue { checkSuppression("SuppressWarnings", "detekt.Test") }
+			assertThat(checkSuppression("SuppressWarnings", "detekt.Test")).isTrue()
 		}
 
 		it("should not be suppressed by a @Suppress annotation with a 'detekt' prefix with a wrong separator") {
-			assertFalse { checkSuppression("Suppress", "detekt/Test") }
+			assertThat(checkSuppression("Suppress", "detekt/Test")).isFalse()
 		}
 
 		it("should not be suppressed by a @SuppressWarnings annotation with a 'detekt' prefix with a wrong separator") {
-			assertFalse { checkSuppression("SuppressWarnings", "detekt/Test") }
+			assertThat(checkSuppression("SuppressWarnings", "detekt/Test")).isFalse()
 		}
 
 		it("should be suppressed by a @Suppress annotation with an alias") {
-			assertTrue { checkSuppression("Suppress", "alias") }
+			assertThat(checkSuppression("Suppress", "alias")).isTrue()
 		}
 
 		it("should be suppressed by a @SuppressWarnings annotation with an alias") {
-			assertTrue { checkSuppression("SuppressWarnings", "alias") }
+			assertThat(checkSuppression("SuppressWarnings", "alias")).isTrue()
 		}
 	}
 })

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SuppressionSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SuppressionSpec.kt
@@ -1,13 +1,12 @@
 package io.gitlab.arturbosch.detekt.api
 
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.lastBlockStatementOrThis
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.it
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 /**
  * @author Artur Bosch
@@ -18,21 +17,21 @@ internal class SuppressionSpec : Spek({
 		val ktFile = compilerFor("SuppressedObject.kt")
 		val rule = TestRule()
 		rule.visitFile(ktFile)
-		assertNotNull(rule.expected)
+		assertThat(rule.expected).isNotNull()
 	}
 
 	it("findings are suppressed") {
 		val ktFile = compilerFor("SuppressedElements.kt")
 		val ruleSet = RuleSet("Test", listOf(TestLM(), TestLPL()))
 		val findings = ruleSet.accept(ktFile)
-		assertEquals(0, findings.size)
+		assertThat(findings.size).isZero()
 	}
 
 	it("rule should be suppressed by ALL") {
 		val ktFile = compilerFor("SuppressedByAllObject.kt")
 		val rule = TestRule()
 		rule.visitFile(ktFile)
-		assertNotNull(rule.expected)
+		assertThat(rule.expected).isNotNull()
 	}
 
 	it("rule should be suppressed by detekt prefix in uppercase with dot separator") {
@@ -47,7 +46,7 @@ internal class SuppressionSpec : Spek({
 			""")
 		val rule = TestRule()
 		rule.visitFile(ktFile)
-		assertNotNull(rule.expected)
+		assertThat(rule.expected).isNotNull()
 	}
 
 	it("rule should be suppressed by detekt prefix in lowercase with colon separator") {
@@ -62,7 +61,7 @@ internal class SuppressionSpec : Spek({
 			""")
 		val rule = TestRule()
 		rule.visitFile(ktFile)
-		assertNotNull(rule.expected)
+		assertThat(rule.expected).isNotNull()
 	}
 
 	it("rule should be suppressed by detekt prefix in all caps with colon separator") {
@@ -77,7 +76,7 @@ internal class SuppressionSpec : Spek({
 			""")
 		val rule = TestRule()
 		rule.visitFile(ktFile)
-		assertNotNull(rule.expected)
+		assertThat(rule.expected).isNotNull()
 	}
 })
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigurationsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigurationsSpec.kt
@@ -1,12 +1,16 @@
 package io.gitlab.arturbosch.detekt.cli
 
+import com.beust.jcommander.ParameterException
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.core.PathFilter
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
-import kotlin.test.assertFails
 
 /**
  * @author Artur Bosch
@@ -44,9 +48,9 @@ internal class ConfigurationsSpec : Spek({
 		}
 
 		it("should fail on invalid config value") {
-			assertFails { CliArgs().apply { config = "," }.loadConfiguration() }
-			assertFails { CliArgs().apply { config = "sfsjfsdkfsd" }.loadConfiguration() }
-			assertFails { CliArgs().apply { config = "./i.do.not.exist.yml" }.loadConfiguration() }
+			assertThatIllegalArgumentException().isThrownBy { CliArgs().apply { config = "," }.loadConfiguration() }
+			assertThatExceptionOfType(ParameterException::class.java).isThrownBy { CliArgs().apply { config = "sfsjfsdkfsd" }.loadConfiguration() }
+			assertThatExceptionOfType(ParameterException::class.java).isThrownBy { CliArgs().apply { config = "./i.do.not.exist.yml" }.loadConfiguration() }
 		}
 	}
 
@@ -73,9 +77,9 @@ internal class ConfigurationsSpec : Spek({
 		}
 
 		it("should fail on invalid config value") {
-			assertFails { CliArgs().apply { configResource = "," }.loadConfiguration() }
-			assertFails { CliArgs().apply { configResource = "sfsjfsdkfsd" }.loadConfiguration() }
-			assertFails { CliArgs().apply { configResource = "./i.do.not.exist.yml" }.loadConfiguration() }
+			assertThatExceptionOfType(Config.InvalidConfigurationError::class.java).isThrownBy { CliArgs().apply { configResource = "," }.loadConfiguration() }
+			assertThatExceptionOfType(ParameterException::class.java).isThrownBy { CliArgs().apply { configResource = "sfsjfsdkfsd" }.loadConfiguration() }
+			assertThatExceptionOfType(ParameterException::class.java).isThrownBy { CliArgs().apply { configResource = "./i.do.not.exist.yml" }.loadConfiguration() }
 		}
 	}
 
@@ -146,8 +150,8 @@ internal class ConfigurationsSpec : Spek({
 		}
 
 		it("should fail on invalid filters values") {
-			assertFails { CliArgs().apply { filters = "*." }.createPathFilters() }
-			assertFails { CliArgs().apply { filters = "(ahel" }.createPathFilters() }
+			assertThatIllegalArgumentException().isThrownBy { CliArgs().apply { filters = "*." }.createPathFilters() }
+			assertThatIllegalArgumentException().isThrownBy { CliArgs().apply { filters = "(ahel" }.createPathFilters() }
 		}
 	}
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlSnippetTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlSnippetTest.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.cli.out
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
 class HtmlSnippetTest {
 
@@ -15,7 +15,7 @@ class HtmlSnippetTest {
 			}
 		}
 
-		assertEquals("<h3>Hello World</h3>\n<div class=\"box\">\nTest\n<br />\n</div>", snippet)
+		assertThat(snippet).isEqualTo("<h3>Hello World</h3>\n<div class=\"box\">\nTest\n<br />\n</div>")
 	}
 
 	@Test
@@ -28,6 +28,6 @@ class HtmlSnippetTest {
 			}
 		}
 
-		assertEquals("<ul>\n<li>\n<span class=\"fruit\">\nApple\n</span>\n</li>\n<li>\n<span class=\"fruit\">\nBanana\n</span>\n</li>\n<li>\n<span class=\"fruit\">\nOrange\n</span>\n</li>\n</ul>", snippet)
+		assertThat(snippet).isEqualTo("<ul>\n<li>\n<span class=\"fruit\">\nApple\n</span>\n</li>\n<li>\n<span class=\"fruit\">\nBanana\n</span>\n</li>\n<li>\n<span class=\"fruit\">\nOrange\n</span>\n</li>\n</ul>")
 	}
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektSpec.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.core
 
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
-import kotlin.test.assertTrue
 
 /**
  * @author Artur Bosch
@@ -15,7 +15,7 @@ class DetektSpec : Spek({
 		val detekt = DetektFacade.create(ProcessingSettings(path))
 
 		it("should detect findings from more than one provider") {
-			assertTrue { detekt.run().findings.isNotEmpty() }
+			assertThat(detekt.run().findings).isNotEmpty
 		}
 	}
 })

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektorTest.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.test.yamlConfig
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import kotlin.test.assertTrue
 
 /**
  * @author Artur Bosch
@@ -25,6 +25,6 @@ class DetektorTest {
 				listOf(TestProvider(), TestProvider2()), emptyList())
 
 		val run = instance.run()
-		assertTrue { run.findings["Test"]?.none { "Test.kt" in it.file } ?: true }
+		assertThat(run.findings["Test"]?.none { "Test.kt" in it.file } ?: true).isTrue()
 	}
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
@@ -4,8 +4,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * @author Artur Bosch
@@ -16,14 +14,16 @@ class KtTreeCompilerSpec : Spek({
 
 		it("should compile all files") {
 			val ktFiles = KtTreeCompiler().compile(path)
-			assertTrue(ktFiles.size >= 3, "It should compile more than three files, but did ${ktFiles.size}")
+			assertThat(ktFiles.size)
+					.describedAs("It should compile at least three files, but did ${ktFiles.size}")
+					.isGreaterThanOrEqualTo(3)
 		}
 
 		it("should filter the file 'Default.kt'") {
 			val filter = PathFilter(".*Default.kt")
 			val ktFiles = KtTreeCompiler(filters = listOf(filter)).compile(path)
 			val ktFile = ktFiles.find { it.name == "Default.kt" }
-			assertNull(ktFile, "It should have no Default.kt file")
+			assertThat(ktFile).describedAs("It should have no Default.kt file").isNull()
 		}
 
 		it("should work with two or more filters") {
@@ -36,7 +36,7 @@ class KtTreeCompilerSpec : Spek({
 		}
 
 		it("should also compile regular files") {
-			assertTrue { KtTreeCompiler().compile(path.resolve("Default.kt")).size == 1 }
+			assertThat(KtTreeCompiler().compile(path.resolve("Default.kt")).size).isEqualTo(1)
 		}
 	}
 })

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/PathFilterSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/PathFilterSpec.kt
@@ -1,30 +1,29 @@
 package io.gitlab.arturbosch.detekt.core
 
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
-import org.junit.jupiter.api.assertThrows
 import java.nio.file.Paths
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 internal class PathFilterSpec : Spek({
 
 	given("an invalid regex pattern") {
 		it("throws an IllegalArgumentException") {
-			assertThrows<IllegalArgumentException> { PathFilter("*.") }
+			assertThatIllegalArgumentException().isThrownBy { PathFilter("*.") }
 		}
 	}
 
 	given("an empty pattern") {
 		it("throws an IllegalArgumentException") {
-			assertThrows<IllegalArgumentException> { PathFilter("") }
+			assertThatIllegalArgumentException().isThrownBy { PathFilter("") }
 		}
 	}
 
 	given("an blank pattern") {
 		it("throws an IllegalArgumentException") {
-			assertThrows<IllegalArgumentException> { PathFilter("    ") }
+			assertThatIllegalArgumentException().isThrownBy { PathFilter("    ") }
 		}
 	}
 
@@ -34,13 +33,13 @@ internal class PathFilterSpec : Spek({
 		it("matches a corresponding path") {
 			val path = Paths.get("/tmp/whatever/detekt/build/should/match")
 
-			assertTrue { pathFilter.matches(path) }
+			assertThat(pathFilter.matches(path)).isTrue()
 		}
 
 		it("does not match an unrelated path") {
 			val path = Paths.get("/tmp/whatever/detekt/this/should/NOT/match")
 
-			assertFalse { pathFilter.matches(path) }
+			assertThat(pathFilter.matches(path)).isFalse()
 		}
 	}
 })

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
@@ -14,8 +14,6 @@ import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 import java.nio.file.Paths
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 /**
  * @author Artur Bosch
@@ -30,8 +28,8 @@ class AutoCorrectLevelSpec : Spek({
 
 			it("should reformat the test file") {
 				val (file, findings) = runAnalysis(config)
-				assertTrue(wasLinted(findings))
-				assertTrue(wasFormatted(file))
+				assertThat(wasLinted(findings)).isTrue()
+				assertThat(wasFormatted(file)).isTrue()
 			}
 		}
 
@@ -47,8 +45,8 @@ class AutoCorrectLevelSpec : Spek({
 				val findings = detekt.run(project, listOf(file))
 						.findings.flatMap { it.value }
 
-				assertTrue(wasLinted(findings))
-				assertTrue(wasFormatted(file))
+				assertThat(wasLinted(findings)).isTrue()
+				assertThat(wasFormatted(file)).isTrue()
 				assertThat(loadFileContent("before.kt")).isEqualTo(expected)
 			}
 		}
@@ -59,8 +57,8 @@ class AutoCorrectLevelSpec : Spek({
 
 			it("should not reformat the test file") {
 				val (file, findings) = runAnalysis(config)
-				assertTrue(wasLinted(findings))
-				assertFalse(wasFormatted(file))
+				assertThat(wasLinted(findings)).isTrue()
+				assertThat(wasFormatted(file)).isFalse()
 			}
 		}
 
@@ -70,8 +68,8 @@ class AutoCorrectLevelSpec : Spek({
 
 			it("should not reformat the test file") {
 				val (file, findings) = runAnalysis(config)
-				assertTrue(wasLinted(findings))
-				assertFalse(wasFormatted(file))
+				assertThat(wasLinted(findings)).isTrue()
+				assertThat(wasFormatted(file)).isFalse()
 			}
 		}
 
@@ -81,8 +79,8 @@ class AutoCorrectLevelSpec : Spek({
 
 			it("should not reformat the test file") {
 				val (file, findings) = runAnalysis(config)
-				assertFalse(wasLinted(findings))
-				assertFalse(wasFormatted(file))
+				assertThat(wasLinted(findings)).isFalse()
+				assertThat(wasFormatted(file)).isFalse()
 			}
 		}
 	}

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollectorSpec.kt
@@ -3,10 +3,10 @@ package io.gitlab.arturbosch.detekt.generator.collection
 import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidDocumentationException
 import io.gitlab.arturbosch.detekt.generator.util.run
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
-import kotlin.test.assertFailsWith
 
 class MultiRuleCollectorSpec : SubjectSpek<MultiRuleCollector>({
 
@@ -44,7 +44,7 @@ class MultiRuleCollectorSpec : SubjectSpek<MultiRuleCollector>({
 				class $name: MultiRule {
 				}
 			"""
-			assertFailsWith<InvalidDocumentationException> {
+			assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy {
 				subject.run(code)
 			}
 		}

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -5,10 +5,10 @@ import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidDocumen
 import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidIssueDeclaration
 import io.gitlab.arturbosch.detekt.generator.util.run
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
-import kotlin.test.assertFailsWith
 
 class RuleCollectorSpec : SubjectSpek<RuleCollector>({
 
@@ -45,9 +45,8 @@ class RuleCollectorSpec : SubjectSpek<RuleCollector>({
 				class SomeRandomClass: Rule {
 				}
 			"""
-			assertFailsWith<InvalidDocumentationException> {
-				subject.run(code)
-			}
+			assertThatExceptionOfType(InvalidDocumentationException::class.java)
+					.isThrownBy { subject.run(code) }
 		}
 
 		it("throws when a class extends ThresholdRule but has no valid documentation") {
@@ -57,7 +56,8 @@ class RuleCollectorSpec : SubjectSpek<RuleCollector>({
 				class SomeRandomClass: ThresholdRule {
 				}
 			"""
-			assertFailsWith<InvalidDocumentationException> { subject.run(code) }
+			assertThatExceptionOfType(InvalidDocumentationException::class.java)
+					.isThrownBy { subject.run(code) }
 		}
 
 		it("throws when a class extends ThresholdRule but has no valid documentation") {
@@ -67,7 +67,8 @@ class RuleCollectorSpec : SubjectSpek<RuleCollector>({
 				class SomeRandomClass: FormattingRule {
 				}
 			"""
-			assertFailsWith<InvalidDocumentationException> { subject.run(code) }
+			assertThatExceptionOfType(InvalidDocumentationException::class.java)
+					.isThrownBy { subject.run(code) }
 		}
 
 		it("collects the formatting rule name") {
@@ -308,7 +309,8 @@ class RuleCollectorSpec : SubjectSpek<RuleCollector>({
 				class $name: Rule {
 				}
 			"""
-			assertFailsWith<InvalidDocumentationException> { subject.run(code) }
+			assertThatExceptionOfType(InvalidDocumentationException::class.java)
+					.isThrownBy { subject.run(code) }
 		}
 
 		it("contains compliant and noncompliant code examples") {
@@ -346,7 +348,8 @@ class RuleCollectorSpec : SubjectSpek<RuleCollector>({
 				class RandomClass : Rule {
 				}
 			"""
-			assertFailsWith<InvalidCodeExampleDocumentationException> { subject.run(code) }
+			assertThatExceptionOfType(InvalidCodeExampleDocumentationException::class.java)
+					.isThrownBy { subject.run(code) }
 		}
 
 		it("has wrong compliant code example declaration") {
@@ -364,7 +367,8 @@ class RuleCollectorSpec : SubjectSpek<RuleCollector>({
 				class RandomClass : Rule {
 				}
 			"""
-			assertFailsWith<InvalidCodeExampleDocumentationException> { subject.run(code) }
+			assertThatExceptionOfType(InvalidCodeExampleDocumentationException::class.java)
+					.isThrownBy { subject.run(code) }
 		}
 
 		it("has wrong compliant without noncompliant code example declaration") {
@@ -381,7 +385,8 @@ class RuleCollectorSpec : SubjectSpek<RuleCollector>({
 				class RandomClass : Rule {
 				}
 			"""
-			assertFailsWith<InvalidCodeExampleDocumentationException> { subject.run(code) }
+			assertThatExceptionOfType(InvalidCodeExampleDocumentationException::class.java)
+					.isThrownBy { subject.run(code) }
 		}
 
 		it("has wrong issue style property") {
@@ -402,7 +407,8 @@ class RuleCollectorSpec : SubjectSpek<RuleCollector>({
 							debt = Debt.TEN_MINS)
 				}
 			"""
-			assertFailsWith<InvalidIssueDeclaration> { subject.run(code) }
+			assertThatExceptionOfType(InvalidIssueDeclaration::class.java)
+					.isThrownBy { subject.run(code) }
 		}
 
 		it("has wrong issue aliases property") {
@@ -424,7 +430,8 @@ class RuleCollectorSpec : SubjectSpek<RuleCollector>({
 							aliases = a)
 				}
 			"""
-			assertFailsWith<InvalidIssueDeclaration> { subject.run(code) }
+			assertThatExceptionOfType(InvalidIssueDeclaration::class.java)
+					.isThrownBy { subject.run(code) }
 		}
 	}
 })

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
@@ -3,10 +3,10 @@ package io.gitlab.arturbosch.detekt.generator.collection
 import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidDocumentationException
 import io.gitlab.arturbosch.detekt.generator.util.run
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
-import kotlin.test.assertFailsWith
 
 class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 
@@ -55,9 +55,8 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 			}
 		"""
 		it("throws an exception") {
-			assertFailsWith<InvalidDocumentationException> {
-				subject.run(code)
-			}
+			assertThatExceptionOfType(InvalidDocumentationException::class.java)
+					.isThrownBy { subject.run(code) }
 		}
 	}
 
@@ -73,9 +72,8 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 		"""
 
 		it("throws an exception") {
-			assertFailsWith<InvalidDocumentationException> {
-				subject.run(code)
-			}
+			assertThatExceptionOfType(InvalidDocumentationException::class.java)
+					.isThrownBy { subject.run(code) }
 		}
 	}
 
@@ -180,9 +178,8 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 		"""
 
 		it("throws an exception") {
-			assertFailsWith<InvalidDocumentationException> {
-				subject.run(code)
-			}
+			assertThatExceptionOfType(InvalidDocumentationException::class.java)
+					.isThrownBy { subject.run(code) }
 		}
 	}
 
@@ -204,9 +201,8 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 		"""
 
 		it("throws an exception") {
-			assertFailsWith<InvalidDocumentationException> {
-				subject.run(code)
-			}
+			assertThatExceptionOfType(InvalidDocumentationException::class.java)
+					.isThrownBy { subject.run(code) }
 		}
 	}
 
@@ -225,9 +221,8 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 		"""
 
 		it("throws an exception") {
-			assertFailsWith<InvalidDocumentationException> {
-				subject.run(code)
-			}
+			assertThatExceptionOfType(InvalidDocumentationException::class.java)
+					.isThrownBy { subject.run(code) }
 		}
 	}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
@@ -3,11 +3,11 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 import java.util.regex.PatternSyntaxException
-import kotlin.test.assertFailsWith
 
 class LateinitUsageSpec : Spek({
 
@@ -70,7 +70,7 @@ class LateinitUsageSpec : Spek({
 		}
 
 		it("should fail when enabled with faulty regex pattern") {
-			assertFailsWith<PatternSyntaxException> {
+			assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
 				LateinitUsage(TestConfig(mapOf(LateinitUsage.IGNORE_ON_CLASSES_PATTERN to "*Test"))).lint(code)
 			}
 		}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
@@ -2,10 +2,10 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
-import kotlin.test.assertEquals
 
 class MethodOverloadingSpec : SubjectSpek<MethodOverloading>({
 
@@ -15,7 +15,7 @@ class MethodOverloadingSpec : SubjectSpek<MethodOverloading>({
 
 		it("reports overloaded methods which exceed the threshold") {
 			subject.lint(Case.OverloadedMethods.path())
-			assertEquals(3, subject.findings.size)
+			assertThat(subject.findings.size).isEqualTo(3)
 		}
 
 		it("does not report overloaded methods which do not exceed the threshold") {
@@ -24,7 +24,7 @@ class MethodOverloadingSpec : SubjectSpek<MethodOverloading>({
 					fun x() { }
 					fun x(i: Int) { }
 				}""")
-			assertEquals(0, subject.findings.size)
+			assertThat(subject.findings.size).isZero()
 		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
@@ -7,7 +7,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
-import kotlin.test.assertEquals
 
 /**
  * @author Artur Bosch
@@ -19,8 +18,8 @@ class NestedBlockDepthSpec : SubjectSpek<NestedBlockDepth>({
 	describe("nested classes are also considered") {
 		it("should detect only the nested large class") {
 			subject.lint(Case.NestedClasses.path())
-			assertEquals(subject.findings.size, 1)
-			assertEquals((subject.findings[0] as ThresholdedCodeSmell).value, 5)
+			assertThat(subject.findings.size).isEqualTo(1)
+			assertThat((subject.findings[0] as ThresholdedCodeSmell).value).isEqualTo(5)
 		}
 
 		it("should detect too nested block depth") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.assertj.core.api.Java6Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.given
@@ -10,7 +11,6 @@ import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
 import org.jetbrains.spek.subject.dsl.SubjectProviderDsl
 import java.util.regex.PatternSyntaxException
-import kotlin.test.assertFailsWith
 
 class StringLiteralDuplicationSpec : SubjectSpek<StringLiteralDuplication>({
 
@@ -97,7 +97,7 @@ class StringLiteralDuplicationSpec : SubjectSpek<StringLiteralDuplication>({
 
 		it("should fail with invalid regex") {
 			val config = TestConfig(mapOf(StringLiteralDuplication.IGNORE_STRINGS_REGEX to "*lorem"))
-			assertFailsWith<PatternSyntaxException> {
+			assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
 				StringLiteralDuplication(config).lint(regexTestingCode)
 			}
 		}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeTest.kt
@@ -7,9 +7,9 @@ import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
 import java.util.regex.PatternSyntaxException
-import kotlin.test.assertFailsWith
 
 /**
  * @author Artur Bosch
@@ -149,7 +149,7 @@ class EmptyCodeTest {
 	fun doesFailWithInvalidRegex() {
 		val configValues = mapOf(EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "*foo")
 		val config = TestConfig(configValues)
-		assertFailsWith<PatternSyntaxException> {
+		assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
 			EmptyCatchBlock(config).lint(regexTestingCode)
 		}
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
@@ -5,11 +5,11 @@ import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import java.util.regex.PatternSyntaxException
-import kotlin.test.assertFailsWith
 
 class TooGenericExceptionCaughtSpec : Spek({
 
@@ -59,7 +59,7 @@ class TooGenericExceptionCaughtSpec : Spek({
 		it("should fail with invalid regex on allowed exception names") {
 			val config = TestConfig(mapOf(TooGenericExceptionCaught.ALLOWED_EXCEPTION_NAME_REGEX to "*Foo"))
 			val rule = TooGenericExceptionCaught(config)
-			assertFailsWith<PatternSyntaxException> {
+			assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
 				rule.lint(Case.TooGenericExceptions.path())
 			}
 		}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternTest.kt
@@ -3,9 +3,9 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
 import java.util.regex.PatternSyntaxException
-import kotlin.test.assertFailsWith
 
 class NamingConventionCustomPatternTest {
 
@@ -130,7 +130,7 @@ class NamingConventionCustomPatternTest {
 	@Test
 	fun shouldFailWithInvalidRegexVariableNaming() {
 		val config = TestConfig(mapOf(VariableNaming.EXCLUDE_CLASS_PATTERN to "*Foo"))
-		assertFailsWith<PatternSyntaxException> {
+		assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
 			VariableNaming(config).lint(excludeClassPatternVariableRegexCode)
 		}
 	}
@@ -162,7 +162,7 @@ class NamingConventionCustomPatternTest {
 	@Test
 	fun shouldFailWithInvalidRegexFunctionNaming() {
 		val config = TestConfig(mapOf(FunctionNaming.EXCLUDE_CLASS_PATTERN to "*Foo"))
-		assertFailsWith<PatternSyntaxException> {
+		assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
 			FunctionNaming(config).lint(excludeClassPatternFunctionRegexCode)
 		}
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiationSpec.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.rules.performance
 
 import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.subject.SubjectSpek
-import kotlin.test.assertEquals
 
 class UnnecessaryTemporaryInstantiationSpec : SubjectSpek<UnnecessaryTemporaryInstantiation>({
 	subject { UnnecessaryTemporaryInstantiation() }
@@ -11,12 +11,12 @@ class UnnecessaryTemporaryInstantiationSpec : SubjectSpek<UnnecessaryTemporaryIn
 	describe("temporary instantiation for conversion") {
 		val code = "val i = Integer(1).toString()"
 		subject.lint(code)
-		assertEquals(subject.findings.size, 1)
+		assertThat(subject.findings.size).isEqualTo(1)
 	}
 
 	describe("right conversion without instantiation") {
 		val code = "val i = Integer.toString(1)"
 		subject.lint(code)
-		assertEquals(subject.findings.size, 0)
+		assertThat(subject.findings.size).isZero()
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -5,10 +5,10 @@ import io.gitlab.arturbosch.detekt.test.assert
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
-import kotlin.test.assertFailsWith
 
 class MagicNumberSpec : Spek({
 
@@ -341,7 +341,7 @@ class MagicNumberSpec : Spek({
 	given("an invalid ignoredNumber") {
 
 		it("throws a NumberFormatException") {
-			assertFailsWith(NumberFormatException::class) {
+			assertThatExceptionOfType(NumberFormatException::class.java).isThrownBy {
 				MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "banana")))
 			}
 		}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -4,11 +4,11 @@ import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
 import java.util.regex.PatternSyntaxException
-import kotlin.test.assertFailsWith
 
 class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 
@@ -151,9 +151,8 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 		it("does fail when enabled with invalid regex") {
 			val configRules = mapOf(UnusedPrivateMember.ALLOWED_NAMES_PATTERN to "*foo")
 			val config = TestConfig(configRules)
-			assertFailsWith<PatternSyntaxException> {
-				UnusedPrivateMember(config).lint(regexTestingCode)
-			}
+			assertThatExceptionOfType(PatternSyntaxException::class.java)
+					.isThrownBy{ UnusedPrivateMember(config).lint(regexTestingCode) }
 		}
 	}
 


### PR DESCRIPTION
Retires the "kotlin-test" dependency in favour of AssertJ, and gets rid of the single JUnit Jupiter assertion (also switched to AssertJ).

Addresses the assertions part of #1170.