### PR TITLE
Typealiases for RuleId and RuleSetId

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/BaseRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/BaseRule.kt
@@ -2,10 +2,12 @@ package io.gitlab.arturbosch.detekt.api
 
 import org.jetbrains.kotlin.psi.KtFile
 
+typealias RuleId = String
+
 @Suppress("EmptyFunctionBlock")
 abstract class BaseRule(protected val context: Context = DefaultContext()) : DetektVisitor(), Context by context {
 
-	open val ruleId: String = javaClass.simpleName
+	open val ruleId: RuleId = javaClass.simpleName
 
 	/**
 	 * Before starting visiting kotlin elements, a check is performed if this rule should be triggered.

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigAware.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigAware.kt
@@ -22,7 +22,7 @@ interface ConfigAware : Config {
 	/**
 	 * Id which is used to retrieve the sub config for the rule implementing this interface.
 	 */
-	val ruleId: String
+	val ruleId: RuleId
 
 	/**
 	 * Wrapped configuration of the ruleSet this rule is in.

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Detektion.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Detektion.kt
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.Key
  * @author Artur Bosch
  */
 interface Detektion {
-	val findings: Map<String, List<Finding>>
+	val findings: Map<RuleSetId, List<Finding>>
 	val notifications: Collection<Notification>
 	val metrics: Collection<ProjectMetric>
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/MultiRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/MultiRule.kt
@@ -6,7 +6,7 @@ abstract class MultiRule : BaseRule() {
 
 	abstract val rules: List<Rule>
 	var activeRules: Set<Rule> by SingleAssign()
-	var ruleFilters: Set<String> = emptySet()
+	var ruleFilters: Set<RuleId> = emptySet()
 
 	override fun visitCondition(root: KtFile) = true
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -19,7 +19,7 @@ abstract class Rule(override val ruleSetConfig: Config = Config.empty,
 		BaseRule(ruleContext), ConfigAware {
 
 	abstract val issue: Issue
-	final override val ruleId: String get() = issue.id
+	final override val ruleId: RuleId get() = issue.id
 
 	override fun visitCondition(root: KtFile) = active && !root.isSuppressedBy(ruleId, issue.aliases)
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
@@ -2,12 +2,14 @@ package io.gitlab.arturbosch.detekt.api
 
 import org.jetbrains.kotlin.psi.KtFile
 
+typealias RuleSetId = String
+
 /**
  * A rule set is a collection of rules and must be defined within a rule set provider implementation.
  *
  * @author Artur Bosch
  */
-class RuleSet(val id: String, val rules: List<BaseRule>) {
+class RuleSet(val id: RuleSetId, val rules: List<BaseRule>) {
 
 	init {
 		validateIdentifier(id)
@@ -26,7 +28,7 @@ class RuleSet(val id: String, val rules: List<BaseRule>) {
 	 *
 	 * A list of findings is returned for given [KtFile]
 	 */
-	fun accept(file: KtFile, ruleFilters: Set<String>): List<Finding> =
+	fun accept(file: KtFile, ruleFilters: Set<RuleId>): List<Finding> =
 			rules.asSequence()
 					.filterNot { it.ruleId in ruleFilters }
 					.onEach { if (it is MultiRule) it.ruleFilters = ruleFilters }.toList()

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Suppressible.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Suppressible.kt
@@ -38,7 +38,7 @@ private const val QUOTES = "\""
 /**
  * Checks if this kt element is suppressed by @Suppress or @SuppressWarnings annotations.
  */
-fun KtAnnotated.isSuppressedBy(id: String, aliases: Set<String>): Boolean {
+fun KtAnnotated.isSuppressedBy(id: RuleId, aliases: Set<String>): Boolean {
 	val valid = mutableSetOf(id, "ALL", "all", "All")
 	valid.addAll(aliases)
 	return annotationEntries.find { it.typeReference?.text.let { it == "Suppress" || it == "SuppressWarnings" } }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/FilteredDetectionResult.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/FilteredDetectionResult.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.cli
 
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.cli.baseline.BaselineFacade
 
 /**
@@ -9,7 +10,7 @@ import io.gitlab.arturbosch.detekt.cli.baseline.BaselineFacade
  */
 class FilteredDetectionResult(detektion: Detektion, baselineFacade: BaselineFacade) : Detektion by detektion {
 
-	private val filteredFindings: Map<String, List<Finding>>
+	private val filteredFindings: Map<RuleSetId, List<Finding>>
 
 	init {
 		filteredFindings = detektion.findings

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/BuildFailureReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/BuildFailureReport.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.ConsoleReport
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.SingleAssign
 import java.util.HashMap
 
@@ -61,7 +62,7 @@ class BuildFailureReport : ConsoleReport() {
 		}
 	}
 
-	private fun extractRuleToRuleSetIdMap(detektion: Detektion): HashMap<String, String> {
+	private fun extractRuleToRuleSetIdMap(detektion: Detektion): HashMap<RuleSetId, String> {
 		return detektion.findings.mapValues { it.value.map(Finding::id).toSet() }
 				.map { map -> map.value.map { it to map.key }.toMap() }
 				.fold(HashMap()) { result, map -> result.putAll(map); result }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.cli.runners
 
 import io.gitlab.arturbosch.detekt.api.BaseRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleId
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.cli.CliArgs
@@ -20,7 +21,7 @@ import io.gitlab.arturbosch.detekt.core.RuleSetLocator
 class SingleRuleRunner(private val arguments: CliArgs) : Executable {
 
 	override fun execute() {
-		val (ruleSet, rule) = arguments.runRule?.split(":")
+		val (ruleSet, rule: RuleId) = arguments.runRule?.split(":")
 				?: throw IllegalStateException("Unexpected empty 'runRule' argument.")
 
 		val settings = ProcessingSettings(

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektResult.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektResult.kt
@@ -4,13 +4,14 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
+import io.gitlab.arturbosch.detekt.api.RuleSetId
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.util.keyFMap.KeyFMap
 
 /**
  * @author Artur Bosch
  */
-data class DetektResult(override val findings: Map<String, List<Finding>>) : Detektion {
+data class DetektResult(override val findings: Map<RuleSetId, List<Finding>>) : Detektion {
 
 	override val notifications: MutableCollection<Notification> = ArrayList()
 	private var userData = KeyFMap.EMPTY_MAP

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektor.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.core
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.toMergedMap
 import org.jetbrains.kotlin.psi.KtFile
@@ -20,7 +21,7 @@ class Detektor(settings: ProcessingSettings,
 	private val executor: ExecutorService = settings.executorService
 	private val logger = settings.errorPrinter
 
-	fun run(ktFiles: List<KtFile>): Map<String, List<Finding>> = withExecutor(executor) {
+	fun run(ktFiles: List<KtFile>): Map<RuleSetId, List<Finding>> = withExecutor(executor) {
 
 		val futures = ktFiles.map { file ->
 			runAsync {
@@ -37,7 +38,7 @@ class Detektor(settings: ProcessingSettings,
 			}
 		}
 
-		val result = HashMap<String, List<Finding>>()
+		val result = HashMap<RuleSetId, List<Finding>>()
 		for (map in awaitAll(futures)) {
 			result.mergeSmells(map)
 		}
@@ -45,7 +46,7 @@ class Detektor(settings: ProcessingSettings,
 		result
 	}
 
-	private fun KtFile.analyze(): Map<String, List<Finding>> {
+	private fun KtFile.analyze(): Map<RuleSetId, List<Finding>> {
 		var ruleSets = providers.asSequence()
 				.mapNotNull { it.buildRuleset(config) }
 				.sortedBy { it.id }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/TestPattern.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/TestPattern.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleId
 import io.gitlab.arturbosch.detekt.core.TestPattern.Companion.TEST_PATTERN_SUB_CONFIG
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
@@ -15,7 +16,7 @@ fun createTestPattern(config: Config,
 	return with(config.subConfig(TEST_PATTERN_SUB_CONFIG)) {
 		TestPattern(valueOrDefault(TestPattern.ACTIVE, false),
 				valueOrDefault(TestPattern.PATTERNS, TestPattern.DEFAULT_PATTERNS).toSet(),
-				valueOrDefault(TestPattern.EXCLUDE_RULES, emptyList<String>()).toSet(),
+				valueOrDefault(TestPattern.EXCLUDE_RULES, emptyList<RuleId>()).toSet(),
 				valueOrDefault(TestPattern.EXCLUDE_RULE_SETS, emptyList<String>()).toSet(),
 				root)
 	}
@@ -23,7 +24,7 @@ fun createTestPattern(config: Config,
 
 data class TestPattern(val active: Boolean,
 					   val patterns: Set<String>,
-					   val excludingRules: Set<String>,
+					   val excludingRules: Set<RuleId>,
 					   private val excludingRuleSets: Set<String>,
 					   private val root: Path) {
 


### PR DESCRIPTION
Currently we pass a lot of `String`s around which don't really convey what they actually include.

By introducing these typealiases for `RuleId` and `RuleSetId` it becomes a bit clearer what these types actually contain and mean imo.

I just went through some of the files where I found usages of the Id Strings and replaced them with the typealias, I probably missed some cases.