### PR TITLE
Re-remove kotlin-reflect dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -208,7 +208,6 @@ subprojects {
 		implementation(kotlin("stdlib"))
 		kotlinTest(kotlin("test"))
 		kotlinTest("org.junit.jupiter:junit-jupiter-api:$junitEngineVersion")
-		kotlinTest("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
 		kotlinTest("org.assertj:assertj-core:$assertjVersion")
 		kotlinTest("org.jetbrains.spek:spek-api:$spekVersion")
 		kotlinTest("org.jetbrains.spek:spek-subject-extension:$spekVersion")


### PR DESCRIPTION
Something funky happened when #1151 was merged - this fixes the build which is currently failing.

Fixes #1179 closes #1180 