### PR TITLE
Added first prototype for compiling test snippets

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
@@ -1,7 +1,9 @@
 package io.gitlab.arturbosch.detekt.rules.performance
 
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
@@ -9,6 +11,7 @@ import org.jetbrains.spek.api.dsl.it
 class ForEachOnRangeSpec : Spek({
 
 	given("a kt file with using a forEach on a range") {
+		@Language("kotlin")
 		val code = """
 			fun test() {
 				(1..10).forEach {
@@ -27,7 +30,7 @@ class ForEachOnRangeSpec : Spek({
 		"""
 
 		it("should report the forEach usage") {
-			val findings = ForEachOnRange().lint(code)
+			val findings = ForEachOnRange().compileAndLint(code)
 			assertThat(findings).hasSize(4)
 		}
 	}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
@@ -11,7 +11,6 @@ import org.jetbrains.spek.api.dsl.it
 class ForEachOnRangeSpec : Spek({
 
 	given("a kt file with using a forEach on a range") {
-		@Language("kotlin")
 		val code = """
 			fun test() {
 				(1..10).forEach {

--- a/detekt-rules/src/test/resources/META-INF/services/javax.script.ScriptEngineFactory
+++ b/detekt-rules/src/test/resources/META-INF/services/javax.script.ScriptEngineFactory
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.script.jsr223.KotlinJsr223JvmLocalScriptEngineFactory

--- a/detekt-test/build.gradle.kts
+++ b/detekt-test/build.gradle.kts
@@ -1,7 +1,10 @@
 val assertjVersion: String by project
 
 dependencies {
+	implementation(kotlin("script-runtime"))
 	implementation(kotlin("compiler-embeddable"))
+	implementation(kotlin("script-util"))
+
 	implementation(project(":detekt-core"))
 	implementation("org.assertj:assertj-core:$assertjVersion")
 }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEngine.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEngine.kt
@@ -1,0 +1,33 @@
+package io.gitlab.arturbosch.detekt.test
+
+import org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback
+import org.jetbrains.kotlin.script.jsr223.KotlinJsr223JvmLocalScriptEngine
+import javax.script.ScriptEngineManager
+import javax.script.ScriptException
+
+/**
+ * @author schalkms
+ */
+object KotlinScriptEngine {
+
+	private val engine: KotlinJsr223JvmLocalScriptEngine
+
+	init {
+		setIdeaIoUseFallback() // To avoid error on Windows
+
+		val scriptEngineManager = ScriptEngineManager()
+		val localEngine = scriptEngineManager.getEngineByExtension("kts") as? KotlinJsr223JvmLocalScriptEngine
+		if (localEngine == null) {
+			throw IllegalStateException("Kotlin script engine not supported")
+		}
+		engine = localEngine
+	}
+
+	fun compile(code: String) {
+		try {
+			engine.compile(code)
+		} catch (e: ScriptException) {
+			throw KotlinScriptException(e)
+		}
+	}
+}

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEngine.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEngine.kt
@@ -17,9 +17,7 @@ object KotlinScriptEngine {
 
 		val scriptEngineManager = ScriptEngineManager()
 		val localEngine = scriptEngineManager.getEngineByExtension("kts") as? KotlinJsr223JvmLocalScriptEngine
-		if (localEngine == null) {
-			throw IllegalStateException("Kotlin script engine not supported")
-		}
+		requireNotNull(localEngine) { "Kotlin script engine not supported" }
 		engine = localEngine
 	}
 

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptException.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptException.kt
@@ -1,0 +1,8 @@
+package io.gitlab.arturbosch.detekt.test
+
+import javax.script.ScriptException
+
+/**
+ * @author schalkms
+ */
+class KotlinScriptException(e: ScriptException) : RuntimeException("Given Kotlin code is invalid.", e)

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -4,10 +4,11 @@ import io.gitlab.arturbosch.detekt.api.BaseRule
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.test.KotlinScriptEngine.compile
+import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
 
-fun BaseRule.compileAndLint(content: String): List<Finding> {
+fun BaseRule.compileAndLint(@Language("kotlin") content: String): List<Finding> {
 	compile(content)
 	return lint(content)
 }
@@ -18,7 +19,6 @@ fun BaseRule.lint(content: String): List<Finding> {
 }
 
 fun BaseRule.lint(path: Path): List<Finding> {
-	println(path.toAbsolutePath())
 	val ktFile = KtTestCompiler.compile(path)
 	return findingsAfterVisit(ktFile)
 }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -3,8 +3,14 @@ package io.gitlab.arturbosch.detekt.test
 import io.gitlab.arturbosch.detekt.api.BaseRule
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.test.KotlinScriptEngine.compile
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
+
+fun BaseRule.compileAndLint(content: String): List<Finding> {
+	compile(content)
+	return lint(content)
+}
 
 fun BaseRule.lint(content: String): List<Finding> {
 	val ktFile = KtTestCompiler.compileFromContent(content.trimIndent())
@@ -12,6 +18,7 @@ fun BaseRule.lint(content: String): List<Finding> {
 }
 
 fun BaseRule.lint(path: Path): List<Finding> {
+	println(path.toAbsolutePath())
 	val ktFile = KtTestCompiler.compile(path)
 	return findingsAfterVisit(ktFile)
 }


### PR DESCRIPTION
This commit introduces the compilation of test snippets for detekt's
ruleset. With this compilation step invalid Kotlin code in test snippets
gets detected. The live compilation is based on JSR223 specified under
https://www.openhab.org/docs/configuration/jsr223.html

pros
* actually compiling the code
* more reliable tests
* more readable tests
* test 1 thing per test and thus more maintainable test snippets
* removal of controversial Case files #1089

cons
* longer test runtime (initial 3s then 25-50 ms per test on my machine)
* IDE services not available for writing snippets (code completion...)

___

I think the pros really outweight the cons by far here.
If this is merged, I'll continue to transform these snippets to the new concept step by step in small PRs to make it reviewable.
CC @vanniktech 