### PR TITLE
Removed `MaximumLineLength`

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -214,9 +214,6 @@ formatting:
     autoCorrect: true
     indentSize: 4
     continuationIndentSize: 4
-  MaximumLineLength:
-    active: true
-    maxLineLength: 120
   ModifierOrdering:
     active: true
     autoCorrect: true


### PR DESCRIPTION
I wondered why changing this dind't do anything. Apparently it's called `MaxLineLength` and already present.