### PR TITLE
Reimplement lines of code based rules (LargeClass & LongMethod)

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -86,10 +86,10 @@ complexity:
     ignoredLabels: ""
   LargeClass:
     active: true
-    threshold: 150
+    threshold: 600
   LongMethod:
     active: true
-    threshold: 20
+    threshold: 60
   LongParameterList:
     active: true
     threshold: 6

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/LinesOfCode.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/LinesOfCode.kt
@@ -1,0 +1,63 @@
+package io.gitlab.arturbosch.detekt.rules
+
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiComment
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiCommentImpl
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiCoreCommentImpl
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
+import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
+import org.jetbrains.kotlin.kdoc.psi.api.KDoc
+import org.jetbrains.kotlin.kdoc.psi.api.KDocElement
+import org.jetbrains.kotlin.kdoc.psi.impl.KDocElementImpl
+import org.jetbrains.kotlin.kdoc.psi.impl.KDocImpl
+import org.jetbrains.kotlin.kdoc.psi.impl.KDocLink
+import org.jetbrains.kotlin.kdoc.psi.impl.KDocName
+import org.jetbrains.kotlin.kdoc.psi.impl.KDocSection
+import org.jetbrains.kotlin.kdoc.psi.impl.KDocTag
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtFile
+import java.util.ArrayDeque
+import kotlin.reflect.KClass
+
+fun ASTNode.tokenSequence(skipTreesOf: Set<KClass<out PsiElement>>): Sequence<ASTNode> = sequence {
+	val queue = ArrayDeque<ASTNode>()
+	queue.add(this@tokenSequence)
+	do {
+		val curr = queue.pop()
+		if (curr.psi::class !in skipTreesOf) {
+			// Yields only tokens which can be identified in the source code.
+			// Composite elements, e.g. classes or files, are abstractions over many leaf nodes.
+			if (curr is LeafElement) {
+				yield(curr)
+			}
+			queue.addAll(curr.getChildren(null))
+		}
+	} while (queue.isNotEmpty())
+}
+
+fun KtFile.linesOfCode(): Int = linesOfCode(this)
+fun KtElement.linesOfCode(inFile: KtFile = this.containingKtFile): Int = node.tokenSequence(comments)
+		.map { it.line(inFile) }
+		.distinct()
+		.count()
+
+fun ASTNode.line(inFile: KtFile) = DiagnosticUtils.getLineAndColumnInPsiFile(inFile, this.textRange).line
+
+private val comments: Set<KClass<out PsiElement>> = setOf(
+		PsiWhiteSpace::class,
+		PsiWhiteSpaceImpl::class,
+		PsiComment::class,
+		PsiCommentImpl::class,
+		PsiCoreCommentImpl::class,
+		KDoc::class,
+		KDocImpl::class,
+		KDocElementImpl::class,
+		KDocElement::class,
+		KDocLink::class,
+		KDocSection::class,
+		KDocTag::class,
+		KDocName::class
+)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Traversing.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Traversing.kt
@@ -3,10 +3,22 @@ package io.gitlab.arturbosch.detekt.rules
 import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtFile
 
 /**
  * Returns a list of all parents of type [T] before first occurrence of [S].
  */
+inline fun <reified T : KtElement, reified S : KtElement> KtElement.parentsOfTypeUntil(strict: Boolean = true) =
+		sequence<T> {
+			var current: PsiElement? = if (strict) this@parentsOfTypeUntil.parent else this@parentsOfTypeUntil
+			while (current != null && current !is S) {
+				if (current is T) {
+					yield(current)
+				}
+				current = current.parent
+			}
+		}
+
 @Suppress("UnsafeCast")
 inline fun <reified T : KtElement, reified S : KtElement> KtElement.parentsOfTypeUntil() = sequence<T> {
 	var current: PsiElement? = this@parentsOfTypeUntil
@@ -17,6 +29,9 @@ inline fun <reified T : KtElement, reified S : KtElement> KtElement.parentsOfTyp
 		current = current.parent
 	}
 }
