### PR TITLE
explicitly give KtTestCompiler a filename ending in .kt

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.test.TEST_FILENAME
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
@@ -10,6 +11,8 @@ import org.jetbrains.spek.api.dsl.it
  * @author Artur Bosch
  */
 class FunctionNamingSpec : Spek({
+
+	val fileName = TEST_FILENAME
 
 	it("allows FunctionName as alias for suppressing") {
 		val code = """
@@ -36,7 +39,7 @@ class FunctionNamingSpec : Spek({
 			}
 		"""
 		assertThat(FunctionNaming().lint(code)).hasLocationStrings(
-				"'fun SHOULD_BE_FLAGGED() { }' at (2,2) in /foo.bar"
+				"'fun SHOULD_BE_FLAGGED() { }' at (2,2) in /$fileName"
 		)
 	}
 
@@ -54,7 +57,7 @@ class FunctionNamingSpec : Spek({
 			}
 		"""
 		assertThat(FunctionNaming().lint(code)).hasLocationStrings(
-				"'fun SHOULD_BE_FLAGGED() {}' at (2,2) in /foo.bar"
+				"'fun SHOULD_BE_FLAGGED() {}' at (2,2) in /$fileName"
 		)
 	}
 
@@ -64,7 +67,7 @@ class FunctionNamingSpec : Spek({
 		"""
 		val config = TestConfig(mapOf("ignoreOverridden" to "false"))
 		assertThat(FunctionNaming(config).lint(code)).hasLocationStrings(
-				"'override fun SHOULD_BE_FLAGGED() = TODO()' at (1,1) in /foo.bar"
+				"'override fun SHOULD_BE_FLAGGED() = TODO()' at (1,1) in /$fileName"
 		)
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.test.TEST_FILENAME
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
@@ -8,6 +9,8 @@ import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
 
 class NamingRulesSpec : SubjectSpek<NamingRules>({
+
+	val fileName = TEST_FILENAME
 
 	subject { NamingRules() }
 
@@ -25,14 +28,14 @@ class NamingRulesSpec : SubjectSpek<NamingRules>({
 				}
 			"""
 			assertThat(subject.lint(code)).hasLocationStrings(
-					"'private val _FIELD = 5' at (2,2) in /foo.bar",
-					"'val FIELD get() = _field' at (3,2) in /foo.bar",
-					"'val camel_Case_Property = 5' at (4,2) in /foo.bar",
-					"'const val MY_CONST = 7' at (5,2) in /foo.bar",
-					"'const val MYCONST = 7' at (6,2) in /foo.bar",
-					"'val CONST_PARAMETER: String' at (1,9) in /foo.bar",
-					"'private val PRIVATE_CONST_PARAMETER: Int' at (1,38) in /foo.bar",
-					"'FUN_PARAMETER: String' at (7,14) in /foo.bar"
+					"'private val _FIELD = 5' at (2,2) in /$fileName",
+					"'val FIELD get() = _field' at (3,2) in /$fileName",
+					"'val camel_Case_Property = 5' at (4,2) in /$fileName",
+					"'const val MY_CONST = 7' at (5,2) in /$fileName",
+					"'const val MYCONST = 7' at (6,2) in /$fileName",
+					"'val CONST_PARAMETER: String' at (1,9) in /$fileName",
+					"'private val PRIVATE_CONST_PARAMETER: Int' at (1,38) in /$fileName",
+					"'FUN_PARAMETER: String' at (7,14) in /$fileName"
 			)
 		}
 
@@ -79,8 +82,8 @@ class NamingRulesSpec : SubjectSpek<NamingRules>({
 			"""
 			val config = TestConfig(mapOf("ignoreOverridden" to "false"))
 			assertThat(NamingRules(config).lint(code)).hasLocationStrings(
-					"'override val SHOULD_BE_FLAGGED = \"banana\"' at (2,2) in /foo.bar",
-					"'override val SHOULD_BE_FLAGGED_2 = \"banana\"' at (5,2) in /foo.bar"
+					"'override val SHOULD_BE_FLAGGED = \"banana\"' at (2,2) in /$fileName",
+					"'override val SHOULD_BE_FLAGGED_2 = \"banana\"' at (5,2) in /$fileName"
 			)
 		}
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.test.TEST_FILENAME
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
@@ -9,6 +10,8 @@ import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
 
 class ObjectPropertyNamingSpec : SubjectSpek<ObjectPropertyNaming>({
+
+	val fileName = TEST_FILENAME
 
 	subject { ObjectPropertyNaming() }
 
@@ -39,7 +42,7 @@ class ObjectPropertyNamingSpec : SubjectSpek<ObjectPropertyNaming>({
 				}
 			""")
 			assertThat(subject.lint(code)).hasLocationStrings(
-					"'const val _nAme = \"Artur\"' at (3,6) in /foo.bar"
+					"'const val _nAme = \"Artur\"' at (3,6) in /$fileName"
 			)
 		}
 	}
@@ -66,7 +69,7 @@ class ObjectPropertyNamingSpec : SubjectSpek<ObjectPropertyNaming>({
 				}
 			""")
 			assertThat(subject.lint(code)).hasLocationStrings(
-					"'const val _nAme = \"Artur\"' at (4,7) in /foo.bar"
+					"'const val _nAme = \"Artur\"' at (4,7) in /$fileName"
 			)
 		}
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.test.TEST_FILENAME
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assert
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -12,6 +13,8 @@ import org.jetbrains.spek.api.dsl.it
 
 class MagicNumberSpec : Spek({
 
+	val fileName = TEST_FILENAME
+
 	given("a float of 1") {
 		val ktFile = compileContentForTest("val myFloat = 1.0f")
 
@@ -22,7 +25,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'1.0f' at (1,15) in /Test.kt")
+			assertThat(findings).hasLocationStrings("'1.0f' at (1,15) in /$fileName")
 		}
 	}
 
@@ -50,7 +53,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'1' at (1,13) in /Test.kt")
+			assertThat(findings).hasLocationStrings("'1' at (1,13) in /$fileName")
 		}
 	}
 
@@ -78,7 +81,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'1L' at (1,14) in /Test.kt")
+			assertThat(findings).hasLocationStrings("'1L' at (1,14) in /$fileName")
 		}
 	}
 
@@ -92,7 +95,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'1L' at (1,15) in /Test.kt")
+			assertThat(findings).hasLocationStrings("'1L' at (1,15) in /$fileName")
 		}
 	}
 
@@ -101,7 +104,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasLocationStrings("'2L' at (1,15) in /Test.kt")
+			assertThat(findings).hasLocationStrings("'2L' at (1,15) in /$fileName")
 		}
 
 		it("should be ignored when ignoredNumbers contains it verbatim") {
@@ -116,7 +119,7 @@ class MagicNumberSpec : Spek({
 
 		it("should not be ignored when ignoredNumbers contains 2 but not -2") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "1,2,3,-1,0"))).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'2L' at (1,15) in /Test.kt")
