### PR TITLE
[gradle-plugin] use lazy evaluation of properties

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -31,6 +31,7 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.property
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 
 /**
@@ -52,7 +53,7 @@ open class Detekt : DefaultTask() {
 
 	@Input
 	@Optional
-	var filters: Property<String> = project.objects.property(String::class.java)
+	var filters: Property<String> = project.objects.property()
 
 	@InputFile
 	@Optional
@@ -66,7 +67,7 @@ open class Detekt : DefaultTask() {
 
 	@Input
 	@Optional
-	var plugins: Property<String> = project.objects.property(String::class.java)
+	var plugins: Property<String> = project.objects.property()
 
 	@Internal
 	@Optional

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -46,10 +46,6 @@ import java.io.File
 @CacheableTask
 open class Detekt : DefaultTask() {
 
-	init {
-		group = LifecycleBasePlugin.VERIFICATION_GROUP
-	}
-
 	@InputFiles
 	@PathSensitive(PathSensitivity.RELATIVE)
 	@SkipWhenEmpty
@@ -75,23 +71,34 @@ open class Detekt : DefaultTask() {
 
 	@Internal
 	@Optional
-	var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+	val debugProp: Property<Boolean> = project.objects.property()
+	var debug: Boolean
+		@Internal
+		get() = debugProp.get()
+		set(value) = debugProp.set(value)
 
 	@Internal
 	@Optional
-	var parallel: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+	val parallelProp: Property<Boolean> = project.objects.property()
+	var parallel: Boolean
+		@Internal
+		get() = parallelProp.get()
+		set(value) = parallelProp.set(value)
 
-	@Internal
 	@Optional
 	@Input
-	var disableDefaultRuleSets: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+	val disableDefaultRuleSetsProp: Property<Boolean> = project.objects.property()
+	var disableDefaultRuleSets: Boolean
+		@Internal
+		get() = disableDefaultRuleSetsProp.get()
+		set(value) = disableDefaultRuleSetsProp.set(value)
 
 	@Internal
 	var reports = DetektReports(project)
 
 	fun reports(closure: Closure<*>): DetektReports = ConfigureUtil.configure(closure, reports)
-	fun reports(configure: DetektReports.() -> Unit) = reports.configure()
 
+	fun reports(configure: DetektReports.() -> Unit) = reports.configure()
 	@Internal
 	@Optional
 	var reportsDir: Property<File> = project.objects.property()
@@ -112,6 +119,10 @@ open class Detekt : DefaultTask() {
 
 	private val effectiveReportsDir = project.provider { reportsDir.getOrElse(defaultReportsDir.asFile) }
 
+	init {
+		group = LifecycleBasePlugin.VERIFICATION_GROUP
+	}
+
 	@TaskAction
 	fun check() {
 		val arguments = mutableListOf<CliArgument>() +
@@ -122,11 +133,11 @@ open class Detekt : DefaultTask() {
 				BaselineArgument(baseline.orNull) +
 				XmlReportArgument(xmlReportFile.orNull) +
 				HtmlReportArgument(htmlReportFile.orNull) +
-				DebugArgument(debug.get()) +
-				ParallelArgument(parallel.get()) +
-				DisableDefaultRulesetArgument(disableDefaultRuleSets.get())
+				DebugArgument(debugProp.get()) +
+				ParallelArgument(parallelProp.get()) +
+				DisableDefaultRulesetArgument(disableDefaultRuleSetsProp.get())
 
-		DetektInvoker.invokeCli(project, arguments.toList(), debug.get())
+		DetektInvoker.invokeCli(project, arguments.toList(), debugProp.get())
 	}
 
 	private fun createNewInputFile() = newInputFile()

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -75,15 +75,15 @@ open class Detekt : DefaultTask() {
 
 	@Internal
 	@Optional
-	var debug: Property<Boolean> = project.objects.property()
+	var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
 	@Internal
 	@Optional
-	var parallel: Property<Boolean> = project.objects.property()
+	var parallel: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
 	@Internal
 	@Optional
-	var disableDefaultRuleSets: Property<Boolean> = project.objects.property()
+	var disableDefaultRuleSets: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
 	@Internal
 	var reports = DetektReports(project)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -75,15 +75,15 @@ open class Detekt : DefaultTask() {
 
 	@Internal
 	@Optional
-	var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+	var debug: Property<Boolean> = project.objects.property()
 
 	@Internal
 	@Optional
-	var parallel: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+	var parallel: Property<Boolean> = project.objects.property()
 
 	@Internal
 	@Optional
-	var disableDefaultRuleSets: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+	var disableDefaultRuleSets: Property<Boolean> = project.objects.property()
 
 	@Internal
 	var reports = DetektReports(project)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -62,7 +62,7 @@ open class Detekt : DefaultTask() {
 	@InputFile
 	@Optional
 	@PathSensitive(PathSensitivity.RELATIVE)
-	var baseline: RegularFileProperty = project.layout.fileProperty()
+	var baseline: RegularFileProperty = createNewInputFile()
 
 	@InputFiles
 	@Optional
@@ -128,4 +128,6 @@ open class Detekt : DefaultTask() {
 
 		DetektInvoker.invokeCli(project, arguments.toList(), debug.get())
 	}
+
+	private fun createNewInputFile() = newInputFile()
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt
 
-import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.extensions.DetektReports
 import io.gitlab.arturbosch.detekt.invoke.BaselineArgument
 import io.gitlab.arturbosch.detekt.invoke.CliArgument
@@ -98,7 +97,6 @@ open class Detekt : DefaultTask() {
 
 	@TaskAction
 	fun check() {
-		val debugOrDefault = debug.getOrElse(DetektExtension.DEFAULT_DEBUG_VALUE)
 		val arguments = mutableListOf<CliArgument>() +
 				InputArgument(input) +
 				FiltersArgument(filters.orNull) +
@@ -107,10 +105,10 @@ open class Detekt : DefaultTask() {
 				BaselineArgument(baseline.orNull) +
 				XmlReportArgument(xmlReportFile.orNull) +
 				HtmlReportArgument(htmlReportFile.orNull) +
-				DebugArgument(debugOrDefault) +
-				ParallelArgument(parallel.getOrElse(DetektExtension.DEFAULT_PARALLEL_VALUE)) +
-				DisableDefaultRulesetArgument(disableDefaultRuleSets.getOrElse(DetektExtension.DEFAULT_DISABLE_RULESETS_VALUE))
+				DebugArgument(debug.get()) +
+				ParallelArgument(parallel.get()) +
+				DisableDefaultRulesetArgument(disableDefaultRuleSets.get())
 
-		DetektInvoker.invokeCli(project, arguments.toList(), debugOrDefault)
+		DetektInvoker.invokeCli(project, arguments.toList(), debug.get())
 	}
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -83,6 +83,7 @@ open class Detekt : DefaultTask() {
 
 	@Internal
 	@Optional
+	@Input
 	var disableDefaultRuleSets: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
 	@Internal

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt
 
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.invoke.BaselineArgument
 import io.gitlab.arturbosch.detekt.invoke.CliArgument
 import io.gitlab.arturbosch.detekt.invoke.ConfigArgument
@@ -12,7 +13,9 @@ import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
 import io.gitlab.arturbosch.detekt.invoke.PluginsArgument
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.FileCollection
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
@@ -23,11 +26,11 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.gradle.language.base.plugins.LifecycleBasePlugin
-import java.io.File
 
 /**
  * @author Artur Bosch
  * @author Marvin Ramin
+ * @author Markus Schwarz
  */
 open class DetektCreateBaselineTask : DefaultTask() {
 
@@ -38,50 +41,50 @@ open class DetektCreateBaselineTask : DefaultTask() {
 
 	@OutputFile
 	@PathSensitive(PathSensitivity.RELATIVE)
-	var baseline: File? = null
+	var baseline: RegularFileProperty = project.layout.fileProperty()
 
 	@InputFiles
 	@PathSensitive(PathSensitivity.RELATIVE)
 	@SkipWhenEmpty
-	lateinit var input: FileCollection
+	var input: ConfigurableFileCollection = project.layout.configurableFiles()
 
 	@Input
 	@Optional
-	var filters: String? = null
+	var filters: Property<String> = project.objects.property(String::class.java)
 
 	@InputFiles
 	@Optional
 	@PathSensitive(PathSensitivity.RELATIVE)
-	var config: FileCollection? = null
+	var config: ConfigurableFileCollection = project.layout.configurableFiles()
 
 	@Input
 	@Optional
-	var plugins: String? = null
+	var plugins: Property<String> = project.objects.property(String::class.java)
 
 	@Internal
 	@Optional
-	var debugOrDefault: Boolean = false
+	var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
 	@Internal
 	@Optional
-	var parallelOrDefault: Boolean = false
+	var parallel: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
 	@Internal
 	@Optional
-	var disableDefaultRuleSetsOrDefault: Boolean = false
-
+	var disableDefaultRuleSets: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
 	@TaskAction
 	fun baseline() {
+		val debugOrDefault = debug.getOrElse(DetektExtension.DEFAULT_DEBUG_VALUE)
 		val arguments = mutableListOf<CliArgument>(CreateBaselineArgument) +
-				BaselineArgument(baseline) +
+				BaselineArgument(baseline.get()) +
 				InputArgument(input) +
-				FiltersArgument(filters) +
+				FiltersArgument(filters.orNull) +
 				ConfigArgument(config) +
-				PluginsArgument(plugins) +
+				PluginsArgument(plugins.orNull) +
 				DebugArgument(debugOrDefault) +
-				ParallelArgument(parallelOrDefault) +
-				DisableDefaultRulesetArgument(disableDefaultRuleSetsOrDefault)
+				ParallelArgument(parallel.getOrElse(DetektExtension.DEFAULT_PARALLEL_VALUE)) +
+				DisableDefaultRulesetArgument(disableDefaultRuleSets.getOrElse(DetektExtension.DEFAULT_DISABLE_RULESETS_VALUE))
 
 		DetektInvoker.invokeCli(project, arguments.toList(), debugOrDefault)
 	}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -25,6 +25,7 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.property
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 
 /**
@@ -50,7 +51,7 @@ open class DetektCreateBaselineTask : DefaultTask() {
 
 	@Input
 	@Optional
-	var filters: Property<String> = project.objects.property(String::class.java)
+	var filters: Property<String> = project.objects.property()
 
 	@InputFiles
 	@Optional
@@ -59,7 +60,7 @@ open class DetektCreateBaselineTask : DefaultTask() {
 
 	@Input
 	@Optional
-	var plugins: Property<String> = project.objects.property(String::class.java)
+	var plugins: Property<String> = project.objects.property()
 
 	@Internal
 	@Optional

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt
 
-import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.invoke.BaselineArgument
 import io.gitlab.arturbosch.detekt.invoke.CliArgument
 import io.gitlab.arturbosch.detekt.invoke.ConfigArgument
@@ -76,17 +75,16 @@ open class DetektCreateBaselineTask : DefaultTask() {
 
 	@TaskAction
 	fun baseline() {
-		val debugOrDefault = debug.getOrElse(DetektExtension.DEFAULT_DEBUG_VALUE)
 		val arguments = mutableListOf<CliArgument>(CreateBaselineArgument) +
 				BaselineArgument(baseline.get()) +
 				InputArgument(input) +
 				FiltersArgument(filters.orNull) +
 				ConfigArgument(config) +
 				PluginsArgument(plugins.orNull) +
-				DebugArgument(debugOrDefault) +
-				ParallelArgument(parallel.getOrElse(DetektExtension.DEFAULT_PARALLEL_VALUE)) +
-				DisableDefaultRulesetArgument(disableDefaultRuleSets.getOrElse(DetektExtension.DEFAULT_DISABLE_RULESETS_VALUE))
+				DebugArgument(debug.get()) +
+				ParallelArgument(parallel.get()) +
+				DisableDefaultRulesetArgument(disableDefaultRuleSets.get())
 
-		DetektInvoker.invokeCli(project, arguments.toList(), debugOrDefault)
+		DetektInvoker.invokeCli(project, arguments.toList(), debug.get())
 	}
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.GenerateConfigArgument
 import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.FileCollection
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -27,7 +27,7 @@ open class DetektGenerateConfigTask : DefaultTask() {
 	@InputFiles
 	@PathSensitive(PathSensitivity.RELATIVE)
 	@SkipWhenEmpty
-	lateinit var input: FileCollection
+	var input: ConfigurableFileCollection = project.layout.configurableFiles()
 
 	@TaskAction
 	fun generateConfig() {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaFormatTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaFormatTask.kt
@@ -1,9 +1,11 @@
 package io.gitlab.arturbosch.detekt
 
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.extensions.IdeaExtension
 import io.gitlab.arturbosch.detekt.invoke.ProcessExecutor.startProcess
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.FileCollection
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
@@ -27,17 +29,18 @@ open class DetektIdeaFormatTask : DefaultTask() {
 	@InputFiles
 	@PathSensitive(PathSensitivity.RELATIVE)
 	@SkipWhenEmpty
-	lateinit var input: FileCollection
+	var input: ConfigurableFileCollection = project.layout.configurableFiles()
 
 	@Internal
 	@Optional
-	var debugOrDefault: Boolean = false
+	var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
 	@Internal
 	lateinit var ideaExtension: IdeaExtension
 
 	@TaskAction
 	fun format() {
+		val debugOrDefault = debug.getOrElse(DetektExtension.DEFAULT_DEBUG_VALUE)
 		if (debugOrDefault) println("$ideaExtension")
 
 		startProcess(ideaExtension.formatArgs(input.asPath), debugOrDefault)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaFormatTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaFormatTask.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt
 
-import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.extensions.IdeaExtension
 import io.gitlab.arturbosch.detekt.invoke.ProcessExecutor.startProcess
 import org.gradle.api.DefaultTask
@@ -40,9 +39,8 @@ open class DetektIdeaFormatTask : DefaultTask() {
 
 	@TaskAction
 	fun format() {
-		val debugOrDefault = debug.getOrElse(DetektExtension.DEFAULT_DEBUG_VALUE)
-		if (debugOrDefault) println("$ideaExtension")
+		if (debug.get()) println("$ideaExtension")
 
-		startProcess(ideaExtension.formatArgs(input.asPath), debugOrDefault)
+		startProcess(ideaExtension.formatArgs(input.asPath), debug.get())
 	}
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaInspectionTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaInspectionTask.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt
 
-import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.extensions.IdeaExtension
 import io.gitlab.arturbosch.detekt.invoke.ProcessExecutor
 import org.gradle.api.DefaultTask
@@ -40,10 +39,9 @@ open class DetektIdeaInspectionTask : DefaultTask() {
 
 	@TaskAction
 	fun inspect() {
-		val debugOrDefault = debug.getOrElse(DetektExtension.DEFAULT_DEBUG_VALUE)
-		if (debugOrDefault) println("Running inspection task in debug mode")
+		if (debug.get()) println("Running inspection task in debug mode")
 
-		if (debugOrDefault) println("$ideaExtension")
-		ProcessExecutor.startProcess(ideaExtension.inspectArgs(input.asPath), debugOrDefault)
+		if (debug.get()) println("$ideaExtension")
+		ProcessExecutor.startProcess(ideaExtension.inspectArgs(input.asPath), debug.get())
 	}
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaInspectionTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaInspectionTask.kt
@@ -1,9 +1,11 @@
 package io.gitlab.arturbosch.detekt
 
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.extensions.IdeaExtension
 import io.gitlab.arturbosch.detekt.invoke.ProcessExecutor
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.FileCollection
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
@@ -27,17 +29,18 @@ open class DetektIdeaInspectionTask : DefaultTask() {
 	@InputFiles
 	@PathSensitive(PathSensitivity.RELATIVE)
 	@SkipWhenEmpty
-	lateinit var input: FileCollection
+	var input: ConfigurableFileCollection = project.layout.configurableFiles()
 
 	@Internal
 	@Optional
-	var debugOrDefault: Boolean = false
+	var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
 	@Internal
 	lateinit var ideaExtension: IdeaExtension
 
 	@TaskAction
 	fun inspect() {
+		val debugOrDefault = debug.getOrElse(DetektExtension.DEFAULT_DEBUG_VALUE)
 		if (debugOrDefault) println("Running inspection task in debug mode")
 
 		if (debugOrDefault) println("$ideaExtension")

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -88,8 +88,9 @@ class DetektPlugin : Plugin<Project> {
 			isTransitive = true
 			description = "The $CONFIGURATION_DETEKT dependencies to be used for this project."
 
-			val version = extension.detektVersion ?: DEFAULT_DETEKT_VERSION
 			defaultDependencies {
+				@Suppress("USELESS_ELVIS")
+				val version = extension.toolVersion ?: DEFAULT_DETEKT_VERSION
 				add(project.dependencies.create("io.gitlab.arturbosch.detekt:detekt-cli:$version"))
 			}
 		}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -9,6 +9,7 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
 
 /**
  * @author Marvin Ramin
+ * @author Markus Schwarz
  */
 class DetektPlugin : Plugin<Project> {
 
@@ -34,9 +35,8 @@ class DetektPlugin : Plugin<Project> {
 			baseline.set(project.layout.file(project.provider { extension.baseline }))
 			plugins.set(project.provider { extension.plugins })
 			input.setFrom(existingInputDirectoriesProvider(project, extension))
-			extension.reports.forEach { extReport ->
-				setReportFileProvider(extReport.name, extReport.getTargetFileProvider(extension.reportsDirProvider))
-			}
+			reportsDir.set(project.provider { extension.customReportsDir })
+			reports = extension.reports
 		}
 
 		project.tasks.findByName(LifecycleBasePlugin.CHECK_TASK_NAME)?.dependsOn(detektTask)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -26,13 +26,13 @@ class DetektPlugin : Plugin<Project> {
 
 	private fun createAndConfigureDetektTask(project: Project, extension: DetektExtension) {
 		val detektTask = project.tasks.register(DETEKT, Detekt::class.java) {
-			debug.set(project.provider({ extension.debug }))
-			parallel.set(project.provider({ extension.parallel }))
-			disableDefaultRuleSets.set(project.provider({ extension.disableDefaultRuleSets }))
-			filters.set(project.provider({ extension.filters }))
+			debug.set(project.provider { extension.debug })
+			parallel.set(project.provider { extension.parallel })
+			disableDefaultRuleSets.set(project.provider { extension.disableDefaultRuleSets })
+			filters.set(project.provider { extension.filters })
 			config.setFrom(project.provider { extension.config })
-			baseline.set(project.layout.file(project.provider({ extension.baseline })))
-			plugins.set(project.provider({ extension.plugins }))
+			baseline.set(project.layout.file(project.provider { extension.baseline }))
+			plugins.set(project.provider { extension.plugins })
 			input.setFrom(existingInputDirectoriesProvider(project, extension))
 			extension.reports.forEach { extReport ->
 				setReportFileProvider(extReport.name, extReport.getTargetFileProvider(extension.reportsDirProvider))
@@ -44,13 +44,13 @@ class DetektPlugin : Plugin<Project> {
 
 	private fun createAndConfigureCreateBaselineTask(project: Project, extension: DetektExtension) =
 			project.tasks.register(BASELINE, DetektCreateBaselineTask::class.java) {
-				baseline.set(project.layout.file(project.provider({ extension.baseline })))
+				baseline.set(project.layout.file(project.provider { extension.baseline }))
 				config.setFrom(project.provider { extension.config })
-				debug.set(project.provider({ extension.debug }))
-				parallel.set(project.provider({ extension.parallel }))
-				disableDefaultRuleSets.set(project.provider({ extension.disableDefaultRuleSets }))
-				filters.set(project.provider({ extension.filters }))
-				plugins.set(project.provider({ extension.plugins }))
+				debug.set(project.provider { extension.debug })
+				parallel.set(project.provider { extension.parallel })
+				disableDefaultRuleSets.set(project.provider { extension.disableDefaultRuleSets })
+				filters.set(project.provider { extension.filters })
+				plugins.set(project.provider { extension.plugins })
 				input.setFrom(existingInputDirectoriesProvider(project, extension))
 			}
 
@@ -61,20 +61,20 @@ class DetektPlugin : Plugin<Project> {
 
 	private fun createAndConfigureIdeaTasks(project: Project, extension: DetektExtension) {
 		project.tasks.register(IDEA_FORMAT, DetektIdeaFormatTask::class.java) {
-			debug.set(project.provider({ extension.debug }))
+			debug.set(project.provider { extension.debug })
 			input.setFrom(existingInputDirectoriesProvider(project, extension))
 			ideaExtension = extension.idea
 		}
 
 		project.tasks.register(IDEA_INSPECT, DetektIdeaInspectionTask::class.java) {
-			debug.set(project.provider({ extension.debug }))
+			debug.set(project.provider { extension.debug })
 			input.setFrom(existingInputDirectoriesProvider(project, extension))
 			ideaExtension = extension.idea
 		}
 	}
 
 	private fun existingInputDirectoriesProvider(project: Project, extension: DetektExtension): Provider<FileCollection> =
-			project.provider({ extension.input.filter { it.exists() } })
+			project.provider { extension.input.filter { it.exists() } }
 
 	private fun configurePluginDependencies(project: Project, extension: DetektExtension) {
 		project.configurations.create(CONFIGURATION_DETEKT_PLUGINS) {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -27,9 +27,9 @@ class DetektPlugin : Plugin<Project> {
 
 	private fun createAndConfigureDetektTask(project: Project, extension: DetektExtension) {
 		val detektTask = project.tasks.register(DETEKT, Detekt::class.java) {
-			debug.set(project.provider { extension.debug })
-			parallel.set(project.provider { extension.parallel })
-			disableDefaultRuleSets.set(project.provider { extension.disableDefaultRuleSets })
+			debugProp.set(project.provider { extension.debug })
+			parallelProp.set(project.provider { extension.parallel })
+			disableDefaultRuleSetsProp.set(project.provider { extension.disableDefaultRuleSets })
 			filters.set(project.provider { extension.filters })
 			config.setFrom(project.provider { extension.config })
 			baseline.set(project.layout.file(project.provider { extension.baseline }))

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -50,13 +50,13 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
 
 	var plugins: String? = null
 
-	val reportsDirProvider: Provider<Directory> = project.provider({
+	val reportsDirProvider: Provider<Directory> = project.provider {
 		val dir = customReportsDir
 		if (dir == null)
 			defaultReportsDir
 		else
 			project.layout.projectDirectory.dir(dir.path)
-	})
+	}
 
 	companion object {
 		const val DEFAULT_SRC_DIR_JAVA = "src/main/java"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -21,9 +21,6 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
 	val customReportsDir: File?
 		get() = reportsDir
 
-	val detektVersion: String?
-		get() = toolVersion
-
 	private val defaultReportsDir: Directory = project.layout.buildDirectory.get()
 			.dir(ReportingExtension.DEFAULT_REPORTS_DIR_NAME)
 			.dir("detekt")

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -40,11 +40,11 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
 
 	var config: ConfigurableFileCollection = project.layout.configurableFiles()
 
-	var debug: Boolean? = null
+	var debug: Boolean = DEFAULT_DEBUG_VALUE
 
-	var parallel: Boolean? = null
+	var parallel: Boolean = DEFAULT_PARALLEL_VALUE
 
-	var disableDefaultRuleSets: Boolean? = null
+	var disableDefaultRuleSets: Boolean = DEFAULT_DISABLE_RULESETS_VALUE
 
 	var filters: String? = null
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -3,10 +3,7 @@ package io.gitlab.arturbosch.detekt.extensions
 import groovy.lang.Closure
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.Directory
 import org.gradle.api.plugins.quality.CodeQualityExtension
-import org.gradle.api.provider.Provider
-import org.gradle.api.reporting.ReportingExtension
 import org.gradle.util.ConfigureUtil
 import java.io.File
 
@@ -20,10 +17,6 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
 
 	val customReportsDir: File?
 		get() = reportsDir
-
-	private val defaultReportsDir: Directory = project.layout.buildDirectory.get()
-			.dir(ReportingExtension.DEFAULT_REPORTS_DIR_NAME)
-			.dir("detekt")
 
 	val reports = DetektReports(project)
 	fun reports(configure: DetektReports.() -> Unit) = reports.configure()
@@ -49,14 +42,6 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
 	var filters: String? = null
 
 	var plugins: String? = null
-
-	val reportsDirProvider: Provider<Directory> = project.provider {
-		val dir = customReportsDir
-		if (dir == null)
-			defaultReportsDir
-		else
-			project.layout.projectDirectory.dir(dir.path)
-	}
 
 	companion object {
 		const val DEFAULT_SRC_DIR_JAVA = "src/main/java"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -2,8 +2,10 @@ package io.gitlab.arturbosch.detekt.extensions
 
 import groovy.lang.Closure
 import org.gradle.api.Project
-import org.gradle.api.file.FileCollection
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.Directory
 import org.gradle.api.plugins.quality.CodeQualityExtension
+import org.gradle.api.provider.Provider
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.util.ConfigureUtil
 import java.io.File
@@ -15,11 +17,18 @@ import java.io.File
  * @author Markus Schwarz
  */
 open class DetektExtension(project: Project) : CodeQualityExtension() {
-	val defaultReportsDir: File = project.layout.buildDirectory.get()
-			.dir(ReportingExtension.DEFAULT_REPORTS_DIR_NAME)
-			.dir("detekt").asFile
 
-	val reports = DetektReports()
+	val customReportsDir: File?
+		get() = reportsDir
+
+	val detektVersion: String?
+		get() = toolVersion
+
+	private val defaultReportsDir: Directory = project.layout.buildDirectory.get()
+			.dir(ReportingExtension.DEFAULT_REPORTS_DIR_NAME)
+			.dir("detekt")
+
+	val reports = DetektReports(project)
 	fun reports(configure: DetektReports.() -> Unit) = reports.configure()
 	fun reports(configure: Closure<*>): DetektReports = ConfigureUtil.configure(configure, reports)
 
@@ -28,21 +37,29 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
 	fun idea(configure: IdeaExtension.() -> Unit) = idea.configure()
 	fun idea(configure: Closure<*>): IdeaExtension = ConfigureUtil.configure(configure, idea)
 
-	var input: FileCollection = project.files(DEFAULT_SRC_DIR_JAVA, DEFAULT_SRC_DIR_KOTLIN)
+	var input: ConfigurableFileCollection = project.layout.configurableFiles(DEFAULT_SRC_DIR_JAVA, DEFAULT_SRC_DIR_KOTLIN)
 
 	var baseline: File? = null
 
-	var config: FileCollection? = null
+	var config: ConfigurableFileCollection = project.layout.configurableFiles()
 
-	var debug: Boolean = DEFAULT_DEBUG_VALUE
+	var debug: Boolean? = null
 
-	var parallel: Boolean = DEFAULT_PARALLEL_VALUE
+	var parallel: Boolean? = null
 
-	var disableDefaultRuleSets: Boolean = DEFAULT_DISABLE_RULESETS_VALUE
+	var disableDefaultRuleSets: Boolean? = null
 
 	var filters: String? = null
 
 	var plugins: String? = null
+
+	val reportsDirProvider: Provider<Directory> = project.provider({
+		val dir = customReportsDir
+		if (dir == null)
+			defaultReportsDir
+		else
+			project.layout.projectDirectory.dir(dir.path)
+	})
 
 	companion object {
 		const val DEFAULT_SRC_DIR_JAVA = "src/main/java"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
@@ -11,11 +11,8 @@ class DetektReport(val type: DetektReportType, private val project: Project) {
 
 	var destination: File? = null
 
-	private val reportFileExtension
-		get() = type.extension
-
 	override fun toString(): String {
-		return "DetektReport(name='$type', enabled=$enabled, destination=$destination)"
+		return "DetektReport(type='$type', enabled=$enabled, destination=$destination)"
 	}
 
 	fun getTargetFileProvider(reportsDir: Provider<File>): Provider<RegularFile> {
@@ -33,7 +30,7 @@ class DetektReport(val type: DetektReportType, private val project: Project) {
 		if (customDestination != null)
 			prop.set(customDestination)
 		else
-			prop.set(File(reportsDir, "$DEFAULT_FILENAME.$reportFileExtension"))
+			prop.set(File(reportsDir, "$DEFAULT_FILENAME.${type.extension}"))
 
 		return prop.get()
 	}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
@@ -5,17 +5,17 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import java.io.File
 
-class DetektReport(val name: String, private val project: Project) {
+class DetektReport(val type: DetektReportType, private val project: Project) {
 
 	var enabled: Boolean? = null
 
 	var destination: File? = null
 
 	private val reportFileExtension
-		get() = name
+		get() = type.extension
 
 	override fun toString(): String {
-		return "DetektReport(name='$name', enabled=$enabled, destination=$destination)"
+		return "DetektReport(name='$type', enabled=$enabled, destination=$destination)"
 	}
 
 	fun getTargetFileProvider(reportsDir: Provider<File>): Provider<RegularFile> {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
@@ -20,12 +20,12 @@ class DetektReport(val name: String, private val project: Project) {
 	}
 
 	fun getTargetFileProvider(reportsDir: Provider<Directory>): Provider<RegularFile> {
-		return project.provider({
+		return project.provider {
 			if (enabled ?: DetektExtension.DEFAULT_REPORT_ENABLED_VALUE)
 				getTargetFile(reportsDir.get())
 			else
 				null
-		})
+		}
 	}
 
 	private fun getTargetFile(reportsDir: Directory): RegularFile {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.extensions
 
 import org.gradle.api.Project
-import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import java.io.File
@@ -19,7 +18,7 @@ class DetektReport(val name: String, private val project: Project) {
 		return "DetektReport(name='$name', enabled=$enabled, destination=$destination)"
 	}
 
-	fun getTargetFileProvider(reportsDir: Provider<Directory>): Provider<RegularFile> {
+	fun getTargetFileProvider(reportsDir: Provider<File>): Provider<RegularFile> {
 		return project.provider {
 			if (enabled ?: DetektExtension.DEFAULT_REPORT_ENABLED_VALUE)
 				getTargetFile(reportsDir.get())
@@ -28,13 +27,13 @@ class DetektReport(val name: String, private val project: Project) {
 		}
 	}
 
-	private fun getTargetFile(reportsDir: Directory): RegularFile {
+	private fun getTargetFile(reportsDir: File): RegularFile {
 		val prop = project.layout.fileProperty()
 		val customDestination = destination
 		if (customDestination != null)
 			prop.set(customDestination)
 		else
-			prop.set(File(reportsDir.asFile, "$DEFAULT_FILENAME.$reportFileExtension"))
+			prop.set(File(reportsDir, "$DEFAULT_FILENAME.$reportFileExtension"))
 
 		return prop.get()
 	}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
@@ -1,16 +1,45 @@
 package io.gitlab.arturbosch.detekt.extensions
 
+import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
 import java.io.File
 
-class DetektReport(val name: String) {
+class DetektReport(val name: String, private val project: Project) {
 
-	var enabled: Boolean = DetektExtension.DEFAULT_REPORT_ENABLED_VALUE
+	var enabled: Boolean? = null
 
 	var destination: File? = null
+
+	private val reportFileExtension
+		get() = name
 
 	override fun toString(): String {
 		return "DetektReport(name='$name', enabled=$enabled, destination=$destination)"
 	}
 
+	fun getTargetFileProvider(reportsDir: Provider<Directory>): Provider<RegularFile> {
+		return project.provider({
+			if (enabled ?: DetektExtension.DEFAULT_REPORT_ENABLED_VALUE)
+				getTargetFile(reportsDir.get())
+			else
+				null
+		})
+	}
 
+	private fun getTargetFile(reportsDir: Directory): RegularFile {
+		val prop = project.layout.fileProperty()
+		val customDestination = destination
+		if (customDestination != null)
+			prop.set(customDestination)
+		else
+			prop.set(File(reportsDir.asFile, "$DEFAULT_FILENAME.$reportFileExtension"))
+
+		return prop.get()
+	}
+
+	companion object {
+		const val DEFAULT_FILENAME = "detekt"
+	}
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReportType.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReportType.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.extensions
 
-enum class DetektReportType(val reportName: String, val extension: String = reportName) {
+enum class DetektReportType(val extension: String) {
 
 	XML("xml"),
 	HTML("html")

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReportType.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReportType.kt
@@ -1,0 +1,7 @@
+package io.gitlab.arturbosch.detekt.extensions
+
+enum class DetektReportType(val reportName: String, val extension: String = reportName) {
+
+	XML("xml"),
+	HTML("html")
+}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
@@ -1,13 +1,14 @@
 package io.gitlab.arturbosch.detekt.extensions
 
 import groovy.lang.Closure
+import org.gradle.api.Project
 import org.gradle.util.ConfigureUtil
 
-class DetektReports {
+class DetektReports(project: Project) {
 
-	val xml = DetektReport("xml")
+	val xml = DetektReport(XML_REPORT_NAME, project)
 
-	val html = DetektReport("html")
+	val html = DetektReport(HTML_REPORT_NAME, project)
 
 	val all = listOf(xml, html)
 
@@ -20,4 +21,9 @@ class DetektReports {
 
 	fun html(configure: DetektReport.() -> Unit) = html.configure()
 	fun html(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, html)
+
+	companion object {
+		const val XML_REPORT_NAME = "xml"
+		const val HTML_REPORT_NAME = "html"
+	}
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
@@ -1,29 +1,20 @@
 package io.gitlab.arturbosch.detekt.extensions
 
 import groovy.lang.Closure
+import io.gitlab.arturbosch.detekt.extensions.DetektReportType.HTML
+import io.gitlab.arturbosch.detekt.extensions.DetektReportType.XML
 import org.gradle.api.Project
 import org.gradle.util.ConfigureUtil
 
 class DetektReports(project: Project) {
 
-	val xml = DetektReport(XML_REPORT_NAME, project)
+	val xml = DetektReport(XML, project)
 
-	val html = DetektReport(HTML_REPORT_NAME, project)
-
-	val all = listOf(xml, html)
-
-	fun forEach(configure: (DetektReport) -> Unit) = all.forEach(configure)
-
-	fun withName(name: String, configure: DetektReport.() -> Unit) = all.find { it.name == name }?.let(configure)
+	val html = DetektReport(HTML, project)
 
 	fun xml(configure: DetektReport.() -> Unit) = xml.configure()
 	fun xml(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, xml)
 
 	fun html(configure: DetektReport.() -> Unit) = html.configure()
 	fun html(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, html)
-
-	companion object {
-		const val XML_REPORT_NAME = "xml"
-		const val HTML_REPORT_NAME = "html"
-	}
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.invoke
 
 import org.gradle.api.file.FileCollection
-import java.io.File
+import org.gradle.api.file.RegularFile
 
 private const val DEBUG_PARAMETER = "--debug"
 private const val FILTERS_PARAMETER = "--filters"
@@ -39,22 +39,23 @@ internal data class PluginsArgument(val plugins: String?) : CliArgument() {
 	override fun toArgument() = plugins?.let { listOf(PLUGINS_PARAMETER, it) } ?: emptyList()
 }
 
-internal data class BaselineArgument(val baseline: File?) : CliArgument() {
-	override fun toArgument() = baseline?.let { listOf(BASELINE_PARAMETER, it.absolutePath) } ?: emptyList()
+internal data class BaselineArgument(val baseline: RegularFile?) : CliArgument() {
+	override fun toArgument() = baseline?.let { listOf(BASELINE_PARAMETER, it.asFile.absolutePath) } ?: emptyList()
 }
 
-internal data class XmlReportArgument(val file: File?) : CliArgument() {
-	override fun toArgument() = file?.let { listOf(REPORT_PARAMETER, "xml:${it.absolutePath}") } ?: emptyList()
+internal data class XmlReportArgument(val file: RegularFile?) : CliArgument() {
+	override fun toArgument() = file?.let { listOf(REPORT_PARAMETER, "xml:${it.asFile.absoluteFile}") } ?: emptyList()
 }
 
-internal data class HtmlReportArgument(val file: File?) : CliArgument() {
-	override fun toArgument() = file?.let { listOf(REPORT_PARAMETER, "html:${it.absolutePath}") } ?: emptyList()
+internal data class HtmlReportArgument(val file: RegularFile?) : CliArgument() {
+	override fun toArgument() = file?.let { listOf(REPORT_PARAMETER, "html:${it.asFile.absolutePath}") } ?: emptyList()
 }
 
-internal data class ConfigArgument(val config: FileCollection?) : CliArgument() {
-	override fun toArgument() = config?.let { configPaths ->
-		listOf(CONFIG_PARAMETER, configPaths.joinToString(",") { it.absolutePath })
-	} ?: emptyList()
+internal data class ConfigArgument(val config: FileCollection) : CliArgument() {
+	override fun toArgument() = if (config.isEmpty)
+		emptyList()
+	else
+		listOf(CONFIG_PARAMETER, config.joinToString(",") { it.absolutePath })
 }
 
 internal data class DebugArgument(val value: Boolean) : CliArgument() {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskGroovyDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskGroovyDslTest.kt
@@ -23,6 +23,7 @@ internal class CreateBaselineTaskGroovyDslTest : Spek({
 			val detektConfig = """
 				|detekt {
     			| 	baseline = file("build/detekt/baseline.xml")
+				| 	debug = true
 				|}
 				"""
 
@@ -35,8 +36,7 @@ internal class CreateBaselineTaskGroovyDslTest : Spek({
 					.withPluginClasspath()
 					.build()
 
-			assertThat(result.output).contains("number of classes: 1")
-			assertThat(result.output).contains("Ruleset: comments")
+			assertThat(result.output).contains("number of classes: 1", "Ruleset: comments", "--debug")
 			assertThat(result.task(":detektBaseline")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 			assertThat(File(rootDir, "build/detekt/baseline.xml")).exists()
 		}

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslTest.kt
@@ -55,9 +55,9 @@ internal class DetektTaskGroovyDslTest : Spek({
 			assertThat(File(rootDir, "build/reports/detekt/detekt.xml")).exists()
 			assertThat(File(rootDir, "build/reports/detekt/detekt.html")).exists()
 		}
-		it("can be applied with a custom detekt version") {
+		it("is possible to select a custom version") {
 
-			val customVersion = "1.0.0-gradle-rework-beta3"
+			val customVersion = "1.0.0.RC8"
 			val detektConfig = """
 					|detekt {
 					|	toolVersion = "$customVersion"
@@ -70,16 +70,12 @@ internal class DetektTaskGroovyDslTest : Spek({
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
 					.withProjectDir(rootDir)
-					.withArguments("--project-cache-dir", createTempDir(prefix = "cache").absolutePath, "check", "--stacktrace", "--info")
+					.withArguments("--project-cache-dir", createTempDir(prefix = "cache").absolutePath, "dependencies", "--configuration", "detekt")
 					.withPluginClasspath()
 					.build()
 
-			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-			assertThat(result.output).contains("io.gitlab.arturbosch.detekt/detekt-cli/$customVersion")
-
-			// Asserts that the "custom" module is not built, and that custom ruleset is not enabled
-			assertThat(result.output).doesNotContain("Ruleset: test-custom")
-			assertThat(File(rootDir, "custom/build")).doesNotExist()
+			assertThat(result.task(":dependencies")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+			assertThat(result.output).contains("io.gitlab.arturbosch.detekt:detekt-cli:${customVersion}")
 		}
 		it("can change specific report destination") {
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslTest.kt
@@ -344,8 +344,13 @@ internal class DetektTaskGroovyDslTest : Spek({
 					|
 					|	input = files("src/main/java")
 					|	debug = true
-					|	xmlReportFile = file("build/reports/failfast.xml")
-					|	htmlReportFile = file("build/reports/failfast.html")
+					|	reports {
+					|		xml {
+					|			enabled = true
+					|			destination = file("build/reports/failfast.xml")
+					|		}
+					|		html.destination = file("build/reports/failfast.html")
+					|	}
 					|}
 				"""
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslTest.kt
@@ -10,6 +10,7 @@ import java.io.File
 
 /**
  * @author Marvin Ramin
+ * @author Markus Schwarz
  */
 internal class DetektTaskGroovyDslTest : Spek({
 
@@ -133,7 +134,7 @@ internal class DetektTaskGroovyDslTest : Spek({
 			assertThat(File(rootDir, "build/detekt-reports/detekt.xml")).exists()
 			assertThat(File(rootDir, "build/detekt-reports/detekt.html")).exists()
 		}
-		it("can change reportsDir but overdslTest.write single report destination") {
+		it("can change reportsDir but overwrite single report destination") {
 
 			val detektConfig = """
 				|detekt {
@@ -206,20 +207,22 @@ internal class DetektTaskGroovyDslTest : Spek({
 					.withPluginClasspath()
 					.build()
 
-			assertThat(result.output).contains("number of classes: 1")
-			assertThat(result.output).contains("Ruleset: comments")
+			assertThat(result.output).contains("number of classes: 1", "Ruleset: comments")
+			assertThat(result.output).contains("--report xml:")
+			assertThat(result.output).doesNotContain("--report html:")
 			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
 			assertThat(File(rootDir, "build/reports/detekt/detekt.xml")).exists()
 			assertThat(File(rootDir, "build/reports/detekt/detekt.html")).doesNotExist()
 		}
 		it("can configure the input directory") {
-			val customSourceLocation = File(rootDir, "gensrc/kotlin")
+			val customSource = "gensrc/kotlin"
+			val customSourceLocation = File(rootDir, customSource)
 			val detektConfig = """
 					|detekt {
 					| debug = true
 					| input = files(
-					|	 "${customSourceLocation.safeAbsolutePath}",
+					|	 "$customSource",
 					|	 "some/location/thatdoesnotexist"
 					| )
 					|}
@@ -236,10 +239,10 @@ internal class DetektTaskGroovyDslTest : Spek({
 					.build()
 
 			assertThat(result.output).contains("number of classes: 1")
-			assertThat(result.output).contains("--input, ${customSourceLocation.absolutePath}")
+			assertThat(result.output).contains("--input ${customSourceLocation.absolutePath}")
 			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 		}
-		it("can configure multiple input directories") {
+		it("can configure multiple absolute input directories") {
 			val customSourceLocation = File(rootDir, "gensrc/kotlin")
 			val otherCustomSourceLocation = File(rootDir, "gensrc/foo")
 			val detektConfig = """
@@ -263,25 +266,91 @@ internal class DetektTaskGroovyDslTest : Spek({
 					.build()
 
 			assertThat(result.output).contains("number of classes: 2")
-			assertThat(result.output).contains("--input, ${customSourceLocation.absolutePath},${otherCustomSourceLocation.absolutePath}")
+			assertThat(result.output).contains("--input ${customSourceLocation.absolutePath},${otherCustomSourceLocation.absolutePath}")
 			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 		}
-		it("can configure a new custom detekt task") {
-			val configFile = File(rootDir, "config.yml")
+		it("uses the flags") {
 
+			val detektConfig = """
+					|detekt {
+					|	debug = true
+					|	parallel = true
+					|	disableDefaultRuleSets = true
+					|}
+				"""
+
+			dslTest.writeFiles(rootDir, detektConfig)
+			dslTest.writeConfig(rootDir)
+
+			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
+			val result = GradleRunner.create()
+					.withProjectDir(rootDir)
+					.withArguments("--project-cache-dir", createTempDir(prefix = "cache").absolutePath, "detekt",
+							"--stacktrace", "--info")
+					.withPluginClasspath()
+					.build()
+
+			assertThat(result.output).contains("--debug")
+			assertThat(result.output).contains("--parallel")
+			assertThat(result.output).contains("--disable-default-rulesets")
+			assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+		}
+		it("can set filters") {
+			val filters = ".*test.*,.*/resources/.*,.*/tmp/.*"
+
+			val detektConfig = """
+					|detekt {
+					|	filters = "$filters"
+					|}
+				"""
+
+			dslTest.writeFiles(rootDir, detektConfig)
+			dslTest.writeConfig(rootDir)
+
+			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
+			val result = GradleRunner.create()
+					.withProjectDir(rootDir)
+					.withArguments("--project-cache-dir", createTempDir(prefix = "cache").absolutePath, "detekt",
+							"--stacktrace", "--info")
+					.withPluginClasspath()
+					.build()
+
+			assertThat(result.output).contains("--filters $filters")
+			assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+		}
+		it("can set plugins") {
+			val additionalPlugin = "plugin.jar"
+			File(rootDir, additionalPlugin).createNewFile()
+
+			val detektConfig = """
+					|detekt {
+					|	plugins = "$additionalPlugin"
+					|}
+				"""
+
+			dslTest.writeFiles(rootDir, detektConfig)
+			dslTest.writeConfig(rootDir)
+
+			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
+			val result = GradleRunner.create()
+					.withProjectDir(rootDir)
+					.withArguments("--project-cache-dir", createTempDir(prefix = "cache").absolutePath, "detekt",
+							"--stacktrace", "--info")
+					.withPluginClasspath()
+					.build()
+
+			assertThat(result.output).contains("--plugins $additionalPlugin")
+			assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+		}
+		it("can configure a new custom detekt task") {
 			val detektConfig = """
 					|task detektFailFast(type: io.gitlab.arturbosch.detekt.Detekt) {
 					|	description = "Runs a failfast detekt build."
 					|
 					|	input = files("src/main/java")
-					|	config = files("${configFile.safeAbsolutePath}")
 					|	debug = true
-					|	reports {
-					|		xml {
-					|			destination = file("build/reports/failfast.xml")
-					|		}
-					|		html.destination = file("build/reports/failfast.html")
-					|	}
+					|	xmlReportFile = file("build/reports/failfast.xml")
+					|	htmlReportFile = file("build/reports/failfast.html")
 					|}
 				"""
 
@@ -298,6 +367,7 @@ internal class DetektTaskGroovyDslTest : Spek({
 			assertThat(result.output).contains("number of classes: 1")
 			assertThat(result.output).contains("Ruleset: comments")
 			assertThat(result.task(":detektFailFast")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+			assertThat(result.output).contains("--debug")
 
 			assertThat(File(rootDir, "build/reports/failfast.xml")).exists()
 			assertThat(File(rootDir, "build/reports/failfast.html")).exists()

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslTest.kt
@@ -55,15 +55,17 @@ internal class DetektTaskGroovyDslTest : Spek({
 			assertThat(File(rootDir, "build/reports/detekt/detekt.xml")).exists()
 			assertThat(File(rootDir, "build/reports/detekt/detekt.html")).exists()
 		}
-		it("can be applied with a version only") {
+		it("can be applied with a custom detekt version") {
 
+			val customVersion = "1.0.0-gradle-rework-beta3"
 			val detektConfig = """
-				|detekt {
-				|	toolVersion = "$VERSION_UNDER_TEST"
-				|}
+					|detekt {
+					|	toolVersion = "$customVersion"
+					|}
 				"""
 
 			dslTest.writeFiles(rootDir, detektConfig)
+			dslTest.writeConfig(rootDir)
 
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
@@ -72,15 +74,12 @@ internal class DetektTaskGroovyDslTest : Spek({
 					.withPluginClasspath()
 					.build()
 
-			assertThat(result.output).contains("number of classes: 1")
-			assertThat(result.output).contains("Ruleset: comments")
 			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+			assertThat(result.output).contains("io.gitlab.arturbosch.detekt/detekt-cli/$customVersion")
 
 			// Asserts that the "custom" module is not built, and that custom ruleset is not enabled
 			assertThat(result.output).doesNotContain("Ruleset: test-custom")
 			assertThat(File(rootDir, "custom/build")).doesNotExist()
-			assertThat(File(rootDir, "build/reports/detekt/detekt.xml")).exists()
-			assertThat(File(rootDir, "build/reports/detekt/detekt.html")).exists()
 		}
 		it("can change specific report destination") {
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
@@ -72,9 +72,9 @@ internal class DetektTaskKotlinDslTest : Spek({
 			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 		}
 
-		it("can be applied with a custom detekt version") {
+		it("is possible to select a custom version") {
 
-			val customVersion = "1.0.0-gradle-rework-beta3"
+			val customVersion = "1.0.0.RC8"
 			val detektConfig = """
 					|detekt {
 					|	toolVersion = "$customVersion"
@@ -87,16 +87,12 @@ internal class DetektTaskKotlinDslTest : Spek({
 			// Using a custom "project-cache-dir" to avoid a Gradle error on Windows
 			val result = GradleRunner.create()
 					.withProjectDir(rootDir)
-					.withArguments("--project-cache-dir", createTempDir(prefix = "cache").absolutePath, "check", "--stacktrace", "--info")
+					.withArguments("--project-cache-dir", createTempDir(prefix = "cache").absolutePath, "dependencies", "--configuration", "detekt")
 					.withPluginClasspath()
 					.build()
 
-			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-			assertThat(result.output).contains("io.gitlab.arturbosch.detekt/detekt-cli/$customVersion")
-
-			// Asserts that the "custom" module is not built, and that custom ruleset is not enabled
-			assertThat(result.output).doesNotContain("Ruleset: test-custom")
-			assertThat(File(rootDir, "custom/build")).doesNotExist()
+			assertThat(result.task(":dependencies")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+			assertThat(result.output).contains("io.gitlab.arturbosch.detekt:detekt-cli:${customVersion}")
 		}
 
 		it("can be applied with a custom config file") {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
@@ -161,6 +161,8 @@ internal class DetektTaskKotlinDslTest : Spek({
 					|	input = files("src/main/java")
 					|	config = files("${configFile.safeAbsolutePath}")
 					|	debug = true
+					|	parallel = true
+					|	disableDefaultRuleSets = true
 					|	reports {
 					|		xml {
 					|			enabled = true
@@ -183,7 +185,6 @@ internal class DetektTaskKotlinDslTest : Spek({
 					.build()
 
 			assertThat(result.output).contains("number of classes: 1")
-			assertThat(result.output).contains("Ruleset: comments")
 			assertThat(result.task(":detektFailFast")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
 			assertThat(File(rootDir, "build/reports/failfast.xml")).exists()

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
@@ -150,7 +150,7 @@ internal class DetektTaskKotlinDslTest : Spek({
 					.build()
 
 			assertThat(result.output).contains("number of classes: 1")
-			assertThat(result.output).contains("--parallel", "--debug", "--disable-default-rulesets")
+			assertThat(result.output).contains("--parallel", "--debug", "--disable-default-rulesets", "--filters .*/resources/.*, .*/build/.*")
 			assertThat(result.output).doesNotContain("Ruleset: comments")
 			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 		}
@@ -164,13 +164,9 @@ internal class DetektTaskKotlinDslTest : Spek({
 					|
 					|	input = files("src/main/java")
 					|	config = files("${configFile.safeAbsolutePath}")
-					|	debug = true
-					|	reports {
-					|		xml {
-					|			destination = file("build/reports/failfast.xml")
-					|		}
-					|		html.destination = file("build/reports/failfast.html")
-					|	}
+					|	debug.set(true)
+					|	xmlReportFile.set(file("build/reports/failfast.xml"))
+					|	htmlReportFile.set(file("build/reports/failfast.html"))
 					|}
 				"""
 
@@ -269,7 +265,7 @@ internal class DetektTaskKotlinDslTest : Spek({
 					.build()
 
 			assertThat(result.output).contains("number of classes: 1")
-			assertThat(result.output).contains("--input, ${customSourceLocation.absolutePath}")
+			assertThat(result.output).contains("--input ${customSourceLocation.absolutePath}")
 			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 		}
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
@@ -74,9 +74,10 @@ internal class DetektTaskKotlinDslTest : Spek({
 
 		it("can be applied with a custom detekt version") {
 
+			val customVersion = "1.0.0-gradle-rework-beta3"
 			val detektConfig = """
 					|detekt {
-					|	toolVersion = "$VERSION_UNDER_TEST"
+					|	toolVersion = "$customVersion"
 					|}
 				"""
 
@@ -90,9 +91,8 @@ internal class DetektTaskKotlinDslTest : Spek({
 					.withPluginClasspath()
 					.build()
 
-			assertThat(result.output).contains("number of classes: 1")
-			assertThat(result.output).contains("Ruleset: comments")
 			assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+			assertThat(result.output).contains("io.gitlab.arturbosch.detekt/detekt-cli/$customVersion")
 
 			// Asserts that the "custom" module is not built, and that custom ruleset is not enabled
 			assertThat(result.output).doesNotContain("Ruleset: test-custom")

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
@@ -161,8 +161,13 @@ internal class DetektTaskKotlinDslTest : Spek({
 					|	input = files("src/main/java")
 					|	config = files("${configFile.safeAbsolutePath}")
 					|	debug.set(true)
-					|	xmlReportFile.set(file("build/reports/failfast.xml"))
-					|	htmlReportFile.set(file("build/reports/failfast.html"))
+					|	reports {
+					|		xml {
+					|			enabled = true
+					|			destination = file("build/reports/failfast.xml")
+					|		}
+					|		html.destination = file("build/reports/failfast.html")
+					|	}
 					|}
 				"""
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskKotlinDslTest.kt
@@ -160,7 +160,7 @@ internal class DetektTaskKotlinDslTest : Spek({
 					|
 					|	input = files("src/main/java")
 					|	config = files("${configFile.safeAbsolutePath}")
-					|	debug.set(true)
+					|	debug = true
 					|	reports {
 					|		xml {
 					|			enabled = true

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslBaseTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslBaseTest.kt
@@ -7,6 +7,8 @@ class DslBaseTest(private val buildGradleFileName: String, private val buildGrad
 	private fun getBuildFileContent(customConfig: String): String {
 		return """
     	|$buildGradleFile
+    	|
+    	|tasks.all {}
 		|
     	|$customConfig
 		""".trimMargin()
@@ -35,7 +37,7 @@ class DslBaseTest(private val buildGradleFileName: String, private val buildGrad
 		""".trimMargin())
 	}
 
-	fun writeFiles(root: File, detektConfiguration: String, srcDir: File = File(root, "src/main/java")) {
+	fun writeFiles(root: File, detektConfiguration: String = "", srcDir: File = File(root, "src/main/java")) {
 		File(root, buildGradleFileName).writeText(getBuildFileContent(detektConfiguration))
 		File(root, "settings.gradle").writeText(settingsFileContent)
 		writeSourceFile(root, srcDir)

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslBaseTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslBaseTest.kt
@@ -1,8 +1,20 @@
 package io.gitlab.arturbosch.detekt
 
 import java.io.File
+import java.util.Random
+import kotlin.streams.asSequence
 
-class DslBaseTest(private val buildGradleFileName: String, private val buildGradleFile: String) {
+class DslBaseTest(
+		private val buildGradleFileName: String,
+		private val buildGradleFile: String,
+		private val createUniqueSourceFiles: Boolean = false) {
+
+	private fun uniqueStringValue(): String =
+			Random().ints(VARIABLE_NAME_LENGTH, 0, VARIABLE_NAME_SOURCE.length)
+					.asSequence()
+					.map(VARIABLE_NAME_SOURCE::get)
+					.joinToString("")
+
 
 	private fun getBuildFileContent(customConfig: String): String {
 		return """
@@ -14,8 +26,10 @@ class DslBaseTest(private val buildGradleFileName: String, private val buildGrad
 		""".trimMargin()
 	}
 
-	private val ktFileContent = """
-	|internal class MyClass
+	private fun ktFileContent(className: String) = """
+	|internal class ${className} {
+	|
+	|  val aString = "${if (createUniqueSourceFiles) uniqueStringValue() else ""}"
 	|
 	""".trimMargin()
 
@@ -51,9 +65,14 @@ class DslBaseTest(private val buildGradleFileName: String, private val buildGrad
 		}
 	}
 
-	fun writeSourceFile(root: File, srcDir: File = File(root, "src/main/java"), filename: String = "MyClass.kt") {
+	fun writeSourceFile(root: File, srcDir: File = File(root, "src/main/java"), className: String = "MyClass") {
 		srcDir.mkdirs()
-		File(srcDir, filename).writeText(ktFileContent)
+		File(srcDir, "$className.kt").writeText(ktFileContent(className))
+	}
+
+	companion object {
+		const val VARIABLE_NAME_SOURCE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+		const val VARIABLE_NAME_LENGTH: Long = 10
 	}
 }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorTest.kt
@@ -27,7 +27,7 @@ internal class PluginTaskBehaviorTest : Spek({
 		|	mavenLocal()
 		|}
 		""".trimMargin()
-	val dslTest = DslBaseTest("build.gradle.kts", buildGradle)
+	val dslTest = DslBaseTest("build.gradle.kts", buildGradle, true)
 
 	describe("The Detekt Gradle Plugin :detekt Task") {
 		lateinit var rootDir: File
@@ -79,7 +79,6 @@ internal class PluginTaskBehaviorTest : Spek({
 
 		it("should pick up build artifacts from the build cache on a 2nd run after deleting the build/ dir") {
 			val gradleRunner = GradleRunner.create()
-					.withTestKitDir(createTempDir())
 					.withProjectDir(rootDir)
 					.withPluginClasspath()
 
@@ -104,7 +103,6 @@ internal class PluginTaskBehaviorTest : Spek({
 
 		it("should pick up build artifacts from the build cache on a 2nd run after running :clean") {
 			val gradleRunner = GradleRunner.create()
-					.withTestKitDir(createTempDir())
 					.withProjectDir(rootDir)
 					.withPluginClasspath()
 
@@ -201,7 +199,7 @@ internal class PluginTaskBehaviorTest : Spek({
 
 			assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
-			dslTest.writeSourceFile(rootDir, filename = "OtherFile.kt")
+			dslTest.writeSourceFile(rootDir, className = "OtherFile")
 
 			// Running the same task again should NOT be UP-TO-DATE
 			val secondResult = gradleRunner

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/TestVersion.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/TestVersion.kt
@@ -3,4 +3,4 @@ package io.gitlab.arturbosch.detekt
 /**
  * @author Artur Bosch
  */
-const val VERSION_UNDER_TEST: String = "1.0.0-gradle-rework-beta3"
+const val VERSION_UNDER_TEST: String = "1.0.0.RC9.2"

--- a/docs/pages/gettingstarted/groovydsl.md
+++ b/docs/pages/gettingstarted/groovydsl.md
@@ -123,8 +123,12 @@ task detektFailFast(type: io.gitlab.arturbosch.detekt.Detekt) {
    input = files("src/main/java")
    config = files("$rootDir/config.yml")
    debug = true
-   xmlReportFile = file("build/reports/failfast.xml")       // if omitted no xml report is generated
-   htmlReportFile = file("build/reports/failfast.html")     // if omitted no html report is generated
+   reports {
+       xml {
+           destination = file("build/reports/failfast.xml")
+       }
+       html.destination = file("build/reports/failfast.html")
+   }
 }
 ```
 

--- a/docs/pages/gettingstarted/groovydsl.md
+++ b/docs/pages/gettingstarted/groovydsl.md
@@ -93,7 +93,7 @@ detekt {
     parallel = false                                      // Runs detekt in parallel. Can lead to speedups in larger projects. `false` by default.
     config = files("path/to/config.yml")                  // Define the detekt configuration(s) you want to use. Defaults to the default detekt configuration.
     baseline = file("path/to/baseline.xml")               // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
-    filters = ''                                          // Regular expression of paths that should be excluded separated by `;`.
+    filters = ''                                          // Regular expression of paths that should be excluded separated by `;` or `,`.
     disableDefaultRuleSets = false                        // Disables all default detekt rulesets and will only run detekt with custom rules defined in `plugins`. `false` by default.
     plugins = "other/optional/ruleset.jar"                // Additional jar file containing custom detekt rules.
     debug = false                                         // Adds debug output during task execution. `false` by default.
@@ -123,12 +123,8 @@ task detektFailFast(type: io.gitlab.arturbosch.detekt.Detekt) {
    input = files("src/main/java")
    config = files("$rootDir/config.yml")
    debug = true
-   reports {
-       xml {
-           destination = file("build/reports/failfast.xml")
-       }
-       html.destination = file("build/reports/failfast.html")
-   }
+   xmlReportFile = file("build/reports/failfast.xml")       // if omitted no xml report is generated
+   htmlReportFile = file("build/reports/failfast.html")     // if omitted no html report is generated
 }
 ```
 

--- a/docs/pages/gettingstarted/kotlindsl.md
+++ b/docs/pages/gettingstarted/kotlindsl.md
@@ -66,13 +66,9 @@ task<io.gitlab.arturbosch.detekt.Detekt>("detektFailFast") {
 
     input = files("src/main/kotlin", "src/test/kotlin")
     config = files("$rootDir/config.yml")
-    debug = true
-    reports {
-        xml {
-            destination = file("build/reports/failfast.xml")
-        }
-        html.destination = file("build/reports/failfast.html")
-    }
+    debug.set(true)
+    xmlReportFile.set(file("build/reports/failfast.xml"))       // if omitted no xml report is generated
+    htmlReportFile.set(file("build/reports/failfast.html"))     // if omitted no html report is generated
 }
 ```
 

--- a/docs/pages/gettingstarted/kotlindsl.md
+++ b/docs/pages/gettingstarted/kotlindsl.md
@@ -66,9 +66,13 @@ task<io.gitlab.arturbosch.detekt.Detekt>("detektFailFast") {
 
     input = files("src/main/kotlin", "src/test/kotlin")
     config = files("$rootDir/config.yml")
-    debug.set(true)
-    xmlReportFile.set(file("build/reports/failfast.xml"))       // if omitted no xml report is generated
-    htmlReportFile.set(file("build/reports/failfast.html"))     // if omitted no html report is generated
+    debug = true
+    reports {
+        xml {
+            destination = file("build/reports/failfast.xml")
+        }
+        html.destination = file("build/reports/failfast.html")
+    }
 }
 ```
 


### PR DESCRIPTION
This PR attempts to solve #1193, #1181 and #1171 as they are all essentially the same thing.

I basically kept the extensions as is to avoid breaking changes and to keep groovy and kotlin dsl close together. 