### PR TITLE
Expose compiler-embeddable as a transitive dependency

### DIFF
--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -6,7 +6,7 @@ val spekVersion: String by project
 
 dependencies {
 	implementation("org.yaml:snakeyaml:$yamlVersion")
-	implementation(kotlin("compiler-embeddable"))
+	api(kotlin("compiler-embeddable"))
 
 	testImplementation(project(":detekt-test"))
 

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -8,7 +8,6 @@ val reflectionsVersion: String by project
 
 dependencies {
 	implementation(project(":detekt-api"))
-	implementation(kotlin("compiler-embeddable"))
 
 	testImplementation("org.reflections:reflections:$reflectionsVersion")
 	testImplementation(project(":detekt-test"))


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation

> Dependencies appearing in the api configurations will be transitively exposed to consumers of the library, and as such will appear on the compile classpath of consumers.

This is desired for consumers of `detekt-api`.