### PR TITLE
Drop kotlin-dsl plugin from detekt-gradle-plugin

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -24,15 +24,9 @@ plugins {
 	id("com.gradle.plugin-publish") version "0.10.0"
 	id("com.jfrog.bintray") version "1.8.4"
 	kotlin("jvm") version "1.2.61"
-	`kotlin-dsl`
 	id("org.jetbrains.dokka") version "0.9.17"
 	id("com.github.ben-manes.versions") version "0.20.0"
 }
-
-kotlinDslPluginOptions {
-	experimentalWarning.set(false)
-}
-
 apply {
 	plugin("maven-publish")
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -33,7 +33,6 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
-import org.gradle.kotlin.dsl.property
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import java.io.File
 
@@ -52,7 +51,7 @@ open class Detekt : DefaultTask() {
 
 	@Input
 	@Optional
-	var filters: Property<String> = project.objects.property()
+	var filters = project.objects.property(String::class.java)
 
 	@InputFile
 	@Optional
@@ -66,11 +65,11 @@ open class Detekt : DefaultTask() {
 
 	@Input
 	@Optional
-	var plugins: Property<String> = project.objects.property()
+	var plugins = project.objects.property(String::class.java)
 
 	@Internal
 	@Optional
-	val debugProp: Property<Boolean> = project.objects.property()
+	val debugProp = project.objects.property(Boolean::class.javaObjectType)
 	var debug: Boolean
 		@Internal
 		get() = debugProp.get()
@@ -78,7 +77,7 @@ open class Detekt : DefaultTask() {
 
 	@Internal
 	@Optional
-	val parallelProp: Property<Boolean> = project.objects.property()
+	val parallelProp = project.objects.property(Boolean::class.javaObjectType)
 	var parallel: Boolean
 		@Internal
 		get() = parallelProp.get()
@@ -86,7 +85,7 @@ open class Detekt : DefaultTask() {
 
 	@Optional
 	@Input
-	val disableDefaultRuleSetsProp: Property<Boolean> = project.objects.property()
+	val disableDefaultRuleSetsProp = project.objects.property(Boolean::class.javaObjectType)
 	var disableDefaultRuleSets: Boolean
 		@Internal
 		get() = disableDefaultRuleSetsProp.get()
@@ -99,7 +98,7 @@ open class Detekt : DefaultTask() {
 
 	@Internal
 	@Optional
-	var reportsDir: Property<File> = project.objects.property()
+	var reportsDir = project.objects.property(File::class.java)
 
 	val xmlReportFile: Provider<RegularFile>
 		@OutputFile

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -24,7 +24,6 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
-import org.gradle.kotlin.dsl.property
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 
 /**
@@ -50,7 +49,7 @@ open class DetektCreateBaselineTask : DefaultTask() {
 
 	@Input
 	@Optional
-	var filters: Property<String> = project.objects.property()
+	var filters = project.objects.property(String::class.java)
 
 	@InputFiles
 	@Optional
@@ -59,7 +58,7 @@ open class DetektCreateBaselineTask : DefaultTask() {
 
 	@Input
 	@Optional
-	var plugins: Property<String> = project.objects.property()
+	var plugins = project.objects.property(String::class.java)
 
 	@Internal
 	@Optional

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -27,16 +27,16 @@ class DetektPlugin : Plugin<Project> {
 
 	private fun createAndConfigureDetektTask(project: Project, extension: DetektExtension) {
 		val detektTask = project.tasks.register(DETEKT, Detekt::class.java) {
-			debugProp.set(project.provider { extension.debug })
-			parallelProp.set(project.provider { extension.parallel })
-			disableDefaultRuleSetsProp.set(project.provider { extension.disableDefaultRuleSets })
-			filters.set(project.provider { extension.filters })
-			config.setFrom(project.provider { extension.config })
-			baseline.set(project.layout.file(project.provider { extension.baseline }))
-			plugins.set(project.provider { extension.plugins })
-			input.setFrom(existingInputDirectoriesProvider(project, extension))
-			reportsDir.set(project.provider { extension.customReportsDir })
-			reports = extension.reports
+			it.debugProp.set(project.provider { extension.debug })
+			it.parallelProp.set(project.provider { extension.parallel })
+			it.disableDefaultRuleSetsProp.set(project.provider { extension.disableDefaultRuleSets })
+			it.filters.set(project.provider { extension.filters })
+			it.config.setFrom(project.provider { extension.config })
+			it.baseline.set(project.layout.file(project.provider { extension.baseline }))
+			it.plugins.set(project.provider { extension.plugins })
+			it.input.setFrom(existingInputDirectoriesProvider(project, extension))
+			it.reportsDir.set(project.provider { extension.customReportsDir })
+			it.reports = extension.reports
 		}
 
 		project.tasks.findByName(LifecycleBasePlugin.CHECK_TASK_NAME)?.dependsOn(detektTask)
@@ -44,32 +44,32 @@ class DetektPlugin : Plugin<Project> {
 
 	private fun createAndConfigureCreateBaselineTask(project: Project, extension: DetektExtension) =
 			project.tasks.register(BASELINE, DetektCreateBaselineTask::class.java) {
-				baseline.set(project.layout.file(project.provider { extension.baseline }))
-				config.setFrom(project.provider { extension.config })
-				debug.set(project.provider { extension.debug })
-				parallel.set(project.provider { extension.parallel })
-				disableDefaultRuleSets.set(project.provider { extension.disableDefaultRuleSets })
-				filters.set(project.provider { extension.filters })
-				plugins.set(project.provider { extension.plugins })
-				input.setFrom(existingInputDirectoriesProvider(project, extension))
+				it.baseline.set(project.layout.file(project.provider { extension.baseline }))
+				it.config.setFrom(project.provider { extension.config })
+				it.debug.set(project.provider { extension.debug })
+				it.parallel.set(project.provider { extension.parallel })
+				it.disableDefaultRuleSets.set(project.provider { extension.disableDefaultRuleSets })
+				it.filters.set(project.provider { extension.filters })
+				it.plugins.set(project.provider { extension.plugins })
+				it.input.setFrom(existingInputDirectoriesProvider(project, extension))
 			}
 
 	private fun createAndConfigureGenerateConfigTask(project: Project, extension: DetektExtension) =
 			project.tasks.register(GENERATE_CONFIG, DetektGenerateConfigTask::class.java) {
-				input.setFrom(existingInputDirectoriesProvider(project, extension))
+				it.input.setFrom(existingInputDirectoriesProvider(project, extension))
 			}
 
 	private fun createAndConfigureIdeaTasks(project: Project, extension: DetektExtension) {
 		project.tasks.register(IDEA_FORMAT, DetektIdeaFormatTask::class.java) {
-			debug.set(project.provider { extension.debug })
-			input.setFrom(existingInputDirectoriesProvider(project, extension))
-			ideaExtension = extension.idea
+			it.debug.set(project.provider { extension.debug })
+			it.input.setFrom(existingInputDirectoriesProvider(project, extension))
+			it.ideaExtension = extension.idea
 		}
 
 		project.tasks.register(IDEA_INSPECT, DetektIdeaInspectionTask::class.java) {
-			debug.set(project.provider { extension.debug })
-			input.setFrom(existingInputDirectoriesProvider(project, extension))
-			ideaExtension = extension.idea
+			it.debug.set(project.provider { extension.debug })
+			it.input.setFrom(existingInputDirectoriesProvider(project, extension))
+			it.ideaExtension = extension.idea
 		}
 	}
 
@@ -77,21 +77,21 @@ class DetektPlugin : Plugin<Project> {
 			project.provider { extension.input.filter { it.exists() } }
 
 	private fun configurePluginDependencies(project: Project, extension: DetektExtension) {
-		project.configurations.create(CONFIGURATION_DETEKT_PLUGINS) {
-			isVisible = false
-			isTransitive = true
-			description = "The $CONFIGURATION_DETEKT_PLUGINS libraries to be used for this project."
+		project.configurations.create(CONFIGURATION_DETEKT_PLUGINS) { configuration ->
+			configuration.isVisible = false
+			configuration.isTransitive = true
+			configuration.description = "The $CONFIGURATION_DETEKT_PLUGINS libraries to be used for this project."
 		}
 
-		project.configurations.create(CONFIGURATION_DETEKT) {
-			isVisible = false
-			isTransitive = true
-			description = "The $CONFIGURATION_DETEKT dependencies to be used for this project."
+		project.configurations.create(CONFIGURATION_DETEKT) { configuration ->
+			configuration.isVisible = false
+			configuration.isTransitive = true
+			configuration.description = "The $CONFIGURATION_DETEKT dependencies to be used for this project."
 
-			defaultDependencies {
+			configuration.defaultDependencies { dependencySet ->
 				@Suppress("USELESS_ELVIS")
 				val version = extension.toolVersion ?: DEFAULT_DETEKT_VERSION
-				add(project.dependencies.create("io.gitlab.arturbosch.detekt:detekt-cli:$version"))
+				dependencySet.add(project.dependencies.create("io.gitlab.arturbosch.detekt:detekt-cli:$version"))
 			}
 		}
 	}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -14,9 +14,9 @@ object DetektInvoker {
 
 		if (debug) println(cliArguments)
 		project.javaexec {
-			main = DETEKT_MAIN
-			classpath = getConfigurations(project, debug)
-			args = cliArguments
+			it.main = DETEKT_MAIN
+			it.classpath = getConfigurations(project, debug)
+			it.args = cliArguments
 		}
 	}
 


### PR DESCRIPTION
Resolves #1286 

I just did a straight conversion without introducing new extension functions. They'd make the code a little cleaner, but as is I don't think it's hard to follow (and ends up being a net reduction in LOC).