### PR TITLE
Ignore InstanceOfCheckForException by default for tests.

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -21,6 +21,7 @@ test-pattern: # Configure exclusions for test sources
     - 'ForEachOnRange'
     - 'FunctionMaxLength'
     - 'TooGenericExceptionCaught'
+    - 'InstanceOfCheckForException'
 
 build:
   maxIssues: 10

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -90,6 +90,7 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
 			    - 'ForEachOnRange'
 			    - 'FunctionMaxLength'
 			    - 'TooGenericExceptionCaught'
+			    - 'InstanceOfCheckForException'
 			""".trimIndent()
 	}
 


### PR DESCRIPTION
Should be fine to use while testing and asserting that we've got a certain exception.