### PR TITLE
AppVeyor: Disable Kotlin's incremental build support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
 
 init:
   - git config --global --unset core.autocrlf
-  - set GRADLE_OPTS=-Dorg.gradle.daemon=false
+  - set GRADLE_OPTS="-Dorg.gradle.daemon=false -Pkotlin.incremental=false"
 
 install:
   - SET PATH=%JAVA_HOME%\bin;%PATH%


### PR DESCRIPTION
(Hopefully) fixes #1230 finally leading to reliable builds on AppVeyor.

Have now done three green AppVeyor builds with this configuration before submitting the PR (so will be 4 in a row if the PR build is OK).

Kotlin incremental compilation and Gradle daemon are now both disabled. Unlikely to have much effect on build speed (AppVeyor's build times are all over the place as it is).