### PR TITLE
Drop JDK 9 & 10 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: java
 jdk:
   - openjdk8
-  - openjdk9
-  - openjdk10
   - openjdk11
 script:
   - ./gradlew build -PwarningsAsErrors=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,6 @@ environment:
   TERM: dumb
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-    - JAVA_HOME: C:\Program Files\Java\jdk9
-    - JAVA_HOME: C:\Program Files\Java\jdk10
     - JAVA_HOME: C:\Program Files\Java\jdk11
 
 init:


### PR DESCRIPTION
Java 9 & 10 are no longer supported, so dropping from CI.

Should unblock #1332 and #1350