### PR TITLE
Nested*Depth Rules (#248)

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -97,6 +97,18 @@ complexity:
   NestedBlockDepth:
     active: true
     threshold: 4
+  NestedForDepth:
+    active: false
+    threshold: 2
+  NestedIfDepth:
+    active: false
+    threshold: 2
+  NestedTryDepth:
+    active: false
+    threshold: 1
+  NestedWhenDepth:
+    active: false
+    threshold: 1
   StringLiteralDuplication:
     active: false
     threshold: 3

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedForDepth.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedForDepth.kt
@@ -1,0 +1,59 @@
+package io.gitlab.arturbosch.detekt.rules.complexity
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Metric
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.ThresholdRule
+import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
+import io.gitlab.arturbosch.detekt.rules.collectByType
+import org.jetbrains.kotlin.psi.KtForExpression
+
+/**
+ * This rule reports excessive nesting depth of `for` expressions. Excessively nested for loops can be
+ * harder to manage in one's head, and commonly masks the intended behavior of the function.
+ *
+ * Prefer extracting the nested code into well-named functions and/or using expressive comprehensions to
+ * make it easier to understand.
+ *
+ * @configuration threshold - maximum allowed nesting depth (default: 2)
+ *
+ * @author Bob Boring
+ */
+class NestedForDepth(config: Config = Config.empty,
+					 threshold: Int = DEFAULT_ACCEPTED_NESTING) : ThresholdRule(config, threshold) {
+
+	override val issue = Issue("NestedForDepth",
+			Severity.Maintainability,
+			"Excessive nesting leads to hidden complexity and obscures meaning. " +
+					"Prefer extracting code to make it easier to understand.",
+			Debt.TWENTY_MINS)
+
+	private val seenFors: MutableSet<KtForExpression> = mutableSetOf()
+
+	override fun visitForExpression(expression: KtForExpression) {
+		// filter out fors that are nested within other fors
+		if (expression !in seenFors) {
+			checkDepthOf(expression)
+		}
+		super.visitForExpression(expression)
+	}
+
+	private fun checkDepthOf(expression: KtForExpression) {
+		val nestedFors = expression.collectByType<KtForExpression>()
+		seenFors.addAll(nestedFors)
+		if (nestedFors.size > threshold) {
+			report(ThresholdedCodeSmell(issue,
+					Entity.from(expression),
+					Metric("NESTING DEPTH", nestedFors.size, threshold),
+					"These for expressions are nested too deeply."))
+		}
+	}
+
+	companion object {
+
+		const val DEFAULT_ACCEPTED_NESTING = 2
+	}
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedIfDepth.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedIfDepth.kt
@@ -1,0 +1,61 @@
+package io.gitlab.arturbosch.detekt.rules.complexity
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Metric
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.ThresholdRule
+import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
+import io.gitlab.arturbosch.detekt.rules.collectByType
+import org.jetbrains.kotlin.psi.KtContainerNodeForControlStructureBody
+import org.jetbrains.kotlin.psi.KtIfExpression
+
+/**
+ * This rule reports excessive nesting depth of `if` expressions. Excessively nested `if`s increase the complexity of
+ * a function by increasing the number of possible execution paths and state dependencies.
+ *
+ * Prefer simplifying the conditional logic or extracting the nested code into well-named functions
+ * to make it easier to understand.
+ *
+ * @configuration threshold - maximum allowed nesting depth (default: 2)
+ *
+ * @author Bob Boring
+ */
+class NestedIfDepth(config: Config = Config.empty,
+					threshold: Int = DEFAULT_ACCEPTED_NESTING) : ThresholdRule(config, threshold) {
+
+	override val issue = Issue("NestedIfDepth",
+			Severity.Maintainability,
+			"Excessive nesting leads to hidden complexity and obscures meaning. " +
+					"Prefer extracting code to make it easier to understand.",
+			Debt.TWENTY_MINS)
+
+	private val seenIfs: MutableSet<KtIfExpression> = mutableSetOf()
+
+	override fun visitIfExpression(expression: KtIfExpression) {
+		// filter out ifs that are nested within other ifs
+		if (expression !in seenIfs) {
+			checkDepthOf(expression)
+		}
+		super.visitIfExpression(expression)
+	}
+
+	private fun checkDepthOf(expression: KtIfExpression) {
+		val nestedIfs = expression.collectByType<KtIfExpression>()
+				.filter { it.parent !is KtContainerNodeForControlStructureBody }
+		seenIfs.addAll(nestedIfs)
+		if (nestedIfs.size > threshold) {
+			report(ThresholdedCodeSmell(issue,
+					Entity.from(expression),
+					Metric("NESTING DEPTH", nestedIfs.size, threshold),
+					"These if expressions are nested too deeply."))
+		}
+	}
+
+	companion object {
+
+		const val DEFAULT_ACCEPTED_NESTING = 2
+	}
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedTryDepth.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedTryDepth.kt
@@ -33,7 +33,7 @@ class NestedTryDepth(config: Config = Config.empty,
 	private val seenTries: MutableSet<KtTryExpression> = mutableSetOf()
 
 	override fun visitTryExpression(expression: KtTryExpression) {
-		// filter out fors that are nested within other fors
+		// filter out try blocks that are nested within other try blocks
 		if (expression !in seenTries) {
 			checkDepthOf(expression)
 		}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedTryDepth.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedTryDepth.kt
@@ -1,0 +1,58 @@
+package io.gitlab.arturbosch.detekt.rules.complexity
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Metric
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.ThresholdRule
+import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
+import io.gitlab.arturbosch.detekt.rules.collectByType
+import org.jetbrains.kotlin.psi.KtTryExpression
+
+/**
+ * This rule reports excessive nesting depth of `try` blocks. Excessively nested `try` blocks greatly increase the
+ * complexity of a function, and frequently signal that a function is taking on too much responsibility.
+ *
+ * Prefer extracting the nested code into well-named functions to make it easier to understand.
+ *
+ * @configuration threshold - maximum allowed nesting depth (default: 1)
+ *
+ * @author Bob Boring
+ */
+class NestedTryDepth(config: Config = Config.empty,
+					 threshold: Int = DEFAULT_ACCEPTED_NESTING) : ThresholdRule(config, threshold) {
+
+	override val issue = Issue("NestedForDepth",
+			Severity.Maintainability,
+			"Excessive nesting leads to hidden complexity and obscures meaning. " +
+					"Prefer extracting code to make it easier to understand.",
+			Debt.TWENTY_MINS)
+
+	private val seenTries: MutableSet<KtTryExpression> = mutableSetOf()
+
+	override fun visitTryExpression(expression: KtTryExpression) {
+		// filter out fors that are nested within other fors
+		if (expression !in seenTries) {
+			checkDepthOf(expression)
+		}
+		super.visitTryExpression(expression)
+	}
+
+	private fun checkDepthOf(expression: KtTryExpression) {
+		val nestedTries = expression.collectByType<KtTryExpression>()
+		seenTries.addAll(nestedTries)
+		if (nestedTries.size > threshold) {
+			report(ThresholdedCodeSmell(issue,
+					Entity.from(expression),
+					Metric("NESTING DEPTH", nestedTries.size, threshold),
+					"These try blocks are nested too deeply."))
+		}
+	}
+
+	companion object {
+
+		const val DEFAULT_ACCEPTED_NESTING = 1
+	}
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedWhenDepth.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedWhenDepth.kt
@@ -1,0 +1,59 @@
+package io.gitlab.arturbosch.detekt.rules.complexity
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Metric
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.ThresholdRule
+import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
+import io.gitlab.arturbosch.detekt.rules.collectByType
+import org.jetbrains.kotlin.psi.KtWhenExpression
+
+/**
+ * This rule reports excessive nesting depth of `when` expressions. Excessively nested when expressions clutter code
+ * and commonly indicate that a function may be handling too many disparate conditional branches.
+ *
+ * Prefer extracting the nested code into well-named functions to
+ * make it easier to understand.
+ *
+ * @configuration threshold - maximum allowed nesting depth (default: 1)
+ *
+ * @author Bob Boring
+ */
+class NestedWhenDepth(config: Config = Config.empty,
+					  threshold: Int = DEFAULT_ACCEPTED_NESTING) : ThresholdRule(config, threshold) {
+
+	override val issue = Issue("NestedWhenDepth",
+			Severity.Maintainability,
+			"Excessive nesting leads to hidden complexity and obscures meaning. " +
+					"Prefer extracting code to make it easier to understand.",
+			Debt.TWENTY_MINS)
+
+	private val seenWhens: MutableSet<KtWhenExpression> = mutableSetOf()
+
+	override fun visitWhenExpression(expression: KtWhenExpression) {
+		// filter out whens that are nested within other whens
+		if (expression !in seenWhens) {
+			checkDepthOf(expression)
+		}
+		super.visitWhenExpression(expression)
+	}
+
+	private fun checkDepthOf(expression: KtWhenExpression) {
+		val nestedWhens = expression.collectByType<KtWhenExpression>()
+		seenWhens.addAll(nestedWhens)
+		if (nestedWhens.size > threshold) {
+			report(ThresholdedCodeSmell(issue,
+					Entity.from(expression),
+					Metric("NESTING DEPTH", nestedWhens.size, threshold),
+					"These for expressions are nested too deeply."))
+		}
+	}
+
+	companion object {
+
+		const val DEFAULT_ACCEPTED_NESTING = 1
+	}
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedWhenDepth.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedWhenDepth.kt
@@ -48,7 +48,7 @@ class NestedWhenDepth(config: Config = Config.empty,
 			report(ThresholdedCodeSmell(issue,
 					Entity.from(expression),
 					Metric("NESTING DEPTH", nestedWhens.size, threshold),
-					"These for expressions are nested too deeply."))
+					"These when expressions are nested too deeply."))
 		}
 	}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/ComplexityProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/ComplexityProvider.kt
@@ -12,6 +12,10 @@ import io.gitlab.arturbosch.detekt.rules.complexity.LongMethod
 import io.gitlab.arturbosch.detekt.rules.complexity.LongParameterList
 import io.gitlab.arturbosch.detekt.rules.complexity.MethodOverloading
 import io.gitlab.arturbosch.detekt.rules.complexity.NestedBlockDepth
+import io.gitlab.arturbosch.detekt.rules.complexity.NestedForDepth
+import io.gitlab.arturbosch.detekt.rules.complexity.NestedIfDepth
+import io.gitlab.arturbosch.detekt.rules.complexity.NestedTryDepth
+import io.gitlab.arturbosch.detekt.rules.complexity.NestedWhenDepth
 import io.gitlab.arturbosch.detekt.rules.complexity.StringLiteralDuplication
 import io.gitlab.arturbosch.detekt.rules.complexity.TooManyFunctions
 
@@ -35,6 +39,10 @@ class ComplexityProvider : RuleSetProvider {
 				StringLiteralDuplication(config),
 				MethodOverloading(config),
 				NestedBlockDepth(config),
+				NestedForDepth(config),
+				NestedIfDepth(config),
+				NestedTryDepth(config),
+				NestedWhenDepth(config),
 				TooManyFunctions(config),
 				ComplexCondition(config),
 				LabeledExpression(config)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedForDepthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedForDepthSpec.kt
@@ -1,0 +1,105 @@
+package io.gitlab.arturbosch.detekt.rules.complexity
+
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
+
+class NestedForDepthSpec : SubjectSpek<NestedForDepth>({
+
+	subject { NestedForDepth(threshold = 2) }
+
+	describe("simple nested fors") {
+
+		it("should detect too many nested fors") {
+			val code = """
+				fun tooDeep() {
+					for (i in 1..3) {
+						for (j in 1..3) {
+							for (k in 1..3) {
+								for (l in 1..3) {
+								}
+							}
+						}
+					}
+				}"""
+			assertThat(subject.lint(code)).hasSize(1)
+		}
+
+		it("should not detect nested fors at or below threshold") {
+			val code = """
+				fun notTooDeep() {
+					for (i in 1..3) {
+						for (j in 1..3) {
+						}
+					}
+				}"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+	}
+
+	describe("complex fors") {
+
+		it("should detect ifs nested in other blocks") {
+			subject.lint(forsInOtherBlocks)
+			assertThat(subject.findings).hasSize(1)
+		}
+
+		it("should detect multiple findings in one file") {
+			subject.lint(multipleForFindingsInOneFile)
+			assertThat(subject.findings).hasSize(2)
+			assertThat(subject.findings.filter { it.metricByType("NESTING DEPTH")?.value == 5 }).hasSize(1)
+			assertThat(subject.findings.filter { it.metricByType("NESTING DEPTH")?.value == 3 }).hasSize(1)
+		}
+	}
+})
+
+const val forsInOtherBlocks = """
+    fun buriedInBlocks() {
+        while (true) {
+            for (i in 1..3) {
+                (1..5).forEach {
+                    if (2 > 1) {
+                        for (j in 1..3) {
+                            for (k in 1..3) {
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+const val multipleForFindingsInOneFile = """
+    fun wayTooDeep() {
+        for (i in 1..3) {
+            for (j in 1..3) {
+                for (k in 1..3) {
+                    for (l in 1..3) {
+                        for (m in 1..3) {
+                        }
+					}
+				}
+			}
+		}
+    }
+
+    fun notTooDeep() {
+        for (i in 1..3) {
+            for (j in 1..3) {
+            }
+		}
+    }
+
+    fun justTooDeep {
+        for (i in 1..3) {
+            for (j in 1..3) {
+                for (k in 1..3) {
+    			}
+    		}
+    	}
+    }
+"""
+

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedIfDepthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedIfDepthSpec.kt
@@ -1,0 +1,133 @@
+package io.gitlab.arturbosch.detekt.rules.complexity
+
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
+
+class NestedIfDepthSpec : SubjectSpek<NestedIfDepth>({
+
+	subject { NestedIfDepth(threshold = 2) }
+
+	describe("simple nested ifs") {
+
+		it("should detect too many nested ifs") {
+			val code = """
+				fun tooDeep() {
+					if (1 > 0) {
+						if (2 > 1) {
+							if (3 > 2) {
+								if (4 > 3) {
+								}
+							}
+						}
+					}
+				}"""
+			assertThat(subject.lint(code)).hasSize(1)
+		}
+
+		it("should not detect nested ifs at or below threshold") {
+			val code = """
+				fun notTooDeep() {
+					if (1 > 0) {
+						if (2 > 1) {
+						}
+					}
+				}"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+	}
+
+	describe("complex(ish) ifs") {
+
+		it("should detect ifs nested in other blocks") {
+			subject.lint(ifsInOtherBlocks)
+			assertThat(subject.findings).hasSize(1)
+		}
+
+		it("should detect multiple findings in one file") {
+			subject.lint(multipleFindingsInOneFile)
+			assertThat(subject.findings).hasSize(2)
+			assertThat(subject.findings.filter { it.metricByType("NESTING DEPTH")?.value == 5 }).hasSize(1)
+			assertThat(subject.findings.filter { it.metricByType("NESTING DEPTH")?.value == 3 }).hasSize(1)
+		}
+
+		it("should not count else if as two") {
+			subject.lint(nestedIfCode)
+			assertThat(subject.findings).isEmpty()
+		}
+	}
+})
+
+const val ifsInOtherBlocks = """
+    fun buriedInBlocks() {
+        while (true) {
+            if (1 > 0) {
+                (1..5).forEach {
+                    if (2 > 1) {
+                    } else {
+                        while (true) {
+                            if (3 > 2) {
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+const val multipleFindingsInOneFile = """
+    fun wayTooDeep() {
+        if (1 > 0) {
+            if (2 > 1) {
+                if (3 > 2) {
+                    if (4 > 3) {
+                        if (5 > 4) {
+                        }
+					}
+				}
+			}
+		}
+    }
+
+    fun notTooDeep() {
+        if (1 > 0) {
+            if (2 > 1) {
+            }
+		}
+        if (3 > 2) {
+            if (4 > 3) {
+            }
+		}
+    }
+
+    fun justTooDeep {
+        if (1 > 0) {
+            if (2 > 1) {
+                if (3 > 2) {
+    			}
+    		}
+    	}
+    }
+"""
+
+const val nestedIfCode = """
+	override fun procedure(node: ASTNode) {
+		val psi = node.psi
+		if (psi.isNotPartOfEnum() && psi.isNotPartOfString()) {
+			if (psi.isDoubleSemicolon()) {
+				addFindings(CodeSmell(id, Entity.from(psi)))
+				withAutoCorrect {
+					deleteOneOrTwoSemicolons(node as LeafPsiElement)
+				}
+			} else if (psi.isSemicolon()) {
+				val nextLeaf = psi.nextLeaf()
+			}
+		} else if (psi.isNotPartOfEnum) {
+            println("meaningful text")
+        } else {
+            println("meaningless text"
+    	}
+	}"""

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedTryDepthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedTryDepthSpec.kt
@@ -1,0 +1,123 @@
+package io.gitlab.arturbosch.detekt.rules.complexity
+
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
+
+class NestedTryDepthSpec : SubjectSpek<NestedTryDepth>({
+
+	subject { NestedTryDepth(threshold = 2) }
+
+	describe("simple nested tries") {
+
+		it("should detect too many nested tries") {
+			val code = """
+				fun tooDeep() {
+	            	try {
+	            		try {
+	            			try {
+	        				} catch (e: Exception) {
+	        				}
+	        			} catch (e: Exception) {
+	        			}
+	        		} catch (e: Exception) {
+	        		}
+				}"""
+			assertThat(subject.lint(code)).hasSize(1)
+		}
+
+		it("should not detect nested tries at or below threshold") {
+			val code = """
+				fun notTooDeep() {
+        			try {
+        				try {
+        				} catch (e: Exception) {
+        				}
+        			} catch (e: Exception) {
+        			}
+				}"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+	}
+
+	describe("complex(ish) tries") {
+
+		it("should detect tries nested in other blocks") {
+			subject.lint(triesInOtherBlocks)
+			assertThat(subject.findings).hasSize(1)
+		}
+
+		it("should detect multiple findings in one file") {
+			subject.lint(multipleTryDepthFindingsInOneFile)
+			assertThat(subject.findings).hasSize(2)
+			assertThat(subject.findings.filter { it.metricByType("NESTING DEPTH")?.value == 5 }).hasSize(1)
+			assertThat(subject.findings.filter { it.metricByType("NESTING DEPTH")?.value == 3 }).hasSize(1)
+		}
+	}
+})
+
+const val triesInOtherBlocks = """
+    fun buriedInBlocks() {
+        while (true) {
+            try {
+                (1..5).forEach {
+                    try {
+                        while (true) {
+                            try {
+                            } catch (e: Exception) {
+                            }
+                        }
+                    } catch (e: Exception) {
+					}
+                }
+            } catch (e: Exception) {
+			}
+        }
+    }
+"""
+
+const val multipleTryDepthFindingsInOneFile = """
+    fun wayTooDeep() {
+        try {
+            try {
+            	try {
+            		try {
+            			try {
+        				} catch (e: Exception) {
+        				}
+        			} catch (e: Exception) {
+        			}
+        		} catch (e: Exception) {
+        		}
+        	} catch (e: Exception) {
+        	}
+        } catch (e: Exception) {
+        }
+    }
+
+    fun notTooDeep() {
+        try {
+        	try {
+        	} catch (e: Exception) {
+        	}
+        } catch (e: Exception) {
+        }
+
+        try {
+        } catch (e: Exception) {
+        }
+    }
+
+    fun justTooDeep {
+        try {
+			try {
+				try {
+				} catch (e: Exception) {
+				}
+			} catch (e: Exception) {
+		}
+		catch (e: Exception) {
+    }
+"""

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedWhenDepthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedWhenDepthSpec.kt
@@ -1,0 +1,129 @@
+package io.gitlab.arturbosch.detekt.rules.complexity
+
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
+
+class NestedWhenDepthSpec : SubjectSpek<NestedWhenDepth>({
+
+	subject { NestedWhenDepth(threshold = 1) }
+
+	describe("simple nested whens") {
+
+		it("should detect too many nested whens") {
+			val code = """
+				fun tooDeep() {
+				    when {
+				        1 > 0 -> {
+				            when {
+				                2 > 1 -> {
+				                    when {
+				                        3 > 2 -> {
+				                            when {
+				                                4 > 3 -> {}
+				                            }
+				                        }
+				                    }
+				                }
+				            }
+				        }
+				    }
+				}"""
+			assertThat(subject.lint(code)).hasSize(1)
+		}
+
+		it("should not detect nested whens at or below threshold") {
+			val code = """
+				fun notTooDeep() {
+				    when {
+				        1 > 0 -> {
+				        }
+				    }
+				}"""
+			assertThat(subject.lint(code)).isEmpty()
+		}
+	}
+
+	describe("complex(ish) ifs") {
+
+		it("should detect ifs nested in other blocks") {
+			subject.lint(whensInOtherBlocks)
+			assertThat(subject.findings).hasSize(1)
+		}
+
+		it("should detect multiple findings in one file") {
+			subject.lint(multipleWhenDepthFindingsInOneFile)
+			assertThat(subject.findings).hasSize(2)
+			assertThat(subject.findings.filter { it.metricByType("NESTING DEPTH")?.value == 3 }).hasSize(1)
+			assertThat(subject.findings.filter { it.metricByType("NESTING DEPTH")?.value == 2 }).hasSize(1)
+		}
+
+	}
+})
+
+const val whensInOtherBlocks = """
+    fun buriedInBlocks() {
+	    val nesting = 2
+	    when {
+	        1 > 0 -> {
+	            if (2 > 1) {
+					while (true) {
+	                	when(nesting) {
+	                    	2 -> { }
+	                	}
+					}
+	            }
+	        }
+	    }
+    }
+"""
+
+const val multipleWhenDepthFindingsInOneFile = """
+    fun wayTooDeep() {
+	    val nesting = 3
+	    when {
+	        1 > 0 -> {
+	            }
+	        else -> {
+	            when (nesting) {
+	                2 -> {
+	                    when {
+	                        5 > 4 -> {
+
+	                        }
+	                    }
+	                }
+	                3 -> {
+	                }
+	            }
+	        }
+	    }
+    }
+
+    fun notTooDeep() {
+	    when {
+	        1 > 0 -> {
+	            }
+	        else -> {
+	        }
+	    }
+	}
+
+    fun justTooDeep {
+	    val nesting = 2
+	    when {
+	        1 > 0 -> {
+	            if (2 > 1) {
+	                when (nesting) {
+	                    2 -> {
+	                    }
+	                    else -> {
+	                    }
+	                }
+	            }
+	        }
+	    }
+    }
+"""

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -216,6 +216,77 @@ Prefer extracting the nested code into well-named functions to make it easier to
 
    maximum nesting depth
 
+### NestedForDepth
+
+This rule reports excessive nesting depth of `for` expressions. Excessively nested for loops can be
+harder to manage in one's head, and commonly masks the intended behavior of the function.
+
+Prefer extracting the nested code into well-named functions and/or using expressive comprehensions to
+make it easier to understand.
+
+**Severity**: Maintainability
+
+**Debt**: 20min
+
+#### Configuration options:
+
+* `threshold` (default: `2`)
+
+   maximum allowed nesting depth
+
+### NestedIfDepth
+
+This rule reports excessive nesting depth of `if` expressions. Excessively nested `if`s increase the complexity of
+a function by increasing the number of possible execution paths and state dependencies.
+
+Prefer simplifying the conditional logic or extracting the nested code into well-named functions
+to make it easier to understand.
+
+**Severity**: Maintainability
+
+**Debt**: 20min
+
+#### Configuration options:
+
+* `threshold` (default: `2`)
+
+   maximum allowed nesting depth
+
+### NestedTryDepth
+
+This rule reports excessive nesting depth of `try` blocks. Excessively nested `try` blocks greatly increase the
+complexity of a function, and frequently signal that a function is taking on too much responsibility.
+
+Prefer extracting the nested code into well-named functions to make it easier to understand.
+
+**Severity**: Maintainability
+
+**Debt**: 20min
+
+#### Configuration options:
+
+* `threshold` (default: `1`)
+
+   maximum allowed nesting depth
+
+### NestedWhenDepth
+
+This rule reports excessive nesting depth of `when` expressions. Excessively nested when expressions clutter code
+and commonly indicate that a function may be handling too many disparate conditional branches.
+
+Prefer extracting the nested code into well-named functions to
+make it easier to understand.
+
+**Severity**: Maintainability
+
+**Debt**: 20min
+
+#### Configuration options:
+
+* `threshold` (default: `1`)
+
+   maximum allowed nesting depth
+
 ### StringLiteralDuplication
 
 This rule detects and reports duplicated String literals. Repeatedly typing out the same String literal across the


### PR DESCRIPTION
Add rules for checking the depth of `if`, `for`, `try`, and `when` blocks/expressions. I think the speks are relatively thorough, but I'm certainly open to being convinced otherwise. 

Probably very open for debate is the default thresholds for each rule. I went for thresholds of 2 for `if` and `for`, and 1 for `try` and `when`. My rationale is that `if` and `for` are generally more constrained than the others in the complexity/number of their possible outcomes. For example, `if` is a "this or that" proposition, but `when` has a more arbitrary number of outcomes.