### PR TITLE
Support multiple it refs in UnnecessaryLet (#1359)

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -53,5 +53,14 @@ class UnnecessaryLetSpec : SubjectSpek<UnnecessaryLet>({
 				}""")
 			assertThat(findings).hasSize(0)
 		}
+		it("does not report lets where it is used multiple times") {
+			val findings = subject.lint("""
+				fun f() {
+					val a : Int? = null
+					a?.let { it.plus(it) }
+					a?.let { foo -> foo.plus(foo) }
+				}""")
+			assertThat(findings).hasSize(0)
+		}
 	}
 })

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -945,6 +945,8 @@ a.let { print(it) }
 a?.let { msg -> print(msg) }
 a.let { msg -> print(msg) }
 a?.let { 1.plus(it) } ?.let { msg -> print(msg) }
+a?.let { it.plus(it) }
+a?.let { param -> param.plus(param) }
 ```
 
 ### UnnecessaryParentheses


### PR DESCRIPTION
See the bug report here: https://github.com/arturbosch/detekt/issues/1359

This change updates the `UnnecessaryLet` rule to count the number of references in a `let` lambda for the parameter. If it finds more than one, the rule passes rather than failing.