### PR TITLE
Hide dev flags in CLI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -84,6 +84,8 @@ Run detekt on itself and other kotlin projects with the `--run-rule RuleSet:Rule
 Make use of the `scripts/get_analysis_projects.groovy` script to automatically establish a set of analysis projects.
 - ... do not forget to run `./gradlew build`. This will execute tests locally and update the `default-detekt.config.yml`
 as well as add the new/changed rules to the documentation.
+- To print the AST of sources you can pass the `--print-ast` flag to the CLI which will print each
+Kotlin files AST. This can be helpful when implementing and debugging rules.
 - be aware that your PR will stay open for at least two days so that other users can give feedback.
 
 After some time and testing there is a chance this rule will become active on default.

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -76,11 +76,13 @@ class CliArgs : Args {
 	override var help: Boolean = false
 
 	@Parameter(names = ["--run-rule"],
-			description = "Specify a rule by [RuleSet:Rule] pattern and run it on input.")
+			description = "Specify a rule by [RuleSet:Rule] pattern and run it on input.",
+			hidden = true)
 	var runRule: String? = null
 
 	@Parameter(names = ["--print-ast"],
-			description = "Prints the AST for given [input] file. Must be no directory.")
+			description = "Prints the AST for given [input] file. Must be no directory.",
+			hidden = true)
 	var printAst: Boolean = false
 
 	val inputPaths: List<Path> by lazy {

--- a/docs/pages/gettingstarted/cli.md
+++ b/docs/pages/gettingstarted/cli.md
@@ -36,29 +36,27 @@ Usage: detekt [options]
       Disables default rule sets.
       Default: false
     --filters, -f
-      Path filters defined through regex with separator ';' (".*test.*").
+      Path filters defined through regex with separator ';' or ','
+      (".*test.*"). These filters apply on relative paths from the project
+      root.
     --generate-config, -gc
       Export default config to default-detekt-config.yml.
       Default: false
     --help, -h
       Shows the usage.
     --input, -i
-      Input paths to analyze. Multiple paths are separated by comma. 
-      Default: The current working directory.
+      Input paths to analyze. Multiple paths are separated by comma. If not
+      specified the current working directory is used.
     --parallel
       Enables parallel compilation of source files. Should only be used if the
       analyzing project has more than ~200 kotlin files.
       Default: false
     --plugins, -p
       Extra paths to plugin jars separated by ',' or ';'.
-    --print-ast
-      Prints the AST for given [input] file. Must be no directory.
-      Default: false
     --report, -r
       Generates a report for given 'report-id' and stores it on given 'path'.
-      Entry should consist of: [report-id:path-to-store-report]+
-    --run-rule
-      Specify a rule by [RuleSet:Rule] pattern and run it on input.
-
+      Entry should consist of: [report-id:path]. Available 'report-id' values:
+      'txt', 'xml', 'html'. These can also be used in combination with each
+      other e.g. '-r txt:reports/detekt.txt -r xml:reports/detekt.xml'
 
 ```


### PR DESCRIPTION
Given that the CLI already has quite a few arguments which might be a bit overwhelming for new users we could hide the flags used soley during development.

- `--print-ast`
- `--run-rule`

I made sure both of them are mentioned in the `CONTRIBUTING.md`.