### PR TITLE
Use a default baseline in gradle and add support for consolidated baseline files.

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -83,6 +83,12 @@ class CliArgs : Args {
 			description = "Prints the AST for given [input] file. Must be no directory.")
 	var printAst: Boolean = false
 
+	@Parameter(names = ["--source-set-id"],
+			hidden = true,
+			description = "The source set identifier to use. Needs to be specified for consolidated baselines and " +
+					"reports in multi project environment.")
+	var sourceSetId: String? = null
+
 	val inputPaths: List<Path> by lazy {
 		MultipleExistingPathConverter().convert(input ?: System.getProperty("user.dir"))
 	}

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/OutputFacade.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/OutputFacade.kt
@@ -17,7 +17,7 @@ class OutputFacade(arguments: CliArgs,
 
 	private val printStream = settings.outPrinter
 	private val config = settings.config
-	private val baselineFacade = arguments.baseline?.let { BaselineFacade(it) }
+	private val baselineFacade = arguments.baseline?.let { BaselineFacade(it, arguments.sourceSetId) }
 	private val createBaseline = arguments.createBaseline
 	private val reportPaths = arguments.reportPaths.toHashMap({ it.kind }, { it.path })
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/Baseline.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/Baseline.kt
@@ -2,18 +2,21 @@ package io.gitlab.arturbosch.detekt.cli.baseline
 
 /**
  * @author Artur Bosch
+ * @author Markus Schwarz
  */
-data class Baseline(val blacklist: Blacklist, val whitelist: Whitelist) {
+internal data class Baseline(val blacklist: Blacklist, val whitelist: Whitelist)
 
-	override fun toString(): String {
-		return "Baseline(blacklist=$blacklist, whitelist=$whitelist)"
-	}
-}
+internal data class ConsolidatedBaseline(
+		val blacklist: Blacklist,
+		val defaultWhitelist: Whitelist? = null,
+		val whitelists: Map<String, Whitelist> = emptyMap()
+)
 
-const val SMELL_BASELINE = "SmellBaseline"
-const val BLACKLIST = "Blacklist"
-const val WHITELIST = "Whitelist"
-const val TIMESTAMP = "timestamp"
-const val ID = "ID"
+internal const val SMELL_BASELINE = "SmellBaseline"
+internal const val BLACKLIST = "Blacklist"
+internal const val WHITELIST = "Whitelist"
+internal const val TIMESTAMP = "timestamp"
+internal const val ID = "ID"
+internal const val SOURCE_SET_ID = "sourceSet"
 
-class InvalidBaselineState(msg: String, error: Throwable) : IllegalStateException(msg, error)
+class InvalidBaselineState(msg: String, error: Throwable? = null) : IllegalStateException(msg, error)

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/Baseline.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/Baseline.kt
@@ -4,14 +4,22 @@ package io.gitlab.arturbosch.detekt.cli.baseline
  * @author Artur Bosch
  * @author Markus Schwarz
  */
-internal data class Baseline(val blacklist: Blacklist, val whitelist: Whitelist)
+internal data class Baseline(val sourceSetId: String?, val blacklist: Blacklist, val whitelist: Whitelist)
 
-internal data class ConsolidatedBaseline(
-		val blacklist: Blacklist,
-		val defaultWhitelist: Whitelist? = null,
-		val whitelists: Map<String, Whitelist> = emptyMap()
-)
+internal data class ConsolidatedBaseline(val baselines: List<Baseline> = emptyList()) {
+	fun withSourceSetId(sourceSetId: String?) = baselines.firstOrNull { it.sourceSetId == sourceSetId }
+	fun contains(sourceSetId: String?) = baselines.any { it.sourceSetId == sourceSetId }
 
+	fun addOrReplace(baseline: Baseline): ConsolidatedBaseline {
+
+		return if (contains(baseline.sourceSetId))
+			copy(baselines = baselines.filter { it.sourceSetId != baseline.sourceSetId } + baseline)
+		else
+			copy(baselines = baselines + baseline)
+	}
+}
+
+internal const val SMELL_BASELINE_CONTAINER = "SmellBaselines"
 internal const val SMELL_BASELINE = "SmellBaseline"
 internal const val BLACKLIST = "Blacklist"
 internal const val WHITELIST = "Whitelist"

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFormat.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFormat.kt
@@ -46,27 +46,22 @@ internal class BaselineFormat {
 	private val XMLStreamException.positions
 		get() = location.lineNumber to location.columnNumber
 
-	private fun XMLStreamWriter.save(baseline: ConsolidatedBaseline) {
+	private fun XMLStreamWriter.save(consolidated: ConsolidatedBaseline) {
 		document {
-			tag(SMELL_BASELINE) {
-				tag(BLACKLIST) {
-					val (ids, timestamp) = baseline.blacklist
-					attribute(TIMESTAMP, timestamp)
-					ids.forEach { tag(ID, it) }
-				}
-				baseline.defaultWhitelist?.let { whitelist ->
-					tag(WHITELIST) {
-						val (sourceSetId, ids, timestamp) = whitelist
-						sourceSetId?.let { attribute(SOURCE_SET_ID, sourceSetId) }
-						attribute(TIMESTAMP, timestamp)
-						ids.forEach { tag(ID, it) }
-					}
-				}
-				baseline.whitelists.forEach { sourceSetId, whitelist ->
-					tag(WHITELIST) {
-						attribute(SOURCE_SET_ID, sourceSetId)
-						attribute(TIMESTAMP, whitelist.timestamp)
-						whitelist.ids.forEach { tag(ID, it) }
+			tag(SMELL_BASELINE_CONTAINER) {
+				consolidated.baselines.forEach { baseline ->
+					tag(SMELL_BASELINE) {
+						baseline.sourceSetId?.let { attribute(SOURCE_SET_ID, it) }
+						tag(BLACKLIST) {
+							val (ids, timestamp) = baseline.blacklist
+							attribute(TIMESTAMP, timestamp)
+							ids.forEach { tag(ID, it) }
+						}
+						tag(WHITELIST) {
+							val (ids, timestamp) = baseline.whitelist
+							attribute(TIMESTAMP, timestamp)
+							ids.forEach { tag(ID, it) }
+						}
 					}
 				}
 			}

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineHandler.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineHandler.kt
@@ -7,19 +7,58 @@ import java.time.Instant
 /**
  * @author Artur Bosch
  */
-class BaselineHandler : DefaultHandler() {
+internal class BaselineHandler : DefaultHandler() {
 
 	private var current: String? = null
 	private var content: String = ""
 	private var whitestamp: String? = null
 	private var blackstamp: String? = null
-	private val whiteIds = mutableSetOf<String>()
+	private var currentSourceSetId: String? = null
+
+	private val currentWhitelists = mutableListOf<Whitelist>()
+	private val currentWhiteIds = mutableSetOf<String>()
 	private val blackIds = mutableSetOf<String>()
 
-	internal fun createBaseline() = Baseline(
-			Blacklist(blackIds, blackstamp ?: now()), Whitelist(whiteIds, whitestamp ?: now()))
+	internal fun createConsolidatedBaseline() = ConsolidatedBaseline(
+			Blacklist(blackIds, blackstamp ?: now()),
+			whitelistIdentifiedBy(null),
+			sourceSetWhitelistsAsMap()
+	)
+
+	private fun sourceSetWhitelistsAsMap(): Map<String, Whitelist> {
+		val sourceSets = currentWhitelists.map(Whitelist::sourceSetId)
+
+		val result = mutableMapOf<String, Whitelist>()
+		// by iterating over the ids we also check for duplicates
+		sourceSets.forEach {
+			it?.let { sourceSetId ->
+				val whitelist = whitelistIdentifiedBy(sourceSetId)
+				if (whitelist != null) {
+					result.put(sourceSetId, whitelist)
+				}
+			}
+		}
+
+		return result
+	}
+
+	internal fun createBaseline(sourceSetId: String?) = Baseline(
+			Blacklist(blackIds, blackstamp ?: now()),
+			whitelistIdentifiedBy(sourceSetId) ?: Whitelist(sourceSetId, emptySet(), whitestamp ?: now())
+	)
 
 	private fun now() = Instant.now().toEpochMilli().toString()
+
+	private fun whitelistIdentifiedBy(sourceSetId: String?): Whitelist? {
+		val matching = currentWhitelists.filter { it.sourceSetId == sourceSetId }
+		if (matching.size > 1) {
+			val msg = if (sourceSetId == null)
+				"There are multiple whitelists not associated to a source set"
+			else "There are multiple whitelists associated to source set $sourceSetId"
+			throw InvalidBaselineState(msg)
+		}
+		return matching.firstOrNull()
+	}
 
 	override fun startElement(uri: String, localName: String, qName: String, attributes: Attributes) {
 		when (qName) {
@@ -29,6 +68,7 @@ class BaselineHandler : DefaultHandler() {
 			}
 			WHITELIST -> {
 				current = WHITELIST
+				currentSourceSetId = attributes.getValue(SOURCE_SET_ID)
 				whitestamp = attributes.getValue(TIMESTAMP)
 			}
 			ID -> content = ""
@@ -40,11 +80,18 @@ class BaselineHandler : DefaultHandler() {
 			ID -> if (content.isNotBlank()) {
 				when (current) {
 					BLACKLIST -> blackIds.add(content)
-					WHITELIST -> whiteIds.add(content)
+					WHITELIST -> currentWhiteIds.add(content)
 				}
 				content = ""
 			}
-			BLACKLIST, WHITELIST -> current == null
+			BLACKLIST -> current == null
+			WHITELIST -> {
+				currentWhitelists.add(Whitelist(currentSourceSetId, currentWhiteIds.toSet(), whitestamp ?: now()))
+				current = null
+				currentSourceSetId = null
+				currentWhiteIds.clear()
+			}
+
 		}
 	}
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/Blacklist.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/Blacklist.kt
@@ -3,8 +3,4 @@ package io.gitlab.arturbosch.detekt.cli.baseline
 /**
  * @author Artur Bosch
  */
-internal data class Blacklist(
-		override val ids: Set<String>,
-		override val timestamp: String
-) : Listing<Blacklist>
-
+internal data class Blacklist(override val ids: Set<String>, override val timestamp: String) : Listing<Blacklist>

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/Blacklist.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/Blacklist.kt
@@ -3,13 +3,8 @@ package io.gitlab.arturbosch.detekt.cli.baseline
 /**
  * @author Artur Bosch
  */
-data class Blacklist(override val ids: Set<String>,
-					 override val timestamp: String) : Listing<Blacklist> {
+internal data class Blacklist(
+		override val ids: Set<String>,
+		override val timestamp: String
+) : Listing<Blacklist>
 
-	override fun withNewTimestamp(timestamp: String,
-								  list: Blacklist) = Blacklist(list.ids, timestamp)
-
-	override fun toString(): String {
-		return "Blacklist(ids=$ids, timestamp='$timestamp')"
-	}
-}

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/Listing.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/Listing.kt
@@ -7,6 +7,4 @@ interface Listing<T> {
 
 	val timestamp: String
 	val ids: Set<String>
-
-	fun withNewTimestamp(timestamp: String, list: T): T
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/Whitelist.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/Whitelist.kt
@@ -3,7 +3,4 @@ package io.gitlab.arturbosch.detekt.cli.baseline
 /**
  * @author Artur Bosch
  */
-internal data class Whitelist(val sourceSetId: String?,
-							  override val ids: Set<String>,
-							  override val timestamp: String
-) : Listing<Whitelist>
+internal data class Whitelist(override val ids: Set<String>, override val timestamp: String) : Listing<Whitelist>

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/Whitelist.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/Whitelist.kt
@@ -3,13 +3,7 @@ package io.gitlab.arturbosch.detekt.cli.baseline
 /**
  * @author Artur Bosch
  */
-data class Whitelist(override val ids: Set<String>,
-					 override val timestamp: String) : Listing<Whitelist> {
-
-	override fun withNewTimestamp(timestamp: String,
-								  list: Whitelist) = Whitelist(list.ids, timestamp)
-
-	override fun toString(): String {
-		return "Blacklist(ids=$ids, timestamp='$timestamp')"
-	}
-}
+internal data class Whitelist(val sourceSetId: String?,
+							  override val ids: Set<String>,
+							  override val timestamp: String
+) : Listing<Whitelist>

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFacadeTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFacadeTest.kt
@@ -4,14 +4,11 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.cli.createFinding
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.ListAssert
 import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
-import java.io.BufferedReader
-import java.io.InputStream
-import java.io.InputStreamReader
+import java.io.File
 import java.nio.file.Files
-import java.nio.file.Path
 import java.nio.file.Paths
 
 /**
@@ -22,28 +19,158 @@ class BaselineFacadeTest : Spek({
 
 	val dir = Files.createTempDirectory("baseline_format")
 
-	it("create") {
-		val fullPath = dir.resolve("baseline.xml")
-		val baselineFacade = BaselineFacade(fullPath)
-		baselineFacade.create(emptyList())
-		Files.newInputStream(fullPath).use<InputStream?, ListAssert<String>?> {
-			val reader = BufferedReader(InputStreamReader(it))
-			assertThat(reader.lines()).isNotEmpty
+	describe("writing a new baseline file") {
+
+		describe("without a source set id") {
+
+			it("creates a baseline file without smells") {
+				val baselineFile = newBaselineFile()
+				val baselineFacade = BaselineFacade(baselineFile.toPath())
+				baselineFacade.create(emptyList())
+
+				assertThat(baselineFile.readText()).isNotBlank()
+			}
+			it("creates a baseline file with smells") {
+				val baselineFile = newBaselineFile()
+				val ruleName = "TheRule"
+				val baselineFacade = BaselineFacade(baselineFile.toPath())
+				baselineFacade.create(
+						listOf(createFinding(ruleName))
+				)
+
+				assertThat(baselineFile.readText()).contains(ruleName)
+			}
+		}
+
+		describe("with a source set id") {
+			val sourceSetId = "project:main"
+
+			it("creates a baseline file without smells") {
+				val baselineFile = newBaselineFile()
+				val baselineFacade = BaselineFacade(baselineFile.toPath(), sourceSetId)
+				baselineFacade.create(emptyList())
+
+				assertThat(baselineFile.readText()).isNotBlank()
+			}
+			it("creates a baseline file with smells") {
+				val baselineFile = newBaselineFile()
+				val ruleName = "TheRule"
+				val baselineFacade = BaselineFacade(baselineFile.toPath(), sourceSetId)
+				baselineFacade.create(
+						listOf(createFinding(ruleName))
+				)
+
+				assertThat(baselineFile.readText()).contains(ruleName)
+			}
 		}
 	}
 
-	it("filterWithExistingBaseline") {
-		assertFilter(dir)
+	describe("writing to an existing baseline file") {
+
+		describe("without a source set id") {
+
+			it("overwrites the default whitelist") {
+				val baselineFile = newBaselineFile()
+				val baselineFacade = BaselineFacade(baselineFile.toPath())
+				val oldRule = "OLD_RULE"
+				baselineFacade.create(listOf(createFinding(oldRule)))
+				assertThat(baselineFile.readText()).contains(oldRule)
+
+				// udpate with new whitelist
+				val newRule = "NEW_RULE"
+				baselineFacade.create(listOf(createFinding(newRule)))
+
+				// verify
+				assertThat(baselineFile.readText()).doesNotContain(oldRule)
+				assertThat(baselineFile.readText()).contains(newRule)
+			}
+			it("adds a default whitelist") {
+				val baselineFile = newBaselineFile()
+				val withSourceSetFacade = BaselineFacade(baselineFile.toPath(), "project:foo")
+				val noSourceSetFacade = BaselineFacade(baselineFile.toPath())
+				val oldRule = "OLD_RULE"
+				withSourceSetFacade.create(listOf(createFinding(oldRule)))
+				assertThat(baselineFile.readText()).contains(oldRule)
+
+				// udpate with new whitelist
+				val newRule = "NEW_RULE"
+				noSourceSetFacade.create(listOf(createFinding(newRule)))
+
+				// verify
+				assertThat(baselineFile.readText()).contains(oldRule)
+				assertThat(baselineFile.readText()).contains(newRule)
+			}
+		}
+		describe("with a source set id") {
+
+			it("overwrites the project whitelist") {
+				val baselineFile = newBaselineFile()
+				val baselineFacade = BaselineFacade(baselineFile.toPath(), "project")
+				val oldRule = "OLD_RULE"
+				baselineFacade.create(listOf(createFinding(oldRule)))
+				assertThat(baselineFile.readText()).contains(oldRule)
+
+				// udpate with new whitelist
+				val newRule = "NEW_RULE"
+				baselineFacade.create(listOf(createFinding(newRule)))
+
+				// verify
+				assertThat(baselineFile.readText()).doesNotContain(oldRule)
+				assertThat(baselineFile.readText()).contains(newRule)
+			}
+			it("adds to a default whitelist") {
+				val baselineFile = newBaselineFile()
+				val noSourceSetFacade = BaselineFacade(baselineFile.toPath())
+				val withSourceSetFacade = BaselineFacade(baselineFile.toPath(), "project:foo")
+				val oldRule = "OLD_RULE"
+				noSourceSetFacade.create(listOf(createFinding(oldRule)))
+				assertThat(baselineFile.readText()).contains(oldRule)
+
+				// udpate with new whitelist
+				val newRule = "NEW_RULE"
+				withSourceSetFacade.create(listOf(createFinding(newRule)))
+
+				// verify
+				assertThat(baselineFile.readText()).contains(oldRule)
+				assertThat(baselineFile.readText()).contains(newRule)
+			}
+			it("adds to a whitelist from a different project") {
+				val baselineFile = newBaselineFile()
+				val existingSourceSetFacade = BaselineFacade(baselineFile.toPath(), "project:foo")
+				val newSourceSetFacade = BaselineFacade(baselineFile.toPath(), "project:bar")
+				val oldRule = "OLD_RULE"
+				existingSourceSetFacade.create(listOf(createFinding(oldRule)))
+				assertThat(baselineFile.readText()).contains(oldRule)
+
+				// udpate with new whitelist
+				val newRule = "NEW_RULE"
+				newSourceSetFacade.create(listOf(createFinding(newRule)))
+
+				// verify
+				assertThat(baselineFile.readText()).contains(oldRule)
+				assertThat(baselineFile.readText()).contains(newRule)
+			}
+		}
 	}
 
-	it("filterWithoutExistingBaseline") {
-		val path = Paths.get(resource("/smell-baseline.xml"))
-		assertFilter(path)
+	describe("filtering smells") {
+		it("filterWithExistingBaseline") {
+			val findings = listOf(createFinding())
+			val result = BaselineFacade(dir).filter(findings)
+			assertThat(result).isEqualTo(findings)
+		}
+
+		it("filterWithoutExistingBaseline") {
+			val path = Paths.get(resource("/smell-baseline.xml"))
+			val findings = listOf<Finding>(createFinding())
+			val result = BaselineFacade(path).filter(findings)
+			assertThat(result).isEqualTo(findings)
+		}
 	}
 })
 
-private fun assertFilter(path: Path) {
-	val findings = listOf<Finding>(createFinding())
-	val result = BaselineFacade(path).filter(findings)
-	assertThat(result).isEqualTo(findings)
+private fun newBaselineFile(): File {
+	val baselineFile = createTempDir("baseline-").resolve("baseline.xml")
+	return baselineFile
 }
+

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFormatTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFormatTest.kt
@@ -3,7 +3,9 @@ package io.gitlab.arturbosch.detekt.cli.baseline
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.jetbrains.kotlin.com.intellij.util.ObjectUtils.assertNotNull
 import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -15,36 +17,149 @@ import java.time.Instant
  */
 class BaselineFormatTest : Spek({
 
-	it("loadBaseline") {
-		val path = Paths.get(resource("/smell-baseline.xml"))
-		val (blacklist, whitelist) = BaselineFormat().read(path)
+	describe("Without baseline id") {
+		it("can be loaded") {
+			val path = Paths.get(resource("/smell-baseline.xml"))
+			val (blacklist, defaultWhitelist, _) = BaselineFormat().readConsolidated(path)
 
-		assertThat(blacklist.ids).hasSize(2)
-		assertThat(blacklist.ids).anySatisfy { it.startsWith("LongParameterList") }
-		assertThat(blacklist.ids).anySatisfy { it.startsWith("LongMethod") }
-		assertThat(blacklist.timestamp).isEqualTo("123456789")
-		assertThat(whitelist.ids).hasSize(1)
-		assertThat(whitelist.ids).anySatisfy { it.startsWith("FeatureEnvy") }
-		assertThat(whitelist.timestamp).isEqualTo("987654321")
+			assertThat(blacklist.ids).hasSize(2)
+			assertThat(blacklist.ids).anySatisfy { it.startsWith("LongParameterList") }
+			assertThat(blacklist.ids).anySatisfy { it.startsWith("LongMethod") }
+			assertThat(blacklist.timestamp).isEqualTo("123456789")
+			assertNotNull(defaultWhitelist).let { whitelist ->
+				assertThat(whitelist.ids).hasSize(1)
+				assertThat(whitelist.ids).anySatisfy { it.startsWith("FeatureEnvy") }
+				assertThat(whitelist.timestamp).isEqualTo("987654321")
+			}
+		}
+
+		it("saved and loaded xml are equal") {
+			val now = Instant.now().toEpochMilli().toString()
+			val tempFile = Files.createTempFile("baseline", now)
+
+			val blacklist = Blacklist(setOf("4", "2", "2"), now)
+			val whitelist = Whitelist(null, setOf("1", "2", "3"), now)
+			val savedBaseline = ConsolidatedBaseline(blacklist, whitelist)
+
+			val format = BaselineFormat()
+			format.write(savedBaseline, tempFile)
+			val loadedBaseline = format.read(tempFile)
+
+			assertThat(loadedBaseline).isEqualTo(Baseline(blacklist, whitelist))
+		}
+
+		it("load fails if file is invalid") {
+			val path = Paths.get(resource("/invalid-smell-baseline.txt"))
+			assertThatThrownBy { BaselineFormat().read(path) }.isInstanceOf(InvalidBaselineState::class.java)
+		}
 	}
 
-	it("savedAndLoadedXmlAreEqual") {
-		val now = Instant.now().toEpochMilli().toString()
-		val tempFile = Files.createTempFile("baseline", now)
+	describe("With a named source set") {
+		it("default baseline can be loaded") {
+			val path = Paths.get(resource("/smell-consolidated-baseline.xml"))
+			val (blacklist, whitelist) = BaselineFormat().read(path)
 
-		val savedBaseline = Baseline(
-				Blacklist(setOf("4", "2", "2"), now),
-				Whitelist(setOf("1", "2", "3"), now))
+			assertThat(blacklist.ids).hasSize(2)
+			assertThat(blacklist.ids).anySatisfy { it.startsWith("LongParameterList") }
+			assertThat(blacklist.ids).anySatisfy { it.startsWith("LongMethod") }
+			assertThat(blacklist.timestamp).isEqualTo("123456789")
+			assertThat(whitelist.ids).hasSize(1)
+			assertThat(whitelist.ids).anySatisfy { it.startsWith("ComplexInterface") }
+			assertThat(whitelist.timestamp).isEqualTo("666666666")
+		}
+		it("whitelist for source set can be loaded") {
+			val path = Paths.get(resource("/smell-consolidated-baseline.xml"))
+			val (blacklist, whitelist) = BaselineFormat().read(path, "foo")
 
-		val format = BaselineFormat()
-		format.write(savedBaseline, tempFile)
-		val loadedBaseline = format.read(tempFile)
+			assertThat(blacklist.ids).hasSize(2)
+			assertThat(blacklist.ids).anySatisfy { it.startsWith("LongParameterList") }
+			assertThat(blacklist.ids).anySatisfy { it.startsWith("LongMethod") }
+			assertThat(blacklist.timestamp).isEqualTo("123456789")
+			assertThat(whitelist.ids).hasSize(1)
+			assertThat(whitelist.ids).anySatisfy { it.startsWith("FeatureEnvy") }
+			assertThat(whitelist.timestamp).isEqualTo("987654321")
+		}
+		it("whitelist for source set with empty whitelist can be loaded") {
+			val path = Paths.get(resource("/smell-consolidated-baseline.xml"))
+			val (blacklist, whitelist) = BaselineFormat().read(path, "bar")
 
-		assertThat(loadedBaseline).isEqualTo(savedBaseline)
-	}
+			assertThat(blacklist.ids).hasSize(2)
+			assertThat(blacklist.ids).anySatisfy { it.startsWith("LongParameterList") }
+			assertThat(blacklist.ids).anySatisfy { it.startsWith("LongMethod") }
+			assertThat(blacklist.timestamp).isEqualTo("123456789")
+			assertThat(whitelist.ids).isEmpty()
+			assertThat(whitelist.timestamp).isEqualTo("555555555")
+		}
+		it("can be saved and loaded with an single source set") {
+			val sourceSetId = "foo"
+			val now = Instant.now().toEpochMilli().toString()
+			val tempFile = Files.createTempFile("baseline", now)
 
-	it("loadInvalidBaseline") {
-		val path = Paths.get(resource("/invalid-smell-baseline.txt"))
-		assertThatThrownBy { BaselineFormat().read(path) }.isInstanceOf(InvalidBaselineState::class.java)
+			val blacklist = Blacklist(setOf("4", "2", "2"), now)
+			val whitelist = Whitelist(sourceSetId, setOf("1", "2", "3"), now)
+			val savedBaseline = ConsolidatedBaseline(blacklist, whitelists = mapOf(sourceSetId to whitelist))
+
+			val format = BaselineFormat()
+			format.write(savedBaseline, tempFile)
+			val loadedBaseline = format.read(tempFile, sourceSetId)
+
+			assertThat(loadedBaseline).isEqualTo(Baseline(blacklist, whitelist))
+		}
+		it("a single named source set can be replaced and loaded") {
+			val sourceSetId = "foo"
+			val now = "12345"
+			val tempFile = Files.createTempFile("baseline", now)
+			val format = BaselineFormat()
+
+			// create initially
+			val blacklist = Blacklist(setOf("4", "2", "2"), now)
+			val sourceSetWhitelist = Whitelist(sourceSetId, setOf("1", "2", "3"), now)
+			val savedBaseline = ConsolidatedBaseline(
+					blacklist,
+					whitelists = mapOf(sourceSetId to sourceSetWhitelist))
+			format.write(savedBaseline, tempFile)
+
+			// update
+			val updatedWhitelist = sourceSetWhitelist.copy(ids = setOf("9"))
+			val updatedBaseline = savedBaseline.copy(
+					whitelists = savedBaseline.whitelists + (sourceSetId to updatedWhitelist)
+			)
+			format.write(updatedBaseline, tempFile)
+
+			// load and verify
+			val loadedBaseline = format.read(tempFile, sourceSetId)
+			assertThat(loadedBaseline).isEqualTo(Baseline(blacklist, updatedWhitelist))
+		}
+		it("a second named source set can be added without overwriting the first") {
+			val firstSourceSetId = "foo"
+			val secondSourceSetId = "bar"
+			val now = "12345"
+			val tempFile = Files.createTempFile("baseline", now)
+			val format = BaselineFormat()
+
+			// create initially
+			val blacklist = Blacklist(setOf("4", "2", "2"), now)
+			val firstSourceWhitelist = Whitelist(firstSourceSetId, setOf("1", "2", "3"), now)
+			val savedBaseline = ConsolidatedBaseline(
+					blacklist,
+					whitelists = mapOf(firstSourceSetId to firstSourceWhitelist)
+			)
+			format.write(savedBaseline, tempFile)
+
+			// update
+			val secondSourceWhitelist = Whitelist(secondSourceSetId, setOf("9"), now)
+			val updatedBaseline = savedBaseline.copy(
+					whitelists = savedBaseline.whitelists + (secondSourceSetId to secondSourceWhitelist)
+			)
+			format.write(updatedBaseline, tempFile)
+
+			// load and verify
+			format.read(tempFile, firstSourceSetId).let {
+				assertThat(it).isEqualTo(Baseline(blacklist, firstSourceWhitelist))
+			}
+			format.read(tempFile, secondSourceSetId).let {
+				assertThat(it).isEqualTo(Baseline(blacklist, secondSourceWhitelist))
+			}
+		}
 	}
 })

--- a/detekt-cli/src/test/resources/smell-consolidated-baseline.xml
+++ b/detekt-cli/src/test/resources/smell-consolidated-baseline.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<SmellBaseline>
+    <Blacklist timestamp="123456789">
+        <ID>LongParameterList:Signature</ID>
+        <ID>LongMethod:Signature</ID>
+    </Blacklist>
+    <Whitelist sourceSet="foo" timestamp="987654321">
+        <ID>FeatureEnvy:Signature</ID>
+    </Whitelist>
+    <Whitelist sourceSet="bar" timestamp="555555555">
+    </Whitelist>
+    <Whitelist timestamp="666666666">
+        <ID>ComplexInterface:Signature</ID>
+    </Whitelist>
+</SmellBaseline>

--- a/detekt-cli/src/test/resources/smell-consolidated-baseline.xml
+++ b/detekt-cli/src/test/resources/smell-consolidated-baseline.xml
@@ -1,15 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<SmellBaseline>
-    <Blacklist timestamp="123456789">
-        <ID>LongParameterList:Signature</ID>
-        <ID>LongMethod:Signature</ID>
-    </Blacklist>
-    <Whitelist sourceSet="foo" timestamp="987654321">
-        <ID>FeatureEnvy:Signature</ID>
-    </Whitelist>
-    <Whitelist sourceSet="bar" timestamp="555555555">
-    </Whitelist>
-    <Whitelist timestamp="666666666">
-        <ID>ComplexInterface:Signature</ID>
-    </Whitelist>
-</SmellBaseline>
+<SmellBaselines>
+    <SmellBaseline sourceSet="foo">
+        <Blacklist timestamp="123456789">
+            <ID>LongParameterList:Signature</ID>
+            <ID>LongMethod:Signature</ID>
+        </Blacklist>
+        <Whitelist timestamp="987654321">
+            <ID>FeatureEnvy:Signature</ID>
+        </Whitelist>
+    </SmellBaseline>
+    <SmellBaseline sourceSet="bar">
+        <Blacklist timestamp="123456789"/>
+        <Whitelist timestamp="555555555"/>
+    </SmellBaseline>
+    <SmellBaseline>
+        <Blacklist timestamp="123456789">
+            <ID>LongMethod:Signature</ID>
+        </Blacklist>
+        <Whitelist timestamp="666666666">
+            <ID>ComplexInterface:Signature</ID>
+        </Whitelist>
+    </SmellBaseline>
+</SmellBaselines>

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -32,7 +32,7 @@ class DetektPlugin : Plugin<Project> {
 			it.disableDefaultRuleSetsProp.set(project.provider { extension.disableDefaultRuleSets })
 			it.filters.set(project.provider { extension.filters })
 			it.config.setFrom(project.provider { extension.config })
-			it.baseline.set(project.layout.file(project.provider { extension.baseline }))
+			it.baseline.set(project.layout.file(project.provider { extension.baselineOrDefaultIfExists }))
 			it.plugins.set(project.provider { extension.plugins })
 			it.input.setFrom(existingInputDirectoriesProvider(project, extension))
 			it.reportsDir.set(project.provider { extension.customReportsDir })

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -13,7 +13,7 @@ import java.io.File
  * @author Markus Schwarz
  */
 open class DetektExtension(project: Project) : CodeQualityExtension() {
-
+	private val defaultBaselineFile = project.rootProject.file(DEFAULT_BASELINE_FILE)
 	val customReportsDir: File?
 		get() = reportsDir
 
@@ -25,7 +25,9 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
 
 	var input: ConfigurableFileCollection = project.layout.configurableFiles(DEFAULT_SRC_DIR_JAVA, DEFAULT_SRC_DIR_KOTLIN)
 
-	var baseline: File? = null
+	var baseline: File? = defaultBaselineFile
+	val baselineOrDefaultIfExists: File?
+		get() = if (baseline == defaultBaselineFile && !defaultBaselineFile.exists()) null else baseline
 
 	var config: ConfigurableFileCollection = project.layout.configurableFiles()
 
@@ -39,6 +41,7 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
 
 	var plugins: String? = null
 
+
 	companion object {
 		const val DEFAULT_SRC_DIR_JAVA = "src/main/java"
 		const val DEFAULT_SRC_DIR_KOTLIN = "src/main/kotlin"
@@ -46,6 +49,7 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
 		const val DEFAULT_PARALLEL_VALUE = false
 		const val DEFAULT_DISABLE_RULESETS_VALUE = false
 		const val DEFAULT_REPORT_ENABLED_VALUE = true
+		const val DEFAULT_BASELINE_FILE = "config/detekt/baseline.xml"
 	}
 }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslTest.kt
@@ -13,10 +13,21 @@ internal class CreateBaselineTaskDslTest : Spek({
 	describe("The detektBaseline task of the Detekt Gradle plugin") {
 		listOf(DslTestBuilder.groovy(), DslTestBuilder.kotlin()).forEach { builder ->
 			describe("using ${builder.gradleBuildName}") {
+				it("can be executed without any configuration") {
+					val gradleRunner = builder
+							.build()
+
+					gradleRunner.runTasksAndCheckResult("detektBaseline") { result ->
+						assertThat(result.task(":detektBaseline")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+						assertThat(projectFile("config/detekt/baseline.xml")).exists()
+					}
+
+				}
 				it("can be executed when baseline file is specified") {
+					val targetFile = "config/detekt-baseline.xml"
 					val detektConfig = """
 						|detekt {
-						| 	baseline = file("build/baseline.xml")
+						| 	baseline = file("${targetFile}")
 						|}
 						"""
 					val gradleRunner = builder
@@ -25,7 +36,7 @@ internal class CreateBaselineTaskDslTest : Spek({
 
 					gradleRunner.runTasksAndCheckResult("detektBaseline") { result ->
 						assertThat(result.task(":detektBaseline")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-						assertThat(projectFile("build/baseline.xml")).exists()
+						assertThat(projectFile(targetFile)).exists()
 					}
 
 				}


### PR DESCRIPTION
This PR is not yet ready but I would like to get your feedback. Eventually it is supposed to resolve #1260.

* The baseline is created by default in `$rootProject.projectDir/config/detekt/baseline.xml`
* If the file `$rootProject.projectDir/config/detekt/baseline.xml` exists, it is used as the baseline for the `detekt` task unless configured differently.
* The CLI accepts an optional `--source-set-id` parameter in order to be able to use one baseline file for multiple subprojects (and in the future source sets within those).
* The baseline file format is changed since there has to be a container for multiple baselines. Existing files in the current format can still be read.

The change missing is to actually use the sourceSetId in the gradle plugin. Could someone please tell me (or point me to some documentation) on how to use this changed cli from within the gradle subproject and how to make it work in CI?