### PR TITLE
Swallowed exception update

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -23,6 +23,16 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  *     } catch(e: IOException) {
  *         throw MyException(e.message) // e is swallowed
  *     }
+ *     try {
+ *         // ...
+ *     } catch(e: IOException) {
+ *         throw MyException() // e is swallowed
+ *     }
+ *     try {
+ *         // ...
+ *     } catch(e: IOException) {
+ *         bar() // exception is unused
+ *     }
  * }
  * </noncompliant>
  *
@@ -32,6 +42,11 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  *         // ...
  *     } catch(e: IOException) {
  *         throw MyException(e)
+ *     }
+ *     try {
+ *         // ...
+ *     } catch(e: IOException) {
+ *         println(e) // logging is ok here
  *     }
  * }
  * </compliant>

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -46,12 +46,20 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
 			Debt.TWENTY_MINS)
 
 	override fun visitCatchSection(catchClause: KtCatchClause) {
-		if (isExceptionSwallowed(catchClause) == true) {
+		if (isExceptionUnused(catchClause) || isExceptionSwallowed(catchClause)) {
 			report(CodeSmell(issue, Entity.from(catchClause), issue.description))
 		}
 	}
 
-	private fun isExceptionSwallowed(catchClause: KtCatchClause): Boolean? {
+	private fun isExceptionUnused(catchClause: KtCatchClause): Boolean {
+		val parameterName = catchClause.catchParameter?.name
+		val catchBody = catchClause.catchBody ?: return true
+		return !catchBody
+				.collectByType<KtNameReferenceExpression>()
+				.any { it.text == parameterName }
+	}
+
+	private fun isExceptionSwallowed(catchClause: KtCatchClause): Boolean {
 		val parameterName = catchClause.catchParameter?.name
 		val throwExpressions = catchClause.catchBody?.collectByType<KtThrowExpression>()
 		throwExpressions?.forEach { throwExpr ->

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -13,7 +13,7 @@ class SwallowedExceptionSpec : SubjectSpek<SwallowedException>({
 	given("several catch blocks") {
 
 		it("reports swallowed exceptions") {
-			assertThat(subject.lint(Case.SwallowedExceptionPositive.path())).hasSize(3)
+			assertThat(subject.lint(Case.SwallowedExceptionPositive.path())).hasSize(5)
 		}
 
 		it("does not report thrown catch blocks") {

--- a/detekt-rules/src/test/resources/cases/SwallowedExceptionNegative.kt
+++ b/detekt-rules/src/test/resources/cases/SwallowedExceptionNegative.kt
@@ -4,15 +4,20 @@ import java.io.IOException
 
 fun noSwallowedException() {
 	try {
-	} catch (e: Exception) {
-		println()
-	} catch (e: Exception) {
-		throw IOException()
 	} catch(e: Exception) {
 		throw IOException(e.message, e)
 	} catch(e: Exception) {
 		throw IOException(e)
 	} catch (e: Exception) {
 		throw Exception(e)
+	}
+}
+
+fun usedException() {
+	try {
+	} catch (e: Exception) {
+		print(e)
+	} catch(e: Exception) {
+		print(e.message)
 	}
 }

--- a/detekt-rules/src/test/resources/cases/SwallowedExceptionPositive.kt
+++ b/detekt-rules/src/test/resources/cases/SwallowedExceptionPositive.kt
@@ -10,5 +10,14 @@ fun swallowedExceptions() {
 		throw Exception(IOException(e.toString())) // violation
 	} catch(e: Exception) {
 		throw IOException(e.message) // violation
+	} catch(e: Exception) {
+		throw IOException() // violation
+	}
+}
+
+fun unusedException() {
+	try {
+	} catch (e: Exception) {
+		println() // violation
 	}
 }

--- a/docs/pages/documentation/exceptions.md
+++ b/docs/pages/documentation/exceptions.md
@@ -215,6 +215,16 @@ fun foo() {
     } catch(e: IOException) {
         throw MyException(e.message) // e is swallowed
     }
+    try {
+        // ...
+    } catch(e: IOException) {
+        throw MyException() // e is swallowed
+    }
+    try {
+        // ...
+    } catch(e: IOException) {
+        bar() // exception is unused
+    }
 }
 ```
 
@@ -226,6 +236,11 @@ fun foo() {
         // ...
     } catch(e: IOException) {
         throw MyException(e)
+    }
+    try {
+        // ...
+    } catch(e: IOException) {
+        println(e) // logging is ok here
     }
 }
 ```

--- a/reports/failfast.yml
+++ b/reports/failfast.yml
@@ -47,7 +47,7 @@ exceptions:
   ReturnFromFinally:
     active: true
   SwallowedException:
-    active: true
+    active: false
   ThrowingExceptionFromFinally:
     active: true
   ThrowingExceptionsWithoutMessageOrCause:


### PR DESCRIPTION
When this PR is merged, I suggest to add a config parameter to this rule.
There are exception types like NumberFormatException and ParseException that indicate nonexceptional outcomes. This rule should ignore unhandled exception of this type specified in the config.