+
+inline fun <reified T : KtElement> KtElement.parentOfType(strict: Boolean = true) =
+		parentsOfTypeUntil<T, KtFile>(strict).firstOrNull()
 
 inline fun <reified T : KtElement> KtElement.collectByType(): List<T> {
 	val list = mutableListOf<T>()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -21,7 +21,7 @@ import java.util.IdentityHashMap
  * split up large classes into smaller classes. These smaller classes are then easier to understand and handle less
  * things.
  *
- * @configuration threshold - maximum size of a class (default: 150)
+ * @configuration threshold - maximum size of a class (default: 600)
  *
  * @active since v1.0.0
  * @author Artur Bosch
@@ -77,6 +77,6 @@ class LargeClass(config: Config = Config.empty,
 	}
 
 	companion object {
-		const val DEFAULT_ACCEPTED_CLASS_LENGTH = 150
+		const val DEFAULT_ACCEPTED_CLASS_LENGTH = 600
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -8,19 +8,12 @@ import io.gitlab.arturbosch.detekt.api.Metric
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.ThresholdRule
 import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
-import io.gitlab.arturbosch.detekt.rules.asBlockExpression
-import org.jetbrains.kotlin.com.intellij.psi.PsiFile
-import org.jetbrains.kotlin.psi.KtBlockExpression
-import org.jetbrains.kotlin.psi.KtCallExpression
+import io.gitlab.arturbosch.detekt.rules.linesOfCode
+import io.gitlab.arturbosch.detekt.rules.parentOfType
 import org.jetbrains.kotlin.psi.KtClassOrObject
-import org.jetbrains.kotlin.psi.KtIfExpression
-import org.jetbrains.kotlin.psi.KtLoopExpression
-import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.psi.KtTryExpression
-import org.jetbrains.kotlin.psi.KtWhenEntry
-import org.jetbrains.kotlin.psi.KtWhenExpression
-import java.util.ArrayDeque
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.utils.addToStdlib.flattenTo
+import java.util.IdentityHashMap
 
 /**
  * This rule reports large classes. Classes should generally have one responsibility. Large classes can indicate that
@@ -37,96 +30,50 @@ import java.util.ArrayDeque
 class LargeClass(config: Config = Config.empty,
 				 threshold: Int = DEFAULT_ACCEPTED_CLASS_LENGTH) : ThresholdRule(config, threshold) {
 
-	private var containsClassOrObject = false
-
 	override val issue = Issue("LargeClass",
 			Severity.Maintainability,
 			"One class should have one responsibility. Large classes tend to handle many things at once. " +
 					"Split up large classes into smaller classes that are easier to understand.",
 			Debt.TWENTY_MINS)
 
-	private val locStack = ArrayDeque<Int>()
+	private val classToLinesCache = IdentityHashMap<KtClassOrObject, Int>()
+	private val nestedClassTracking = IdentityHashMap<KtClassOrObject, HashSet<KtClassOrObject>>()
 
-	private fun incHead() {
-		addToHead(1)
+	override fun preVisit(root: KtFile) {
+		classToLinesCache.clear()
+		nestedClassTracking.clear()
 	}
 
-	private fun addToHead(amount: Int) {
-		if (containsClassOrObject) {
-			locStack.push(locStack.pop() + amount)
+	override fun postVisit(root: KtFile) {
+		for ((clazz, lines) in classToLinesCache) {
+			if (lines >= threshold) {
+				println(clazz.name)
+				report(ThresholdedCodeSmell(issue,
+						Entity.from(clazz),
+						Metric("SIZE", lines, threshold),
+						"Class ${clazz.name} is too large. Consider splitting it into smaller pieces."))
+			}
 		}
-	}
-
-	override fun visitFile(file: PsiFile?) {
-		locStack.clear()
-		super.visitFile(file)
 	}
 
 	override fun visitClassOrObject(classOrObject: KtClassOrObject) {
-		containsClassOrObject = true
-		locStack.push(0)
-		classOrObject.body?.let {
-			addToHead(it.declarations.size)
-		}
-		incHead() // for class body
+		val lines = classOrObject.linesOfCode()
+		classToLinesCache[classOrObject] = lines
+		classOrObject.parentOfType<KtClassOrObject>()
+				?.let { nestedClassTracking.getOrPut(it) { HashSet() }.add(classOrObject) }
 		super.visitClassOrObject(classOrObject)
-		val loc = locStack.pop()
-		if (loc >= threshold) {
-			report(ThresholdedCodeSmell(issue,
-					Entity.from(classOrObject),
-					Metric("SIZE", loc, threshold),
-					"Class ${classOrObject.name} is too large. Consider splitting it into smaller pieces."))
+		findAllNestedClasses(classOrObject)
+				.fold(0) { acc, next -> acc + (classToLinesCache[next] ?: 0) }
+				.takeIf { it > 0 }
+				?.let { classToLinesCache[classOrObject] = lines - it }
+	}
+
+	private fun findAllNestedClasses(startClass: KtClassOrObject): Sequence<KtClassOrObject> = sequence {
+		var nestedClasses = nestedClassTracking[startClass]
+		while (!nestedClasses.isNullOrEmpty()) {
+			yieldAll(nestedClasses)
+			nestedClasses = nestedClasses.mapNotNull { nestedClassTracking[it] }.flattenTo(HashSet())
 		}
-	}
-
-	/**
-	 * Top level members must be skipped as loc stack can be empty. See #64 for more info.
-	 */
-	override fun visitProperty(property: KtProperty) {
-		if (property.isTopLevel) return
-		super.visitProperty(property)
-	}
-
-	override fun visitNamedFunction(function: KtNamedFunction) {
-		if (function.isTopLevel) return
-		val body: KtBlockExpression? = function.bodyExpression.asBlockExpression()
-		body?.let { addToHead(body.statements.size) }
-		super.visitNamedFunction(function)
-	}
-
-	override fun visitIfExpression(expression: KtIfExpression) {
-		expression.then?.let { addToHead(it.children.size) }
-		expression.`else`?.let { addToHead(it.children.size) }
-		super.visitIfExpression(expression)
-	}
-
-	override fun visitLoopExpression(loopExpression: KtLoopExpression) {
-		loopExpression.body?.let { addToHead(it.children.size) }
-		super.visitLoopExpression(loopExpression)
-	}
-
-	override fun visitWhenExpression(expression: KtWhenExpression) {
-		addToHead(expression.children.filter { it is KtWhenEntry }.size)
-		super.visitWhenExpression(expression)
-	}
-
-	override fun visitTryExpression(expression: KtTryExpression) {
-		addToHead(expression.tryBlock.statements.size)
-		addToHead(expression.catchClauses.size)
-		expression.catchClauses.map { it.catchBody?.children?.size }.forEach { addToHead(it ?: 0) }
-		expression.finallyBlock?.finalExpression?.statements?.size?.let { addToHead(it) }
-		super.visitTryExpression(expression)
-	}
-
-	override fun visitCallExpression(expression: KtCallExpression) {
-		val lambdaArguments = expression.lambdaArguments
-		if (lambdaArguments.size > 0) {
-			val lambdaArgument = lambdaArguments[0]
-			lambdaArgument.getLambdaExpression()?.bodyExpression?.let {
-				addToHead(it.statements.size)
-			}
-		}
-		super.visitCallExpression(expression)
 	}
 
 	companion object {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -47,7 +47,6 @@ class LargeClass(config: Config = Config.empty,
 	override fun postVisit(root: KtFile) {
 		for ((clazz, lines) in classToLinesCache) {
 			if (lines >= threshold) {
-				println(clazz.name)
 				report(ThresholdedCodeSmell(issue,
 						Entity.from(clazz),
 						Metric("SIZE", lines, threshold),

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -12,6 +12,7 @@ import io.gitlab.arturbosch.detekt.rules.linesOfCode
 import io.gitlab.arturbosch.detekt.rules.parentOfType
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.utils.addToStdlib.flattenTo
 import java.util.IdentityHashMap
 
 /**
@@ -64,6 +65,14 @@ class LongMethod(config: Config = Config.empty,
 		nestedFunctionTracking[function]
 				?.fold(0) { acc, next -> acc + (functionToLinesCache[next] ?: 0) }
 				?.let { functionToLinesCache[function] = lines - it }
+	}
+
+	private fun findAllNestedFunctions(startClass: KtNamedFunction): Sequence<KtNamedFunction> = sequence {
+		var nestedFunctions = nestedFunctionTracking[startClass]
+		while (!nestedFunctions.isNullOrEmpty()) {
+			yieldAll(nestedFunctions)
+			nestedFunctions = nestedFunctions.mapNotNull { nestedFunctionTracking[it] }.flattenTo(HashSet())
+		}
 	}
 
 	companion object {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -21,7 +21,7 @@ import java.util.IdentityHashMap
  *
  * Extract parts of the functionality of long methods into separate, smaller methods.
  *
- * @configuration threshold - maximum lines in a method (default: 20)
+ * @configuration threshold - maximum lines in a method (default: 60)
  *
  * @active since v1.0.0
  * @author Artur Bosch
@@ -77,6 +77,6 @@ class LongMethod(config: Config = Config.empty,
 	}
 
 	companion object {
-		const val DEFAULT_ACCEPTED_METHOD_LENGTH = 20
+		const val DEFAULT_ACCEPTED_METHOD_LENGTH = 60
 	}
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -62,13 +62,14 @@ class LongMethod(config: Config = Config.empty,
 		function.parentOfType<KtNamedFunction>()
 				?.let { nestedFunctionTracking.getOrPut(it) { HashSet() }.add(function) }
 		super.visitNamedFunction(function)
-		nestedFunctionTracking[function]
-				?.fold(0) { acc, next -> acc + (functionToLinesCache[next] ?: 0) }
+		findAllNestedFunctions(function)
+				.fold(0) { acc, next -> acc + (functionToLinesCache[next] ?: 0) }
+				.takeIf { it > 0 }
 				?.let { functionToLinesCache[function] = lines - it }
 	}
 
-	private fun findAllNestedFunctions(startClass: KtNamedFunction): Sequence<KtNamedFunction> = sequence {
-		var nestedFunctions = nestedFunctionTracking[startClass]
+	private fun findAllNestedFunctions(startFunction: KtNamedFunction): Sequence<KtNamedFunction> = sequence {
+		var nestedFunctions = nestedFunctionTracking[startFunction]
 		while (!nestedFunctions.isNullOrEmpty()) {
 			yieldAll(nestedFunctions)
 			nestedFunctions = nestedFunctions.mapNotNull { nestedFunctionTracking[it] }.flattenTo(HashSet())

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
@@ -15,16 +15,14 @@ class LargeClassSpec : Spek({
 	describe("nested classes are also considered") {
 
 		it("should detect only the nested large class which exceeds threshold 70") {
-			val findings = LargeClass(threshold = 70).lint(Case.NestedClasses.path())
-			assertThat(findings).hasSize(1)
+			assertThat(LargeClass(threshold = 70).lint(Case.NestedClasses.path())).hasSize(1)
 		}
 	}
 
 	describe("files without classes should not be considered") {
 
 		it("should not report anything in large files without classes") {
-			val findings = LargeClass().lint(Case.NoClasses.path())
-			assertThat(findings).isEmpty()
+			assertThat(LargeClass().lint(Case.NoClasses.path())).isEmpty()
 		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethodSpec.kt
@@ -12,7 +12,7 @@ import org.jetbrains.spek.subject.SubjectSpek
  */
 class LongMethodSpec : SubjectSpek<LongMethod>({
 
-	subject { LongMethod(threshold = 3) }
+	subject { LongMethod(threshold = 5) }
 
 	describe("nested functions can be long") {
 

--- a/detekt-rules/src/test/resources/cases/LongMethodNegative.kt
+++ b/detekt-rules/src/test/resources/cases/LongMethodNegative.kt
@@ -4,9 +4,9 @@ package cases
 
 class LongMethodNegative {
 
-	fun methodOk() {
+	fun methodOk() { // 3 lines
 		println()
-		fun localMethodOk() {
+		fun localMethodOk() { // 4 lines
 			println()
 			println()
 		}

--- a/detekt-rules/src/test/resources/cases/LongMethodPositive.kt
+++ b/detekt-rules/src/test/resources/cases/LongMethodPositive.kt
@@ -6,14 +6,12 @@ package cases
 @Suppress("unused")
 class LongMethodPositive {
 
-	// reports 1 - too many statements
-	fun longMethod() {
+	fun longMethod() { // 5 lines
 		println()
 		println()
 		println()
 
-		// reports 1 - too many statements
-		fun nestedLongMethod() {
+		fun nestedLongMethod() { // 5 lines
 			println()
 			println()
 			println()

--- a/detekt-rules/src/test/resources/cases/NestedClasses.kt
+++ b/detekt-rules/src/test/resources/cases/NestedClasses.kt
@@ -107,4 +107,4 @@ class NestedClasses {
 /**
  * Top level members must be skipped for LargeClass rule
  */
-val aTopLevelProperty = 0
+val aTopLevelPropertyOfNestedClasses = 0

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -160,7 +160,7 @@ things.
 
 #### Configuration options:
 
-* `threshold` (default: `150`)
+* `threshold` (default: `600`)
 
    maximum size of a class
 
@@ -177,7 +177,7 @@ Extract parts of the functionality of long methods into separate, smaller method
 
 #### Configuration options:
 
-* `threshold` (default: `20`)
+* `threshold` (default: `60`)
 
    maximum lines in a method
 


### PR DESCRIPTION
- based on source tokens
- closes #1279 

With this change, our thresholds may be to restrictive with (150 & 20 lines). Pmd has defaults of 1000 for LargeClass (https://github.com/pmd/pmd/blob/master/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveClassLengthRule.java) and 100 for LongMethod (https://github.com/pmd/pmd/blob/master/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveMethodLengthRule.java). 

There are anecdotal evidence [here](https://kotlinlang.org/docs/reference/faq.html) and [here](https://medium.com/wearebase/from-java-to-kotlin-the-joys-of-new-code-d9b0ff7593fb) that in Kotlin you write ~40% less code. Therefore, how about defaults of 600 and 60? 