### PR TITLE
Travis: oraclejdk10 > openjdk10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
+  - openjdk10
 script:
   - ./gradlew build -PwarningsAsErrors=true
   - ./gradlew shadowJar


### PR DESCRIPTION
Closes #1251.

Oracle :heart: license agreements. If you try and download from the URL that Travis is trying to use, you get this error:

![image](https://user-images.githubusercontent.com/170028/47127342-76a39100-d2d8-11e8-980a-ab232f5ddba3.png)

Travis may come up with a solution but in case they don't it's simple enough to switch from Oracle's to OpenJDK's build for JDK 10.