### PR TITLE
Show error messages for unused properties distinguish (#1243)

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -603,4 +603,40 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 			assertThat(subject.lint(code)).isEmpty()
 		}
 	}
+
+	given("error messages") {
+		it("are specific for function parameters"){
+			val code = """
+				fun foo(unused: Int){}
+			"""
+
+			val lint = subject.lint(code)
+
+			assertThat(lint.first().message).startsWith("Function parameter")
+		}
+
+		it("are specific for local variables"){
+			val code = """
+				fun foo(){ val unused = 1 }
+			"""
+
+			val lint = subject.lint(code)
+
+			assertThat(lint.first().message).startsWith("Private property")
+		}
+
+		it("are specific for private functions"){
+			val code = """
+			class Test {
+				private fun unusedFunction(): Int {
+					return 5
+				}
+			}
+			"""
+
+			val lint = subject.lint(code)
+
+			assertThat(lint.first().message).startsWith("Private function")
+		}
+	}
 })


### PR DESCRIPTION
Error messages for unused function parameters, unused local variables and unused private functions all start differently and indicate why they were triggered.

It seems I only needed to add tests to show that function parameters are already recognizable in the error messages. This handles both cases that were mentioned explicitly in #1243 and additionally also unused private functions.