### PR TITLE
Remove duplicate configurations for reports.

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt
 
-import groovy.lang.Closure
 import io.gitlab.arturbosch.detekt.extensions.DetektReports
 import io.gitlab.arturbosch.detekt.invoke.BaselineArgument
 import io.gitlab.arturbosch.detekt.invoke.CliArgument
@@ -14,6 +13,7 @@ import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
 import io.gitlab.arturbosch.detekt.invoke.PluginsArgument
 import io.gitlab.arturbosch.detekt.invoke.XmlReportArgument
+import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
@@ -35,7 +35,6 @@ import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.property
 import org.gradle.language.base.plugins.LifecycleBasePlugin
-import org.gradle.util.ConfigureUtil
 import java.io.File
 
 /**
@@ -96,9 +95,8 @@ open class Detekt : DefaultTask() {
 	@Internal
 	var reports = DetektReports(project)
 
-	fun reports(closure: Closure<*>): DetektReports = ConfigureUtil.configure(closure, reports)
+	fun reports(configure: Action<DetektReports>) = configure.execute(reports)
 
-	fun reports(configure: DetektReports.() -> Unit) = reports.configure()
 	@Internal
 	@Optional
 	var reportsDir: Property<File> = project.objects.property()

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -1,10 +1,9 @@
 package io.gitlab.arturbosch.detekt.extensions
 
-import groovy.lang.Closure
+import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.plugins.quality.CodeQualityExtension
-import org.gradle.util.ConfigureUtil
 import java.io.File
 
 /**
@@ -19,13 +18,10 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
 		get() = reportsDir
 
 	val reports = DetektReports(project)
-	fun reports(configure: DetektReports.() -> Unit) = reports.configure()
-	fun reports(configure: Closure<*>): DetektReports = ConfigureUtil.configure(configure, reports)
-
+	fun reports(configure: Action<DetektReports>) = configure.execute(reports)
 
 	val idea = IdeaExtension()
-	fun idea(configure: IdeaExtension.() -> Unit) = idea.configure()
-	fun idea(configure: Closure<*>): IdeaExtension = ConfigureUtil.configure(configure, idea)
+	fun idea(configure: Action<IdeaExtension>) = configure.execute(idea)
 
 	var input: ConfigurableFileCollection = project.layout.configurableFiles(DEFAULT_SRC_DIR_JAVA, DEFAULT_SRC_DIR_KOTLIN)
 


### PR DESCRIPTION
Right before #1194 was merged @JLLeitschuh commented that the functions that let the user configure reports can be expressed by a single function using an `Action`.