### PR TITLE
Generate test coverage report and upload to Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ script:
   - ./gradlew verifyGeneratorOutput
 after_success:
   - .buildscript/deploy_snapshot.sh
+  - ./gradlew jacocoTestReport
+  - bash <(curl -s https://codecov.io/bash)
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![Visit the website at https://arturbosch.github.io/detekt/](https://img.shields.io/badge/visit-website-red.svg?style=flat-square)](https://arturbosch.github.io/detekt/)
 [![build status](https://travis-ci.org/arturbosch/detekt.svg?branch=master)](https://travis-ci.org/arturbosch/detekt)
 [![build status windows](https://ci.appveyor.com/api/projects/status/3q9g98vveiul7yut/branch/master?svg=true)](https://ci.appveyor.com/project/arturbosch/detekt)
-[ ![Download](https://api.bintray.com/packages/arturbosch/code-analysis/detekt/images/download.svg) ](https://bintray.com/arturbosch/code-analysis/detekt/_latestVersion)
+[![codecov](https://codecov.io/gh/arturbosch/detekt/branch/master/graph/badge.svg)](https://codecov.io/gh/arturbosch/detekt)
+[![Download](https://api.bintray.com/packages/arturbosch/code-analysis/detekt/images/download.svg) ](https://bintray.com/arturbosch/code-analysis/detekt/_latestVersion)
 [![gradle plugin](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/gradle/plugin/io/gitlab/arturbosch/detekt/detekt-gradle-plugin/maven-metadata.xml.svg?label=gradle&style=flat-square)](https://plugins.gradle.org/plugin/io.gitlab.arturbosch.detekt)
 
 [![All Contributors](https://img.shields.io/badge/all_contributors-56-orange.svg?style=flat-square)](#contributors)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ plugins {
 	id("org.sonarqube") version "2.6.2"
 	id("io.gitlab.arturbosch.detekt")
 	id("org.jetbrains.dokka") version "0.9.17"
+	jacoco
 }
 
 tasks.withType<Wrapper> {
@@ -68,6 +69,16 @@ subprojects {
 		plugin("maven-publish")
 		plugin("io.gitlab.arturbosch.detekt")
 		plugin("org.jetbrains.dokka")
+		plugin("jacoco")
+	}
+
+	val jacocoVersion: String by project
+	jacoco.toolVersion = jacocoVersion
+
+	tasks.getByName<JacocoReport>("jacocoTestReport") {
+		reports.xml.isEnabled = true
+		reports.html.isEnabled = true
+		dependsOn("test")
 	}
 
 	val userHome = System.getProperty("user.home")

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,7 @@ jcommanderVersion=1.74
 assertjVersion=3.11.1
 kshVersion=0.1.1
 reflectionsVersion=0.9.11
+jacocoVersion=0.8.2
 
 systemProp.sonar.host.url=http://localhost:9000
 systemProp.detektVersion=detektVersion


### PR DESCRIPTION
Closes #301 (for everything except the Gradle plugin, which is trickier than I thought, so didn't pursue it yet. See [here](https://discuss.gradle.org/t/gradle-plugins-integration-tests-code-coverage-with-jacoco-plugin/12403) for more).

Results have started coming through already as a result of this PR: https://codecov.io/gh/arturbosch/detekt

There will be some areas marked not covered, but actually are. There are some open Kotlin-related issues in JaCoCo. The report should be used as an indication only about relative test coverage, but won't be 100% accurate.