### PR TITLE
Request Codecov service to ignore AppVeyor

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  ci:
+    - !appveyor


### PR DESCRIPTION
Code coverage reports are not uploaded when run in AppVeyor. This informs Codecov of that fact.

My hope is that this improves the reliability of Codecov providing reports in comments on PRs (I've noticed it's very hit and miss, and checking the Codecov site many PRs have a message saying it's waiting for CI to complete).