### PR TITLE
Ignore FunctionMaxLength by default for tests.

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -19,6 +19,7 @@ test-pattern: # Configure exclusions for test sources
     - 'SpreadOperator'
     - 'TooManyFunctions'
     - 'ForEachOnRange'
+    - 'FunctionMaxLength'
 
 build:
   maxIssues: 10

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -88,6 +88,7 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
 			    - 'SpreadOperator'
 			    - 'TooManyFunctions'
 			    - 'ForEachOnRange'
+			    - 'FunctionMaxLength'
 			""".trimIndent()
 	}
 


### PR DESCRIPTION
Personally, I like if function names for tests are a bit longer and expressive. Detekt itself does not have that problem since it's using Spek and the 'name' is passed as a String. Otherwise we'd have a lot of warnings reported in the Detekt codebase itself.