### PR TITLE
Add UnderscoresInNumericLiterals Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Paweł Gajda](https://github.com/pawegio) - Rule improvement: FunctionParameterNaming
 - [Alistair Sykes](https://github.com/alistairsykes) - Doc improvement
 - [Andrew Arnott](https://github.com/andrew-arnott) - UnusedPrivateMember improvement
+- [Tyler Wong](https://github.com/tylerbwong) - UnderscoresInNumericLiterals rule
 
 ### Mentions
 

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -489,6 +489,9 @@ style:
     max: 2
   TrailingWhitespace:
     active: false
+  UnderscoresInNumericLiterals:
+    active: false
+    minAcceptableLength: 4
   UnnecessaryAbstractClass:
     active: false
     excludeAnnotatedClasses: "dagger.Module"

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -491,8 +491,7 @@ style:
     active: false
   UnderscoresInNumericLiterals:
     active: false
-    minAcceptableLength: 4
-    ignoredNames: ""
+    acceptableDecimalLength: 4
   UnnecessaryAbstractClass:
     active: false
     excludeAnnotatedClasses: "dagger.Module"

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -492,6 +492,7 @@ style:
   UnderscoresInNumericLiterals:
     active: false
     minAcceptableLength: 4
+    ignoredNames: ""
   UnnecessaryAbstractClass:
     active: false
     excludeAnnotatedClasses: "dagger.Module"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -29,6 +29,7 @@ import io.gitlab.arturbosch.detekt.rules.style.SafeCast
 import io.gitlab.arturbosch.detekt.rules.style.SerialVersionUIDInSerializableClass
 import io.gitlab.arturbosch.detekt.rules.style.SpacingBetweenPackageAndImports
 import io.gitlab.arturbosch.detekt.rules.style.ThrowsCount
+import io.gitlab.arturbosch.detekt.rules.style.UnderscoresInNumericLiterals
 import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryAbstractClass
 import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryApply
 import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryInheritance
@@ -101,7 +102,8 @@ class StyleGuideProvider : RuleSetProvider {
                 MandatoryBracesIfStatements(config),
                 VarCouldBeVal(config),
                 ForbiddenVoid(config),
-                ExplicitItLambdaParameter(config)
+                ExplicitItLambdaParameter(config),
+                UnderscoresInNumericLiterals(config)
         ))
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -1,0 +1,75 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtConstantExpression
+import org.jetbrains.kotlin.psi.KtOperationReferenceExpression
+import org.jetbrains.kotlin.psi.KtPrefixExpression
+
+/**
+ * This rule detects and reports base 10 numeric literals above a certain length that should be underscore separated for
+ * readability.
+ *
+ * <noncompliant>
+ * object Money {
+ *     const val DEFAULT_AMOUNT = 1000000
+ * }
+ * </noncompliant>
+ *
+ * <compliant>
+ * object Money {
+ *     const val DEFAULT_AMOUNT = 1_000_000
+ * }
+ * </compliant>
+ *
+ * @configuration minAcceptableLength - Length under which base 10 literals are not required to have underscores
+ * (default: 4)
+ *
+ * @author Tyler Wong
+ */
+class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config) {
+
+	override val issue = Issue(javaClass.simpleName, Severity.Style,
+			"Report missing underscores in numeric literals. Numeric literals should be underscore " +
+					"separated for increase readability. Underscores that do not make groups of 3 digits are also " +
+					"reported. Currently, only base 10 numeric literals are supported", Debt.FIVE_MINS)
+
+	private val underscoreNumberRegex = Regex("^[0-9]{1,3}(_[0-9]{3})*\$")
+
+	private val minAcceptableLength = valueOrDefault(MIN_ACCEPTABLE_LENGTH, DEFAULT_MIN_ACCEPTABLE_LENGTH_VALUE)
+
+	override fun visitConstantExpression(expression: KtConstantExpression) {
+		val parent = expression.parent
+
+		val numberString = if (parent.hasUnaryMinusPrefix()) {
+			parent.text
+		} else {
+			expression.text
+		}
+
+		if (numberString.replace("_", "").length < minAcceptableLength) {
+			return
+		}
+
+		if (!numberString.matches(underscoreNumberRegex)) {
+			report(CodeSmell(issue, Entity.from(expression), "This numeric literal should be underscore " +
+					"separated for readability."))
+		}
+	}
+
+	private fun PsiElement.hasUnaryMinusPrefix(): Boolean = this is KtPrefixExpression &&
+			(this.firstChild as? KtOperationReferenceExpression)?.operationSignTokenType == KtTokens.MINUS
+
+	companion object {
+		const val MIN_ACCEPTABLE_LENGTH = "minAcceptableLength"
+
+		private const val DEFAULT_MIN_ACCEPTABLE_LENGTH_VALUE = 4
+	}
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -7,11 +7,11 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import java.util.Locale
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
-import java.util.Locale
 
 /**
  * This rule detects and reports decimal base 10 numeric literals above a certain length that should be underscore

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -8,10 +8,10 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtConstantExpression
-import org.jetbrains.kotlin.psi.KtOperationReferenceExpression
-import org.jetbrains.kotlin.psi.KtPrefixExpression
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtProperty
+import java.util.Locale
 
 /**
  * This rule detects and reports base 10 numeric literals above a certain length that should be underscore separated for
@@ -31,44 +31,85 @@ import org.jetbrains.kotlin.psi.KtPrefixExpression
  *
  * @configuration minAcceptableLength - Length under which base 10 literals are not required to have underscores
  * (default: 4)
+ * @configuration ignoredNames - Names that are not to be reported on (default: "")
  *
  * @author Tyler Wong
  */
 class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName, Severity.Style,
-			"Report missing underscores in numeric literals. Numeric literals should be underscore " +
-					"separated for increase readability. Underscores that do not make groups of 3 digits are also " +
-					"reported. Currently, only base 10 numeric literals are supported", Debt.FIVE_MINS)
+			"Report missing or invalid underscores in base 10 numeric literals. Numeric literals should " +
+					"be underscore separated to increase readability. Underscores that do not make groups of 3 " +
+					"digits are also reported.", Debt.FIVE_MINS)
 
 	private val underscoreNumberRegex = Regex("^[0-9]{1,3}(_[0-9]{3})*\$")
 
 	private val minAcceptableLength = valueOrDefault(MIN_ACCEPTABLE_LENGTH, DEFAULT_MIN_ACCEPTABLE_LENGTH_VALUE)
+	private val ignoredFieldNames = valueOrDefault(IGNORED_NAMES, "")
+			.splitToSequence(",")
+			.filterNot { it.isEmpty() }
+			.toList()
 
-	override fun visitConstantExpression(expression: KtConstantExpression) {
-		val parent = expression.parent
+	private val KtConstantExpression.associatedName: String?
+		get() {
+			var propertyName: String? = null
+			var element: PsiElement? = parent
 
-		val numberString = if (parent.hasUnaryMinusPrefix()) {
-			parent.text
-		} else {
-			expression.text
+			while (propertyName == null || element == null) {
+				propertyName = when (element) {
+					is KtProperty -> element.name
+					is KtParameter -> element.name
+					else -> null
+				}
+				element = element?.parent
+			}
+
+			return propertyName
 		}
 
-		if (numberString.replace("_", "").length < minAcceptableLength) {
+	override fun visitConstantExpression(expression: KtConstantExpression) {
+		if (propertyNameIsExcluded(expression)) {
 			return
 		}
 
-		if (!numberString.matches(underscoreNumberRegex)) {
-			report(CodeSmell(issue, Entity.from(expression), "This numeric literal should be underscore " +
-					"separated for readability."))
+		val numberStringParts = normalizeForMatching(expression.text).split('.')
+
+		if (numberStringParts.sumBy { it.length } < minAcceptableLength) {
+			if (numberStringParts.any { it.contains('_') }) {
+				reportIfInvalid(expression, numberStringParts)
+			}
+			return
+		}
+
+		reportIfInvalid(expression, numberStringParts)
+	}
+
+	private fun reportIfInvalid(expression: KtConstantExpression, numberStringParts: List<String>) {
+		for (part in numberStringParts) {
+			if (!part.matches(underscoreNumberRegex)) {
+				report(CodeSmell(issue, Entity.from(expression), "This numeric literal should be separated " +
+						"by underscores in order to increase readability."))
+				break
+			}
 		}
 	}
 
-	private fun PsiElement.hasUnaryMinusPrefix(): Boolean = this is KtPrefixExpression &&
-			(this.firstChild as? KtOperationReferenceExpression)?.operationSignTokenType == KtTokens.MINUS
+	private fun propertyNameIsExcluded(expression: KtConstantExpression): Boolean {
+		val propertyName = expression.associatedName
+		return ignoredFieldNames.contains(propertyName)
+	}
+
+	private fun normalizeForMatching(text: String): String {
+		return text.trim()
+				.toLowerCase(Locale.US)
+				.removeSuffix("l")
+				.removeSuffix("d")
+				.removeSuffix("f")
+	}
 
 	companion object {
 		const val MIN_ACCEPTABLE_LENGTH = "minAcceptableLength"
+		const val IGNORED_NAMES = "ignoredNames"
 
 		private const val DEFAULT_MIN_ACCEPTABLE_LENGTH_VALUE = 4
 	}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -45,7 +45,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
     private val underscoreNumberRegex = Regex("^[0-9]{1,3}(_[0-9]{3})*\$")
 
     private val minAcceptableLength = valueOrDefault(MIN_ACCEPTABLE_LENGTH, DEFAULT_MIN_ACCEPTABLE_LENGTH_VALUE)
-    private val ignoredFieldNames = valueOrDefault(IGNORED_NAMES, "")
+    private val ignoredNames = valueOrDefault(IGNORED_NAMES, "")
             .splitToSequence(",")
             .filterNot { it.isEmpty() }
             .toList()
@@ -99,10 +99,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
         return rawText.startsWith(HEX_PREFIX) || rawText.startsWith(BIN_PREFIX)
     }
 
-    private fun isNameExcluded(expression: KtConstantExpression): Boolean {
-        val propertyName = expression.associatedName
-        return ignoredFieldNames.contains(propertyName)
-    }
+    private fun isNameExcluded(expression: KtConstantExpression) = ignoredNames.contains(expression.associatedName)
 
     private fun normalizeForMatching(text: String): String {
         return text.trim()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -52,11 +52,11 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 
 	private val KtConstantExpression.associatedName: String?
 		get() {
-			var propertyName: String? = null
+			var associatedName: String? = null
 			var element: PsiElement? = parent
 
-			while (propertyName == null || element == null) {
-				propertyName = when (element) {
+			while (associatedName == null || element == null) {
+				associatedName = when (element) {
 					is KtProperty -> element.name
 					is KtParameter -> element.name
 					else -> null
@@ -64,7 +64,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 				element = element?.parent
 			}
 
-			return propertyName
+			return associatedName
 		}
 
 	override fun visitConstantExpression(expression: KtConstantExpression) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -31,7 +31,7 @@ import org.jetbrains.kotlin.psi.KtProperty
  *
  * @configuration minAcceptableLength - Length under which decimal base 10 literals are not required to have underscores
  * (default: 4)
- * @configuration ignoredNames - Names that are not to be reported on (default: "")
+ * @configuration ignoredNames - Parameter or property names that are not to be reported on (default: "")
  *
  * @author Tyler Wong
  */
@@ -68,7 +68,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
         }
 
     override fun visitConstantExpression(expression: KtConstantExpression) {
-        if (propertyNameIsExcluded(expression) || isNotDecimal(expression)) {
+        if (isNameExcluded(expression) || isNotDecimal(expression)) {
             return
         }
 
@@ -96,10 +96,10 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 
     private fun isNotDecimal(expression: KtConstantExpression): Boolean {
         val rawText = expression.text.toLowerCase(Locale.US)
-        return rawText.startsWith("0x") || rawText.startsWith("0b")
+        return rawText.startsWith(HEX_PREFIX) || rawText.startsWith(BIN_PREFIX)
     }
 
-    private fun propertyNameIsExcluded(expression: KtConstantExpression): Boolean {
+    private fun isNameExcluded(expression: KtConstantExpression): Boolean {
         val propertyName = expression.associatedName
         return ignoredFieldNames.contains(propertyName)
     }
@@ -116,6 +116,8 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
         const val MIN_ACCEPTABLE_LENGTH = "minAcceptableLength"
         const val IGNORED_NAMES = "ignoredNames"
 
+        private const val HEX_PREFIX = "0x"
+        private const val BIN_PREFIX = "0b"
         private const val DEFAULT_MIN_ACCEPTABLE_LENGTH_VALUE = 4
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -14,8 +14,8 @@ import org.jetbrains.kotlin.psi.KtProperty
 import java.util.Locale
 
 /**
- * This rule detects and reports base 10 numeric literals above a certain length that should be underscore separated for
- * readability.
+ * This rule detects and reports decimal base 10 numeric literals above a certain length that should be underscore
+ * separated for readability.
  *
  * <noncompliant>
  * object Money {
@@ -29,7 +29,7 @@ import java.util.Locale
  * }
  * </compliant>
  *
- * @configuration minAcceptableLength - Length under which base 10 literals are not required to have underscores
+ * @configuration minAcceptableLength - Length under which decimal base 10 literals are not required to have underscores
  * (default: 4)
  * @configuration ignoredNames - Names that are not to be reported on (default: "")
  *
@@ -38,9 +38,9 @@ import java.util.Locale
 class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config) {
 
 	override val issue = Issue(javaClass.simpleName, Severity.Style,
-			"Report missing or invalid underscores in base 10 numeric literals. Numeric literals should " +
-					"be underscore separated to increase readability. Underscores that do not make groups of 3 " +
-					"digits are also reported.", Debt.FIVE_MINS)
+			"Report missing or invalid underscores in decimal base 10 numeric literals. Numeric literals " +
+                    "should be underscore separated to increase readability. Underscores that do not make groups of " +
+                    "3 digits are also reported.", Debt.FIVE_MINS)
 
 	private val underscoreNumberRegex = Regex("^[0-9]{1,3}(_[0-9]{3})*\$")
 
@@ -68,7 +68,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 		}
 
 	override fun visitConstantExpression(expression: KtConstantExpression) {
-		if (propertyNameIsExcluded(expression)) {
+		if (propertyNameIsExcluded(expression) || isNotBase10(expression)) {
 			return
 		}
 
@@ -93,6 +93,11 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 			}
 		}
 	}
+
+    private fun isNotBase10(expression: KtConstantExpression): Boolean {
+        val rawText = expression.text.toLowerCase(Locale.US)
+        return rawText.startsWith("0x") || rawText.startsWith("0b")
+    }
 
 	private fun propertyNameIsExcluded(expression: KtConstantExpression): Boolean {
 		val propertyName = expression.associatedName

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -68,7 +68,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 		}
 
 	override fun visitConstantExpression(expression: KtConstantExpression) {
-		if (propertyNameIsExcluded(expression) || isNotBase10(expression)) {
+		if (propertyNameIsExcluded(expression) || isNotDecimal(expression)) {
 			return
 		}
 
@@ -94,7 +94,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 		}
 	}
 
-    private fun isNotBase10(expression: KtConstantExpression): Boolean {
+    private fun isNotDecimal(expression: KtConstantExpression): Boolean {
         val rawText = expression.text.toLowerCase(Locale.US)
         return rawText.startsWith("0x") || rawText.startsWith("0b")
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -37,85 +37,85 @@ import org.jetbrains.kotlin.psi.KtProperty
  */
 class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config) {
 
-	override val issue = Issue(javaClass.simpleName, Severity.Style,
-			"Report missing or invalid underscores in decimal base 10 numeric literals. Numeric literals " +
+    override val issue = Issue(javaClass.simpleName, Severity.Style,
+            "Report missing or invalid underscores in decimal base 10 numeric literals. Numeric literals " +
                     "should be underscore separated to increase readability. Underscores that do not make groups of " +
                     "3 digits are also reported.", Debt.FIVE_MINS)
 
-	private val underscoreNumberRegex = Regex("^[0-9]{1,3}(_[0-9]{3})*\$")
+    private val underscoreNumberRegex = Regex("^[0-9]{1,3}(_[0-9]{3})*\$")
 
-	private val minAcceptableLength = valueOrDefault(MIN_ACCEPTABLE_LENGTH, DEFAULT_MIN_ACCEPTABLE_LENGTH_VALUE)
-	private val ignoredFieldNames = valueOrDefault(IGNORED_NAMES, "")
-			.splitToSequence(",")
-			.filterNot { it.isEmpty() }
-			.toList()
+    private val minAcceptableLength = valueOrDefault(MIN_ACCEPTABLE_LENGTH, DEFAULT_MIN_ACCEPTABLE_LENGTH_VALUE)
+    private val ignoredFieldNames = valueOrDefault(IGNORED_NAMES, "")
+            .splitToSequence(",")
+            .filterNot { it.isEmpty() }
+            .toList()
 
-	private val KtConstantExpression.associatedName: String?
-		get() {
-			var associatedName: String? = null
-			var element: PsiElement? = parent
+    private val KtConstantExpression.associatedName: String?
+        get() {
+            var associatedName: String? = null
+            var element: PsiElement? = parent
 
-			while (associatedName == null || element == null) {
-				associatedName = when (element) {
-					is KtProperty -> element.name
-					is KtParameter -> element.name
-					else -> null
-				}
-				element = element?.parent
-			}
+            while (associatedName == null || element == null) {
+                associatedName = when (element) {
+                    is KtProperty -> element.name
+                    is KtParameter -> element.name
+                    else -> null
+                }
+                element = element?.parent
+            }
 
-			return associatedName
-		}
+            return associatedName
+        }
 
-	override fun visitConstantExpression(expression: KtConstantExpression) {
-		if (propertyNameIsExcluded(expression) || isNotDecimal(expression)) {
-			return
-		}
+    override fun visitConstantExpression(expression: KtConstantExpression) {
+        if (propertyNameIsExcluded(expression) || isNotDecimal(expression)) {
+            return
+        }
 
-		val numberStringParts = normalizeForMatching(expression.text).split('.')
+        val numberStringParts = normalizeForMatching(expression.text).split('.')
 
-		if (numberStringParts.sumBy { it.length } < minAcceptableLength) {
-			if (numberStringParts.any { it.contains('_') }) {
-				reportIfInvalid(expression, numberStringParts)
-			}
-			return
-		}
+        if (numberStringParts.sumBy { it.length } < minAcceptableLength) {
+            if (numberStringParts.any { it.contains('_') }) {
+                reportIfInvalid(expression, numberStringParts)
+            }
+            return
+        }
 
-		reportIfInvalid(expression, numberStringParts)
-	}
+        reportIfInvalid(expression, numberStringParts)
+    }
 
-	private fun reportIfInvalid(expression: KtConstantExpression, numberStringParts: List<String>) {
-		for (part in numberStringParts) {
-			if (!part.matches(underscoreNumberRegex)) {
-				report(CodeSmell(issue, Entity.from(expression), "This numeric literal should be separated " +
-						"by underscores in order to increase readability."))
-				break
-			}
-		}
-	}
+    private fun reportIfInvalid(expression: KtConstantExpression, numberStringParts: List<String>) {
+        for (part in numberStringParts) {
+            if (!part.matches(underscoreNumberRegex)) {
+                report(CodeSmell(issue, Entity.from(expression), "This numeric literal should be separated " +
+                        "by underscores in order to increase readability."))
+                break
+            }
+        }
+    }
 
     private fun isNotDecimal(expression: KtConstantExpression): Boolean {
         val rawText = expression.text.toLowerCase(Locale.US)
         return rawText.startsWith("0x") || rawText.startsWith("0b")
     }
 
-	private fun propertyNameIsExcluded(expression: KtConstantExpression): Boolean {
-		val propertyName = expression.associatedName
-		return ignoredFieldNames.contains(propertyName)
-	}
+    private fun propertyNameIsExcluded(expression: KtConstantExpression): Boolean {
+        val propertyName = expression.associatedName
+        return ignoredFieldNames.contains(propertyName)
+    }
 
-	private fun normalizeForMatching(text: String): String {
-		return text.trim()
-				.toLowerCase(Locale.US)
-				.removeSuffix("l")
-				.removeSuffix("d")
-				.removeSuffix("f")
-	}
+    private fun normalizeForMatching(text: String): String {
+        return text.trim()
+                .toLowerCase(Locale.US)
+                .removeSuffix("l")
+                .removeSuffix("d")
+                .removeSuffix("f")
+    }
 
-	companion object {
-		const val MIN_ACCEPTABLE_LENGTH = "minAcceptableLength"
-		const val IGNORED_NAMES = "ignoredNames"
+    companion object {
+        const val MIN_ACCEPTABLE_LENGTH = "minAcceptableLength"
+        const val IGNORED_NAMES = "ignoredNames"
 
-		private const val DEFAULT_MIN_ACCEPTABLE_LENGTH_VALUE = 4
-	}
+        private const val DEFAULT_MIN_ACCEPTABLE_LENGTH_VALUE = 4
+    }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -9,6 +9,7 @@ import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 
 class UnderscoresInNumericLiteralsSpec : Spek({
+
 	given("an Int of 1000") {
 		val ktFile = compileContentForTest("val myInt = 1000")
 
@@ -23,6 +24,13 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 			).lint(ktFile)
 			assertThat(findings).isEmpty()
 		}
+
+		it("should not be reported if ignoredPropertyNames contains myInt") {
+			val findings = UnderscoresInNumericLiterals(
+					TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "myInt,myFloat"))
+			).lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
 	}
 
 	given("an Int of 1_000_000") {
@@ -31,6 +39,156 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 		it("should not be reported") {
 			val findings = UnderscoresInNumericLiterals().lint(ktFile)
 			assertThat(findings).isEmpty()
+		}
+	}
+
+	given("a const Int of 1000000") {
+		val ktFile = compileContentForTest("const val myInt = 1000000")
+
+		it("should be reported by default") {
+			val findings = UnderscoresInNumericLiterals().lint(ktFile)
+			assertThat(findings).isNotEmpty
+		}
+
+		it("should not be reported if minAcceptableLength is 8") {
+			val findings = UnderscoresInNumericLiterals(
+					TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "8"))
+			).lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+	}
+
+	given("a Float of 1000f") {
+		val ktFile = compileContentForTest("val myFloat = 1000f")
+
+		it("should be reported by default") {
+			val findings = UnderscoresInNumericLiterals().lint(ktFile)
+			assertThat(findings).isNotEmpty
+		}
+
+		it("should not be reported if minAcceptableLength is 5") {
+			val findings = UnderscoresInNumericLiterals(
+					TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "5"))
+			).lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+	}
+
+	given("a Float of -1000f") {
+		val ktFile = compileContentForTest("val myFloat = -1000f")
+
+		it("should be reported by default") {
+			val findings = UnderscoresInNumericLiterals().lint(ktFile)
+			assertThat(findings).isNotEmpty
+		}
+
+		it("should not be reported if minAcceptableLength is 5") {
+			val findings = UnderscoresInNumericLiterals(
+					TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "5"))
+			).lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+	}
+
+	given("a Float of -1_000f") {
+		val ktFile = compileContentForTest("const val myFloat = -1_000f")
+
+		it("should not be reported") {
+			val findings = UnderscoresInNumericLiterals().lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+	}
+
+	given("a Long of 1000000L") {
+		val ktFile = compileContentForTest("const val myLong = 1000000L")
+
+		it("should be reported by default") {
+			val findings = UnderscoresInNumericLiterals().lint(ktFile)
+			assertThat(findings).isNotEmpty
+		}
+
+		it("should not be reported if ignoredPropertyNames contains myLong") {
+			val findings = UnderscoresInNumericLiterals(
+					TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "myLong,myInt,myFloat"))
+			).lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+
+		it("should not be reported if ignored minAcceptableLength is 8") {
+			val findings = UnderscoresInNumericLiterals(
+					TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "8"))
+			).lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+	}
+
+	given("a Double of 1_000_000.00_000_000") {
+		val ktFile = compileContentForTest("val myDouble = 1_000_000.00_000_000")
+
+		it("should not be reported") {
+			val findings = UnderscoresInNumericLiterals().lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+	}
+
+	given("a function with default Int parameter value 1000") {
+		val ktFile = compileContentForTest("fun testFunction(testParam: Int = 1000) {}")
+
+		it("should be reported by default") {
+			val findings = UnderscoresInNumericLiterals().lint(ktFile)
+			assertThat(findings).isNotEmpty
+		}
+
+		it("should not be reported when ignoredNames contains testParam") {
+			val findings = UnderscoresInNumericLiterals(
+					TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "testParam"))
+			).lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+	}
+
+	given("an annotation with numeric literals 0 and 10") {
+		val ktFile = compileContentForTest(
+				"fun setCustomDimension(@IntRange(from = 0, to = 10) index: Int, value: String?) {}"
+		)
+
+		it("should not be reported") {
+			val findings = UnderscoresInNumericLiterals().lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+	}
+
+	given("an annotation with numeric literals 0 and 1000000") {
+		val ktFile = compileContentForTest(
+				"fun setCustomDimension(@IntRange(from = 0, to = 1000000) index: Int, value: String?) {}"
+		)
+
+		it("should be reported by default") {
+			val findings = UnderscoresInNumericLiterals().lint(ktFile)
+			assertThat(findings).isNotEmpty
+		}
+
+		it("should not be reported if ignoredNames contains index") {
+			val findings = UnderscoresInNumericLiterals(
+					TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "index"))
+			).lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+	}
+
+	given("an Int of 10_00_00") {
+		val ktFile = compileContentForTest("const val myInt = 10_00_00")
+
+		it("should be reported by default") {
+			val findings = UnderscoresInNumericLiterals().lint(ktFile)
+			assertThat(findings).isNotEmpty
+		}
+
+		it("should still be reported even if minAcceptableLength is 7") {
+			val findings = UnderscoresInNumericLiterals(
+					TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "7"))
+			).lint(ktFile)
+			assertThat(findings).isNotEmpty
 		}
 	}
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -10,187 +10,187 @@ import org.jetbrains.spek.api.dsl.it
 
 class UnderscoresInNumericLiteralsSpec : Spek({
 
-	given("an Int of 1000") {
-		val ktFile = compileContentForTest("val myInt = 1000")
+    given("an Int of 1000") {
+        val ktFile = compileContentForTest("val myInt = 1000")
 
-		it("should be reported by default") {
-			val findings = UnderscoresInNumericLiterals().lint(ktFile)
-			assertThat(findings).isNotEmpty
-		}
+        it("should be reported by default") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isNotEmpty
+        }
 
-		it("should not be reported if minAcceptableLength is 5") {
-			val findings = UnderscoresInNumericLiterals(
-					TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "5"))
-			).lint(ktFile)
-			assertThat(findings).isEmpty()
-		}
+        it("should not be reported if minAcceptableLength is 5") {
+            val findings = UnderscoresInNumericLiterals(
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "5"))
+            ).lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
 
-		it("should not be reported if ignoredPropertyNames contains myInt") {
-			val findings = UnderscoresInNumericLiterals(
-					TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "myInt,myFloat"))
-			).lint(ktFile)
-			assertThat(findings).isEmpty()
-		}
-	}
+        it("should not be reported if ignoredPropertyNames contains myInt") {
+            val findings = UnderscoresInNumericLiterals(
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "myInt,myFloat"))
+            ).lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
 
