### PR TITLE
CliArgs Doc Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Andreas Volkmann](https://github.com/AndreasVolkmann) - yaml code comments
 - [glammers](https://github.com/glammers) - Documentation improvement
 - [Ahmad El-Melegy](https://github.com/mlegy) - yaml syntax fix
+- [Alistair Sykes](https://github.com/alistairsykes) - Doc improvement
 
 ### Mentions
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -57,7 +57,7 @@ class CliArgs : Args {
 	@Parameter(names = ["--report", "-r"],
 			description = "Generates a report for given 'report-id' and stores it on given 'path'. " +
 					"Entry should consist of: [report-id:path]. " +
-		   			"Available 'report-id' values: 'plain', 'xml', 'html' )
+		   			"Available 'report-id' values: 'txt', 'xml', 'html' )
 	private var reports: List<String>? = null
 
 	@Parameter(names = ["--disable-default-rulesets", "-dd"],

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -57,7 +57,9 @@ class CliArgs : Args {
 	@Parameter(names = ["--report", "-r"],
 			description = "Generates a report for given 'report-id' and stores it on given 'path'. " +
 					"Entry should consist of: [report-id:path]. " +
-		   			"Available 'report-id' values: 'txt', 'xml', 'html'")
+		   			"Available 'report-id' values: 'txt', 'xml', 'html'. " +
+		  			"These can also be used in combination with each other " + 
+					"e.g. '-r txt:reports/detekt.txt -r xml:reports/detekt.xml'")
 	private var reports: List<String>? = null
 
 	@Parameter(names = ["--disable-default-rulesets", "-dd"],

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -56,7 +56,8 @@ class CliArgs : Args {
 
 	@Parameter(names = ["--report", "-r"],
 			description = "Generates a report for given 'report-id' and stores it on given 'path'. " +
-					"Entry should consist of: [report-id:path-to-store-report]+")
+					"Entry should consist of: [report-id:path]. " +
+		   			"Available 'report-id' values: 'plain', 'xml', 'html' )
 	private var reports: List<String>? = null
 
 	@Parameter(names = ["--disable-default-rulesets", "-dd"],

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -57,7 +57,7 @@ class CliArgs : Args {
 	@Parameter(names = ["--report", "-r"],
 			description = "Generates a report for given 'report-id' and stores it on given 'path'. " +
 					"Entry should consist of: [report-id:path]. " +
-		   			"Available 'report-id' values: 'txt', 'xml', 'html' )
+		   			"Available 'report-id' values: 'txt', 'xml', 'html'")
 	private var reports: List<String>? = null
 
 	@Parameter(names = ["--disable-default-rulesets", "-dd"],


### PR DESCRIPTION
Issue: #1113. The documentation around the --report option didn't specify the available 'report-id''s. 

- Updated to include available report-id's
- Remove the stray '+' within the comment.
- Changed "path-to-store-report" to "path", since path has already been mention "and stores it on given 'path'". Therefore should be consistent for clarity.