### PR TITLE
Exclude external functions from unused parameter check.

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtModifierList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtModifierList.kt
@@ -12,6 +12,8 @@ fun KtModifierListOwner.isOverridden() = hasModifier(KtTokens.OVERRIDE_KEYWORD)
 
 fun KtModifierListOwner.isOpen() = hasModifier(KtTokens.OPEN_KEYWORD)
 
+fun KtModifierListOwner.isExternal() = hasModifier(KtTokens.EXTERNAL_KEYWORD)
+
 fun KtModifierListOwner.isOperator() = hasModifier(KtTokens.OPERATOR_KEYWORD)
 
 fun KtModifierListOwner.isPublic(): Boolean {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.isAbstract
+import io.gitlab.arturbosch.detekt.rules.isExternal
 import io.gitlab.arturbosch.detekt.rules.isMainFunction
 import io.gitlab.arturbosch.detekt.rules.isOpen
 import io.gitlab.arturbosch.detekt.rules.isOperator
@@ -149,12 +150,8 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 		if (function.isPrivate()) {
 			collectFunction(function)
 		}
-		// Overriddable/Overridden functions need to declare parameters, even if they don't use them
-		when {
-			function.isAbstract() || function.isOpen() || function.isOverridden() || function.isOperator() ||
-					function.isMainFunction() -> {
-			}
-			else -> collectParameters(function)
+		if (function.isRelevant()) {
+			collectParameters(function)
 		}
 
 		super.visitNamedFunction(function)
@@ -236,4 +233,9 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 			callExpressions.add(calledMethodName)
 		}
 	}
+
+	private fun KtNamedFunction.isRelevant() = !isAllowedToHaveUnusedParameters()
+
+	private fun KtNamedFunction.isAllowedToHaveUnusedParameters() =
+			isAbstract() || isOpen() || isOverridden() || isOperator() || isMainFunction() || isExternal()
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -49,6 +49,14 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 		}
 	}
 
+	given("external functions") {
+
+		it("should not report parameters in external functions") {
+			val code = "external fun foo(bar: String)"
+			assertThat(subject.lint(code)).isEmpty()
+		}
+	}
+
 	given("overridden functions") {
 
 		it("should not report parameters in not private functions") {


### PR DESCRIPTION
This resolves #1227.