### PR TITLE
Split UnnecessaryApply tests

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -11,12 +11,12 @@ class UnnecessaryApplySpec : SubjectSpek<UnnecessaryApply>({
 
 	subject { UnnecessaryApply(Config.empty) }
 
-	given("unnecessary applies that can be changed to ordinary method call") {
+	given("unnecessary apply expressions that can be changed to ordinary method call") {
 
 		it("reports an apply on non-nullable type") {
 			assertThat(subject.lint("""
 				fun f() {
-					val a : Int? = null
+					val a : Int = 0
 					a.apply {
 						plus(1)
 					}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -56,7 +56,7 @@ class UnnecessaryApplySpec : SubjectSpek<UnnecessaryApply>({
 						toString()
 					})
 				}
-			""")).hasSize(1)
+			""")).isEmpty()
 		}
 
 		it("does not report applies with lambda body containing more than one statement") {


### PR DESCRIPTION
- fixes formatting issues due to activation of detekt-formatting
- splits positive test cases