+			assertThat(findings).hasLocationStrings("'2L' at (1,15) in /$fileName")
 		}
 	}
 
@@ -144,7 +147,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'1.0' at (1,16) in /Test.kt")
+			assertThat(findings).hasLocationStrings("'1.0' at (1,16) in /$fileName")
 		}
 	}
 
@@ -172,7 +175,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'0x1' at (1,13) in /Test.kt")
+			assertThat(findings).hasLocationStrings("'0x1' at (1,13) in /$fileName")
 		}
 	}
 
@@ -223,7 +226,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasLocationStrings("'100_000' at (1,13) in /Test.kt")
+			assertThat(findings).hasLocationStrings("'100_000' at (1,13) in /$fileName")
 		}
 
 		it("should not be reported when ignored verbatim") {
@@ -248,10 +251,10 @@ class MagicNumberSpec : Spek({
 		it("should be reported") {
 			val findings = MagicNumber().lint(ktFile)
 			assertThat(findings).hasLocationStrings(
-					"'5' at (1,17) in /Test.kt",
-					"'6' at (1,21) in /Test.kt",
-					"'7' at (1,24) in /Test.kt",
-					"'8' at (1,31) in /Test.kt"
+					"'5' at (1,17) in /$fileName",
+					"'6' at (1,21) in /$fileName",
+					"'7' at (1,24) in /$fileName",
+					"'8' at (1,31) in /$fileName"
 			)
 		}
 	}
@@ -270,12 +273,12 @@ class MagicNumberSpec : Spek({
 		it("should be reported") {
 			val findings = MagicNumber().lint(ktFile)
 			assertThat(findings).hasLocationStrings(
-					"'5' at (3,6) in /Test.kt",
-					"'5' at (3,18) in /Test.kt",
-					"'4' at (4,6) in /Test.kt",
-					"'4' at (4,18) in /Test.kt",
-					"'3' at (5,6) in /Test.kt",
-					"'3' at (5,18) in /Test.kt"
+					"'5' at (3,6) in /$fileName",
+					"'5' at (3,18) in /$fileName",
+					"'4' at (4,6) in /$fileName",
+					"'4' at (4,18) in /$fileName",
+					"'3' at (5,6) in /$fileName",
+					"'3' at (5,18) in /$fileName"
 			)
 		}
 	}
@@ -289,7 +292,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasLocationStrings("'5' at (2,13) in /Test.kt")
+			assertThat(findings).hasLocationStrings("'5' at (2,13) in /$fileName")
 		}
 	}
 
@@ -320,7 +323,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasLocationStrings("'0.5f' at (1,12) in /Test.kt")
+			assertThat(findings).hasLocationStrings("'0.5f' at (1,12) in /$fileName")
 		}
 
 		it("should not be reported when ignoredNumbers contains it") {
@@ -385,12 +388,12 @@ class MagicNumberSpec : Spek({
 
 			val findings = MagicNumber(config).lint(ktFile)
 			assertThat(findings).hasLocationStrings(
-					"'69' at (1,20) in /Test.kt",
-					"'42' at (3,24) in /Test.kt",
-					"'93871' at (4,33) in /Test.kt",
-					"'7328672' at (7,23) in /Test.kt",
-					"'43' at (11,35) in /Test.kt",
-					"'93872' at (12,40) in /Test.kt"
+					"'69' at (1,20) in /$fileName",
+					"'42' at (3,24) in /$fileName",
+					"'93871' at (4,33) in /$fileName",
+					"'7328672' at (7,23) in /$fileName",
+					"'43' at (11,35) in /$fileName",
+					"'93872' at (12,40) in /$fileName"
 			)
 		}
 
@@ -488,7 +491,7 @@ class MagicNumberSpec : Spek({
 			)
 
 			val findings = MagicNumber(config).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'43' at (4,35) in /Test.kt")
+			assertThat(findings).hasLocationStrings("'43' at (4,35) in /$fileName")
 		}
 
 		it("should report property and constant when not ignoring properties, constants nor companion objects") {
@@ -501,7 +504,7 @@ class MagicNumberSpec : Spek({
 			)
 
 			val findings = MagicNumber(config).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'43' at (4,35) in /Test.kt", "'93872' at (5,40) in /Test.kt")
+			assertThat(findings).hasLocationStrings("'43' at (4,35) in /$fileName", "'93872' at (5,40) in /$fileName")
 		}
 	}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -22,7 +22,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'1.0f' at (1,15) in /foo.bar")
+			assertThat(findings).hasLocationStrings("'1.0f' at (1,15) in /Test.kt")
 		}
 	}
 