-	given("an Int of 1_000_000") {
-		val ktFile = compileContentForTest("val myInt = 1_000_000")
+    given("an Int of 1_000_000") {
+        val ktFile = compileContentForTest("val myInt = 1_000_000")
 
-		it("should not be reported") {
-			val findings = UnderscoresInNumericLiterals().lint(ktFile)
-			assertThat(findings).isEmpty()
-		}
-	}
+        it("should not be reported") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
 
-	given("a const Int of 1000000") {
-		val ktFile = compileContentForTest("const val myInt = 1000000")
+    given("a const Int of 1000000") {
+        val ktFile = compileContentForTest("const val myInt = 1000000")
 
-		it("should be reported by default") {
-			val findings = UnderscoresInNumericLiterals().lint(ktFile)
-			assertThat(findings).isNotEmpty
-		}
+        it("should be reported by default") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isNotEmpty
+        }
 
-		it("should not be reported if minAcceptableLength is 8") {
-			val findings = UnderscoresInNumericLiterals(
-					TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "8"))
-			).lint(ktFile)
-			assertThat(findings).isEmpty()
-		}
-	}
+        it("should not be reported if minAcceptableLength is 8") {
+            val findings = UnderscoresInNumericLiterals(
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "8"))
+            ).lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
 
-	given("a Float of 1000f") {
-		val ktFile = compileContentForTest("val myFloat = 1000f")
+    given("a Float of 1000f") {
+        val ktFile = compileContentForTest("val myFloat = 1000f")
 
-		it("should be reported by default") {
-			val findings = UnderscoresInNumericLiterals().lint(ktFile)
-			assertThat(findings).isNotEmpty
-		}
+        it("should be reported by default") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isNotEmpty
+        }
 
-		it("should not be reported if minAcceptableLength is 5") {
-			val findings = UnderscoresInNumericLiterals(
-					TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "5"))
-			).lint(ktFile)
-			assertThat(findings).isEmpty()
-		}
-	}
+        it("should not be reported if minAcceptableLength is 5") {
+            val findings = UnderscoresInNumericLiterals(
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "5"))
+            ).lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
 
