### PR TITLE
Update default package naming rule according to official style guide. Closes #1429

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -336,7 +336,7 @@ naming:
     privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
   PackageNaming:
     active: true
-    packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
+    packagePattern: '^[a-z]+(\.[a-z][A-Za-z0-9]*)*$'
   TopLevelPropertyNaming:
     active: true
     constantPattern: '[A-Z][_A-Z0-9]*'

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
 /**
  * Reports when package names which do not follow the specified naming convention are used.
  *
- * @configuration packagePattern - naming pattern (default: '^[a-z]+(\.[a-z][a-z0-9]*)*$')
+ * @configuration packagePattern - naming pattern (default: '^[a-z]+(\.[a-z][A-Za-z0-9]*)*$')
  * @active since v1.0.0
  * @author Marvin Ramin
  */
@@ -23,7 +23,7 @@ class PackageNaming(config: Config = Config.empty) : Rule(config) {
 			Severity.Style,
 			"Package names should match the naming convention set in the configuration.",
 			debt = Debt.FIVE_MINS)
-	private val packagePattern by LazyRegex(PACKAGE_PATTERN, "^[a-z]+(\\.[a-z][a-z0-9]*)*$")
+	private val packagePattern by LazyRegex(PACKAGE_PATTERN, "^[a-z]+(\\.[a-z][A-Za-z0-9]*)*$")
 
 	override fun visitPackageDirective(directive: KtPackageDirective) {
 		val name = directive.qualifiedName

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -261,7 +261,7 @@ Reports when package names which do not follow the specified naming convention a
 
 #### Configuration options:
 
-* `packagePattern` (default: `'^[a-z]+(\.[a-z][a-z0-9]*)*$'`)
+* `packagePattern` (default: `'^[a-z]+(\.[a-z][A-Za-z0-9]*)*$'`)
 
    naming pattern
 


### PR DESCRIPTION
For more information, see [this issue](https://github.com/arturbosch/detekt/issues/1429)