@@ -50,7 +50,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'1' at (1,13) in /foo.bar")
+			assertThat(findings).hasLocationStrings("'1' at (1,13) in /Test.kt")
 		}
 	}
 
@@ -78,7 +78,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'1L' at (1,14) in /foo.bar")
+			assertThat(findings).hasLocationStrings("'1L' at (1,14) in /Test.kt")
 		}
 	}
 
@@ -92,7 +92,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'1L' at (1,15) in /foo.bar")
+			assertThat(findings).hasLocationStrings("'1L' at (1,15) in /Test.kt")
 		}
 	}
 
@@ -101,7 +101,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasLocationStrings("'2L' at (1,15) in /foo.bar")
+			assertThat(findings).hasLocationStrings("'2L' at (1,15) in /Test.kt")
 		}
 
 		it("should be ignored when ignoredNumbers contains it verbatim") {
@@ -116,7 +116,7 @@ class MagicNumberSpec : Spek({
 
 		it("should not be ignored when ignoredNumbers contains 2 but not -2") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "1,2,3,-1,0"))).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'2L' at (1,15) in /foo.bar")
+			assertThat(findings).hasLocationStrings("'2L' at (1,15) in /Test.kt")
 		}
 	}
 
@@ -144,7 +144,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'1.0' at (1,16) in /foo.bar")
+			assertThat(findings).hasLocationStrings("'1.0' at (1,16) in /Test.kt")
 		}
 	}
 
@@ -172,7 +172,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported when ignoredNumbers is empty") {
 			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'0x1' at (1,13) in /foo.bar")
+			assertThat(findings).hasLocationStrings("'0x1' at (1,13) in /Test.kt")
 		}
 	}
 
