### PR TITLE
Change --filters argument to only check relative paths

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -19,7 +19,8 @@ class CliArgs : Args {
 	private var input: String? = null
 
 	@Parameter(names = ["--filters", "-f"],
-			description = "Path filters defined through regex with separator ';' or ',' (\".*test.*\").")
+			description = "Path filters defined through regex with separator ';' or ',' (\".*test.*\"). " + 
+                    "These filters apply on relative paths from the project root.")
 	var filters: String? = null // Using a converter for List<PathFilter> resulted in a ClassCastException
 
 	@Parameter(names = ["--config", "-c"],

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -15,7 +15,7 @@ fun CliArgs.createPathFilters(): List<PathFilter> = filters.letIfNonEmpty {
 			.asSequence()
 			.map { it.trim() }
 			.filter { it.isNotEmpty() }
-			.map(::PathFilter)
+			.map { filter -> PathFilter(filter) }
 			.toList()
 }
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/PathFilter.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/PathFilter.kt
@@ -1,12 +1,17 @@
 package io.gitlab.arturbosch.detekt.core
 
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.regex.PatternSyntaxException
 
 /**
+ * Filter that works on relative paths to the project root.
+ * Filters out files that match the regex defined in the CLI --filters argument.
+ * Respects both *nix and Windows paths.
+ *
  * @author Artur Bosch
  */
-class PathFilter(pattern: String) {
+class PathFilter(pattern: String, private val root: Path = Paths.get("").toAbsolutePath()) {
 
 	companion object {
 		val IS_WINDOWS = System.getProperty("os.name").contains("Windows")
@@ -27,7 +32,17 @@ class PathFilter(pattern: String) {
 		}
 	}
 
-	fun matches(path: Path): Boolean = path.toAbsolutePath().toString().matches(regex)
+	fun matches(path: Path): Boolean {
+		val prefix = if (IS_WINDOWS) {
+			"\\"
+		} else {
+			"./"
+		}
+		val relativePath = "$prefix${root.relativize(path)}"
+		println(root)
+		println(relativePath)
+		return relativePath.matches(regex)
+	}
 
 	override fun equals(other: Any?): Boolean {
 		if (this === other) return true

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/PathFilter.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/PathFilter.kt
@@ -33,14 +33,16 @@ class PathFilter(pattern: String, private val root: Path = Paths.get("").toAbsol
 	}
 
 	fun matches(path: Path): Boolean {
-		val prefix = if (IS_WINDOWS) {
-			"\\"
+		val relativePath = if (path.isAbsolute()) {
+			val prefix = if (IS_WINDOWS) {
+				"\\"
+			} else {
+				"./"
+			}
+			"$prefix${root.relativize(path)}"
 		} else {
-			"./"
+			path.toString()
 		}
-		val relativePath = "$prefix${root.relativize(path)}"
-		println(root)
-		println(relativePath)
 		return relativePath.matches(regex)
 	}
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/PathFilter.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/PathFilter.kt
@@ -33,15 +33,19 @@ class PathFilter(pattern: String, private val root: Path = Paths.get("").toAbsol
 	}
 
 	fun matches(path: Path): Boolean {
-		val relativePath = if (path.isAbsolute()) {
-			val prefix = if (IS_WINDOWS) {
+		val prefix = if (IS_WINDOWS) {
 				"\\"
 			} else {
 				"./"
 			}
+		val relativePath = if (path.isAbsolute()) {
 			"$prefix${root.relativize(path)}"
 		} else {
-			path.toString()
+			if (!path.startsWith(prefix)) {
+				"$prefix${path.toString()}"
+			} else {
+				path.toString()
+			}
 		}
 		return relativePath.matches(regex)
 	}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/PathFilterSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/PathFilterSpec.kt
@@ -27,19 +27,40 @@ internal class PathFilterSpec : Spek({
 		}
 	}
 
-	given("a single regex pattern") {
-		val pathFilter = PathFilter(".*/build/.*")
+	given("a single regex pattern on Unix systems") {
+		val filter = ".*/build/.*"
+		val defaultRoot = Paths.get("").toAbsolutePath()
 
-		it("matches a corresponding path") {
-			val path = Paths.get("/tmp/whatever/detekt/build/should/match")
+		it("matches a corresponding relative path") {
+			val path = defaultRoot.resolve("some/build/path/should/match")
 
-			assertThat(pathFilter.matches(path)).isTrue()
+			assertThat(PathFilter(filter).matches(path)).isTrue()
+		}
+
+		it("matches a corresponding relative path with the filter in the beginning") {
+			val path = defaultRoot.resolve("build/path/should/match")
+
+			assertThat(PathFilter(filter).matches(path)).isTrue()
 		}
 
 		it("does not match an unrelated path") {
-			val path = Paths.get("/tmp/whatever/detekt/this/should/NOT/match")
+			val path = defaultRoot.resolve("this/should/NOT/match")
 
-			assertThat(pathFilter.matches(path)).isFalse()
+			assertThat(PathFilter(filter).matches(path)).isFalse()
+		}
+
+		it("does not match the pattern in the absolute path") {
+			val root = Paths.get("/tmp/build/detekt").toAbsolutePath()
+			val path = root.resolve("should/not/match")
+
+			assertThat(PathFilter(filter, root).matches(path)).isFalse()
+		}
+
+		it("does not match the pattern in the absolute path but the relative path") {
+			val root = Paths.get("/tmp/detekt").toAbsolutePath()
+			val path = root.resolve("should/match/build/path")
+
+			assertThat(PathFilter(filter, root).matches(path)).isTrue()
 		}
 	}
 })

--- a/docs/pages/changelog.md
+++ b/docs/pages/changelog.md
@@ -30,6 +30,8 @@ dependencies {
 
 The report id `plain` has been renamed to `txt`. If you were using `--report "plain:/tmp/plaintxt"` before it's now `--report "txt:/tmp/plaintxt"`.
 
+The `--filters` argument no longer checks on the absolute path of files, but rather relative paths to the project root.
+
 -->
 
 #### RC9.2


### PR DESCRIPTION
Fixes #1212 and should therefore also allow Travis to again check files during the CI build.

This change will make the `--filters` argument only operate on the relative path to from the current directory.
This would be:
 - Possibly wherever the user currently invokes the CLI from manually
 - The root of the project/module if using the Gradle plugin
