### PR TITLE
Publish shadowed jars (-all)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,8 @@ allprojects {
 
 subprojects {
 
+	val project = this
+
 	apply {
 		plugin("java-library")
 		plugin("kotlin")
@@ -108,7 +110,9 @@ subprojects {
 		}
 	}
 
-	if (this.name in listOf("detekt-cli", "detekt-watcher", "detekt-generator")) {
+	val shadowedProjects = listOf("detekt-cli", "detekt-watcher", "detekt-generator")
+
+	if (project.name in shadowedProjects) {
 		apply {
 			plugin("application")
 			plugin("com.github.johnrengelman.shadow")
@@ -207,6 +211,9 @@ subprojects {
 			from(components["java"])
 			artifact(sourcesJar)
 			artifact(javadocJar)
+			if (project.name in shadowedProjects) {
+				artifact(tasks.getByName("shadowJar"))
+			}
 			groupId = this@subprojects.group as? String
 			artifactId = this@subprojects.name
 			version = this@subprojects.version as? String


### PR DESCRIPTION
Fixes #1168.

Publishes `-all` jars for shadowed | uber | fat (keywords for future searchers lol) modules:

- `detekt-cli`
- `detekt-watcher`
- `detekt-generator`

This will allow fetching from jcenter for those who integrate Detekt with non-Gradle builds (me integrates it with Buck & Bazel).

Tested with `./gradlew :detekt-cli:publishToMavenLocal`:

```console
tree ~/.m2/repository/io/gitlab
/Users/artem_zin/.m2/repository/io/gitlab
└── arturbosch
    └── detekt
        └── detekt-cli
            ├── 1.0.0-RC12
            │   ├── detekt-cli-1.0.0-RC12-all.jar
            │   ├── detekt-cli-1.0.0-RC12-javadoc.jar
            │   ├── detekt-cli-1.0.0-RC12-sources.jar
            │   ├── detekt-cli-1.0.0-RC12.jar
            │   └── detekt-cli-1.0.0-RC12.pom
            └── maven-metadata-local.xml

4 directories, 6 files
```