-	given("a Float of -1000f") {
-		val ktFile = compileContentForTest("val myFloat = -1000f")
+    given("a Float of -1000f") {
+        val ktFile = compileContentForTest("val myFloat = -1000f")
 
-		it("should be reported by default") {
-			val findings = UnderscoresInNumericLiterals().lint(ktFile)
-			assertThat(findings).isNotEmpty
-		}
+        it("should be reported by default") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isNotEmpty
+        }
 
-		it("should not be reported if minAcceptableLength is 5") {
-			val findings = UnderscoresInNumericLiterals(
-					TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "5"))
-			).lint(ktFile)
-			assertThat(findings).isEmpty()
-		}
-	}
+        it("should not be reported if minAcceptableLength is 5") {
+            val findings = UnderscoresInNumericLiterals(
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "5"))
+            ).lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
 
-	given("a Float of -1_000f") {
-		val ktFile = compileContentForTest("const val myFloat = -1_000f")
+    given("a Float of -1_000f") {
+        val ktFile = compileContentForTest("const val myFloat = -1_000f")
 
-		it("should not be reported") {
-			val findings = UnderscoresInNumericLiterals().lint(ktFile)
-			assertThat(findings).isEmpty()
-		}
-	}
+        it("should not be reported") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
 
-	given("a Long of 1000000L") {
-		val ktFile = compileContentForTest("const val myLong = 1000000L")
+    given("a Long of 1000000L") {
+        val ktFile = compileContentForTest("const val myLong = 1000000L")
 
-		it("should be reported by default") {
-			val findings = UnderscoresInNumericLiterals().lint(ktFile)
-			assertThat(findings).isNotEmpty
-		}
+        it("should be reported by default") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isNotEmpty
+        }
 
-		it("should not be reported if ignoredPropertyNames contains myLong") {
-			val findings = UnderscoresInNumericLiterals(
-					TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "myLong,myInt,myFloat"))
-			).lint(ktFile)
-			assertThat(findings).isEmpty()
-		}
+        it("should not be reported if ignoredPropertyNames contains myLong") {
+            val findings = UnderscoresInNumericLiterals(
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "myLong,myInt,myFloat"))
+            ).lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
 
