### PR TITLE
[WIP] AppVeyor: Save Gradle cache to the AppVeyor build cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ environment:
 
 init:
   - git config --global --unset core.autocrlf
+  - set GRADLE_OPTS=-Dorg.gradle.daemon=false
 
 install:
   - SET PATH=%JAVA_HOME%\bin;%PATH%
@@ -32,6 +33,14 @@ build_script:
 test_script:
   - detekt-cli\build\install\detekt-cli-shadow\bin\detekt-cli -i . --baseline reports\baseline.xml -f ".*/resources/.*,.*/build/.*" -c detekt-cli\src\main\resources\default-detekt-config.yml,reports\failfast.yml
   - gradlew verifyGeneratorOutput
+
+after_test:
+  - ps: del C:\Users\appveyor\.gradle\caches\modules-2\modules-2.lock
+  - ps: del -Recurse C:\Users\appveyor\.gradle\caches\*\plugin-resolution
+
+cache:
+  - C:\Users\appveyor\.gradle\wrapper
+  - C:\Users\appveyor\.gradle\caches
 
 on_finish:
   - ps: |


### PR DESCRIPTION
Note that this won't save build cache in PRs by default, [according to AppVeyor docs](https://www.appveyor.com/docs/build-cache/#saveupdate-cache-before-build-finishes):
> Note: By default, saving cache is disabled in Pull Request builds. Use Save build cache in Pull Requests checkbox on the General tab of project settings if you need to save cache during PR builds. This setting is not exposed in YAML to prevent unauthorized cache modifications.

This means the build log for this PR will not show the build cache being saved.

The lock file is deleted in `after_test` since that seemed most logical. [See here for other options](https://www.appveyor.com/docs/build-configuration/#build-pipeline).

Closes #1217 