### PR TITLE
Updated MethodOverloading message - fixed #1223

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
@@ -58,7 +58,7 @@ class MethodOverloading(config: Config = Config.empty,
 				report(ThresholdedCodeSmell(issue,
 						Entity.from(element),
 						Metric("OVERLOAD SIZE: ", it.value, threshold),
-						message = "This method is overloaded too many times."))
+						message = "The method '${it.key}' is overloaded too many times."))
 			}
 		}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
@@ -58,7 +58,7 @@ class MethodOverloading(config: Config = Config.empty,
 				report(ThresholdedCodeSmell(issue,
 						Entity.from(element),
 						Metric("OVERLOAD SIZE: ", it.value, threshold),
-						message = "The method '${it.key}' is overloaded too many times."))
+						message = "The method '${it.key}' is overloaded ${it.value} times."))
 			}
 		}
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
@@ -13,9 +13,15 @@ class MethodOverloadingSpec : SubjectSpek<MethodOverloading>({
 
 	given("several overloaded methods") {
 
+		val findings = subject.lint(Case.OverloadedMethods.path())
+
 		it("reports overloaded methods which exceed the threshold") {
-			subject.lint(Case.OverloadedMethods.path())
-			assertThat(subject.findings.size).isEqualTo(3)
+			assertThat(findings.size).isEqualTo(3)
+		}
+
+		it("reports the correct method name") {
+			val expected = "The method 'overloadedMethod' is overloaded too many times."
+			assertThat(findings[0].message).isEqualTo(expected)
 		}
 
 		it("does not report overloaded methods which do not exceed the threshold") {
@@ -26,6 +32,9 @@ class MethodOverloadingSpec : SubjectSpek<MethodOverloading>({
 				}""")
 			assertThat(subject.findings.size).isZero()
 		}
+	}
+
+	given("several overloaded extensions functions") {
 
 		it("does not report extension methods with a different receiver") {
 			subject.lint("""

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
@@ -20,7 +20,7 @@ class MethodOverloadingSpec : SubjectSpek<MethodOverloading>({
 		}
 
 		it("reports the correct method name") {
-			val expected = "The method 'overloadedMethod' is overloaded too many times."
+			val expected = "The method 'overloadedMethod' is overloaded 3 times."
 			assertThat(findings[0].message).isEqualTo(expected)
 		}
 


### PR DESCRIPTION
The reported message for the MethodOverloading rule includes the method,
which is overloaded too many times.