### PR TITLE
Generate one detekt task per source set and pass classpath to CLI

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -23,6 +23,14 @@ class CliArgs : Args {
 					"These filters apply on relative paths from the project root.")
 	var filters: String? = null // Using a converter for List<PathFilter> resulted in a ClassCastException
 
+	// This is currently unused and was added for experimenting with type resolution.
+	@Suppress("detekt:UnusedPrivateMember")
+	@Parameter(names = ["--classpath", "-cp"],
+			required = false,
+			hidden = true,
+			description = "Compile Classpath of the project.")
+	private var classpath: String? = null
+
 	@Parameter(names = ["--config", "-c"],
 			description = "Path to the config file (path/to/config.yml). " +
 					"Multiple configuration files can be specified with ',' or ';' as separator.")

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -43,6 +43,7 @@ val assertjVersion = "3.11.1"
 dependencies {
 	implementation(gradleApi())
 	implementation(kotlin("stdlib"))
+	implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api:1.3.0")
 
 	testImplementation("org.assertj:assertj-core:$assertjVersion")
 	testImplementation("org.jetbrains.spek:spek-api:$spekVersion")

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.extensions.DetektReports
 import io.gitlab.arturbosch.detekt.invoke.BaselineArgument
+import io.gitlab.arturbosch.detekt.invoke.ClasspathArgument
 import io.gitlab.arturbosch.detekt.invoke.CliArgument
 import io.gitlab.arturbosch.detekt.invoke.ConfigArgument
 import io.gitlab.arturbosch.detekt.invoke.DebugArgument
@@ -23,6 +24,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.CompileClasspath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
@@ -48,6 +50,10 @@ open class Detekt : DefaultTask() {
 	@PathSensitive(PathSensitivity.RELATIVE)
 	@SkipWhenEmpty
 	var input: ConfigurableFileCollection = project.layout.configurableFiles()
+
+	@CompileClasspath
+	@Optional
+	var classpath: ConfigurableFileCollection = project.layout.configurableFiles()
 
 	@Input
 	@Optional
@@ -124,6 +130,7 @@ open class Detekt : DefaultTask() {
 	fun check() {
 		val arguments = mutableListOf<CliArgument>() +
 				InputArgument(input) +
+				ClasspathArgument(classpath) +
 				FiltersArgument(filters.orNull) +
 				ConfigArgument(config) +
 				PluginsArgument(plugins.orNull) +

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -7,6 +7,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskProvider
@@ -51,6 +53,7 @@ class DetektPlugin : Plugin<Project> {
 		setOf("kotlin", "kotlin-multiplatform", "kotlin-android", "kotlin2js")
 				.forEach { pluginId ->
 					project.plugins.withId(pluginId) {
+						println("$pluginId exists")
 						project.applyKotlinSourceSetDetektTasks(extension, sourceSets)
 					}
 				}
@@ -69,6 +72,7 @@ class DetektPlugin : Plugin<Project> {
 		project.kotlinSourceSets
 				.filter { !existingSourceSets.contains(it.name) }
 				.forEach { sourceSet ->
+					println(sourceSet.name)
 					existingSourceSets += sourceSet.name
 					val name = "$DETEKT${sourceSet.name.capitalize()}"
 					val description = "Runs detekt on the kotlin ${sourceSet.name} source set."
@@ -106,7 +110,6 @@ class DetektPlugin : Plugin<Project> {
 			it.input.setFrom(project.provider { inputSources })
 			it.classpath.setFrom(project.provider { compileClasspath })
 			it.reportsDir.set(project.provider { extension.customReportsDir })
-			// TODO this does not set the report name correctly
 			it.reports = extension.reports.apply {
 				xml.setReportName(name)
 				html.setReportName(name)
@@ -163,6 +166,7 @@ class DetektPlugin : Plugin<Project> {
 			configuration.defaultDependencies { dependencySet ->
 				@Suppress("USELESS_ELVIS")
 				val version = extension.toolVersion ?: DEFAULT_DETEKT_VERSION
+				println("Using detekt $version")
 				dependencySet.add(project.dependencies.create("io.gitlab.arturbosch.detekt:detekt-cli:$version"))
 			}
 		}
@@ -170,6 +174,7 @@ class DetektPlugin : Plugin<Project> {
 
 	private val Project.sourceSets: SourceSetContainer?
 		get() = project.extensions.findByType(SourceSetContainer::class.java)
+
 
 	private val Project.kotlinSourceSets: NamedDomainObjectCollection<out Named>
 		get() {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -93,6 +93,7 @@ class DetektPlugin : Plugin<Project> {
 											 taskDescription: String,
 											 inputSources: Provider<FileCollection>,
 											 compileClasspath: FileCollection = project.files()): TaskProvider<Detekt> {
+
 		return project.tasks.register(name, Detekt::class.java) {
 			it.description = taskDescription
 			it.debugProp.set(project.provider { extension.debug })
@@ -105,8 +106,10 @@ class DetektPlugin : Plugin<Project> {
 			it.input.setFrom(project.provider { inputSources })
 			it.classpath.setFrom(project.provider { compileClasspath })
 			it.reportsDir.set(project.provider { extension.customReportsDir })
+			// TODO this does not set the report name correctly
 			it.reports = extension.reports.apply {
-				reportName = name
+				xml.setReportName(name)
+				html.setReportName(name)
 			}
 		}
 	}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
@@ -3,9 +3,12 @@ package io.gitlab.arturbosch.detekt.extensions
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
+import org.gradle.internal.impldep.org.testng.xml.Parser.DEFAULT_FILENAME
 import java.io.File
 
-class DetektReport(val type: DetektReportType, private val project: Project) {
+class DetektReport(val type: DetektReportType,
+				   private val project: Project,
+				   private val reportName: String = DEFAULT_FILENAME) {
 
 	var enabled: Boolean? = null
 
@@ -30,7 +33,7 @@ class DetektReport(val type: DetektReportType, private val project: Project) {
 		if (customDestination != null)
 			prop.set(customDestination)
 		else
-			prop.set(File(reportsDir, "$DEFAULT_FILENAME.${type.extension}"))
+			prop.set(File(reportsDir, "$reportName.${type.extension}"))
 
 		return prop.get()
 	}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
@@ -3,16 +3,26 @@ package io.gitlab.arturbosch.detekt.extensions
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
-import org.gradle.internal.impldep.org.testng.xml.Parser.DEFAULT_FILENAME
 import java.io.File
 
 class DetektReport(val type: DetektReportType,
-				   private val project: Project,
-				   private val reportName: String = DEFAULT_FILENAME) {
+				   private val project: Project) {
+
+	private var reportName: String = DEFAULT_FILENAME
 
 	var enabled: Boolean? = null
 
 	var destination: File? = null
+
+	fun setReportName(reportName: String) {
+		val customDestination = destination
+		if (customDestination != null && reportName != DEFAULT_FILENAME) {
+			val parent = customDestination.parent
+			destination = File(parent, "$reportName.${type.extension}")
+		} else {
+			this.reportName = reportName
+		}
+	}
 
 	override fun toString(): String {
 		return "DetektReport(type='$type', enabled=$enabled, destination=$destination)"
@@ -20,21 +30,23 @@ class DetektReport(val type: DetektReportType,
 
 	fun getTargetFileProvider(reportsDir: Provider<File>): Provider<RegularFile> {
 		return project.provider {
-			if (enabled ?: DetektExtension.DEFAULT_REPORT_ENABLED_VALUE)
+			if (enabled ?: DetektExtension.DEFAULT_REPORT_ENABLED_VALUE) {
 				getTargetFile(reportsDir.get())
-			else
+			} else {
 				null
+			}
 		}
 	}
 
 	private fun getTargetFile(reportsDir: File): RegularFile {
 		val prop = project.layout.fileProperty()
 		val customDestination = destination
-		if (customDestination != null)
+		if (customDestination != null) {
 			prop.set(customDestination)
-		else
-			prop.set(File(reportsDir, "$reportName.${type.extension}"))
-
+		} else {
+			val name = "$reportName.${type.extension}"
+			prop.set(File(reportsDir, name))
+		}
 		return prop.get()
 	}
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
@@ -6,11 +6,15 @@ import io.gitlab.arturbosch.detekt.extensions.DetektReportType.XML
 import org.gradle.api.Project
 import org.gradle.util.ConfigureUtil
 
-class DetektReports(project: Project) {
+class DetektReports(private val project: Project) {
 
-	val xml = DetektReport(XML, project)
+	var reportName = ""
 
-	val html = DetektReport(HTML, project)
+	val xml
+		get() = DetektReport(XML, project, reportName)
+
+	val html
+		get() = DetektReport(HTML, project, reportName)
 
 	fun xml(configure: DetektReport.() -> Unit) = xml.configure()
 	fun xml(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, xml)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
@@ -6,15 +6,11 @@ import io.gitlab.arturbosch.detekt.extensions.DetektReportType.XML
 import org.gradle.api.Project
 import org.gradle.util.ConfigureUtil
 
-class DetektReports(private val project: Project) {
+class DetektReports(project: Project) {
 
-	var reportName = ""
+	val xml = DetektReport(XML, project)
 
-	val xml
-		get() = DetektReport(XML, project, reportName)
-
-	val html
-		get() = DetektReport(HTML, project, reportName)
+	val html = DetektReport(HTML, project)
 
 	fun xml(configure: DetektReport.() -> Unit) = xml.configure()
 	fun xml(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, xml)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -7,6 +7,7 @@ private const val DEBUG_PARAMETER = "--debug"
 private const val FILTERS_PARAMETER = "--filters"
 private const val INPUT_PARAMETER = "--input"
 private const val CONFIG_PARAMETER = "--config"
+private const val CLASSPATH_PARAMETER = "--classpath"
 private const val BASELINE_PARAMETER = "--baseline"
 private const val PARALLEL_PARAMETER = "--parallel"
 private const val DISABLE_DEFAULT_RULESETS_PARAMETER = "--disable-default-rulesets"
@@ -21,6 +22,13 @@ internal sealed class CliArgument {
 
 internal object CreateBaselineArgument : CliArgument() {
 	override fun toArgument() = listOf(CREATE_BASELINE_PARAMETER)
+}
+
+internal data class ClasspathArgument(val fileCollection: FileCollection) : CliArgument() {
+	override fun toArgument(): List<String> {
+		if (fileCollection.isEmpty()) return emptyList()
+		return listOf(CLASSPATH_PARAMETER, fileCollection.joinToString(",") { it.absolutePath })	
+	}
 }
 
 internal object GenerateConfigArgument : CliArgument() {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.invoke
 
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
+import java.io.File
 
 private const val DEBUG_PARAMETER = "--debug"
 private const val FILTERS_PARAMETER = "--filters"
@@ -27,7 +28,7 @@ internal object CreateBaselineArgument : CliArgument() {
 internal data class ClasspathArgument(val fileCollection: FileCollection) : CliArgument() {
 	override fun toArgument(): List<String> {
 		if (fileCollection.isEmpty()) return emptyList()
-		return listOf(CLASSPATH_PARAMETER, fileCollection.joinToString(",") { it.absolutePath })	
+		return listOf(CLASSPATH_PARAMETER, fileCollection.joinToString(File.pathSeparator) { it.absolutePath })
 	}
 }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -263,6 +263,9 @@ internal class DetektTaskDslTest : Spek({
 					}
 
 				}
+				it("generates one task for each (java) source set of the project") {
+
+				}
 			}
 		}
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
@@ -21,6 +21,14 @@ class DslGradleRunner(
     	|rootProject.name = "rootDir-project"
 		|include(${projectLayout.submodules.map { "\"${it.name}\"" }.joinToString(",")})
 		|
+		|// Include original detekt dependencies as composite build
+		|includeBuild("${System.getProperty("user.dir")}/../") {
+		|    dependencySubstitution {
+		|    	 // Use local detekt-cli to be able to use local changes to the CLI in Gradle Plugin
+		|    	 // tests immediately.
+		|        substitute module("io.gitlab.arturbosch.detekt:detekt-cli") with project(":detekt-cli")
+		|    }
+		|}
 		""".trimMargin()
 
 	private val baselineContent = """

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt
 
+
 /**
  * @author Markus Schwarz
  */
@@ -12,6 +13,9 @@ abstract class DslTestBuilder {
 	private var projectLayout: ProjectLayout = ProjectLayout(1)
 	private var baselineFile: String? = null
 	private var configFile: String? = null
+	var buildGradleExtension: String? = null
+	var buildGradleKtsExtension: String? = null
+	var baseGradlePlugin: GradlePlugin = GradlePlugin.JavaLibrary
 
 	fun withDetektConfig(config: String): DslTestBuilder {
 		detektConfig = config
@@ -30,6 +34,17 @@ abstract class DslTestBuilder {
 
 	fun withConfigFile(filename: String): DslTestBuilder {
 		configFile = filename
+		return this
+	}
+
+	fun withBuildGradleExtension(buildGradle: String, buildGradleKts: String): DslTestBuilder {
+		buildGradleExtension = buildGradle
+		buildGradleKtsExtension = buildGradleKts
+		return this
+	}
+
+	fun withBaseGradlePlugin(plugin: GradlePlugin): DslTestBuilder {
+		baseGradlePlugin = plugin
 		return this
 	}
 
@@ -52,9 +67,8 @@ abstract class DslTestBuilder {
 		override val gradleBuildName: String = "build.gradle"
 		override val gradleBuildConfig: String = """
 				|import io.gitlab.arturbosch.detekt.DetektPlugin
-				|
 				|plugins {
-				|   id "java-library"
+				|   ${baseGradlePlugin.groovy}
 				|   id "io.gitlab.arturbosch.detekt"
 				|}
 				|
@@ -62,8 +76,8 @@ abstract class DslTestBuilder {
 				|	jcenter()
 				|	mavenLocal()
 				|}
-				""".trimMargin()
-
+				|$buildGradleExtension
+			""".trimMargin()
 	}
 
 	private class KotlinBuilder : DslTestBuilder() {
@@ -72,7 +86,7 @@ abstract class DslTestBuilder {
 				|import io.gitlab.arturbosch.detekt.detekt
 				|
 				|plugins {
-				|   `java-library`
+				|   ${baseGradlePlugin.kotlin}
 				|	id("io.gitlab.arturbosch.detekt")
 				|}
 				|
@@ -80,11 +94,42 @@ abstract class DslTestBuilder {
 				|	jcenter()
 				|	mavenLocal()
 				|}
+				|$buildGradleKtsExtension
 				""".trimMargin()
 	}
 
 	companion object {
 		fun kotlin(): DslTestBuilder = KotlinBuilder()
 		fun groovy(): DslTestBuilder = GroovyBuilder()
+	}
+}
+
+sealed class GradlePlugin {
+	abstract val groovy: String
+	abstract val kotlin: String
+
+	object JavaLibrary : GradlePlugin() {
+		override val groovy = "id \"java-library\""
+		override val kotlin = "`java-library`"
+	}
+
+	object Kotlin : GradlePlugin() {
+		override val groovy = "id \"org.jetbrains.kotlin.jvm\" version \"1.3.0\""
+		override val kotlin = "kotlin(\"jvm\") version \"1.3.0\""
+	}
+
+	object KotlinMultiPlatform : GradlePlugin() {
+		override val groovy = "id \"org.jetbrains.kotlin.multiplatform\" version \"1.3.0\""
+		override val kotlin = "kotlin(\"multiplatform\") version \"1.3.0\""
+	}
+
+	object Kotlin2Js : GradlePlugin() {
+		override val groovy = "id \"org.jetbrains.kotlin.kotlin2js\" version \"1.3.0\""
+		override val kotlin = "kotlin(\"kotlin2js\") version \"1.3.0\""
+	}
+
+	object KotlinAndroid : GradlePlugin() {
+		override val groovy = "id \"org.jetbrains.kotlin.android\" version \"1.3.0\""
+		override val kotlin = "kotlin(\"android\") version \"1.3.0\""
 	}
 }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorTest.kt
@@ -118,5 +118,10 @@ internal class PluginTaskBehaviorTest : Spek({
 				assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 			}
 		}
+		it("should report NO_SOURCE for tasks that point to no sources") {
+			gradleRunner.runDetektTaskAndCheckResult { result ->
+				assertThat(result.task(":detektTest")?.outcome).isEqualTo(TaskOutcome.NO_SOURCE)
+			}
+		}
 	}
 })

--- a/docs/pages/changelog.md
+++ b/docs/pages/changelog.md
@@ -10,6 +10,12 @@ toc: true
 #### Coming up
 The --input parameter is no longer required. If it is missing, the current working directory is used instead.
 
+The detekt Gradle Plugin now generates one task per sourceSet in the Gradle Project. The old `detekt` task remains.
+All detekt tasks are executed with the `./gradlew check` task.
+ - detektMain -> Executes detekt on all sources in the `main` sourceSet
+ - detektTest -> Executes detekt on all sources in the `test` sourceSet
+ - more tasks for each and every sourceSet with the name `detekt{sourceSetName}`
+
 ##### Migration
 
 -->


### PR DESCRIPTION
Wanted to do this as a 2nd stage to #1220 but GitHub doesn't allow me to base the PRs on top of each other.

So here are both changes combined:
- Creating one detekt task per sourceset
- Add the `--classpath` argument to the CLI
- Path classpath to CLI for each sourceset task (not the default `detekt` task at the moment)

This is missing tests, which I will add once we're happy with the changes overall (marking the PR as blocked because of this)

#1198 