### PR TITLE
update kotlin to v1.2.71

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ import org.jetbrains.dokka.gradle.DokkaTask
 import java.util.Date
 
 plugins {
-	kotlin("jvm") version "1.2.61"
+	kotlin("jvm") version "1.2.71"
 	id("com.jfrog.bintray") version "1.8.4"
 	id("com.github.ben-manes.versions") version "0.20.0"
 	id("com.github.johnrengelman.shadow") version "2.0.4" apply false


### PR DESCRIPTION
Update Kotlin to v1.2.71

As the dependency on `kotlin-dsl` in the Gradle Plugin we cannot update the Kotlin version there right now. That feels kinda weird having two different Kotlin versions flying around the project.