### PR TITLE
Fix a simple typo in TooManyFunctions rule's description text

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -40,7 +40,7 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
 	override val issue = Issue("TooManyFunctions",
 			Severity.Maintainability,
 			"Too many functions inside a/an file/class/object/interface always indicate a violation of " +
-					"the single responsibility principle. Maybe the file/class/object/interface wants to manage to " +
+					"the single responsibility principle. Maybe the file/class/object/interface wants to manage too " +
 					"many things at once. Extract functionality which clearly belongs together.",
 			Debt.TWENTY_MINS)
 


### PR DESCRIPTION
This is just a simple fix for a type in the TooManyFunctions rule's description text.