@@ -223,7 +223,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasLocationStrings("'100_000' at (1,13) in /foo.bar")
+			assertThat(findings).hasLocationStrings("'100_000' at (1,13) in /Test.kt")
 		}
 
 		it("should not be reported when ignored verbatim") {
@@ -248,10 +248,10 @@ class MagicNumberSpec : Spek({
 		it("should be reported") {
 			val findings = MagicNumber().lint(ktFile)
 			assertThat(findings).hasLocationStrings(
-					"'5' at (1,17) in /foo.bar",
-					"'6' at (1,21) in /foo.bar",
-					"'7' at (1,24) in /foo.bar",
-					"'8' at (1,31) in /foo.bar"
+					"'5' at (1,17) in /Test.kt",
+					"'6' at (1,21) in /Test.kt",
+					"'7' at (1,24) in /Test.kt",
+					"'8' at (1,31) in /Test.kt"
 			)
 		}
 	}
@@ -270,12 +270,12 @@ class MagicNumberSpec : Spek({
 		it("should be reported") {
 			val findings = MagicNumber().lint(ktFile)
 			assertThat(findings).hasLocationStrings(
-					"'5' at (3,6) in /foo.bar",
-					"'5' at (3,18) in /foo.bar",
-					"'4' at (4,6) in /foo.bar",
-					"'4' at (4,18) in /foo.bar",
-					"'3' at (5,6) in /foo.bar",
-					"'3' at (5,18) in /foo.bar"
+					"'5' at (3,6) in /Test.kt",
+					"'5' at (3,18) in /Test.kt",
+					"'4' at (4,6) in /Test.kt",
+					"'4' at (4,18) in /Test.kt",
+					"'3' at (5,6) in /Test.kt",
+					"'3' at (5,18) in /Test.kt"
 			)
 		}
 	}
@@ -289,7 +289,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasLocationStrings("'5' at (2,13) in /foo.bar")
+			assertThat(findings).hasLocationStrings("'5' at (2,13) in /Test.kt")
 		}
 	}
 
@@ -320,7 +320,7 @@ class MagicNumberSpec : Spek({
 
 		it("should be reported by default") {
 			val findings = MagicNumber().lint(ktFile)
-			assertThat(findings).hasLocationStrings("'0.5f' at (1,12) in /foo.bar")
+			assertThat(findings).hasLocationStrings("'0.5f' at (1,12) in /Test.kt")
 		}
 
 		it("should not be reported when ignoredNumbers contains it") {
@@ -385,12 +385,12 @@ class MagicNumberSpec : Spek({
 
 			val findings = MagicNumber(config).lint(ktFile)
 			assertThat(findings).hasLocationStrings(
-					"'69' at (1,20) in /foo.bar",
-					"'42' at (3,24) in /foo.bar",
-					"'93871' at (4,33) in /foo.bar",
-					"'7328672' at (7,23) in /foo.bar",
-					"'43' at (11,35) in /foo.bar",
-					"'93872' at (12,40) in /foo.bar"
+					"'69' at (1,20) in /Test.kt",
+					"'42' at (3,24) in /Test.kt",
+					"'93871' at (4,33) in /Test.kt",
+					"'7328672' at (7,23) in /Test.kt",
+					"'43' at (11,35) in /Test.kt",
+					"'93872' at (12,40) in /Test.kt"
 			)
 		}
 
@@ -488,7 +488,7 @@ class MagicNumberSpec : Spek({
 			)
 
 			val findings = MagicNumber(config).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'43' at (4,35) in /foo.bar")
+			assertThat(findings).hasLocationStrings("'43' at (4,35) in /Test.kt")
 		}
 
 		it("should report property and constant when not ignoring properties, constants nor companion objects") {
@@ -501,7 +501,7 @@ class MagicNumberSpec : Spek({
 			)
 
 			val findings = MagicNumber(config).lint(ktFile)
-			assertThat(findings).hasLocationStrings("'43' at (4,35) in /foo.bar", "'93872' at (5,40) in /foo.bar")
+			assertThat(findings).hasLocationStrings("'43' at (4,35) in /Test.kt", "'93872' at (5,40) in /Test.kt")
 		}
 	}
 

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
@@ -20,6 +20,7 @@ object KtTestCompiler : KtCompiler() {
 
 	fun compileFromContent(content: String): KtFile {
 		val psiFile = psiFileFactory.createFileFromText(
+				"Test.kt",
 				KotlinLanguage.INSTANCE,
 				StringUtilRt.convertLineSeparators(content))
 		return psiFile as? KtFile ?: throw IllegalStateException("kotlin file expected")

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
@@ -20,9 +20,11 @@ object KtTestCompiler : KtCompiler() {
 
 	fun compileFromContent(content: String): KtFile {
 		val psiFile = psiFileFactory.createFileFromText(
-				"Test.kt",
+				TEST_FILENAME,
 				KotlinLanguage.INSTANCE,
 				StringUtilRt.convertLineSeparators(content))
 		return psiFile as? KtFile ?: throw IllegalStateException("kotlin file expected")
 	}
 }
+
+const val TEST_FILENAME = "Test.kt"


### PR DESCRIPTION
Solves the test issues seen in #1185.

It seems that `PsiFileFactory` in Kotlin >= v1.2.70 treats files/content without a filename as `KtScripts` with the default filename `foo.bar`.

By passing along an explicit filename ending in `.kt` the test passes correctly. Once this is merged #1185 should be good to go.