### PR TITLE
Rule `Explicit it lambda parameter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Dmitriy Samaryan](https://github.com/samarjan92) - Rule fix: SerialVersionUIDInSerializableClass
 - [Mariano Simone](https://github.com/marianosimone) - Rule improvement: UnusedPrivateMember
 - [Shunsuke Maeda](https://github.com/duck8823) - Fix: to work on multi module project using [maven plugin](https://github.com/Ozsie/detekt-maven-plugin)
-- [Mikhail Levchenko](https://github.com/mishkun) - New rule: Unnecessary let
+- [Mikhail Levchenko](https://github.com/mishkun) - New rules: Unnecessary let, ExplicitItLambdaParameter
 - [Scott Kennedy](https://github.com/scottkennedy) - Minor fixes
 - [Mickele Moriconi](https://github.com/mickele) - Added: ConstructorParameterNaming and FunctionParameterNaming rules
 - [Lukasz Jazgar](https://github.com/ljazgar) - Fixed configuring formatting rules

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -401,6 +401,8 @@ style:
     conversionFunctionPrefix: 'to'
   EqualsNullCall:
     active: false
+  ExplicitItLambdaParameter:
+    active: false
   ExpressionBodySyntax:
     active: false
     includeLineWrapping: false

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Keywords.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Keywords.kt
@@ -1,0 +1,10 @@
+package io.gitlab.arturbosch.detekt.rules
+
+/**
+ * This file contains common literals of keywords, library functions and other idioms of Kotlin language
+ *
+ * @author mishkun
+ */
+
+const val IT_LITERAL = "it"
+const val LET_LITERAL = "let"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.rules.style.CollapsibleIfStatements
 import io.gitlab.arturbosch.detekt.rules.style.DataClassContainsFunctions
 import io.gitlab.arturbosch.detekt.rules.style.EqualsNullCall
+import io.gitlab.arturbosch.detekt.rules.style.ExplicitItLambdaParameter
 import io.gitlab.arturbosch.detekt.rules.style.ExpressionBodySyntax
 import io.gitlab.arturbosch.detekt.rules.style.FileParsingRule
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenComment
@@ -95,7 +96,8 @@ class StyleGuideProvider : RuleSetProvider {
 				PreferToOverPairSyntax(config),
 				MandatoryBracesIfStatements(config),
 				VarCouldBeVal(config),
-				ForbiddenVoid(config)
+				ForbiddenVoid(config),
+				ExplicitItLambdaParameter(config)
 		))
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 
 /**
@@ -51,9 +52,5 @@ class ExplicitItLambdaParameter(val config: Config) : Rule(config) {
 					"explicit `it` parameter declaration can be omitted"
 			))
 		}
-	}
-
-	companion object {
-		private const val IT_LITERAL = "it"
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
@@ -30,7 +30,8 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
  * a?.let { it.plus(1) } // Much better to use implicit it
  * foo.flatMapObservable(Observable::fromIterable) // Here we can have a method reference
  * listOfPairs.map(::second).forEach { apiRequest -> // For multiline blocks better come up with meaningful name
- * 		it.execute()
+ * 		apiRequest.execute()
+ * }
  * collection.zipWithNext { prev, next -> // Why do one parameter was named appropriately, and other was not?
  * 		Pair(prev, next)
  * }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
@@ -9,7 +9,31 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 
-
+/**
+ * Lambda expressions are one of the core features of the language. They often include very small chunks of
+ * code using only one parameter. In this cases Kotlin can supply the implicit `it` parameter
+ * to make code more concise. It fits most usecases, but when faced larger or nested chunks of code,
+ * you might want to add an explicit name for the parameter. Naming it just `it` is meaningless and only
+ * clutters the code.
+ *
+ * <noncompliant>
+ * a?.let { it -> it.plus(1) }
+ * foo.flatMapObservable { it -> Observable.fromIterable(it) }
+ * listOfPairs.map(::second).forEach { it ->
+ * 		it.execute()
+ * }
+ * </noncompliant>
+ *
+ * <compliant>
+ * a?.let { it.plus(1) } // Much better to use implicit it
+ * foo.flatMapObservable(Observable::fromIterable) // Here we can have a method reference
+ * listOfPairs.map(::second).forEach { apiRequest -> // For multiline blocks better come up with meaningful name
+ * 		it.execute()
+ * }
+ * </compliant>
+ *
+ * @author mishkun
+ */
 class ExplicitItLambdaParameter(val config: Config) : Rule(config) {
 	override val issue = Issue(javaClass.simpleName, Severity.Style,
 			"Declaring single explicit `it` parameter is redundant", Debt.FIVE_MINS)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
@@ -1,0 +1,35 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+
+
+class ExplicitItLambdaParameter(val config: Config) : Rule(config) {
+	override val issue = Issue(javaClass.simpleName, Severity.Style,
+			"Declaring single explicit `it` parameter is redundant", Debt.FIVE_MINS)
+
+	override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
+		super.visitLambdaExpression(lambdaExpression)
+
+		val isSingleParameterLambda = lambdaExpression.valueParameters.size == 1
+		if (!isSingleParameterLambda) return
+
+		val singleParameter = lambdaExpression.valueParameters.first()
+		if (singleParameter.name == IT_LITERAL) {
+			report(CodeSmell(
+					issue, Entity.from(lambdaExpression),
+					"explicit `it` parameter declaration can be omitted"
+			))
+		}
+	}
+
+	companion object {
+		private const val IT_LITERAL = "it"
+	}
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
  * code using only one parameter. In this cases Kotlin can supply the implicit `it` parameter
  * to make code more concise. It fits most usecases, but when faced larger or nested chunks of code,
  * you might want to add an explicit name for the parameter. Naming it just `it` is meaningless and only
- * clutters the code.
+ * makes your code misleading, especially when dealing with nested functions.
  *
  * <noncompliant>
  * a?.let { it -> it.plus(1) }
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
  * listOfPairs.map(::second).forEach { it ->
  * 		it.execute()
  * }
+ * collection.zipWithNext { it, next -> Pair(it, next) }
  * </noncompliant>
  *
  * <compliant>
@@ -30,6 +31,8 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
  * foo.flatMapObservable(Observable::fromIterable) // Here we can have a method reference
  * listOfPairs.map(::second).forEach { apiRequest -> // For multiline blocks better come up with meaningful name
  * 		it.execute()
+ * collection.zipWithNext { prev, next -> // Why do one parameter was named appropriately, and other was not?
+ * 		Pair(prev, next)
  * }
  * </compliant>
  *
@@ -41,12 +44,8 @@ class ExplicitItLambdaParameter(val config: Config) : Rule(config) {
 
 	override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
 		super.visitLambdaExpression(lambdaExpression)
-
-		val isSingleParameterLambda = lambdaExpression.valueParameters.size == 1
-		if (!isSingleParameterLambda) return
-
-		val singleParameter = lambdaExpression.valueParameters.first()
-		if (singleParameter.name == IT_LITERAL) {
+		val parameterNames = lambdaExpression.valueParameters.map { it.name }
+		if (IT_LITERAL in parameterNames) {
 			report(CodeSmell(
 					issue, Entity.from(lambdaExpression),
 					"explicit `it` parameter declaration can be omitted"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
@@ -29,10 +29,10 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
  * <compliant>
  * a?.let { it.plus(1) } // Much better to use implicit it
  * foo.flatMapObservable(Observable::fromIterable) // Here we can have a method reference
- * listOfPairs.map(::second).forEach { apiRequest -> // For multiline blocks better come up with meaningful name
+ * listOfPairs.map(::second).forEach { apiRequest -> // For multiline blocks it is usually better come up with a clear and more meaningful name
  * 		apiRequest.execute()
  * }
- * collection.zipWithNext { prev, next -> // Why do one parameter was named appropriately, and other was not?
+ * collection.zipWithNext { prev, next -> // Lambdas with multiple parameter should be named clearly, using it for one of them can be confusing
  * 		Pair(prev, next)
  * }
  * </compliant>
@@ -41,7 +41,7 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
  */
 class ExplicitItLambdaParameter(val config: Config) : Rule(config) {
 	override val issue = Issue(javaClass.simpleName, Severity.Style,
-			"Declaring single explicit `it` parameter is redundant", Debt.FIVE_MINS)
+			"Declaring lambda parameters as `it` is redundant.", Debt.FIVE_MINS)
 
 	override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
 		super.visitLambdaExpression(lambdaExpression)
@@ -49,7 +49,7 @@ class ExplicitItLambdaParameter(val config: Config) : Rule(config) {
 		if (IT_LITERAL in parameterNames) {
 			report(CodeSmell(
 					issue, Entity.from(lambdaExpression),
-					"explicit `it` parameter declaration can be omitted"
+					"This explicit usage of `it` as the lambda parameter name can be omitted."
 			))
 		}
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -7,6 +7,8 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
+import io.gitlab.arturbosch.detekt.rules.LET_LITERAL
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
@@ -67,9 +69,6 @@ class UnnecessaryLet(config: Config) : Rule(config) {
 		}
 	}
 }
-
-private const val LET_LITERAL = "let"
-private const val IT_LITERAL = "it"
 
 private fun KtCallExpression.isLetExpr() = calleeExpression?.textMatches(LET_LITERAL) == true
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
@@ -42,19 +42,19 @@ class ExplicitItLambdaParameterSpec : SubjectSpek<ExplicitItLambdaParameter>({
 	}
 	given("some code using lambdas with (slightly) better style guidelines") {
 		on("multiple parameters one of which with name `it` declared explicitly") {
-			it("does not report when parameter types are not declared") {
+			it("reports when parameter types are not declared") {
 				val findings = subject.lint("""
 				fun f() {
 					val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it -> it + index }
 				}""")
-				assertThat(findings).isEmpty()
+				assertThat(findings).hasSize(1)
 			}
-			it("does not report when parameter types are declared explicitly"){
+			it("reports when parameter types are declared explicitly"){
 				val findings = subject.lint("""
 				fun f() {
 					val lambda = { it: Int, that: String -> it.toString() + that }
 				}""")
-				assertThat(findings).isEmpty()
+				assertThat(findings).hasSize(1)
 			}
 		}
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
@@ -18,7 +18,7 @@ class ExplicitItLambdaParameterSpec : SubjectSpek<ExplicitItLambdaParameter>({
 					val digits = 1234.let { it -> lambda(it) }.toList()
 					val flat = listOf(listOf(1), listOf(2)).flatMap { it -> it }
 				}""")
-			Assertions.assertThat(findings).hasSize(3)
+			assertThat(findings).hasSize(3)
 		}
 	}
 	given("some code using lambdas with (slightly) better style guidelines"){
@@ -28,7 +28,7 @@ class ExplicitItLambdaParameterSpec : SubjectSpek<ExplicitItLambdaParameter>({
 					val lambda = { it: Int, that: String -> it.toString() + that }
 					val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it -> it + index }
 				}""")
-			Assertions.assertThat(findings).isEmpty()
+			assertThat(findings).isEmpty()
 		}
 		it("does not report compliant (implicit) it parameters") {
 			val findings = subject.lint("""
@@ -37,7 +37,7 @@ class ExplicitItLambdaParameterSpec : SubjectSpek<ExplicitItLambdaParameter>({
 					val digits = 1234.let { lambda(it) }.toList()
 					val flat = listOf(listOf(1), listOf(2)).flatMap { it }
 				}""")
-			Assertions.assertThat(findings).isEmpty()
+			assertThat(findings).isEmpty()
 		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
@@ -1,0 +1,43 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
+
+class ExplicitItLambdaParameterSpec : SubjectSpek<ExplicitItLambdaParameter>({
+	subject { ExplicitItLambdaParameter(Config.empty) }
+
+	given("some code using single parameter lambdas extensively with poor style guidelines") {
+		it("reports every single it parameter declared explicitly") {
+			val findings = subject.lint("""
+				fun f() {
+					val lambda = { it: Int -> it.toString() }
+					val digits = 1234.let { it -> lambda(it) }.toList()
+					val flat = listOf(listOf(1), listOf(2)).flatMap { it -> it }
+				}""")
+			Assertions.assertThat(findings).hasSize(3)
+		}
+	}
+	given("some code using lambdas with (slightly) better style guidelines"){
+		it("does not report explicit it parameter when there are multiple parameters") {
+			val findings = subject.lint("""
+				fun f() {
+					val lambda = { it: Int, that: String -> it.toString() + that }
+					val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it -> it + index }
+				}""")
+			Assertions.assertThat(findings).isEmpty()
+		}
+		it("does not report compliant (implicit) it parameters") {
+			val findings = subject.lint("""
+				fun f() {
+					val lambda = { it.toString() }
+					val digits = 1234.let { lambda(it) }.toList()
+					val flat = listOf(listOf(1), listOf(2)).flatMap { it }
+				}""")
+			Assertions.assertThat(findings).isEmpty()
+		}
+	}
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
@@ -5,39 +5,57 @@ import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
 import org.jetbrains.spek.subject.SubjectSpek
 
 class ExplicitItLambdaParameterSpec : SubjectSpek<ExplicitItLambdaParameter>({
 	subject { ExplicitItLambdaParameter(Config.empty) }
 
-	given("some code using single parameter lambdas extensively with poor style guidelines") {
-		it("reports every single it parameter declared explicitly") {
-			val findings = subject.lint("""
+	given("lambda with single parameter") {
+		on("single parameter with name `it` declared explicitly") {
+			it("reports when parameter type is not declared") {
+				val findings = subject.lint("""
+				fun f() {
+					val digits = 1234.let { it -> listOf(it) }
+				}""")
+				assertThat(findings).hasSize(1)
+			}
+			it("reports when parameter type is declared explicitly") {
+				val findings = subject.lint("""
 				fun f() {
 					val lambda = { it: Int -> it.toString() }
-					val digits = 1234.let { it -> lambda(it) }.toList()
-					val flat = listOf(listOf(1), listOf(2)).flatMap { it -> it }
 				}""")
-			assertThat(findings).hasSize(3)
+				assertThat(findings).hasSize(1)
+			}
 		}
-	}
-	given("some code using lambdas with (slightly) better style guidelines"){
-		it("does not report explicit it parameter when there are multiple parameters") {
-			val findings = subject.lint("""
-				fun f() {
-					val lambda = { it: Int, that: String -> it.toString() + that }
-					val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it -> it + index }
-				}""")
-			assertThat(findings).isEmpty()
-		}
-		it("does not report compliant (implicit) it parameters") {
-			val findings = subject.lint("""
+		on("no parameter declared explicitly") {
+			it("does not report implicit `it` parameter usage") {
+				val findings = subject.lint("""
 				fun f() {
 					val lambda = { it.toString() }
 					val digits = 1234.let { lambda(it) }.toList()
 					val flat = listOf(listOf(1), listOf(2)).flatMap { it }
 				}""")
-			assertThat(findings).isEmpty()
+				assertThat(findings).isEmpty()
+			}
+		}
+	}
+	given("some code using lambdas with (slightly) better style guidelines") {
+		on("multiple parameters one of which with name `it` declared explicitly") {
+			it("does not report when parameter types are not declared") {
+				val findings = subject.lint("""
+				fun f() {
+					val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it -> it + index }
+				}""")
+				assertThat(findings).isEmpty()
+			}
+			it("does not report when parameter types are declared explicitly"){
+				val findings = subject.lint("""
+				fun f() {
+					val lambda = { it: Int, that: String -> it.toString() + that }
+				}""")
+				assertThat(findings).isEmpty()
+			}
 		}
 	}
 })

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -116,10 +116,10 @@ collection.zipWithNext { it, next -> Pair(it, next) }
 ```kotlin
 a?.let { it.plus(1) } // Much better to use implicit it
 foo.flatMapObservable(Observable::fromIterable) // Here we can have a method reference
