### PR TITLE
Fixed #1238 - MethodOverloading false positive

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
 
 /**
  * This rule reports methods which are overloaded often.
@@ -62,7 +63,11 @@ class MethodOverloading(config: Config = Config.empty,
 		}
 
 		override fun visitNamedFunction(function: KtNamedFunction) {
-			val name = function.name ?: return
+			var name = function.name ?: return
+			val receiver = function.receiverTypeReference
+			if (function.isExtensionDeclaration() && receiver != null) {
+				name = receiver.text + '.' + name
+			}
 			methods[name] = methods.getOrDefault(name, 0) + 1
 		}
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
@@ -26,5 +26,21 @@ class MethodOverloadingSpec : SubjectSpek<MethodOverloading>({
 				}""")
 			assertThat(subject.findings.size).isZero()
 		}
+
+		it("does not report extension methods with a different receiver") {
+			subject.lint("""
+				fun Boolean.foo() {}
+				fun Int.foo() {}
+				fun Long.foo() {}""")
+			assertThat(subject.findings.size).isZero()
+		}
+
+		it("reports extension methods with the same receiver") {
+			subject.lint("""
+				fun Int.foo() {}
+				fun Int.foo(i: Int) {}
+				fun Int.foo(i: String) {}""")
+			assertThat(subject.findings.size).isEqualTo(1)
+		}
 	}
 })


### PR DESCRIPTION
Fixed a case where the MethodOverloading rule reports a false positive if extension functions for different receivers are used.
reference #1238 