-		it("should not be reported if ignored minAcceptableLength is 8") {
-			val findings = UnderscoresInNumericLiterals(
-					TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "8"))
-			).lint(ktFile)
-			assertThat(findings).isEmpty()
-		}
-	}
+        it("should not be reported if ignored minAcceptableLength is 8") {
+            val findings = UnderscoresInNumericLiterals(
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "8"))
+            ).lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
 
-	given("a Double of 1_000_000.00_000_000") {
-		val ktFile = compileContentForTest("val myDouble = 1_000_000.00_000_000")
+    given("a Double of 1_000_000.00_000_000") {
+        val ktFile = compileContentForTest("val myDouble = 1_000_000.00_000_000")
 
-		it("should not be reported") {
-			val findings = UnderscoresInNumericLiterals().lint(ktFile)
-			assertThat(findings).isEmpty()
-		}
-	}
+        it("should not be reported") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
 
-	given("a function with default Int parameter value 1000") {
-		val ktFile = compileContentForTest("fun testFunction(testParam: Int = 1000) {}")
+    given("a function with default Int parameter value 1000") {
+        val ktFile = compileContentForTest("fun testFunction(testParam: Int = 1000) {}")
 
-		it("should be reported by default") {
-			val findings = UnderscoresInNumericLiterals().lint(ktFile)
-			assertThat(findings).isNotEmpty
-		}
+        it("should be reported by default") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isNotEmpty
+        }
 
-		it("should not be reported when ignoredNames contains testParam") {
-			val findings = UnderscoresInNumericLiterals(
-					TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "testParam"))
-			).lint(ktFile)
-			assertThat(findings).isEmpty()
-		}
-	}
+        it("should not be reported when ignoredNames contains testParam") {
+            val findings = UnderscoresInNumericLiterals(
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "testParam"))
+            ).lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
 
