### PR TITLE
Ignores interfaces in NestedClassesVisibility - fixes #1075

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
@@ -45,7 +45,7 @@ class NestedClassesVisibility(config: Config = Config.empty) : Rule(config) {
 			Debt.FIVE_MINS)
 
 	override fun visitClass(klass: KtClass) {
-		if (klass.isTopLevel() && klass.isInternal()) {
+		if (!klass.isInterface() && klass.isTopLevel() && klass.isInternal()) {
 			checkDeclarations(klass)
 		}
 	}

--- a/detekt-rules/src/test/resources/cases/NestedClassVisibilityNegative.kt
+++ b/detekt-rules/src/test/resources/cases/NestedClassVisibilityNegative.kt
@@ -19,4 +19,7 @@ private class PrivateClassWithNestedElements {
 	class Inner
 }
 
+internal interface IgnoreNestedClassInInterface {
 
+	class Nested
+}


### PR DESCRIPTION
Having thought about this, the rule `NestedClassesVisibility` should ignore interfaces at all.
