### PR TITLE
Added tests for excludeClassPattern in NamingRules

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
@@ -9,7 +9,7 @@ import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.identifierName
-import io.gitlab.arturbosch.detekt.rules.naming.util.isContainingExcludedClass
+import io.gitlab.arturbosch.detekt.rules.naming.util.isContainingExcludedClassOrObject
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
@@ -35,7 +35,7 @@ class ConstructorParameterNaming(config: Config = Config.empty) : Rule(config) {
 	private val excludeClassPattern by LazyRegex(EXCLUDE_CLASS_PATTERN, "$^")
 
 	override fun visitParameter(parameter: KtParameter) {
-		if (parameter.isContainingExcludedClass(excludeClassPattern)) {
+		if (parameter.isContainingExcludedClassOrObject(excludeClassPattern)) {
 			return
 		}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.identifierName
 import io.gitlab.arturbosch.detekt.rules.isOverridden
-import io.gitlab.arturbosch.detekt.rules.naming.util.isContainingExcludedClass
+import io.gitlab.arturbosch.detekt.rules.naming.util.isContainingExcludedClassOrObject
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
@@ -44,7 +44,7 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
 			return
 		}
 
-		if (!function.isContainingExcludedClass(excludeClassPattern) &&
+		if (!function.isContainingExcludedClassOrObject(excludeClassPattern) &&
 				!function.identifierName().matches(functionPattern)) {
 			report(CodeSmell(
 					issue,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.identifierName
 import io.gitlab.arturbosch.detekt.rules.isOverridden
-import io.gitlab.arturbosch.detekt.rules.naming.util.isContainingExcludedClass
+import io.gitlab.arturbosch.detekt.rules.naming.util.isContainingExcludedClassOrObject
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
@@ -40,7 +40,7 @@ class VariableNaming(config: Config = Config.empty) : Rule(config) {
 	private val ignoreOverridden = valueOrDefault(IGNORE_OVERRIDDEN, true)
 
 	override fun visitProperty(property: KtProperty) {
-		if (property.isSingleUnderscore || property.isContainingExcludedClass(excludeClassPattern)) {
+		if (property.isSingleUnderscore || property.isContainingExcludedClassOrObject(excludeClassPattern)) {
 			return
 		}
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/util/ExcludeClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/util/ExcludeClass.kt
@@ -2,7 +2,11 @@ package io.gitlab.arturbosch.detekt.rules.naming.util
 
 import io.gitlab.arturbosch.detekt.rules.identifierName
 import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.psiUtil.containingClass
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 
-internal fun KtDeclaration.isContainingExcludedClass(pattern: Regex) =
+internal fun KtDeclaration.isContainingExcludedClassOrObject(pattern: Regex) =
 		containingClassOrObject?.identifierName()?.matches(pattern) == true
+
+internal fun KtDeclaration.isContainingExcludedClass(pattern: Regex) =
+		containingClass()?.identifierName()?.matches(pattern) == true

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ParameterNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ParameterNamingSpec.kt
@@ -79,4 +79,23 @@ class ParameterNamingSpec : Spek({
 			assertThat(NamingRules().lint(code)).hasSize(1)
 		}
 	}
+
+	describe("parameters in a function of an excluded class") {
+
+		val config = TestConfig(mapOf("excludeClassPattern" to "Excluded"))
+
+		it("should not detect function parameter") {
+			val code = """
+				class Excluded {
+					fun f(PARAM: Int)
+				}
+			"""
+			assertThat(FunctionParameterNaming(config).lint(code)).isEmpty()
+		}
+
+		it("should not detect constructor parameter") {
+			val code = "class Excluded(val PARAM: Int) {}"
+			assertThat(ConstructorParameterNaming(config).lint(code)).isEmpty()
+		}
+	}
 })


### PR DESCRIPTION
Since an object cannot have an constructor, the `ConstructorParameterNaming` only has to check for enclosing classes.

