### PR TITLE
Add EqualsOnSignatureLine

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -406,6 +406,8 @@ style:
     conversionFunctionPrefix: 'to'
   EqualsNullCall:
     active: false
+  EqualsOnSignatureLine:
+    active: false
   ExplicitItLambdaParameter:
     active: false
   ExpressionBodySyntax:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.rules.style.CollapsibleIfStatements
 import io.gitlab.arturbosch.detekt.rules.style.DataClassContainsFunctions
+import io.gitlab.arturbosch.detekt.rules.style.EqualsOnSignatureLine
 import io.gitlab.arturbosch.detekt.rules.style.EqualsNullCall
 import io.gitlab.arturbosch.detekt.rules.style.ExplicitItLambdaParameter
 import io.gitlab.arturbosch.detekt.rules.style.ExpressionBodySyntax
@@ -65,6 +66,7 @@ class StyleGuideProvider : RuleSetProvider {
 				NewLineAtEndOfFile(config),
 				WildcardImport(config),
 				FileParsingRule(config),
+				EqualsOnSignatureLine(config),
 				EqualsNullCall(config),
 				ForbiddenComment(config),
 				ForbiddenImport(config),

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLine.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLine.kt
@@ -1,0 +1,62 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.psiUtil.siblings
+
+/**
+ * Requires that the equals sign, when used for an expression style function, is on the same line as the
+ * rest of the function signature.
+ *
+ * <noncompliant>
+ * fun stuff(): Int
+ * 		= 5
+ *
+ * fun <V> foo(): Int where V : Int
+ * 		= 5
+ * </noncompliant>
+ *
+ * <compliant>
+ * fun stuff() = 5
+ *
+ * fun stuff() =
+ * 		foo.bar()
+ *
+ * fun <V> foo(): Int where V : Int = 5
+ * </compliant>
+ */
+class EqualsOnSignatureLine(config: Config = Config.empty) : Rule(config) {
+
+	override val issue = Issue(javaClass.simpleName, Severity.Style, MESSAGE, Debt.FIVE_MINS)
+
+	override fun visitNamedFunction(function: KtNamedFunction) {
+		val equals = function.equalsToken ?: return
+
+		// Get the tokens after the parameter list (but not including)
+		val afterParams = function.valueParameterList?.siblings(forward = true, withItself = false) ?: return
+
+		// Collect tokens until we find the equals sign
+		val untilEquals = afterParams.takeWhile { it !== equals }.toList()
+
+		// Walk backwards from the '=' to find the whitespace right behind it
+		val whitespace = untilEquals.takeLastWhile { it is PsiWhiteSpace }
+
+		// Search the whitespace tokens to see if they contain newlines
+		whitespace.forEach {
+			if (it.textContains('\n')) {
+				report(CodeSmell(issue, Entity.from(equals), MESSAGE))
+			}
+		}
+	}
+
+	private companion object {
+		const val MESSAGE = "Equals signs for expression style functions should be on the same line as the signature"
+	}
+}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLineSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLineSpec.kt
@@ -1,0 +1,141 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.subject.SubjectSpek
+
+class EqualsOnSignatureLineSpec : SubjectSpek<EqualsOnSignatureLine>({
+	subject { EqualsOnSignatureLine(Config.empty) }
+
+	given("a function") {
+
+		given("with expression syntax and without a return type") {
+			it("reports when the equals is on a new line") {
+				val findings = subject.lint("""
+				fun foo()
+					= 1
+				""")
+				assertThat(findings).hasSize(1)
+			}
+
+			it("succeeds when the equals is on the same line") {
+				val findings = subject.lint("""
+				fun foo() = 1
+
+				fun bar() =
+					2
+				""")
+				assertThat(findings).isEmpty()
+			}
+		}
+
+		given("with expression syntax and with a return type") {
+			it("reports when the equals is on a new line") {
+				val findings = subject.lint("""
+				fun one(): Int
+					= 1
+
+				fun two(
+					foo: String
+				)
+					= 2
+
+				fun three(
+					foo: String
+				): Int
+					= 3
+				""")
+				assertThat(findings).hasSize(3)
+			}
+
+			it("succeeds when the equals is on the same line") {
+				val findings = subject.lint("""
+				fun one(): Int =
+					1
+
+				fun two()
+					: Int =
+					2
+
+				fun three():
+					Int =
+					3
+
+				fun four(
+					foo: String
+				): Int =
+					4
+
+				fun five(
+					foo: String
+				)
+				: Int =
+					5
+
+				fun six(
+					foo: String
+				)
+				:
+				Int =
+					6
+				""")
+				assertThat(findings).isEmpty()
+			}
+		}
+
+		given("with expression syntax and with a where clause") {
+			it("reports when the equals is on a new line") {
+				val findings = subject.lint("""
+				fun <V> one(): Int where V : Number
+					= 1
+
+				fun <V> two(
+					foo: String
+				) where V : Number
+					= 2
+
+				fun <V> three(
+					foo: String
+				): Int
+					where V : Number
+					= 3
+				""")
+				assertThat(findings).hasSize(3)
+			}
+
+			it("succeeds when the equals is on the same line") {
+				val findings = subject.lint("""
+				fun <V> one(): Int where V : Number =
+					1
+
+				fun <V> two() : Int
+					where V : Number =
+					2
+
+				""")
+				assertThat(findings).isEmpty()
+			}
+		}
+
+		it("for non-expression functions") {
+			val findings = subject.lint("""
+			fun foo() {
+			}
+
+			fun bar()
+			{
+			}
+
+			fun baz()
+			:
+			Unit
+			{
+			}
+			""")
+			assertThat(findings).isEmpty()
+		}
+	}
+})

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -88,6 +88,36 @@ fun isNull(str: String) = str.equals(null)
 fun isNull(str: String) = str == null
 ```
 
+### EqualsOnSignatureLine
+
+Requires that the equals sign, when used for an expression style function, is on the same line as the
+rest of the function signature.
+
+**Severity**: Style
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+fun stuff(): Int
+= 5
+
+fun <V> foo(): Int where V : Int
+= 5
+```
+
+#### Compliant Code:
+
+```kotlin
+fun stuff() = 5
+
+fun stuff() =
+foo.bar()
+
+fun <V> foo(): Int where V : Int = 5
+```
+
 ### ExplicitItLambdaParameter
 
 Lambda expressions are one of the core features of the language. They often include very small chunks of


### PR DESCRIPTION
This PR adds a new rule to enforce the placement of the `=` sign for functions that use expression based syntax.

For example, these are valid:

```
function foo() = 5

function foo() =
    5
```

But this is considered invalid:

```
function foo()
    = 5
```