### PR TITLE
MagicNumber: Allow 300 by default.

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -421,7 +421,7 @@ style:
     maxJumpCount: 1
   MagicNumber:
     active: true
-    ignoreNumbers: '-1,0,1,2'
+    ignoreNumbers: '-1,0,1,2,300'
     ignoreHashCodeFunction: true
     ignorePropertyDeclaration: false
     ignoreConstantDeclaration: true

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -61,7 +61,7 @@ import java.util.Locale
  * }
  * </compliant>
  *
- * @configuration ignoreNumbers - numbers which do not count as magic numbers (default: '-1,0,1,2')
+ * @configuration ignoreNumbers - numbers which do not count as magic numbers (default: '-1,0,1,2,300')
  * @configuration ignoreHashCodeFunction - whether magic numbers in hashCode functions should be ignored
  * (default: true)
  * @configuration ignorePropertyDeclaration - whether magic numbers in property declarations should be ignored
@@ -87,7 +87,7 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 					"It's better to declare such numbers as constants and give them a proper name. " +
 					"By default, -1, 0, 1, and 2 are not considered to be magic numbers.", Debt.TEN_MINS)
 
-	private val ignoredNumbers = valueOrDefault(IGNORE_NUMBERS, "-1,0,1,2")
+	private val ignoredNumbers = valueOrDefault(IGNORE_NUMBERS, "-1,0,1,2,300")
 			.splitToSequence(",")
 			.filterNot { it.isEmpty() }
 			.map { parseAsDouble(it) }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -57,6 +57,15 @@ class MagicNumberSpec : Spek({
 		}
 	}
 
+	given("an integer of 300") {
+		val ktFile = compileContentForTest("val myInt = 300")
+
+		it("should not be reported by default") {
+			val findings = MagicNumber().lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+	}
+
 	given("a const integer of 1") {
 		val ktFile = compileContentForTest("const val MY_INT = 1")
 
@@ -193,16 +202,16 @@ class MagicNumberSpec : Spek({
 		}
 	}
 
-	given("an integer of 300") {
-		val ktFile = compileContentForTest("val myInt = 300")
+	given("an integer of 400") {
+		val ktFile = compileContentForTest("val myInt = 400")
 
-		it("should not be reported when ignoredNumbers contains 300") {
-			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "300"))).lint(ktFile)
+		it("should not be reported when ignoredNumbers contains 400") {
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "400"))).lint(ktFile)
 			assertThat(findings).isEmpty()
 		}
 
-		it("should not be reported when ignoredNumbers contains a floating point 300") {
-			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "300.0"))).lint(ktFile)
+		it("should not be reported when ignoredNumbers contains a floating point 400") {
+			val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "400.0"))).lint(ktFile)
 			assertThat(findings).isEmpty()
 		}
 	}

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -264,7 +264,7 @@ describing what the magic number means.
 
 #### Configuration options:
 
-* `ignoreNumbers` (default: `'-1,0,1,2'`)
+* `ignoreNumbers` (default: `'-1,0,1,2,300'`)
 
    numbers which do not count as magic numbers
 


### PR DESCRIPTION
I would not consider 300 being a magic number. I use it very often when delaying ui actions or detecting double clicks and I think it's pretty standard. Let me know what you think.