### PR TITLE
fix test-pattern to support windows path separator

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -4,7 +4,7 @@ failFast: false
 test-pattern: # Configure exclusions for test sources
   active: true
   patterns: # Test file regexes
-    - '.*/test/.*'
+    - '.*(/|\\)test(/|\\).*'
     - '.*Test.kt'
     - '.*Spec.kt'
   exclude-rule-sets:

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektorTest.kt
@@ -25,5 +25,7 @@ private fun runDetektWithPattern(patternToUse: String) {
 			listOf(TestProvider(), TestProvider2()), emptyList())
 
 	val run = instance.run()
-	assertThat(run.findings["Test"]?.none { "Test.kt" in it.file } ?: true).isTrue()
+	assertThat(run.findings["Test"] ?: listOf())
+		.filteredOn { "Test.kt" in it.file || "SomeUnusedClass.kt" in it.file }
+		.isEmpty()
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
@@ -28,7 +28,7 @@ class KtTreeCompilerSpec : Spek({
 
 		it("should work with two or more filters") {
 			val filter = PathFilter(".*Default.kt")
-			val filterTwo = PathFilter(".*Test.*")
+			val filterTwo = PathFilter(".*Test.*|.*SomeUnusedClass.*")
 			val filterThree = PathFilter(".*Complex.*")
 			val filterFour = PathFilter(".*KotlinScript.*")
 			val ktFiles = KtTreeCompiler(filters = listOf(filter, filterTwo, filterThree, filterFour)).compile(path)

--- a/detekt-core/src/test/resources/cases/test/SomeUnusedClass.kt
+++ b/detekt-core/src/test/resources/cases/test/SomeUnusedClass.kt
@@ -1,0 +1,4 @@
+package cases.test
+
+@Suppress("Unused")
+class SomeUnusedClass

--- a/detekt-core/src/test/resources/patterns/exclude-FindName.yml
+++ b/detekt-core/src/test/resources/patterns/exclude-FindName.yml
@@ -1,7 +1,7 @@
 test-pattern:
   active: true
   patterns:
-    - '.*/test/.*'
+    - '.*(/|\\)test(/|\\).*'
     - '.*Test.kt'
   exclude-rule-sets:
   exclude-rules:

--- a/detekt-core/src/test/resources/patterns/test-pattern.yml
+++ b/detekt-core/src/test/resources/patterns/test-pattern.yml
@@ -1,7 +1,7 @@
 test-pattern:
   active: true
   patterns:
-    - '.*/test/.*'
+    - '.*(/|\\)test(/|\\).*'
     - '.*Test.kt'
   exclude-rule-sets:
     - 'Test'

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -73,7 +73,7 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
 			test-pattern: # Configure exclusions for test sources
 			  active: true
 			  patterns: # Test file regexes
-			    - '.*/test/.*'
+			    - '.*(/|\\)test(/|\\).*'
 			    - '.*Test.kt'
 			    - '.*Spec.kt'
 			  exclude-rule-sets:

--- a/docs/pages/configurations.md
+++ b/docs/pages/configurations.md
@@ -39,7 +39,7 @@ Specify test patterns to detect test code and exclude rules or rule sets for the
 test-pattern: # Configure exclusions for test sources
   active: true
   patterns: # Test file regexes
-    - '.*/test/.*'
+    - '.*(/|\\)test(/|\\).*'
     - '.*Test.kt'
     - '.*Spec.kt'
   exclude-rule-sets:


### PR DESCRIPTION
The current default value does not work on Windows machines or rather on file systems which use `\` as file separator.

Another possibility would be -- and that would certainly be nicer-- if one can define `/` and it works on Windows as well.
