### PR TITLE
Add rule for detecting arrays of primitive types in function parameters

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -352,6 +352,8 @@ naming:
 
 performance:
   active: true
+  ArrayPrimitive:
+    active: false
   ForEachOnRange:
     active: true
   SpreadOperator:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
@@ -1,0 +1,58 @@
+package io.gitlab.arturbosch.detekt.rules.performance
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtParameter
+
+/**
+ * Using Array<Primitive> leads to implicit boxing and performance hit. Prefer using Kotlin specialized Array
+ * Instances.
+ *
+ * As stated in the Kotlin [documention](https://kotlinlang.org/docs/reference/basic-types.html#arrays) Kotlin has
+ * specialized arrays to represent primitive types without boxing overhead, such as `IntArray`, `ByteArray` and so on.
+ *
+ * <noncompliant>
+ * fun function(array: Array<Int>)
+ * </noncompliant>
+ *
+ * <compliant>
+ * fun function(array: IntArray)
+ * </compliant>
+ *
+ * @author elaydis
+ * @author inytar
+ */
+class ArrayPrimitive(config: Config = Config.empty) : Rule(config) {
+
+	override val issue = Issue("ArrayPrimitive",
+			Severity.Performance,
+			"Using Array<Primitive> leads to implicit boxing and a performance hit",
+			Debt.FIVE_MINS)
+
+	override fun visitParameter(parameter: KtParameter) {
+		val regex = Regex("""^Array<(\w+)>$""")
+		val matchResult = regex.find(parameter.typeReference?.text as CharSequence)
+		matchResult?.let {
+			val type = it.destructured.component1()
+			if (type in primitiveTypes) {
+				report(CodeSmell(issue, Entity.from(parameter), issue.description))
+			}
+		}
+		super.visitParameter(parameter)
+	}
+
+	private val primitiveTypes = listOf(
+			"Int",
+			"Double",
+			"Float",
+			"Short",
+			"Byte",
+			"Long",
+			"Char"
+	)
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
@@ -38,8 +38,6 @@ import org.jetbrains.kotlin.psi.KtTypeReference
  */
 class ArrayPrimitive(config: Config = Config.empty) : Rule(config) {
 
-	private val regex = Regex("""Array<(\w+)>""")
-
 	override val issue = Issue("ArrayPrimitive",
 			Severity.Performance,
 			"Using Array<Primitive> leads to implicit boxing and a performance hit",

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
@@ -34,7 +34,7 @@ import org.jetbrains.kotlin.psi.KtParameter
  */
 class ArrayPrimitive(config: Config = Config.empty) : Rule(config) {
 
-	private val regex = Regex("""^Array<(\w+)>$""")
+	private val regex = Regex("""Array<(\w+)>""")
 
 	override val issue = Issue("ArrayPrimitive",
 			Severity.Performance,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PerformanceProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PerformanceProvider.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.providers
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.rules.performance.ArrayPrimitive
 import io.gitlab.arturbosch.detekt.rules.performance.ForEachOnRange
 import io.gitlab.arturbosch.detekt.rules.performance.SpreadOperator
 import io.gitlab.arturbosch.detekt.rules.performance.UnnecessaryTemporaryInstantiation
@@ -21,7 +22,8 @@ class PerformanceProvider : RuleSetProvider {
 		return RuleSet(ruleSetId, listOf(
 				ForEachOnRange(config),
 				SpreadOperator(config),
-				UnnecessaryTemporaryInstantiation(config)
+				UnnecessaryTemporaryInstantiation(config),
+				ArrayPrimitive(config)
 		))
 	}
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
@@ -9,8 +9,8 @@ import org.jetbrains.spek.subject.SubjectSpek
 class ArrayPrimitiveSpec : SubjectSpek<ArrayPrimitive>({
 	subject { ArrayPrimitive() }
 
-	describe("function parameter") {
-		it("is Array<Primitive>") {
+	describe("one function parameter") {
+		it("is an array of primitive type") {
 			val code = "fun function(array: Array<Int>) {}"
 			subject.lint(code)
 			assertThat(subject.findings.size).isEqualTo(1)
@@ -23,15 +23,53 @@ class ArrayPrimitiveSpec : SubjectSpek<ArrayPrimitive>({
 		}
 
 		it("is a specialized array") {
-			val code = "fun function(array: IntArray) {}"
+			val code = "fun function(array: ByteArray) {}"
+			subject.lint(code)
+			assertThat(subject.findings.size).isZero()
+		}
+
+		it("is not present") {
+			val code = "fun function() {}"
+			subject.lint(code)
+			assertThat(subject.findings.size).isZero()
+		}
+
+		it("is an array of a non-primitive type") {
+			val code = "fun function(array: Array<String>) {}"
+			subject.lint(code)
+			assertThat(subject.findings.size).isZero()
+		}
+
+		it("is an array of an array of a primitive type") {
+			val code = "fun function(array: Array<Array<Int>>) {}"
+			subject.lint(code)
+			assertThat(subject.findings.size).isEqualTo(1)
+		}
+
+		it("is an array of an array of a non-primitive type") {
+			val code = "fun function(array: Array<Array<String>>) {}"
 			subject.lint(code)
 			assertThat(subject.findings.size).isZero()
 		}
 	}
 
+	describe("multiple function parameters") {
+		it("one is Array<Primitive> and the other is not") {
+			val code = "fun function(array: Array<Int>, array2: IntArray) {}"
+			subject.lint(code)
+			assertThat(subject.findings.size).isEqualTo(1)
+		}
+
+		it("both are arrays of primitive types") {
+			val code = "fun function(array: Array<Int>, array2: Array<Double>) {}"
+			subject.lint(code)
+			assertThat(subject.findings.size).isEqualTo(2)
+		}
+	}
+
 	describe("return type") {
 		it("is Array<Primitive>") {
-			val code = "fun returningFunction(): Array<Int> {}"
+			val code = "fun returningFunction(): Array<Float> {}"
 			subject.lint(code)
 			assertThat(subject.findings.size).isEqualTo(1)
 		}
@@ -43,7 +81,13 @@ class ArrayPrimitiveSpec : SubjectSpek<ArrayPrimitive>({
 		}
 
 		it("is a specialized array") {
-			val code = "fun returningFunction(): IntArray {}"
+			val code = "fun returningFunction(): CharArray {}"
+			subject.lint(code)
+			assertThat(subject.findings.size).isZero()
+		}
+
+		it("is not explicitly set") {
+			val code = "fun returningFunction() {}"
 			subject.lint(code)
 			assertThat(subject.findings.size).isZero()
 		}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
@@ -3,26 +3,29 @@ package io.gitlab.arturbosch.detekt.rules.performance
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.subject.SubjectSpek
 
 class ArrayPrimitiveSpec : SubjectSpek<ArrayPrimitive>({
 	subject { ArrayPrimitive() }
 
-	describe("function with Array<Primitive> parameter") {
-		val code = "fun function(array: Array<Int>) {}"
-		subject.lint(code)
-		assertThat(subject.findings.size).isEqualTo(1)
-	}
+	describe("function parameter") {
+		it("is Array<Primitive>") {
+			val code = "fun function(array: Array<Int>) {}"
+			subject.lint(code)
+			assertThat(subject.findings.size).isEqualTo(1)
+		}
 
-	describe("function with non-array parameter") {
-		val code = "fun function(i: Int) {}"
-		subject.lint(code)
-		assertThat(subject.findings.size).isZero()
-	}
+		it("is not an array") {
+			val code = "fun function(i: Int) {}"
+			subject.lint(code)
+			assertThat(subject.findings.size).isZero()
+		}
 
-	describe("function with PrimitiveArray") {
-		val code = "fun function(array: IntArray) {}"
-		subject.lint(code)
-		assertThat(subject.findings.size).isZero()
+		it("is a specialized array") {
+			val code = "fun function(array: IntArray) {}"
+			subject.lint(code)
+			assertThat(subject.findings.size).isZero()
+		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
@@ -46,10 +46,10 @@ class ArrayPrimitiveSpec : SubjectSpek<ArrayPrimitive>({
 			assertThat(subject.findings.size).isEqualTo(1)
 		}
 
-		it("is an array of an array of a non-primitive type") {
-			val code = "fun function(array: Array<Array<String>>) {}"
+		it("is a dictionary with an array of a primitive type as key") {
+			val code = "fun function(dict: Dictionary<Int, Array<Int>>) {}"
 			subject.lint(code)
-			assertThat(subject.findings.size).isZero()
+			assertThat(subject.findings.size).isEqualTo(1)
 		}
 	}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
@@ -1,0 +1,28 @@
+package io.gitlab.arturbosch.detekt.rules.performance
+
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.subject.SubjectSpek
+
+class ArrayPrimitiveSpec : SubjectSpek<ArrayPrimitive>({
+	subject { ArrayPrimitive() }
+
+	describe("function with Array<Primitive> parameter") {
+		val code = "fun function(array: Array<Int>) {}"
+		subject.lint(code)
+		assertThat(subject.findings.size).isEqualTo(1)
+	}
+
+	describe("function with non-array parameter") {
+		val code = "fun function(i: Int) {}"
+		subject.lint(code)
+		assertThat(subject.findings.size).isZero()
+	}
+
+	describe("function with PrimitiveArray") {
+		val code = "fun function(array: IntArray) {}"
+		subject.lint(code)
+		assertThat(subject.findings.size).isZero()
+	}
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
@@ -28,4 +28,24 @@ class ArrayPrimitiveSpec : SubjectSpek<ArrayPrimitive>({
 			assertThat(subject.findings.size).isZero()
 		}
 	}
+
+	describe("return type") {
+		it("is Array<Primitive>") {
+			val code = "fun returningFunction(): Array<Int> {}"
+			subject.lint(code)
+			assertThat(subject.findings.size).isEqualTo(1)
+		}
+
+		it("is not an array") {
+			val code = "fun returningFunction(): Int {}"
+			subject.lint(code)
+			assertThat(subject.findings.size).isZero()
+		}
+
+		it("is a specialized array") {
+			val code = "fun returningFunction(): IntArray {}"
+			subject.lint(code)
+			assertThat(subject.findings.size).isZero()
+		}
+	}
 })

--- a/docs/pages/documentation/performance.md
+++ b/docs/pages/documentation/performance.md
@@ -8,6 +8,30 @@ folder: documentation
 ---
 The performance rule set analyzes code for potential performance problems.
 
+### ArrayPrimitive
+
+Using Array<Primitive> leads to implicit boxing and performance hit. Prefer using Kotlin specialized Array
+Instances.
+
+As stated in the Kotlin [documention](https://kotlinlang.org/docs/reference/basic-types.html#arrays) Kotlin has
+specialized arrays to represent primitive types without boxing overhead, such as `IntArray`, `ByteArray` and so on.
+
+**Severity**: Performance
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+fun function(array: Array<Int>)
+```
+
+#### Compliant Code:
+
+```kotlin
+fun function(array: IntArray)
+```
+
 ### ForEachOnRange
 
 Using the forEach method on ranges has a heavy performance cost. Prefer using simple for loops.

--- a/docs/pages/documentation/performance.md
+++ b/docs/pages/documentation/performance.md
@@ -23,13 +23,17 @@ specialized arrays to represent primitive types without boxing overhead, such as
 #### Noncompliant Code:
 
 ```kotlin
-fun function(array: Array<Int>)
+fun function(array: Array<Int>) { }
+
+fun returningFunction(): Array<Double> { }
 ```
 
 #### Compliant Code:
 
 ```kotlin
-fun function(array: IntArray)
+fun function(array: IntArray) { }
+
+fun returningFunction(): DoubleArray { }
 ```
 
 ### ForEachOnRange


### PR DESCRIPTION
Adds a rule to detect arrays of primitive types in function parameters.
See issue #1245 for more information.