### PR TITLE
Actually load the manifest to report detekt's version

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DebugUtils.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DebugUtils.kt
@@ -28,6 +28,6 @@ fun whichDetekt(): String {
 
 private fun readDetektVersionInManifest(resource: URL) =
 		resource.openStream().use {
-			Manifest().mainAttributes
+			Manifest(it).mainAttributes
 					.getValue("DetektVersion")
 		}


### PR DESCRIPTION
Fixes reporting of `unknown` version...