### PR TITLE
Ignore TooGenericExceptionCaught by default for tests.

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -20,6 +20,7 @@ test-pattern: # Configure exclusions for test sources
     - 'TooManyFunctions'
     - 'ForEachOnRange'
     - 'FunctionMaxLength'
+    - 'TooGenericExceptionCaught'
 
 build:
   maxIssues: 10

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -89,6 +89,7 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
 			    - 'TooManyFunctions'
 			    - 'ForEachOnRange'
 			    - 'FunctionMaxLength'
+			    - 'TooGenericExceptionCaught'
 			""".trimIndent()
 	}
 


### PR DESCRIPTION
Should not be a problem to catch `Exception` or `Throwable` in tests.