### PR TITLE
Revert "Re-add additional empty check for report paths"

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ReportPath.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ReportPath.kt
@@ -8,10 +8,8 @@ import java.nio.file.Paths
 
 /**
  * @author Artur Bosch
- * @author Pavlos-Petros Tournaris
  */
 data class ReportPath(val kind: String, val path: Path) {
-
 	companion object {
 		private const val NUM_OF_PARTS_UNIX = 2
 		private const val NUM_OF_PARTS_WINDOWS = 3
@@ -32,13 +30,7 @@ data class ReportPath(val kind: String, val path: Path) {
 				else -> throw IllegalStateException(ILLEGAL_PARTS_SIZE_ERROR)
 			}
 
-			assertNotEmpty(kind, path)
 			return ReportPath(defaultMapping(kind), Paths.get(path))
-		}
-
-		private fun assertNotEmpty(kind: String, path: String) {
-			require(kind.isNotEmpty()) { "The kind of report must not be empty" }
-			require(path.isNotEmpty()) { "The path of the report must not be empty" }
 		}
 
 		private fun defaultMapping(reportId: String) = when (reportId) {


### PR DESCRIPTION
This reverts commit 4c0df7cd41b7e237064d5363159108d0e8b70323.

AppVeyor is currently red. This is the first commit where it went red with the error:
`Error: Could not find or load main class io.gitlab.arturbosch.detekt.cli.Main`

Hoping this fixes it.