-	given("an annotation with numeric literals 0 and 10") {
-		val ktFile = compileContentForTest(
-				"fun setCustomDimension(@IntRange(from = 0, to = 10) index: Int, value: String?) {}"
-		)
+    given("an annotation with numeric literals 0 and 10") {
+        val ktFile = compileContentForTest(
+                "fun setCustomDimension(@IntRange(from = 0, to = 10) index: Int, value: String?) {}"
+        )
 
-		it("should not be reported") {
-			val findings = UnderscoresInNumericLiterals().lint(ktFile)
-			assertThat(findings).isEmpty()
-		}
-	}
+        it("should not be reported") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
 
-	given("an annotation with numeric literals 0 and 1000000") {
-		val ktFile = compileContentForTest(
-				"fun setCustomDimension(@IntRange(from = 0, to = 1000000) index: Int, value: String?) {}"
-		)
+    given("an annotation with numeric literals 0 and 1000000") {
+        val ktFile = compileContentForTest(
+                "fun setCustomDimension(@IntRange(from = 0, to = 1000000) index: Int, value: String?) {}"
+        )
 
-		it("should be reported by default") {
-			val findings = UnderscoresInNumericLiterals().lint(ktFile)
-			assertThat(findings).isNotEmpty
-		}
+        it("should be reported by default") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isNotEmpty
+        }
 
-		it("should not be reported if ignoredNames contains index") {
-			val findings = UnderscoresInNumericLiterals(
-					TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "index"))
-			).lint(ktFile)
-			assertThat(findings).isEmpty()
-		}
-	}
+        it("should not be reported if ignoredNames contains index") {
+            val findings = UnderscoresInNumericLiterals(
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "index"))
+            ).lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
 