-listOfPairs.map(::second).forEach { apiRequest -> // For multiline blocks better come up with meaningful name
+listOfPairs.map(::second).forEach { apiRequest -> // For multiline blocks it is usually better come up with a clear and more meaningful name
 apiRequest.execute()
 }
-collection.zipWithNext { prev, next -> // Why do one parameter was named appropriately, and other was not?
+collection.zipWithNext { prev, next -> // Lambdas with multiple parameter should be named clearly, using it for one of them can be confusing
 Pair(prev, next)
 }
 ```

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -94,7 +94,7 @@ Lambda expressions are one of the core features of the language. They often incl
 code using only one parameter. In this cases Kotlin can supply the implicit `it` parameter
 to make code more concise. It fits most usecases, but when faced larger or nested chunks of code,
 you might want to add an explicit name for the parameter. Naming it just `it` is meaningless and only
-clutters the code.
+makes your code misleading, especially when dealing with nested functions.
 
 **Severity**: Style
 
@@ -108,6 +108,7 @@ foo.flatMapObservable { it -> Observable.fromIterable(it) }
 listOfPairs.map(::second).forEach { it ->
 it.execute()
 }
+collection.zipWithNext { it, next -> Pair(it, next) }
 ```
 
 #### Compliant Code:
@@ -116,7 +117,10 @@ it.execute()
 a?.let { it.plus(1) } // Much better to use implicit it
 foo.flatMapObservable(Observable::fromIterable) // Here we can have a method reference
 listOfPairs.map(::second).forEach { apiRequest -> // For multiline blocks better come up with meaningful name
-it.execute()
+apiRequest.execute()
+}
+collection.zipWithNext { prev, next -> // Why do one parameter was named appropriately, and other was not?
+Pair(prev, next)
 }
 ```
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -88,6 +88,38 @@ fun isNull(str: String) = str.equals(null)
 fun isNull(str: String) = str == null
 ```
 
+### ExplicitItLambdaParameter
+
+Lambda expressions are one of the core features of the language. They often include very small chunks of
+code using only one parameter. In this cases Kotlin can supply the implicit `it` parameter
+to make code more concise. It fits most usecases, but when faced larger or nested chunks of code,
+you might want to add an explicit name for the parameter. Naming it just `it` is meaningless and only
+clutters the code.
+
+**Severity**: Style
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+a?.let { it -> it.plus(1) }
+foo.flatMapObservable { it -> Observable.fromIterable(it) }
+listOfPairs.map(::second).forEach { it ->
+it.execute()
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+a?.let { it.plus(1) } // Much better to use implicit it
+foo.flatMapObservable(Observable::fromIterable) // Here we can have a method reference
+listOfPairs.map(::second).forEach { apiRequest -> // For multiline blocks better come up with meaningful name
+it.execute()
+}
+```
+
 ### ExpressionBodySyntax
 
 Functions which only contain a `return` statement can be collapsed to an expression body. This shortens and


### PR DESCRIPTION
This PR closes #954 by adding a rule that reports all explicitly declared `it` parameters in lambdas, e.g.
```kotlin
foo.flatMapObservable { it -> Observable.fromIterable(it.bar) }
```
