### PR TITLE
Use PathFilter in TestPattern to make patterns OS independent

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/TestPattern.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/TestPattern.kt
@@ -3,28 +3,35 @@ package io.gitlab.arturbosch.detekt.core
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.core.TestPattern.Companion.TEST_PATTERN_SUB_CONFIG
 import org.jetbrains.kotlin.psi.KtFile
+import java.nio.file.Path
+import java.nio.file.Paths
 
 /**
  * @author Artur Bosch
  */
 
-fun createTestPattern(config: Config) = with(config.subConfig(TEST_PATTERN_SUB_CONFIG)) {
-	TestPattern(valueOrDefault(TestPattern.ACTIVE, false),
-			valueOrDefault(TestPattern.PATTERNS, TestPattern.DEFAULT_PATTERNS).toSet(),
-			valueOrDefault(TestPattern.EXCLUDE_RULES, emptyList<String>()).toSet(),
-			valueOrDefault(TestPattern.EXCLUDE_RULE_SETS, emptyList<String>()).toSet())
+fun createTestPattern(config: Config,
+					  root: Path = Paths.get("").toAbsolutePath()): TestPattern {
+	return with(config.subConfig(TEST_PATTERN_SUB_CONFIG)) {
+		TestPattern(valueOrDefault(TestPattern.ACTIVE, false),
+				valueOrDefault(TestPattern.PATTERNS, TestPattern.DEFAULT_PATTERNS).toSet(),
+				valueOrDefault(TestPattern.EXCLUDE_RULES, emptyList<String>()).toSet(),
+				valueOrDefault(TestPattern.EXCLUDE_RULE_SETS, emptyList<String>()).toSet(),
+				root)
+	}
 }
 
 data class TestPattern(val active: Boolean,
-					   private val patterns: Set<String>,
+					   val patterns: Set<String>,
 					   val excludingRules: Set<String>,
-					   private val excludingRuleSets: Set<String>) {
+					   private val excludingRuleSets: Set<String>,
+					   private val root: Path) {
 
-	private val _patterns = patterns.map { Regex(it) }
+	private val _patterns = patterns.map { PathFilter(it, root) }
 
-	fun matches(path: String) = _patterns.any { it.matches(path) }
+	fun matches(path: String) = _patterns.any { it.matches(Paths.get(path)) }
 	fun matchesRuleSet(ruleSet: String) = excludingRuleSets.any { it == ruleSet }
-	fun isTestSource(file: KtFile) = active && file.relativePath()?.let { matches(it) } == true
+	fun isTestSource(file: KtFile) = active && file.absolutePath()?.let { matches(it) } == true
 
 	companion object {
 		const val TEST_PATTERN_SUB_CONFIG = "test-pattern"

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TestPatternTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TestPatternTest.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.core
 
-import io.gitlab.arturbosch.detekt.api.SplitPattern
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
@@ -25,7 +24,7 @@ class TestPatternTest : Spek({
 			val path = "./test/SomeFile.kt"
 			val (testSources, mainSources) = splitSources(defaultPattern, Paths.get(path))
 
-			assertThat(testSources).allMatch { it.toString().endsWith(path) }
+			assertThat(testSources).allMatch { it.toString().endsWith(path.toFile()) }
 			assertThat(testSources).isNotEmpty()
 			assertThat(mainSources).isEmpty()
 		}
@@ -34,7 +33,7 @@ class TestPatternTest : Spek({
 			val path = "./path/test/SomeFile.kt"
 			val (testSources, mainSources) = splitSources(defaultPattern, Paths.get(path))
 
-			assertThat(testSources).allMatch { it.toString().endsWith(path) }
+			assertThat(testSources).allMatch { it.toString().endsWith(path.toFile()) }
 			assertThat(testSources).isNotEmpty()
 			assertThat(mainSources).isEmpty()
 		}
@@ -43,7 +42,7 @@ class TestPatternTest : Spek({
 			val path = "./some/path/abcTest.kt"
 			val (testSources, mainSources) = splitSources(defaultPattern, Paths.get(path))
 
-			assertThat(testSources).allMatch { it.toString().endsWith(path) }
+			assertThat(testSources).allMatch { it.toString().endsWith(path.toFile()) }
 			assertThat(testSources).isNotEmpty()
 			assertThat(mainSources).isEmpty()
 		}
@@ -54,7 +53,7 @@ class TestPatternTest : Spek({
 			val (testSources, mainSources) = splitSources(pattern, Paths.get(path))
 
 			assertThat(testSources).isEmpty()
-			assertThat(mainSources).allMatch { it.toString().endsWith(path) }
+			assertThat(mainSources).allMatch { it.toString().endsWith(path.toFile()) }
 			assertThat(mainSources).isNotEmpty()
 		}
 
@@ -63,8 +62,10 @@ class TestPatternTest : Spek({
 			val (testSources, mainSources) = splitSources(defaultPattern, Paths.get(path))
 
 			assertThat(testSources).isEmpty()
-			assertThat(mainSources).allMatch { it.toString().endsWith(path) }
+			assertThat(mainSources).allMatch { it.toString().endsWith(path.toFile()) }
 			assertThat(mainSources).isNotEmpty()
 		}
 	}
 })
+
+private fun String.toFile() = this.split('/').last()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TestPatternTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TestPatternTest.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.SplitPattern
 import io.gitlab.arturbosch.detekt.test.yamlConfig
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
@@ -14,29 +14,57 @@ import java.nio.file.Paths
  */
 class TestPatternTest : Spek({
 
-	given("a bunch of paths") {
-		val pathContent = """
-			a/b/c/test/abcTest.kt,
-			a/b/c/test/adeTest.kt,
-			a/b/c/test/afgTest.kt,
-			a/b/c/d/ab.kt,
-			a/b/c/d/bb.kt,
-			a/b/c/d/cb.kt
-		"""
+	given("a test pattern for paths") {
 
-		val paths = SplitPattern(pathContent).mapAll { Paths.get(it) }
+		fun splitSources(pattern: TestPattern, path: Path): Pair<List<Path>, List<Path>> =
+				listOf(path).partition { pattern.matches(it.toString()) }
 
-		fun splitSources(pattern: TestPattern, paths: List<Path>): Pair<List<Path>, List<Path>> =
-				paths.partition { pattern.matches(it.toString()) }
+		val defaultPattern = createTestPattern(yamlConfig("patterns/test-pattern.yml"))
 
-		fun preparePattern() = createTestPattern(yamlConfig("patterns/test-pattern.yml"))
+		it("should identify a kt file in test path as test source with test as the first directory") {
+			val path = "./test/SomeFile.kt"
+			val (testSources, mainSources) = splitSources(defaultPattern, Paths.get(path))
 
-		it("should split the given paths to main and test sources") {
-			val pattern = preparePattern()
-			val (testSources, mainSources) = splitSources(pattern, paths)
+			assertThat(testSources).allMatch { it.toString().endsWith(path) }
+			assertThat(testSources).isNotEmpty()
+			assertThat(mainSources).isEmpty()
+		}
 
-			Assertions.assertThat(testSources).allMatch { it.toString().endsWith("Test.kt") }
-			Assertions.assertThat(mainSources).allMatch { it.toString().endsWith("b.kt") }
+		it("should identify a kt file in test path as test source") {
+			val path = "./path/test/SomeFile.kt"
+			val (testSources, mainSources) = splitSources(defaultPattern, Paths.get(path))
+
+			assertThat(testSources).allMatch { it.toString().endsWith(path) }
+			assertThat(testSources).isNotEmpty()
+			assertThat(mainSources).isEmpty()
+		}
+
+		it("should identify kt Test file as test source") {
+			val path = "./some/path/abcTest.kt"
+			val (testSources, mainSources) = splitSources(defaultPattern, Paths.get(path))
+
+			assertThat(testSources).allMatch { it.toString().endsWith(path) }
+			assertThat(testSources).isNotEmpty()
+			assertThat(mainSources).isEmpty()
+		}
+
+		it("should not identify kt files in an absolute path containing test as test source") {
+			val pattern = createTestPattern(yamlConfig("patterns/test-pattern.yml"), Paths.get("/path/test/detekt"))
+			val path = "./some/path/SomeFile.kt"
+			val (testSources, mainSources) = splitSources(pattern, Paths.get(path))
+
+			assertThat(testSources).isEmpty()
+			assertThat(mainSources).allMatch { it.toString().endsWith(path) }
+			assertThat(mainSources).isNotEmpty()
+		}
+
+		it("should not identify a non-test kt file as test source") {
+			val path = "./some/path/abc.kt"
+			val (testSources, mainSources) = splitSources(defaultPattern, Paths.get(path))
+
+			assertThat(testSources).isEmpty()
+			assertThat(mainSources).allMatch { it.toString().endsWith(path) }
+			assertThat(mainSources).isNotEmpty()
 		}
 	}
 })


### PR DESCRIPTION
`PathFilter` already handles Windows vs. Unix paths. By using `PathFilter` in `TestPattern` we should be able to also apply the test patterns on both OS.

This PR currently contains all the changes from #1250 as well. Only `TestPattern` and `TestPatternTest` were changed for this PR. I'll rebase once #1250 is merged.

This should fix the issue described in #1234 in detekt itself instead of relying on the regex to be OS independent.