-	given("an Int of 10_00_00") {
-		val ktFile = compileContentForTest("const val myInt = 10_00_00")
+    given("an Int of 10_00_00") {
+        val ktFile = compileContentForTest("const val myInt = 10_00_00")
 
-		it("should be reported by default") {
-			val findings = UnderscoresInNumericLiterals().lint(ktFile)
-			assertThat(findings).isNotEmpty
-		}
+        it("should be reported by default") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isNotEmpty
+        }
 
-		it("should still be reported even if minAcceptableLength is 7") {
-			val findings = UnderscoresInNumericLiterals(
-					TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "7"))
-			).lint(ktFile)
-			assertThat(findings).isNotEmpty
-		}
-	}
+        it("should still be reported even if minAcceptableLength is 7") {
+            val findings = UnderscoresInNumericLiterals(
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "7"))
+            ).lint(ktFile)
+            assertThat(findings).isNotEmpty
+        }
+    }
 
     given("a binary Int of 0b1011") {
         val ktFile = compileContentForTest("const val myBinInt = 0b1011")

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -191,4 +191,22 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 			assertThat(findings).isNotEmpty
 		}
 	}
+
+    given("a binary Int of 0b1011") {
+        val ktFile = compileContentForTest("const val myBinInt = 0b1011")
+
+        it("should not be reported") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
+
+    given("a hexadecimal Int of 0x1facdf") {
+        val ktFile = compileContentForTest("const val myHexInt = 0x1facdf")
+
+        it("should not be reported") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -18,16 +18,9 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isNotEmpty
         }
 
-        it("should not be reported if minAcceptableLength is 5") {
+        it("should not be reported if acceptableDecimalLength is 5") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "5"))
-            ).lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-
-        it("should not be reported if ignoredNames contains myInt") {
-            val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "myInt,myFloat"))
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "5"))
             ).lint(ktFile)
             assertThat(findings).isEmpty()
         }
