### PR TITLE
clarify error message in verify documentation task

### DIFF
--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -61,7 +61,7 @@ fun assertDefaultConfigUpToDate() {
 
     if (!configDiff.toString().isEmpty()) {
         throw GradleException("The default-detekt-config.yml is not up-to-date. " +
-                "Please build detekt locally to update it.")
+                "Please build detekt locally to update it and commit the changed files.")
     }
 }
 
@@ -74,7 +74,7 @@ fun assertDocumentationUpToDate() {
 
     if (!configDiff.toString().isEmpty()) {
         throw GradleException("The detekt documentation is not up-to-date. " +
-                "Please build detekt locally to update it.")
+                "Please build detekt locally to update it and commit the changed files.")
     }
 }
 


### PR DESCRIPTION
Fixes #1199 

It would be possible to copy all existing documentation, generate the up-to-date documentation, run a diff, then delete the copied documentation to verify this even better.

But that felt quite verbose for a fix that takes just a commit locally. Let me know what you think @rock3r 