### PR TITLE
AppVeyor: Timeout before deleting Gradle lock file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,6 @@ environment:
 
 init:
   - git config --global --unset core.autocrlf
-  - set GRADLE_OPTS=-Dorg.gradle.daemon=false
 
 install:
   - SET PATH=%JAVA_HOME%\bin;%PATH%
@@ -35,6 +34,8 @@ test_script:
   - gradlew verifyGeneratorOutput
 
 after_test:
+  - gradlew --stop
+  - timeout 3 >nul
   - ps: del C:\Users\appveyor\.gradle\caches\modules-2\modules-2.lock
   - ps: del -Recurse C:\Users\appveyor\.gradle\caches\*\plugin-resolution
 


### PR DESCRIPTION
And re-enable the Gradle daemon.

(Hopefully) fixes #1230 finally leading to reliable builds on AppVeyor.

I did manage to replicate [this problem](https://github.com/arturbosch/detekt/pull/1218#issuecomment-428409486) locally - seems that the process the daemon spawns when running a task is not cleaned up before the daemon itself shuts down. Whether that's a bug in Gradle or in one of the components used when the task runs is unclear, but hopefully this works around it.

If not we'll do [option 3](https://github.com/arturbosch/detekt/pull/1218#issuecomment-428424899) and move on with our lives.