### PR TITLE
 Supports @this expr in extension functions

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
@@ -7,7 +7,11 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
-import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtExpressionWithLabel
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtThisExpression
 import org.jetbrains.kotlin.psi.psiUtil.containingClass
 import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.parents
@@ -24,6 +28,14 @@ import org.jetbrains.kotlin.psi.psiUtil.parents
  *     if (r == "bar") break@loop
  *     println(r)
  * }
+ *
+ * class Outer {
+ *     inner class Inner {
+ *         fun f() {
+ *             val i = this@Inner // referencing itself, use `this instead
+ *         }
+ *     }
+ * }
  * </noncompliant>
  *
  * <compliant>
@@ -37,6 +49,9 @@ import org.jetbrains.kotlin.psi.psiUtil.parents
  *     inner class Inner {
  *         fun f() {
  *             val outer = this@Outer
+ *         }
+ *         fun Int.extend() {
+ *             val inner = this@Inner // this would reference Int and not Inner
  *         }
  *     }
  * }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
@@ -7,11 +7,10 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
-import org.jetbrains.kotlin.psi.KtClass
-import org.jetbrains.kotlin.psi.KtElement
-import org.jetbrains.kotlin.psi.KtExpressionWithLabel
-import org.jetbrains.kotlin.psi.KtThisExpression
+import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.containingClass
+import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
+import org.jetbrains.kotlin.psi.psiUtil.parents
 
 /**
  * This rule reports labeled expressions. Expressions with labels generally increase complexity and worsen the
@@ -48,6 +47,7 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  * @author schalkms
  */
 class LabeledExpression(config: Config = Config.empty) : Rule(config) {
+
 	override val issue: Issue = Issue("LabeledExpression",
 			Severity.Maintainability,
 			"Expression with labels increase complexity and affect maintainability.",
@@ -64,13 +64,22 @@ class LabeledExpression(config: Config = Config.empty) : Rule(config) {
 
 	private fun isNotReferencingOuterClass(expression: KtExpressionWithLabel): Boolean {
 		val containingClasses = mutableListOf<KtClass>()
-		expression.containingClass()?.let { containingClasses(it, containingClasses) }
+		val containingClass = expression.containingClass() ?: return false
+		if (isAllowedToReferenceContainingClass(containingClass, expression)) {
+			containingClasses.add(containingClass)
+		}
+		getClassHierarchy(containingClass, containingClasses)
 		return !containingClasses.any { it.name == expression.getLabelName() }
 	}
 
-	private fun containingClasses(element: KtElement, classes: MutableList<KtClass>) {
+	private fun isAllowedToReferenceContainingClass(klass: KtClass, expression: KtExpressionWithLabel): Boolean {
+		return !klass.isInner() ||
+				expression.parents.filterIsInstance<KtNamedFunction>().any { it.isExtensionDeclaration() }
+    }
+
+	private fun getClassHierarchy(element: KtElement, classes: MutableList<KtClass>) {
 		val containingClass = element.containingClass() ?: return
 		classes.add(containingClass)
-		containingClasses(containingClass, classes)
+		getClassHierarchy(containingClass, classes)
 	}
 }

--- a/detekt-rules/src/test/resources/cases/LabeledExpressionNegative.kt
+++ b/detekt-rules/src/test/resources/cases/LabeledExpressionNegative.kt
@@ -3,17 +3,31 @@ package cases
 @Suppress("unused", "UNUSED_VARIABLE")
 class LabeledOuterNegative {
 
-	inner class Inner1 {
+	inner class Inner {
 
 		fun foo() {
-			val foo = this@LabeledOuterNegative
+			print(this@LabeledOuterNegative)
 		}
 
-		inner class Inner2 {
+		inner class InnerInner {
+			val a = 0
+
 			fun foo() {
-				val foo = this@LabeledOuterNegative
-				val foo2 = this@Inner1
+				print(this@LabeledOuterNegative)
+				print(this@Inner)
 			}
+
+			fun Int.extensionMethod() {
+				print(this@Inner)
+				print(this@InnerInner)
+			}
+		}
+	}
+
+	class Nested {
+
+		fun Int.extensionMethod() {
+			print(this@Nested)
 		}
 	}
 }

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -110,6 +110,14 @@ loop@ for (r in range) {
     if (r == "bar") break@loop
     println(r)
 }
+
+class Outer {
+    inner class Inner {
+        fun f() {
+            val i = this@Inner // referencing itself, use `this instead
+        }
+    }
+}
 ```
 
 #### Compliant Code:
@@ -125,6 +133,9 @@ class Outer {
     inner class Inner {
         fun f() {
             val outer = this@Outer
+        }
+        fun Int.extend() {
+            val inner = this@Inner // this would reference Int and not Inner
         }
     }
 }


### PR DESCRIPTION
Extensions function can now reference their containing classes using a
@this expression.
This not reported by the LabeledExpression rule anymore.
Inner classes referencing itself is still reported.

reference #1226