@@ -50,9 +43,9 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isNotEmpty
         }
 
-        it("should not be reported if minAcceptableLength is 8") {
+        it("should not be reported if acceptableDecimalLength is 8") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "8"))
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
             ).lint(ktFile)
             assertThat(findings).isEmpty()
         }
@@ -66,9 +59,9 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isNotEmpty
         }
 
-        it("should not be reported if minAcceptableLength is 5") {
+        it("should not be reported if acceptableDecimalLength is 5") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "5"))
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "5"))
             ).lint(ktFile)
             assertThat(findings).isEmpty()
         }
@@ -82,9 +75,9 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isNotEmpty
         }
 
-        it("should not be reported if minAcceptableLength is 5") {
+        it("should not be reported if acceptableDecimalLength is 5") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "5"))
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "5"))
             ).lint(ktFile)
             assertThat(findings).isEmpty()
         }
@@ -107,16 +100,9 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isNotEmpty
         }
 
-        it("should not be reported if ignoredNames contains myLong") {
+        it("should not be reported if ignored acceptableDecimalLength is 8") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "myLong,myInt,myFloat"))
-            ).lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-
-        it("should not be reported if ignored minAcceptableLength is 8") {
-            val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "8"))
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
             ).lint(ktFile)
             assertThat(findings).isEmpty()
         }
@@ -137,13 +123,6 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         it("should be reported by default") {
             val findings = UnderscoresInNumericLiterals().lint(ktFile)
             assertThat(findings).isNotEmpty
-        }
-
-        it("should not be reported when ignoredNames contains testParam") {
-            val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "testParam"))
-            ).lint(ktFile)
-            assertThat(findings).isEmpty()
         }
     }
 
@@ -167,13 +146,6 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             val findings = UnderscoresInNumericLiterals().lint(ktFile)
             assertThat(findings).isNotEmpty
         }
-
-        it("should not be reported if ignoredNames contains index") {
-            val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "index"))
-            ).lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
     }
 
     given("an Int of 10_00_00") {
@@ -184,9 +156,9 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isNotEmpty
         }
 
-        it("should still be reported even if minAcceptableLength is 7") {
+        it("should still be reported even if acceptableDecimalLength is 7") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "7"))
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "7"))
             ).lint(ktFile)
             assertThat(findings).isNotEmpty
         }
