### PR TITLE
run travis build on windows and linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: java
+os:
+  - linux
+  - windows
 jdk:
   - oraclejdk8
   - oraclejdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: java
+language: shell
 os:
   - linux
   - windows


### PR DESCRIPTION
Travis announced the early release of support for windows builds and multi-OS builds. https://blog.travis-ci.com/2018-10-11-windows-early-release

This means we can run a build on Windows and Linux both on Travis. As we've had quite a few issues with AppVeyor recently while Travis was more stable, this seems worth a try.

We should fix #1212 before relying purely on Travis, though.