@@ -207,6 +179,32 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         it("should not be reported") {
             val findings = UnderscoresInNumericLiterals().lint(ktFile)
             assertThat(findings).isEmpty()
+        }
+    }
+
+    given("a property named serialVersionUID in an object that implements Serializable") {
+        val ktFile = compileContentForTest("""
+            object TestSerializable : Serializable {
+                private val serialVersionUID = 314159L
+            }
+        """.trimIndent())
+
+        it("should not be reported") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
+
+    given("a property named serialVersionUID in an object that does not implement Serializable") {
+        val ktFile = compileContentForTest("""
+            object TestSerializable {
+                private val serialVersionUID = 314159L
+            }
+        """.trimIndent())
+
+        it("should not be reported") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isNotEmpty
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -25,7 +25,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
-        it("should not be reported if ignoredPropertyNames contains myInt") {
+        it("should not be reported if ignoredNames contains myInt") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "myInt,myFloat"))
             ).lint(ktFile)
@@ -107,7 +107,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isNotEmpty
         }
 
-        it("should not be reported if ignoredPropertyNames contains myLong") {
+        it("should not be reported if ignoredNames contains myLong") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.IGNORED_NAMES to "myLong,myInt,myFloat"))
             ).lint(ktFile)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -1,0 +1,36 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileContentForTest
+import io.gitlab.arturbosch.detekt.test.lint
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+
+class UnderscoresInNumericLiteralsSpec : Spek({
+	given("an Int of 1000") {
+		val ktFile = compileContentForTest("val myInt = 1000")
+
+		it("should be reported by default") {
+			val findings = UnderscoresInNumericLiterals().lint(ktFile)
+			assertThat(findings).isNotEmpty
+		}
+
+		it("should not be reported if minAcceptableLength is 5") {
+			val findings = UnderscoresInNumericLiterals(
+					TestConfig(mapOf(UnderscoresInNumericLiterals.MIN_ACCEPTABLE_LENGTH to "5"))
+			).lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+	}
+
+	given("an Int of 1_000_000") {
+		val ktFile = compileContentForTest("val myInt = 1_000_000")
+
+		it("should not be reported") {
+			val findings = UnderscoresInNumericLiterals().lint(ktFile)
+			assertThat(findings).isEmpty()
+		}
+	}
+})

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -881,6 +881,37 @@ This rule reports lines that end with a whitespace.
 
 **Debt**: 5min
 
+### UnderscoresInNumericLiterals
+
+This rule detects and reports base 10 numeric literals above a certain length that should be underscore separated for
+readability.
+
+**Severity**: Style
+
+**Debt**: 5min
+
+#### Configuration options:
+
+* `minAcceptableLength` (default: `4`)
+
+   Length under which base 10 literals are not required to have underscores
+
+#### Noncompliant Code:
+
+```kotlin
+object Money {
+    const val DEFAULT_AMOUNT = 1000000
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+object Money {
+    const val DEFAULT_AMOUNT = 1_000_000
+}
+```
+
 ### UnnecessaryAbstractClass
 
 This rule inspects `abstract` classes. In case an `abstract class` does not have any concrete members it should be

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -881,6 +881,41 @@ This rule reports lines that end with a whitespace.
 
 **Debt**: 5min
 
+### UnderscoresInNumericLiterals
+
+This rule detects and reports decimal base 10 numeric literals above a certain length that should be underscore
+separated for readability.
+
+**Severity**: Style
+
+**Debt**: 5min
+
+#### Configuration options:
+
+* `minAcceptableLength` (default: `4`)
+
+   Length under which decimal base 10 literals are not required to have underscores
+
+* `ignoredNames` (default: `""`)
+
+   Names that are not to be reported on
+
+#### Noncompliant Code:
+
+```kotlin
+object Money {
+    const val DEFAULT_AMOUNT = 1000000
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+object Money {
+    const val DEFAULT_AMOUNT = 1_000_000
+}
+```
+
 ### UnnecessaryAbstractClass
 
 This rule inspects `abstract` classes. In case an `abstract class` does not have any concrete members it should be

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -898,7 +898,7 @@ separated for readability.
 
 * `ignoredNames` (default: `""`)
 
-   Names that are not to be reported on
+   Parameter or property names that are not to be reported on
 
 #### Noncompliant Code:
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -884,7 +884,8 @@ This rule reports lines that end with a whitespace.
 ### UnderscoresInNumericLiterals
 
 This rule detects and reports decimal base 10 numeric literals above a certain length that should be underscore
-separated for readability.
+separated for readability. For [Serializable] classes or objects, the field [serialVersionUID] is explicitly
+ignored.
 
 **Severity**: Style
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -892,13 +892,10 @@ separated for readability.
 
 #### Configuration options:
 
-* `minAcceptableLength` (default: `4`)
+* `acceptableDecimalLength` (default: `4`)
 
-   Length under which decimal base 10 literals are not required to have underscores
-
-* `ignoredNames` (default: `""`)
-
-   Parameter or property names that are not to be reported on
+   Length under which decimal base 10 literals are not required to have
+underscores
 
 #### Noncompliant Code:
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -881,37 +881,6 @@ This rule reports lines that end with a whitespace.
 
 **Debt**: 5min
 
-### UnderscoresInNumericLiterals
-
-This rule detects and reports base 10 numeric literals above a certain length that should be underscore separated for
-readability.
-
-**Severity**: Style
-
-**Debt**: 5min
-
-#### Configuration options:
-
-* `minAcceptableLength` (default: `4`)
-
-   Length under which base 10 literals are not required to have underscores
-
-#### Noncompliant Code:
-
-```kotlin
-object Money {
-    const val DEFAULT_AMOUNT = 1000000
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-object Money {
-    const val DEFAULT_AMOUNT = 1_000_000
-}
-```
-
 ### UnnecessaryAbstractClass
 
 This rule inspects `abstract` classes. In case an `abstract class` does not have any concrete members it should be


### PR DESCRIPTION
This implements the rule suggested in #1398.

I decided to strictly follow the XPath expression provided in the PMD example [here](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#useunderscoresinnumericliterals), but definitely let me know of any improvements that could be made to make this rule better. 