### PR TITLE
Spek 2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,9 +24,9 @@ tasks.withType<Wrapper> {
     distributionType = Wrapper.DistributionType.ALL
     doLast {
         /*
-		 * Copy the properties file into the detekt-gradle-plugin project.
-		 * This allows IDEs like IntelliJ to import the detekt-gradle-plugin as a standalone project.
-		 */
+         * Copy the properties file into the detekt-gradle-plugin project.
+         * This allows IDEs like IntelliJ to import the detekt-gradle-plugin as a standalone project.
+         */
         val gradlePluginWrapperDir = File(gradle.includedBuild("detekt-gradle-plugin").projectDir, "/gradle/wrapper")
         GFileUtils.mkdirs(gradlePluginWrapperDir)
         copy {
@@ -56,7 +56,6 @@ allprojects {
     repositories {
         mavenLocal()
         jcenter()
-        maven(url = "http://dl.bintray.com/jetbrains/spek")
         maven(url = "https://dl.bintray.com/arturbosch/generic")
     }
 }
@@ -257,8 +256,7 @@ subprojects {
         detektPlugins(project(":detekt-formatting"))
 
         kotlinTest("org.assertj:assertj-core:$assertjVersion")
-        kotlinTest("org.jetbrains.spek:spek-api:$spekVersion")
-        kotlinTest("org.jetbrains.spek:spek-subject-extension:$spekVersion")
+        kotlinTest("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
     }
 
     sourceSets["main"].java.srcDirs("src/main/kotlin")

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -12,5 +12,5 @@ dependencies {
     testImplementation(project(":detekt-test"))
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
+    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
@@ -2,9 +2,8 @@ package io.gitlab.arturbosch.detekt.api
 
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import org.assertj.core.api.Java6Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class AnnotationExcluderSpec : Spek({
     describe("a kt file with some imports") {

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CompositeConfigTest.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CompositeConfigTest.kt
@@ -1,9 +1,8 @@
 package io.gitlab.arturbosch.detekt.api
 
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigSpec.kt
@@ -1,12 +1,11 @@
 package io.gitlab.arturbosch.detekt.api
 
-import java.nio.file.Paths
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.assertj.core.api.Assertions.fail
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.nio.file.Paths
 
 /**
  * @author Artur Bosch

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/DebtSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/DebtSpec.kt
@@ -2,9 +2,8 @@ package io.gitlab.arturbosch.detekt.api
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/MetricSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/MetricSpec.kt
@@ -2,23 +2,26 @@ package io.gitlab.arturbosch.detekt.api
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
 class MetricSpec : Spek({
 
-    it("should convert double values to int") {
-        val metric = Metric("LOC", 0.33, 0.10, 100)
-        assertThat(metric.doubleValue()).isEqualTo(0.33)
-        assertThat(metric.doubleThreshold()).isEqualTo(0.10)
-    }
+    describe("Metrics") {
 
-    it("should throw error if double value is asked for int metric") {
-        assertThatIllegalStateException().isThrownBy {
-            Metric("LOC", 100, 50).doubleValue()
+        it("should convert double values to int") {
+            val metric = Metric("LOC", 0.33, 0.10, 100)
+            assertThat(metric.doubleValue()).isEqualTo(0.33)
+            assertThat(metric.doubleThreshold()).isEqualTo(0.10)
+        }
+
+        it("should throw error if double value is asked for int metric") {
+            assertThatIllegalStateException().isThrownBy {
+                Metric("LOC", 100, 50).doubleValue()
+            }
         }
     }
 })

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/MultiRuleTest.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/MultiRuleTest.kt
@@ -2,9 +2,8 @@ package io.gitlab.arturbosch.detekt.api
 
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SingleAssignTest.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SingleAssignTest.kt
@@ -2,9 +2,8 @@ package io.gitlab.arturbosch.detekt.api
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 internal class SingleAssignTest : Spek({
     describe("value is unset") {

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SplitPatternSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SplitPatternSpec.kt
@@ -1,13 +1,12 @@
 package io.gitlab.arturbosch.detekt.api
 
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class SplitPatternSpec : Spek({
 
-    given("an excludes rule with a single exclude") {
+    describe("an excludes rule with a single exclude") {
         val excludes = SplitPattern("test")
 
         it("contains the `test` parameter") {
@@ -36,7 +35,7 @@ class SplitPatternSpec : Spek({
         }
     }
 
-    given("an excludes rule with multiple excludes") {
+    describe("an excludes rule with multiple excludes") {
         val excludes = SplitPattern("here.there.io, test.com")
 
         it("contains the `test` parameter") {
@@ -64,7 +63,7 @@ class SplitPatternSpec : Spek({
         }
     }
 
-    given("an excludes rule with lots of whitespace and an empty parameter") {
+    describe("an excludes rule with lots of whitespace and an empty parameter") {
         val excludes = SplitPattern("    test,  ,       here.there       ")
 
         it("contains the `test` parameter") {

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SuppressibleSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SuppressibleSpec.kt
@@ -4,16 +4,15 @@ import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtClass
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Marvin Ramin
  */
 internal class SuppressibleSpec : Spek({
 
-    given("a Test rule") {
+    describe("a Test rule") {
 
         it("should not be suppressed by a @Deprecated annotation") {
             assertThat(checkSuppression("Deprecated", "This should no longer be used")).isFalse()

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SuppressionSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SuppressionSpec.kt
@@ -6,9 +6,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.lastBlockStatementOrThis
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     testImplementation(project(":detekt-rules"))
     testImplementation("org.reflections:reflections:$reflectionsVersion")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
+    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }
 
 tasks["test"].dependsOn(":detekt-generator:generateDocumentation")

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -2,13 +2,12 @@ package io.gitlab.arturbosch.detekt.cli
 
 import com.beust.jcommander.ParameterException
 import io.gitlab.arturbosch.detekt.test.resource
-import java.nio.file.Path
-import java.nio.file.Paths
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.nio.file.Path
+import java.nio.file.Paths
 
 internal class CliArgsSpec : Spek({
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigurationsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigurationsSpec.kt
@@ -7,20 +7,22 @@ import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
 internal class ConfigurationsSpec : Spek({
 
-    it("should be an empty config") {
-        val config = CliArgs().loadConfiguration()
-        assertThat(config.valueOrDefault("one", -1)).isEqualTo(-1)
-        assertThat(config.valueOrDefault("two", -1)).isEqualTo(-1)
-        assertThat(config.valueOrDefault("three", -1)).isEqualTo(-1)
+    describe("a configuration") {
+
+        it("should be an empty config") {
+            val config = CliArgs().loadConfiguration()
+            assertThat(config.valueOrDefault("one", -1)).isEqualTo(-1)
+            assertThat(config.valueOrDefault("two", -1)).isEqualTo(-1)
+            assertThat(config.valueOrDefault("three", -1)).isEqualTo(-1)
+        }
     }
 
     describe("parse different path based configuration settings") {

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/DetektYmlConfigTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/DetektYmlConfigTest.kt
@@ -2,69 +2,72 @@ package io.gitlab.arturbosch.detekt.cli
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.YamlConfig
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 import java.io.File
 import java.nio.file.Paths
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
 
 class DetektYmlConfigTest : Spek({
 
-    val config = loadConfig()
+    describe("detekt YAML config") {
 
-    it("complexitySection") {
-        ConfigAssert(
-                config,
-                "complexity",
-                "io.gitlab.arturbosch.detekt.rules.complexity"
-        ).assert()
-    }
+        val config = loadConfig()
 
-    it("documentationSection") {
-        ConfigAssert(
-                config,
-                "comments",
-                "io.gitlab.arturbosch.detekt.rules.documentation"
-        ).assert()
-    }
+        it("complexitySection") {
+            ConfigAssert(
+                    config,
+                    "complexity",
+                    "io.gitlab.arturbosch.detekt.rules.complexity"
+            ).assert()
+        }
 
-    it("emptyBlocksSection") {
-        ConfigAssert(
-                config,
-                "empty-blocks",
-                "io.gitlab.arturbosch.detekt.rules.empty"
-        ).assert()
-    }
+        it("documentationSection") {
+            ConfigAssert(
+                    config,
+                    "comments",
+                    "io.gitlab.arturbosch.detekt.rules.documentation"
+            ).assert()
+        }
 
-    it("exceptionsSection") {
-        ConfigAssert(
-                config,
-                "exceptions",
-                "io.gitlab.arturbosch.detekt.rules.exceptions"
-        ).assert()
-    }
+        it("emptyBlocksSection") {
+            ConfigAssert(
+                    config,
+                    "empty-blocks",
+                    "io.gitlab.arturbosch.detekt.rules.empty"
+            ).assert()
+        }
 
-    it("performanceSection") {
-        ConfigAssert(
-                config,
-                "performance",
-                "io.gitlab.arturbosch.detekt.rules.performance"
-        ).assert()
-    }
+        it("exceptionsSection") {
+            ConfigAssert(
+                    config,
+                    "exceptions",
+                    "io.gitlab.arturbosch.detekt.rules.exceptions"
+            ).assert()
+        }
 
-    it("potentialBugsSection") {
-        ConfigAssert(
-                config,
-                "potential-bugs",
-                "io.gitlab.arturbosch.detekt.rules.bugs"
-        ).assert()
-    }
+        it("performanceSection") {
+            ConfigAssert(
+                    config,
+                    "performance",
+                    "io.gitlab.arturbosch.detekt.rules.performance"
+            ).assert()
+        }
 
-    it("styleSection") {
-        ConfigAssert(
-                config,
-                "style",
-                "io.gitlab.arturbosch.detekt.rules.style"
-        ).assert()
+        it("potentialBugsSection") {
+            ConfigAssert(
+                    config,
+                    "potential-bugs",
+                    "io.gitlab.arturbosch.detekt.rules.bugs"
+            ).assert()
+        }
+
+        it("styleSection") {
+            ConfigAssert(
+                    config,
+                    "style",
+                    "io.gitlab.arturbosch.detekt.rules.style"
+            ).assert()
+        }
     }
 })
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/FileProcessorLocatorTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/FileProcessorLocatorTest.kt
@@ -4,29 +4,32 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.core.FileProcessorLocator
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.test.resource
-import java.lang.reflect.Modifier
-import java.nio.file.Paths
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
 import org.reflections.Reflections
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.lang.reflect.Modifier
+import java.nio.file.Paths
 
 /**
  * This tests the existence of all metric processors in the META-INF config file in the core package
  */
 class FileProcessorLocatorTest : Spek({
 
-    it("containsAllProcessors") {
-        val path = Paths.get(resource(""))
-        val locator = FileProcessorLocator(ProcessingSettings(path))
-        val processors = locator.load()
-        val processorClasses = getProcessorClasses()
+    describe("file processor locator") {
 
-        assertThat(processorClasses).isNotEmpty
-        processorClasses
-                .filter { clazz -> processors.firstOrNull { clazz == it.javaClass } == null }
-                .forEach { Assertions.fail("$it processor is not loaded by the FileProcessorLocator") }
+        it("containsAllProcessors") {
+            val path = Paths.get(resource(""))
+            val locator = FileProcessorLocator(ProcessingSettings(path))
+            val processors = locator.load()
+            val processorClasses = getProcessorClasses()
+
+            assertThat(processorClasses).isNotEmpty
+            processorClasses
+                    .filter { clazz -> processors.firstOrNull { clazz == it.javaClass } == null }
+                    .forEach { Assertions.fail("$it processor is not loaded by the FileProcessorLocator") }
+        }
     }
 })
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/OutputFacadeSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/OutputFacadeSpec.kt
@@ -8,17 +8,16 @@ import io.gitlab.arturbosch.detekt.cli.out.XmlOutputReport
 import io.gitlab.arturbosch.detekt.core.DetektResult
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.test.resource
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.PrintStream
 import java.nio.file.Path
 import java.nio.file.Paths
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatCode
-import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
 
 /**
  * @author Sebastiano Poggi

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ReportPathSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ReportPathSpec.kt
@@ -1,66 +1,68 @@
 package io.gitlab.arturbosch.detekt.cli
 
 import io.gitlab.arturbosch.detekt.core.PathFilter
-import java.nio.file.Paths
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.nio.file.Paths
 
 class ReportPathSpec : Spek({
 
-    if (IS_WINDOWS) {
-        given("a Windows path") {
-            it("parses a valid absolute path correctly") {
-                val reportPath = ReportPath.from("test:C:\\tmp\\valid\\report")
+    describe("report paths") {
 
-                assertThat(reportPath.path).isEqualTo(Paths.get("C:\\tmp\\valid\\report"))
+        if (IS_WINDOWS) {
+            context("a Windows path") {
+                it("parses a valid absolute path correctly") {
+                    val reportPath = ReportPath.from("test:C:\\tmp\\valid\\report")
+
+                    assertThat(reportPath.path).isEqualTo(Paths.get("C:\\tmp\\valid\\report"))
+                }
+
+                it("parses a valid relative path correctly") {
+                    val reportPath = ReportPath.from("test:valid\\report")
+
+                    assertThat(reportPath.path).isEqualTo(Paths.get("valid\\report"))
+                }
+
+                it("fails when the path is empty") {
+                    assertThatIllegalArgumentException()
+                            .isThrownBy { ReportPath.from("test:") }
+                }
+
+                it("fails when the path is malformed") {
+                    assertThatIllegalArgumentException()
+                            .isThrownBy { ReportPath.from("test:a*a") }
+                }
             }
+        } else {
+            context("a POSIX path") {
+                it("parses a valid absolute path correctly") {
+                    val reportPath = ReportPath.from("test:/tmp/valid/report")
 
-            it("parses a valid relative path correctly") {
-                val reportPath = ReportPath.from("test:valid\\report")
+                    assertThat(reportPath.path).isEqualTo(Paths.get("/tmp/valid/report"))
+                }
 
-                assertThat(reportPath.path).isEqualTo(Paths.get("valid\\report"))
-            }
+                it("parses a valid relative path correctly") {
+                    val reportPath = ReportPath.from("test:valid/report")
 
-            it("fails when the path is empty") {
-                assertThatIllegalArgumentException()
-                        .isThrownBy { ReportPath.from("test:") }
-            }
+                    assertThat(reportPath.path).isEqualTo(Paths.get("valid/report"))
+                }
 
-            it("fails when the path is malformed") {
-                assertThatIllegalArgumentException()
-                        .isThrownBy { ReportPath.from("test:a*a") }
-            }
-        }
-    } else {
-        given("a POSIX path") {
-            it("parses a valid absolute path correctly") {
-                val reportPath = ReportPath.from("test:/tmp/valid/report")
+                it("fails when the path is empty") {
+                    assertThatIllegalArgumentException()
+                            .isThrownBy { ReportPath.from("test:") }
+                }
 
-                assertThat(reportPath.path).isEqualTo(Paths.get("/tmp/valid/report"))
-            }
-
-            it("parses a valid relative path correctly") {
-                val reportPath = ReportPath.from("test:valid/report")
-
-                assertThat(reportPath.path).isEqualTo(Paths.get("valid/report"))
-            }
-
-            it("fails when the path is empty") {
-                assertThatIllegalArgumentException()
-                        .isThrownBy { ReportPath.from("test:") }
-            }
-
-            it("fails when the path is malformed") {
-                assertThatIllegalArgumentException()
-                        .isThrownBy { ReportPath.from("test:a${0.toChar()}a") }
+                it("fails when the path is malformed") {
+                    assertThatIllegalArgumentException()
+                            .isThrownBy { ReportPath.from("test:a${0.toChar()}a") }
+                }
             }
         }
     }
 
-    given("a kind") {
+    describe("`kind` processing") {
         it("parses and maps the txt kind correctly") {
             val reportPath = ReportPath.from("txt:/tmp/valid/report")
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFacadeTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFacadeTest.kt
@@ -3,42 +3,44 @@ package io.gitlab.arturbosch.detekt.cli.baseline
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.cli.createFinding
 import io.gitlab.arturbosch.detekt.test.resource
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.ListAssert
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 import java.io.BufferedReader
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.ListAssert
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
 
 /**
  * @author Artur Bosch
  * @author schalkms
  */
 class BaselineFacadeTest : Spek({
+	describe("a baseline facade") {
 
-    val dir = Files.createTempDirectory("baseline_format")
+        val dir = Files.createTempDirectory("baseline_format")
 
-    it("create") {
-        val fullPath = dir.resolve("baseline.xml")
-        val baselineFacade = BaselineFacade(fullPath)
-        baselineFacade.create(emptyList())
-        Files.newInputStream(fullPath).use<InputStream?, ListAssert<String>?> {
-            val reader = BufferedReader(InputStreamReader(it))
-            assertThat(reader.lines()).isNotEmpty
+        it("create") {
+            val fullPath = dir.resolve("baseline.xml")
+            val baselineFacade = BaselineFacade(fullPath)
+            baselineFacade.create(emptyList())
+            Files.newInputStream(fullPath).use<InputStream?, ListAssert<String>?> {
+                val reader = BufferedReader(InputStreamReader(it))
+                assertThat(reader.lines()).isNotEmpty
+            }
         }
-    }
 
-    it("filterWithExistingBaseline") {
-        assertFilter(dir)
-    }
+        it("filterWithExistingBaseline") {
+            assertFilter(dir)
+        }
 
-    it("filterWithoutExistingBaseline") {
-        val path = Paths.get(resource("/smell-baseline.xml"))
-        assertFilter(path)
+        it("filterWithoutExistingBaseline") {
+            val path = Paths.get(resource("/smell-baseline.xml"))
+            assertFilter(path)
+        }
     }
 })
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFormatTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFormatTest.kt
@@ -1,13 +1,13 @@
 package io.gitlab.arturbosch.detekt.cli.baseline
 
 import io.gitlab.arturbosch.detekt.test.resource
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.time.Instant
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
 
 /**
  * @author Artur Bosch
@@ -15,36 +15,39 @@ import org.jetbrains.spek.api.dsl.it
  */
 class BaselineFormatTest : Spek({
 
-    it("loadBaseline") {
-        val path = Paths.get(resource("/smell-baseline.xml"))
-        val (blacklist, whitelist) = BaselineFormat().read(path)
+    describe("baseline format") {
 
-        assertThat(blacklist.ids).hasSize(2)
-        assertThat(blacklist.ids).anySatisfy { it.startsWith("LongParameterList") }
-        assertThat(blacklist.ids).anySatisfy { it.startsWith("LongMethod") }
-        assertThat(blacklist.timestamp).isEqualTo("123456789")
-        assertThat(whitelist.ids).hasSize(1)
-        assertThat(whitelist.ids).anySatisfy { it.startsWith("FeatureEnvy") }
-        assertThat(whitelist.timestamp).isEqualTo("987654321")
-    }
+        it("loadBaseline") {
+            val path = Paths.get(resource("/smell-baseline.xml"))
+            val (blacklist, whitelist) = BaselineFormat().read(path)
 
-    it("savedAndLoadedXmlAreEqual") {
-        val now = Instant.now().toEpochMilli().toString()
-        val tempFile = Files.createTempFile("baseline", now)
+            assertThat(blacklist.ids).hasSize(2)
+            assertThat(blacklist.ids).anySatisfy { it.startsWith("LongParameterList") }
+            assertThat(blacklist.ids).anySatisfy { it.startsWith("LongMethod") }
+            assertThat(blacklist.timestamp).isEqualTo("123456789")
+            assertThat(whitelist.ids).hasSize(1)
+            assertThat(whitelist.ids).anySatisfy { it.startsWith("FeatureEnvy") }
+            assertThat(whitelist.timestamp).isEqualTo("987654321")
+        }
 
-        val savedBaseline = Baseline(
-                Blacklist(setOf("4", "2", "2"), now),
-                Whitelist(setOf("1", "2", "3"), now))
+        it("savedAndLoadedXmlAreEqual") {
+            val now = Instant.now().toEpochMilli().toString()
+            val tempFile = Files.createTempFile("baseline", now)
 
-        val format = BaselineFormat()
-        format.write(savedBaseline, tempFile)
-        val loadedBaseline = format.read(tempFile)
+            val savedBaseline = Baseline(
+                    Blacklist(setOf("4", "2", "2"), now),
+                    Whitelist(setOf("1", "2", "3"), now))
 
-        assertThat(loadedBaseline).isEqualTo(savedBaseline)
-    }
+            val format = BaselineFormat()
+            format.write(savedBaseline, tempFile)
+            val loadedBaseline = format.read(tempFile)
 
-    it("loadInvalidBaseline") {
-        val path = Paths.get(resource("/invalid-smell-baseline.txt"))
-        assertThatThrownBy { BaselineFormat().read(path) }.isInstanceOf(InvalidBaselineState::class.java)
+            assertThat(loadedBaseline).isEqualTo(savedBaseline)
+        }
+
+        it("loadInvalidBaseline") {
+            val path = Paths.get(resource("/invalid-smell-baseline.txt"))
+            assertThatThrownBy { BaselineFormat().read(path) }.isInstanceOf(InvalidBaselineState::class.java)
+        }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/BuildFailureReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/BuildFailureReportSpec.kt
@@ -8,16 +8,15 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.assertj.core.api.Assertions.fail
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
-internal class BuildFailureReportSpec : SubjectSpek<BuildFailureReport>({
+internal class BuildFailureReportSpec : Spek({
 
-    subject { BuildFailureReport() }
+    val subject by memoized { BuildFailureReport() }
 
     describe("build failure threshold is configurable by configuration") {
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportSpec.kt
@@ -9,32 +9,32 @@ import io.gitlab.arturbosch.detekt.core.processors.linesKey
 import io.gitlab.arturbosch.detekt.core.processors.logicalLinesKey
 import io.gitlab.arturbosch.detekt.core.processors.sourceLinesKey
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-internal class ComplexityReportSpec : SubjectSpek<ComplexityReport>({
+internal class ComplexityReportSpec : Spek({
 
-    subject { ComplexityReport() }
+    describe("complexity report") {
 
-    given("several complexity metrics") {
+        context("several complexity metrics") {
 
-        it("successfully generates a complexity report") {
-            val expectedContent = readResource("complexity-report.txt")
-            val detektion = createDetektion()
-            addData(detektion)
-            assertThat(generateComplexityReport(detektion)).isEqualTo(expectedContent)
-        }
+            it("successfully generates a complexity report") {
+                val expectedContent = readResource("complexity-report.txt")
+                val detektion = createDetektion()
+                addData(detektion)
+                assertThat(generateComplexityReport(detektion)).isEqualTo(expectedContent)
+            }
 
-        it("returns null for missing complexity metrics") {
-            val detektion = createDetektion()
-            assertThat(generateComplexityReport(detektion)).isNull()
-        }
+            it("returns null for missing complexity metrics") {
+                val detektion = createDetektion()
+                assertThat(generateComplexityReport(detektion)).isNull()
+            }
 
-        it("returns null for missing complexity metrics in report") {
-            val report = ComplexityReport()
-            val detektion = createDetektion()
-            assertThat(report.render(detektion)).isNull()
+            it("returns null for missing complexity metrics in report") {
+                val report = ComplexityReport()
+                val detektion = createDetektion()
+                assertThat(report.render(detektion)).isNull()
+            }
         }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/DebtSummingSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/DebtSummingSpec.kt
@@ -2,13 +2,12 @@ package io.gitlab.arturbosch.detekt.cli.console
 
 import io.gitlab.arturbosch.detekt.api.Debt
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 internal class DebtSummingSpec : Spek({
 
-    given("debt minutes, hours and days") {
+    describe("debt minutes, hours and days") {
 
         it("outputs correct minutes, hours and days") {
             assertThat(createDebtSumming(1, 23, 62).toString()).isEqualTo("2d 2min")

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/FindingsReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/FindingsReportSpec.kt
@@ -4,29 +4,31 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.cli.TestDetektion
 import io.gitlab.arturbosch.detekt.cli.createFinding
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class FindingsReportSpec : SubjectSpek<FindingsReport>({
+class FindingsReportSpec : Spek({
 
-    subject { FindingsReport() }
+    val subject by memoized { FindingsReport() }
 
-    given("several detekt findings") {
+    describe("findings report") {
 
-        it("reports the debt per ruleset and the overall debt") {
-            val expectedContent = readResource("findings-report.txt")
-            val detektion = object : TestDetektion() {
-                override val findings: Map<String, List<Finding>> = mapOf(
-                        Pair("TestSmell", listOf(createFinding(), createFinding())),
-                        Pair("EmptySmells", emptyList()))
+        context("several detekt findings") {
+
+            it("reports the debt per ruleset and the overall debt") {
+                val expectedContent = readResource("findings-report.txt")
+                val detektion = object : TestDetektion() {
+                    override val findings: Map<String, List<Finding>> = mapOf(
+                            Pair("TestSmell", listOf(createFinding(), createFinding())),
+                            Pair("EmptySmells", emptyList()))
+                }
+                assertThat(subject.render(detektion)?.trimEnd()).isEqualTo(expectedContent)
             }
-            assertThat(subject.render(detektion)?.trimEnd()).isEqualTo(expectedContent)
-        }
 
-        it("reports no findings") {
-            val detektion = TestDetektion()
-            assertThat(subject.render(detektion))
+            it("reports no findings") {
+                val detektion = TestDetektion()
+                assertThat(subject.render(detektion))
+            }
         }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/NotificationReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/NotificationReportSpec.kt
@@ -3,17 +3,16 @@ package io.gitlab.arturbosch.detekt.cli.console
 import io.gitlab.arturbosch.detekt.cli.TestDetektion
 import io.gitlab.arturbosch.detekt.cli.createNotification
 import io.gitlab.arturbosch.detekt.test.resource
-import java.nio.file.Paths
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.nio.file.Paths
 
-class NotificationReportSpec : SubjectSpek<NotificationReport>({
+class NotificationReportSpec : Spek({
 
-    subject { NotificationReport() }
+    val subject by memoized { NotificationReport() }
 
-    given("several notfications") {
+    describe("notification report") {
 
         it("reports two notifications") {
             val path = Paths.get(resource("empty.txt"))

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ProjectStatisticsReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ProjectStatisticsReportSpec.kt
@@ -3,15 +3,14 @@ package io.gitlab.arturbosch.detekt.cli.console
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import io.gitlab.arturbosch.detekt.cli.TestDetektion
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class ProjectStatisticsReportSpec : SubjectSpek<ProjectStatisticsReport>({
+class ProjectStatisticsReportSpec : Spek({
 
-    subject { ProjectStatisticsReport() }
+    val subject by memoized { ProjectStatisticsReport() }
 
-    given("several metrics") {
+    describe("project statistics") {
 
         it("reports the project statistics") {
             val expected = "Project Statistics:\n\t- M2: 2\n\t- M1: 1\n"

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
@@ -11,54 +11,56 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.cli.TestDetektion
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class HtmlOutputFormatTest : Spek({
 
-    val outputFormat = HtmlOutputReport()
+    describe("HTML output format") {
+        val outputFormat = HtmlOutputReport()
 
-    it("testRenderResultLooksLikeHtml") {
-        val result = outputFormat.render(TestDetektion())
+        it("testRenderResultLooksLikeHtml") {
+            val result = outputFormat.render(TestDetektion())
 
-        assertThat(result).startsWith("<!DOCTYPE html>\n<html lang=\"en\">")
-        assertThat(result).endsWith("</html>\n")
+            assertThat(result).startsWith("<!DOCTYPE html>\n<html lang=\"en\">")
+            assertThat(result).endsWith("</html>\n")
 
-        assertThat(result).contains("<h1>detekt report</h1>")
-        assertThat(result).contains("<h2>Metrics</h2>")
-        assertThat(result).contains("<h2>Findings</h2>")
-    }
+            assertThat(result).contains("<h1>detekt report</h1>")
+            assertThat(result).contains("<h2>Metrics</h2>")
+            assertThat(result).contains("<h2>Findings</h2>")
+        }
 
-    it("testRenderResultContainsFileLocations") {
-        val result = outputFormat.render(createTestDetektionWithMultipleSmells())
+        it("testRenderResultContainsFileLocations") {
+            val result = outputFormat.render(createTestDetektionWithMultipleSmells())
 
-        assertThat(result).contains("<span class=\"location\">\nsrc/main/com/sample/Sample1.kt:11:1\n</span>")
-        assertThat(result).contains("<span class=\"location\">\nsrc/main/com/sample/Sample2.kt:22:2\n</span>")
-        assertThat(result).contains("<span class=\"location\">\nsrc/main/com/sample/Sample3.kt:33:3\n</span>")
-    }
+            assertThat(result).contains("<span class=\"location\">\nsrc/main/com/sample/Sample1.kt:11:1\n</span>")
+            assertThat(result).contains("<span class=\"location\">\nsrc/main/com/sample/Sample2.kt:22:2\n</span>")
+            assertThat(result).contains("<span class=\"location\">\nsrc/main/com/sample/Sample3.kt:33:3\n</span>")
+        }
 
-    it("testRenderResultContainsRules") {
-        val result = outputFormat.render(createTestDetektionWithMultipleSmells())
+        it("testRenderResultContainsRules") {
+            val result = outputFormat.render(createTestDetektionWithMultipleSmells())
 
-        assertThat(result).contains("<span class=\"rule\">\nid_a\n</span>")
-        assertThat(result).contains("<span class=\"rule\">\nid_a\n</span>")
-        assertThat(result).contains("<span class=\"rule\">\nid_a\n</span>")
-    }
+            assertThat(result).contains("<span class=\"rule\">\nid_a\n</span>")
+            assertThat(result).contains("<span class=\"rule\">\nid_a\n</span>")
+            assertThat(result).contains("<span class=\"rule\">\nid_a\n</span>")
+        }
 
-    it("testRenderResultContainsMessages") {
-        val result = outputFormat.render(createTestDetektionWithMultipleSmells())
+        it("testRenderResultContainsMessages") {
+            val result = outputFormat.render(createTestDetektionWithMultipleSmells())
 
-        assertThat(result).contains("<span class=\"message\">\nB1\n</span>")
-        assertThat(result).contains("<span class=\"message\">\nB2\n</span>")
-        assertThat(result).contains("<span class=\"message\">\nB3\n</span>")
-    }
+            assertThat(result).contains("<span class=\"message\">\nB1\n</span>")
+            assertThat(result).contains("<span class=\"message\">\nB2\n</span>")
+            assertThat(result).contains("<span class=\"message\">\nB3\n</span>")
+        }
 
-    it("testRenderResultContainsDescriptions") {
-        val result = outputFormat.render(createTestDetektionWithMultipleSmells())
+        it("testRenderResultContainsDescriptions") {
+            val result = outputFormat.render(createTestDetektionWithMultipleSmells())
 
-        assertThat(result).contains("<span class=\"description\">\nA1\n</span>")
-        assertThat(result).contains("<span class=\"description\">\nA2\n</span>")
-        assertThat(result).contains("<span class=\"description\">\nA3\n</span>")
+            assertThat(result).contains("<span class=\"description\">\nA1\n</span>")
+            assertThat(result).contains("<span class=\"description\">\nA2\n</span>")
+            assertThat(result).contains("<span class=\"description\">\nA3\n</span>")
+        }
     }
 })
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlSnippetTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlSnippetTest.kt
@@ -1,32 +1,35 @@
 package io.gitlab.arturbosch.detekt.cli.out
 
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class HtmlSnippetTest : Spek({
 
-    it("testGeneratingSimpleHtmlSnippet") {
-        val snippet = htmlSnippet {
-            h3 { "Hello World" }
-            div("box") {
-                text { "Test" }
-                br()
+    describe("HTML snippet") {
+
+        it("testGeneratingSimpleHtmlSnippet") {
+            val snippet = htmlSnippet {
+                h3 { "Hello World" }
+                div("box") {
+                    text { "Test" }
+                    br()
+                }
             }
+
+            assertThat(snippet).isEqualTo("<h3>Hello World</h3>\n<div class=\"box\">\nTest\n<br />\n</div>")
         }
 
-        assertThat(snippet).isEqualTo("<h3>Hello World</h3>\n<div class=\"box\">\nTest\n<br />\n</div>")
-    }
+        it("testGeneratingList") {
+            val items = listOf("Apple", "Banana", "Orange")
 
-    it("testGeneratingList") {
-        val items = listOf("Apple", "Banana", "Orange")
-
-        val snippet = htmlSnippet {
-            list(items) {
-                span("fruit") { it }
+            val snippet = htmlSnippet {
+                list(items) {
+                    span("fruit") { it }
+                }
             }
-        }
 
-        assertThat(snippet).isEqualTo("<ul>\n<li>\n<span class=\"fruit\">\nApple\n</span>\n</li>\n<li>\n<span class=\"fruit\">\nBanana\n</span>\n</li>\n<li>\n<span class=\"fruit\">\nOrange\n</span>\n</li>\n</ul>")
+            assertThat(snippet).isEqualTo("<ul>\n<li>\n<span class=\"fruit\">\nApple\n</span>\n</li>\n<li>\n<span class=\"fruit\">\nBanana\n</span>\n</li>\n<li>\n<span class=\"fruit\">\nOrange\n</span>\n</li>\n</ul>")
+        }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/ReportsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/ReportsSpec.kt
@@ -6,75 +6,77 @@ import io.gitlab.arturbosch.detekt.cli.CliArgs
 import io.gitlab.arturbosch.detekt.cli.ReportLocator
 import io.gitlab.arturbosch.detekt.cli.parseArguments
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
-import java.nio.file.Paths
-import java.util.function.Predicate
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Condition
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.nio.file.Paths
+import java.util.function.Predicate
 
 /**
  * @author Artur Bosch
  */
 internal class ReportsSpec : Spek({
 
-    given("arguments for jcommander") {
+    describe("reports") {
 
-        val reportUnderTest = TestOutputReport::class.java.simpleName
-        val args = arrayOf(
-                "--report", "xml:/tmp/path1",
-                "--report", "txt:/tmp/path2",
-                "--report", "$reportUnderTest:/tmp/path3",
-                "--report", "html:D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html"
-        )
-        val (cli, _) = parseArguments<CliArgs>(args)
+        context("arguments for jcommander") {
 
-        val reports = cli.reportPaths
+            val reportUnderTest = TestOutputReport::class.java.simpleName
+            val args = arrayOf(
+                    "--report", "xml:/tmp/path1",
+                    "--report", "txt:/tmp/path2",
+                    "--report", "$reportUnderTest:/tmp/path3",
+                    "--report", "html:D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html"
+            )
+            val (cli, _) = parseArguments<CliArgs>(args)
 
-        it("should parse multiple report entries") {
-            assertThat(reports).hasSize(4)
-        }
+            val reports = cli.reportPaths
 
-        it("it should properly parse XML report entry") {
-            val xmlReport = reports[0]
-            assertThat(xmlReport.kind).isEqualTo(XmlOutputReport::class.java.simpleName)
-            assertThat(xmlReport.path).isEqualTo(Paths.get("/tmp/path1"))
-        }
+            it("should parse multiple report entries") {
+                assertThat(reports).hasSize(4)
+            }
 
-        it("it should properly parse TXT report entry") {
-            val txtRepot = reports[1]
-            assertThat(txtRepot.kind).isEqualTo(TxtOutputReport::class.java.simpleName)
-            assertThat(txtRepot.path).isEqualTo(Paths.get("/tmp/path2"))
-        }
+            it("it should properly parse XML report entry") {
+                val xmlReport = reports[0]
+                assertThat(xmlReport.kind).isEqualTo(XmlOutputReport::class.java.simpleName)
+                assertThat(xmlReport.path).isEqualTo(Paths.get("/tmp/path1"))
+            }
 
-        it("it should properly parse custom report entry") {
-            val customReport = reports[2]
-            assertThat(customReport.kind).isEqualTo(reportUnderTest)
-            assertThat(customReport.path).isEqualTo(Paths.get("/tmp/path3"))
-        }
+            it("it should properly parse TXT report entry") {
+                val txtRepot = reports[1]
+                assertThat(txtRepot.kind).isEqualTo(TxtOutputReport::class.java.simpleName)
+                assertThat(txtRepot.path).isEqualTo(Paths.get("/tmp/path2"))
+            }
 
-        it("it should properly parse HTML report entry") {
-            val htmlReport = reports[3]
-            assertThat(htmlReport.kind).isEqualTo(HtmlOutputReport::class.java.simpleName)
-            assertThat(htmlReport.path).isEqualTo(Paths.get("D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html"))
-        }
+            it("it should properly parse custom report entry") {
+                val customReport = reports[2]
+                assertThat(customReport.kind).isEqualTo(reportUnderTest)
+                assertThat(customReport.path).isEqualTo(Paths.get("/tmp/path3"))
+            }
 
-        val extensions = ReportLocator(ProcessingSettings(listOf())).load()
-        val extensionsIds = extensions.mapTo(HashSet()) { it.id }
+            it("it should properly parse HTML report entry") {
+                val htmlReport = reports[3]
+                assertThat(htmlReport.kind).isEqualTo(HtmlOutputReport::class.java.simpleName)
+                assertThat(htmlReport.path).isEqualTo(Paths.get("D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html"))
+            }
 
-        it("should be able to convert to output reports") {
-            assertThat(reports).allMatch { it.kind in extensionsIds }
-        }
+            val extensions = ReportLocator(ProcessingSettings(listOf())).load()
+            val extensionsIds = extensions.mapTo(HashSet()) { it.id }
 
-        it("should recognize custom output format") {
-            assertThat(reports).haveExactly(1,
-                    Condition(Predicate { it.kind == reportUnderTest },
-                            "Corresponds exactly to the test output report."))
+            it("should be able to convert to output reports") {
+                assertThat(reports).allMatch { it.kind in extensionsIds }
+            }
 
-            assertThat(extensions).haveExactly(1,
-                    Condition(Predicate { it is TestOutputReport && it.ending == "yml" },
-                            "Is exactly the test output report."))
+            it("should recognize custom output format") {
+                assertThat(reports).haveExactly(1,
+                        Condition(Predicate { it.kind == reportUnderTest },
+                                "Corresponds exactly to the test output report."))
+
+                assertThat(extensions).haveExactly(1,
+                        Condition(Predicate { it is TestOutputReport && it.ending == "yml" },
+                                "Is exactly the test output report."))
+            }
         }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/TxtOutputReportTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/TxtOutputReportTest.kt
@@ -3,15 +3,18 @@ package io.gitlab.arturbosch.detekt.cli.out
 import io.gitlab.arturbosch.detekt.cli.TestDetektion
 import io.gitlab.arturbosch.detekt.cli.createFinding
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class TxtOutputReportTest : Spek({
 
-    it("render") {
-        val report = TxtOutputReport()
-        val detektion = TestDetektion(createFinding())
-        val renderedText = "TestSmell - [TestEntity] at TestFile.kt:1:1 - Signature=S1"
-        assertThat(report.render(detektion)).isEqualTo(renderedText)
+    describe("TXT output report") {
+
+        it("render") {
+            val report = TxtOutputReport()
+            val detektion = TestDetektion(createFinding())
+            val renderedText = "TestSmell - [TestEntity] at TestFile.kt:1:1 - Signature=S1"
+            assertThat(report.render(detektion)).isEqualTo(renderedText)
+        }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/XmlOutputFormatTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/XmlOutputFormatTest.kt
@@ -10,8 +10,8 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.cli.TestDetektion
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class XmlOutputFormatTest : Spek({
 
@@ -24,46 +24,49 @@ class XmlOutputFormatTest : Spek({
 
     val outputFormat = XmlOutputReport()
 
-    it("renderEmpty") {
-        val result = outputFormat.render(TestDetektion())
+    describe("XML output format") {
 
-        assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n</checkstyle>")
-    }
+        it("renderEmpty") {
+            val result = outputFormat.render(TestDetektion())
 
-    it("renderOneForSingleFile") {
-        val smell = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
+            assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n</checkstyle>")
+        }
 
-        val result = outputFormat.render(TestDetektion(smell))
+        it("renderOneForSingleFile") {
+            val smell = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
 
-        assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n</file>\n</checkstyle>")
-    }
+            val result = outputFormat.render(TestDetektion(smell))
 
-    it("renderTwoForSingleFile") {
-        val smell1 = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
-        val smell2 = CodeSmell(Issue("id_b", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
+            assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n</file>\n</checkstyle>")
+        }
 
-        val result = outputFormat.render(TestDetektion(smell1, smell2))
+        it("renderTwoForSingleFile") {
+            val smell1 = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
+            val smell2 = CodeSmell(Issue("id_b", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
 
-        assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_b\" />\n</file>\n</checkstyle>")
-    }
+            val result = outputFormat.render(TestDetektion(smell1, smell2))
 
-    it("renderOneForMultipleFiles") {
-        val smell1 = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
-        val smell2 = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity2, message = "")
+            assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_b\" />\n</file>\n</checkstyle>")
+        }
 
-        val result = outputFormat.render(TestDetektion(smell1, smell2))
+        it("renderOneForMultipleFiles") {
+            val smell1 = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
+            val smell2 = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity2, message = "")
 
-        assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n</file>\n<file name=\"src/main/com/sample/Sample2.kt\">\n\t<error line=\"22\" column=\"2\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n</file>\n</checkstyle>")
-    }
+            val result = outputFormat.render(TestDetektion(smell1, smell2))
 
-    it("renderTwoForMultipleFiles") {
-        val smell1 = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
-        val smell2 = CodeSmell(Issue("id_b", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
-        val smell3 = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity2, message = "")
-        val smell4 = CodeSmell(Issue("id_b", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity2, message = "")
+            assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n</file>\n<file name=\"src/main/com/sample/Sample2.kt\">\n\t<error line=\"22\" column=\"2\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n</file>\n</checkstyle>")
+        }
 
-        val result = outputFormat.render(TestDetektion(smell1, smell2, smell3, smell4))
+        it("renderTwoForMultipleFiles") {
+            val smell1 = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
+            val smell2 = CodeSmell(Issue("id_b", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
+            val smell3 = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity2, message = "")
+            val smell4 = CodeSmell(Issue("id_b", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity2, message = "")
 
-        assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_b\" />\n</file>\n<file name=\"src/main/com/sample/Sample2.kt\">\n\t<error line=\"22\" column=\"2\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n\t<error line=\"22\" column=\"2\" severity=\"warning\" message=\"\" source=\"detekt.id_b\" />\n</file>\n</checkstyle>")
+            val result = outputFormat.render(TestDetektion(smell1, smell2, smell3, smell4))
+
+            assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_b\" />\n</file>\n<file name=\"src/main/com/sample/Sample2.kt\">\n\t<error line=\"22\" column=\"2\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n\t<error line=\"22\" column=\"2\" severity=\"warning\" message=\"\" source=\"detekt.id_b\" />\n</file>\n</checkstyle>")
+        }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinterSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinterSpec.kt
@@ -2,23 +2,26 @@ package io.gitlab.arturbosch.detekt.cli.runners
 
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import io.gitlab.arturbosch.detekt.test.resource
-import java.nio.file.Paths
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.nio.file.Paths
 
 /**
  * @author Artur Bosch
  */
 class AstPrinterSpec : Spek({
 
-    it("should print the ast as string") {
-        val case = Paths.get(resource("cases/Poko.kt"))
-        val ktFile = compileForTest(case)
+    describe("AST printer") {
 
-        val dump = ElementPrinter.dump(ktFile)
+        it("should print the ast as string") {
+            val case = Paths.get(resource("cases/Poko.kt"))
+            val ktFile = compileForTest(case)
 
-        assertThat(dump.trimIndent()).isEqualTo(expected)
+            val dump = ElementPrinter.dump(ktFile)
+
+            assertThat(dump.trimIndent()).isEqualTo(expected)
+        }
     }
 })
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
@@ -13,28 +13,31 @@ import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.cli.CliArgs
 import io.gitlab.arturbosch.detekt.test.resource
-import java.nio.file.Paths
 import org.assertj.core.api.Assertions
 import org.jetbrains.kotlin.psi.KtClass
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.nio.file.Paths
 
 /**
  * @author Artur Bosch
  */
 class SingleRuleRunnerSpec : Spek({
 
-    it("should load and run custom rule") {
-        val case = Paths.get(resource("cases/Poko.kt"))
+    describe("single rule runner") {
 
-        val args = CliArgs().apply {
-            val field = this.javaClass.getDeclaredField("input")
-            field.isAccessible = true
-            field.set(this, case.toString())
-            runRule = "test:test"
+        it("should load and run custom rule") {
+            val case = Paths.get(resource("cases/Poko.kt"))
+
+            val args = CliArgs().apply {
+                val field = this.javaClass.getDeclaredField("input")
+                field.isAccessible = true
+                field.set(this, case.toString())
+                runRule = "test:test"
+            }
+            // assertion is made inside the custom console report
+            SingleRuleRunner(args).execute() // also indirect assertion that test:test exists
         }
-        // assertion is made inside the custom console report
-        SingleRuleRunner(args).execute() // also indirect assertion that test:test exists
     }
 })
 

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -12,5 +12,5 @@ dependencies {
     testImplementation(project(":detekt-test"))
     testImplementation("org.reflections:reflections:$reflectionsVersion")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
+    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/McCabeVisitorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/McCabeVisitorSpec.kt
@@ -2,15 +2,14 @@ package io.gitlab.arturbosch.detekt.api.internal
 
 import io.gitlab.arturbosch.detekt.test.KtTestCompiler
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 private const val FUN_MCC = 1
 
 class McCabeVisitorSpec : Spek({
 
-    given("ignoreSimpleWhenEntries is false") {
+    describe("ignoreSimpleWhenEntries is false") {
 
         it("counts simple when branches as 1") {
             val code = """
@@ -49,7 +48,7 @@ class McCabeVisitorSpec : Spek({
         }
     }
 
-    given("ignoreSimpleWhenEntries is true") {
+    describe("ignoreSimpleWhenEntries is true") {
 
         it("counts a when with only simple branches as 1") {
             val code = """

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CustomRuleSetProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CustomRuleSetProviderSpec.kt
@@ -1,11 +1,10 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.test.resource
-import java.nio.file.Paths
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.nio.file.Paths
 
 /**
  * This test runs a precompiled jar with a custom rule provider.

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektSpec.kt
@@ -1,9 +1,8 @@
 package io.gitlab.arturbosch.detekt.core
 
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektorTest.kt
@@ -2,20 +2,22 @@ package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
 class DetektorTest : Spek({
 
-    it("TestProvider gets excluded as RuleSet") {
-        runDetektWithPattern("patterns/test-pattern.yml")
-    }
+    describe("detektor") {
+        it("TestProvider gets excluded as RuleSet") {
+            runDetektWithPattern("patterns/test-pattern.yml")
+        }
 
-    it("FindName rule gets excluded") {
-        runDetektWithPattern("patterns/exclude-FindName.yml")
+        it("FindName rule gets excluded") {
+            runDetektWithPattern("patterns/exclude-FindName.yml")
+        }
     }
 })
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtCompilerTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtCompilerTest.kt
@@ -1,21 +1,23 @@
 package io.gitlab.arturbosch.detekt.core
 
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
 class KtCompilerTest : Spek({
+	describe("Kotlin Compiler") {
 
-    it("ktFileHasExtraUserData") {
-        val ktCompiler = KtCompiler()
+        it("ktFileHasExtraUserData") {
+            val ktCompiler = KtCompiler()
 
-        val ktFile = ktCompiler.compile(path, path.resolve("Default.kt"))
+            val ktFile = ktCompiler.compile(path, path.resolve("Default.kt"))
 
-        assertThat(ktFile.getUserData(KtCompiler.LINE_SEPARATOR)).isEqualTo("\n")
-        assertThat(ktFile.getUserData(KtCompiler.RELATIVE_PATH))
-                .isEqualTo(path.fileName.resolve("Default.kt").toString())
+            assertThat(ktFile.getUserData(KtCompiler.LINE_SEPARATOR)).isEqualTo("\n")
+            assertThat(ktFile.getUserData(KtCompiler.RELATIVE_PATH))
+                    .isEqualTo(path.fileName.resolve("Default.kt").toString())
+        }
     }
 })

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
@@ -1,9 +1,8 @@
 package io.gitlab.arturbosch.detekt.core
 
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/PathFilterSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/PathFilterSpec.kt
@@ -1,33 +1,32 @@
 package io.gitlab.arturbosch.detekt.core
 
-import java.nio.file.Paths
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.nio.file.Paths
 
 internal class PathFilterSpec : Spek({
 
-    given("an invalid regex pattern") {
+    describe("an invalid regex pattern") {
         it("throws an IllegalArgumentException") {
             assertThatIllegalArgumentException().isThrownBy { PathFilter("*.") }
         }
     }
 
-    given("an empty pattern") {
+    describe("an empty pattern") {
         it("throws an IllegalArgumentException") {
             assertThatIllegalArgumentException().isThrownBy { PathFilter("") }
         }
     }
 
-    given("an blank pattern") {
+    describe("a blank pattern") {
         it("throws an IllegalArgumentException") {
             assertThatIllegalArgumentException().isThrownBy { PathFilter("    ") }
         }
     }
 
-    given("a single regex pattern on Unix systems") {
+    describe("a single regex pattern on Unix systems") {
         val filter = ".*/build/.*"
         val defaultRoot = Paths.get("").toAbsolutePath()
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/RuleSetLocatorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/RuleSetLocatorTest.kt
@@ -1,24 +1,26 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import java.lang.reflect.Modifier
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
 import org.reflections.Reflections
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.lang.reflect.Modifier
 
 class RuleSetLocatorTest : Spek({
+	describe("Reulset") {
 
-    it("containsAllRuleProviders") {
-        val locator = RuleSetLocator(ProcessingSettings(path))
-        val providers = locator.load()
-        val providerClasses = getProviderClasses()
+        it("containsAllRuleProviders") {
+            val locator = RuleSetLocator(ProcessingSettings(path))
+            val providers = locator.load()
+            val providerClasses = getProviderClasses()
 
-        assertThat(providerClasses).isNotEmpty
-        providerClasses
-                .filter { clazz -> providers.firstOrNull { it.javaClass == clazz } == null }
-                .forEach { Assertions.fail("$it rule set is not loaded by the RuleSetLocator") }
+            assertThat(providerClasses).isNotEmpty
+            providerClasses
+                    .filter { clazz -> providers.firstOrNull { it.javaClass == clazz } == null }
+                    .forEach { Assertions.fail("$it rule set is not loaded by the RuleSetLocator") }
+        }
     }
 })
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TestPatternTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TestPatternTest.kt
@@ -1,19 +1,18 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.test.yamlConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 import java.nio.file.Path
 import java.nio.file.Paths
-import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
 
 /**
  * @author Artur Bosch
  */
 class TestPatternTest : Spek({
 
-    given("a test pattern for paths") {
+    describe("a test pattern for paths") {
 
         fun splitSources(pattern: TestPattern, path: Path): Pair<List<Path>, List<Path>> =
                 listOf(path).partition { pattern.matches(it.toString()) }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/CLOCVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/CLOCVisitorTest.kt
@@ -3,17 +3,19 @@ package io.gitlab.arturbosch.detekt.core.processors
 import io.gitlab.arturbosch.detekt.core.path
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class CLOCVisitorTest : Spek({
+	describe("CLOC") {
 
-    it("commentCases") {
-        val file = compileForTest(path.resolve("../comments/CommentsClass.kt"))
-        val commentLines = with(file) {
-            accept(CLOCVisitor())
-            getUserData(commentLinesKey)
+        it("commentCases") {
+            val file = compileForTest(path.resolve("../comments/CommentsClass.kt"))
+            val commentLines = with(file) {
+                accept(CLOCVisitor())
+                getUserData(commentLinesKey)
+            }
+            assertThat(commentLines).isEqualTo(10)
         }
-        assertThat(commentLines).isEqualTo(10)
     }
 })

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/ClassCountVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/ClassCountVisitorTest.kt
@@ -4,33 +4,35 @@ import io.gitlab.arturbosch.detekt.core.path
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class ClassCountVisitorTest : Spek({
+	describe("something") {
 
-    it("twoClassesInSeparateFile") {
-        val files = arrayOf(
-                compileForTest(path.resolve("Test.kt")),
-                compileForTest(path.resolve("Default.kt"))
-        )
-        val count = getClassCount(files)
-        assertThat(count).isEqualTo(2)
-    }
+        it("twoClassesInSeparateFile") {
+            val files = arrayOf(
+                    compileForTest(path.resolve("Test.kt")),
+                    compileForTest(path.resolve("Default.kt"))
+            )
+            val count = getClassCount(files)
+            assertThat(count).isEqualTo(2)
+        }
 
-    it("oneClassWithOneNestedClass") {
-        val file = compileForTest(path.resolve("ComplexClass.kt"))
-        val count = getClassCount(arrayOf(file))
-        assertThat(count).isEqualTo(2)
-    }
+        it("oneClassWithOneNestedClass") {
+            val file = compileForTest(path.resolve("ComplexClass.kt"))
+            val count = getClassCount(arrayOf(file))
+            assertThat(count).isEqualTo(2)
+        }
 
-    it("testEnumAndInterface") {
-        val files = arrayOf(
-                compileForTest(path.resolve("../empty/EmptyEnum.kt")),
-                compileForTest(path.resolve("../empty/EmptyInterface.kt"))
-        )
-        val count = getClassCount(files)
-        assertThat(count).isEqualTo(2)
+        it("testEnumAndInterface") {
+            val files = arrayOf(
+                    compileForTest(path.resolve("../empty/EmptyEnum.kt")),
+                    compileForTest(path.resolve("../empty/EmptyInterface.kt"))
+            )
+            val count = getClassCount(files)
+            assertThat(count).isEqualTo(2)
+        }
     }
 })
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/ComplexityVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/ComplexityVisitorTest.kt
@@ -2,30 +2,32 @@ package io.gitlab.arturbosch.detekt.core.processors
 
 import io.gitlab.arturbosch.detekt.core.path
 import io.gitlab.arturbosch.detekt.test.compileForTest
-import java.nio.file.Path
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.nio.file.Path
 
 /**
  * @author Artur Bosch
  */
 class ComplexityVisitorTest : Spek({
+	describe("something") {
 
-    it("complexityOfDefaultCaseIsOne") {
-        val path = path.resolve("Default.kt")
+        it("complexityOfDefaultCaseIsOne") {
+            val path = path.resolve("Default.kt")
 
-        val mcc = calcComplexity(path)
+            val mcc = calcComplexity(path)
 
-        assertThat(mcc).isEqualTo(0)
-    }
+            assertThat(mcc).isEqualTo(0)
+        }
 
-    it("complexityOfComplexAndNestedClass") {
-        val path = path.resolve("ComplexClass.kt")
+        it("complexityOfComplexAndNestedClass") {
+            val path = path.resolve("ComplexClass.kt")
 
-        val mcc = calcComplexity(path)
+            val mcc = calcComplexity(path)
 
-        assertThat(mcc).isEqualTo(56)
+            assertThat(mcc).isEqualTo(56)
+        }
     }
 })
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/FieldCountVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/FieldCountVisitorTest.kt
@@ -3,17 +3,19 @@ package io.gitlab.arturbosch.detekt.core.processors
 import io.gitlab.arturbosch.detekt.core.path
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class FieldCountVisitorTest : Spek({
+	describe("something") {
 
-    it("defaultFieldCount") {
-        val file = compileForTest(path.resolve("../fields/ClassWithFields.kt"))
-        val count = with(file) {
-            accept(PropertyCountVisitor())
-            getUserData(numberOfFieldsKey)
+        it("defaultFieldCount") {
+            val file = compileForTest(path.resolve("../fields/ClassWithFields.kt"))
+            val count = with(file) {
+                accept(PropertyCountVisitor())
+                getUserData(numberOfFieldsKey)
+            }
+            assertThat(count).isEqualTo(2)
         }
-        assertThat(count).isEqualTo(2)
     }
 })

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/KtFileCountVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/KtFileCountVisitorTest.kt
@@ -4,20 +4,22 @@ import io.gitlab.arturbosch.detekt.core.path
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.assertj.core.api.Assertions
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class KtFileCountVisitorTest : Spek({
+	describe("files") {
 
-    it("twoFiles") {
-        val files = arrayOf(
-                compileForTest(path.resolve("Default.kt")),
-                compileForTest(path.resolve("Test.kt"))
-        )
-        val count = files
-                .map { getData(it) }
-                .sum()
-        Assertions.assertThat(count).isEqualTo(2)
+        it("twoFiles") {
+            val files = arrayOf(
+                    compileForTest(path.resolve("Default.kt")),
+                    compileForTest(path.resolve("Test.kt"))
+            )
+            val count = files
+                    .map { getData(it) }
+                    .sum()
+            Assertions.assertThat(count).isEqualTo(2)
+        }
     }
 })
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/LLOCVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/LLOCVisitorTest.kt
@@ -3,33 +3,35 @@ package io.gitlab.arturbosch.detekt.core.processors
 import io.gitlab.arturbosch.detekt.core.path
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
 class LLOCVisitorTest : Spek({
+	describe("seomthing") {
 
-    it("defaultCaseHasOneClassAndAnnotationLine") {
-        val file = compileForTest(path.resolve("Default.kt"))
+        it("defaultCaseHasOneClassAndAnnotationLine") {
+            val file = compileForTest(path.resolve("Default.kt"))
 
-        val lloc = with(file) {
-            accept(LLOCVisitor())
-            getUserData(logicalLinesKey)
+            val lloc = with(file) {
+                accept(LLOCVisitor())
+                getUserData(logicalLinesKey)
+            }
+
+            assertThat(lloc).isEqualTo(2)
         }
 
-        assertThat(lloc).isEqualTo(2)
-    }
+        it("llocOfComplexClass") {
+            val file = compileForTest(path.resolve("ComplexClass.kt"))
 
-    it("llocOfComplexClass") {
-        val file = compileForTest(path.resolve("ComplexClass.kt"))
+            val lloc = with(file) {
+                accept(LLOCVisitor())
+                getUserData(logicalLinesKey)
+            }
 
-        val lloc = with(file) {
-            accept(LLOCVisitor())
-            getUserData(logicalLinesKey)
+            assertThat(lloc).isEqualTo(85)
         }
-
-        assertThat(lloc).isEqualTo(85)
     }
 })

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/LOCVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/LOCVisitorTest.kt
@@ -3,17 +3,19 @@ package io.gitlab.arturbosch.detekt.core.processors
 import io.gitlab.arturbosch.detekt.core.path
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.assertj.core.api.Assertions
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class LOCVisitorTest : Spek({
+	describe("LOC Visitor") {
 
-    it("defaultClass") {
-        val file = compileForTest(path.resolve("Default.kt"))
-        val loc = with(file) {
-            accept(LOCVisitor())
-            getUserData(linesKey)
+        it("defaultClass") {
+            val file = compileForTest(path.resolve("Default.kt"))
+            val loc = with(file) {
+                accept(LOCVisitor())
+                getUserData(linesKey)
+            }
+            Assertions.assertThat(loc).isEqualTo(8)
         }
-        Assertions.assertThat(loc).isEqualTo(8)
     }
 })

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/MethodCountVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/MethodCountVisitorTest.kt
@@ -4,15 +4,17 @@ import io.gitlab.arturbosch.detekt.core.path
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class MethodCountVisitorTest : Spek({
+	describe("Method Count Visitor") {
 
-    it("defaultMethodCount") {
-        val file = compileForTest(path.resolve("ComplexClass.kt"))
-        val count = getMethodCount(file)
-        assertThat(count).isEqualTo(6)
+        it("defaultMethodCount") {
+            val file = compileForTest(path.resolve("ComplexClass.kt"))
+            val count = getMethodCount(file)
+            assertThat(count).isEqualTo(6)
+        }
     }
 })
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/PackageCountVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/PackageCountVisitorTest.kt
@@ -4,21 +4,23 @@ import io.gitlab.arturbosch.detekt.core.path
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.assertj.core.api.Assertions
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class PackageCountVisitorTest : Spek({
+	describe("Package Count Visitor") {
 
-    it("twoClassesInSeparatePackage") {
-        val files = arrayOf(
-                compileForTest(path.resolve("Default.kt")),
-                compileForTest(path.resolve("../empty/EmptyEnum.kt"))
-        )
-        val count = files
-                .map { getData(it) }
-                .distinct()
-                .count()
-        Assertions.assertThat(count).isEqualTo(2)
+        it("twoClassesInSeparatePackage") {
+            val files = arrayOf(
+                    compileForTest(path.resolve("Default.kt")),
+                    compileForTest(path.resolve("../empty/EmptyEnum.kt"))
+            )
+            val count = files
+                    .map { getData(it) }
+                    .distinct()
+                    .count()
+            Assertions.assertThat(count).isEqualTo(2)
+        }
     }
 })
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/SLOCVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/SLOCVisitorTest.kt
@@ -3,17 +3,19 @@ package io.gitlab.arturbosch.detekt.core.processors
 import io.gitlab.arturbosch.detekt.core.path
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.assertj.core.api.Assertions
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class SLOCVisitorTest : Spek({
+	describe("SLOC Visitor") {
 
-    it("defaultClass") {
-        val file = compileForTest(path.resolve("Default.kt"))
-        val loc = with(file) {
-            accept(SLOCVisitor())
-            getUserData(sourceLinesKey)
+        it("defaultClass") {
+            val file = compileForTest(path.resolve("Default.kt"))
+            val loc = with(file) {
+                accept(SLOCVisitor())
+                getUserData(sourceLinesKey)
+            }
+            Assertions.assertThat(loc).isEqualTo(3)
         }
-        Assertions.assertThat(loc).isEqualTo(3)
     }
 })

--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     testImplementation(project(":detekt-test"))
     testImplementation(project(":detekt-core"))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
+    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }
 
 tasks.withType<Jar> {

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
@@ -7,13 +7,11 @@ import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.test.loadRuleSet
 import io.gitlab.arturbosch.detekt.test.resource
 import io.gitlab.arturbosch.detekt.test.yamlConfig
-import java.nio.file.Paths
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.nio.file.Paths
 
 /**
  * @author Artur Bosch
@@ -22,7 +20,7 @@ class AutoCorrectLevelSpec : Spek({
 
     describe("test different autoCorrect levels in configuration") {
 
-        given("autoCorrect: true on all levels") {
+        describe("autoCorrect: true on all levels") {
 
             val config = yamlConfig("/autocorrect/autocorrect-all-true.yml")
 
@@ -33,7 +31,7 @@ class AutoCorrectLevelSpec : Spek({
             }
         }
 
-        given("autoCorrect: false on top level") {
+        describe("autoCorrect: false on top level") {
 
             val config = yamlConfig("/autocorrect/autocorrect-toplevel-false.yml")
 
@@ -51,7 +49,7 @@ class AutoCorrectLevelSpec : Spek({
             }
         }
 
-        given("autoCorrect: false on ruleSet level") {
+        describe("autoCorrect: false on ruleSet level") {
 
             val config = yamlConfig("/autocorrect/autocorrect-ruleset-false.yml")
 
@@ -62,7 +60,7 @@ class AutoCorrectLevelSpec : Spek({
             }
         }
 
-        given("autoCorrect: false on rule level") {
+        describe("autoCorrect: false on rule level") {
 
             val config = yamlConfig("/autocorrect/autocorrect-rule-false.yml")
 
@@ -73,7 +71,7 @@ class AutoCorrectLevelSpec : Spek({
             }
         }
 
-        given("autoCorrect: true but rule active false") {
+        describe("autoCorrect: true but rule active false") {
 
             val config = yamlConfig("/autocorrect/autocorrect-true-rule-active-false.yml")
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintIntegrationSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintIntegrationSpec.kt
@@ -3,9 +3,8 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.loadRuleSet
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -93,5 +93,5 @@ dependencies {
 
     testImplementation(project(":detekt-test"))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
+    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollectorSpec.kt
@@ -4,13 +4,12 @@ import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidDocumen
 import io.gitlab.arturbosch.detekt.generator.util.run
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class MultiRuleCollectorSpec : SubjectSpek<MultiRuleCollector>({
+class MultiRuleCollectorSpec : Spek({
 
-    subject { MultiRuleCollector() }
+    val subject by memoized { MultiRuleCollector() }
 
     describe("a MultiRuleCollector") {
 

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -7,13 +7,12 @@ import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidIssueDe
 import io.gitlab.arturbosch.detekt.generator.util.run
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class RuleCollectorSpec : SubjectSpek<RuleCollector>({
+class RuleCollectorSpec : Spek({
 
-    subject { RuleCollector() }
+    val subject by memoized { RuleCollector() }
 
     describe("a RuleCollector") {
 

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
@@ -4,16 +4,16 @@ import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidDocumen
 import io.gitlab.arturbosch.detekt.generator.util.run
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
+class RuleSetProviderCollectorSpec : Spek({
 
-    subject { RuleSetProviderCollector() }
+    val subject by memoized { RuleSetProviderCollector() }
 
-    given("a non-RuleSetProvider class extending nothing") {
-        val code = """
+    describe("RuleSetProviderCollector rule") {
+        context("a non-RuleSetProvider class extending nothing") {
+            val code = """
 			package foo
 
 			class SomeRandomClass {
@@ -22,14 +22,14 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 				}
 			}
 		"""
-        it("collects no rulesets") {
-            val items = subject.run(code)
-            assertThat(items).isEmpty()
+            it("collects no rulesets") {
+                val items = subject.run(code)
+                assertThat(items).isEmpty()
+            }
         }
-    }
 
-    given("a non-RuleSetProvider class extending a class that is not related to rules") {
-        val code = """
+        context("a non-RuleSetProvider class extending a class that is not related to rules") {
+            val code = """
 			package foo
 
 			class SomeRandomClass: SomeOtherClass {
@@ -38,14 +38,14 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 				}
 			}
 		"""
-        it("collects no rulesets") {
-            val items = subject.run(code)
-            assertThat(items).isEmpty()
+            it("collects no rulesets") {
+                val items = subject.run(code)
+                assertThat(items).isEmpty()
+            }
         }
-    }
 
-    given("a RuleSetProvider without documentation") {
-        val code = """
+        context("a RuleSetProvider without documentation") {
+            val code = """
 			package foo
 
 			class TestProvider: RuleSetProvider {
@@ -54,14 +54,14 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 				}
 			}
 		"""
-        it("throws an exception") {
-            assertThatExceptionOfType(InvalidDocumentationException::class.java)
-                    .isThrownBy { subject.run(code) }
+            it("throws an exception") {
+                assertThatExceptionOfType(InvalidDocumentationException::class.java)
+                        .isThrownBy { subject.run(code) }
+            }
         }
-    }
 
-    given("a correct RuleSetProvider class extending RuleSetProvider but missing parameters") {
-        val code = """
+        context("a correct RuleSetProvider class extending RuleSetProvider but missing parameters") {
+            val code = """
 			package foo
 
 			class TestProvider: RuleSetProvider {
@@ -71,17 +71,17 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 			}
 		"""
 
-        it("throws an exception") {
-            assertThatExceptionOfType(InvalidDocumentationException::class.java)
-                    .isThrownBy { subject.run(code) }
+            it("throws an exception") {
+                assertThatExceptionOfType(InvalidDocumentationException::class.java)
+                        .isThrownBy { subject.run(code) }
+            }
         }
-    }
 
-    given("a correct RuleSetProvider class with full parameters") {
-        val description = "This is a description"
-        val ruleSetId = "test"
-        val ruleName = "TestRule"
-        val code = """
+        context("a correct RuleSetProvider class with full parameters") {
+            val description = "This is a description"
+            val ruleSetId = "test"
+            val ruleName = "TestRule"
+            val code = """
 			package foo
 
 			/**
@@ -100,42 +100,42 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 			}
 		"""
 
-        it("collects a RuleSetProvider") {
-            val items = subject.run(code)
-            assertThat(items).hasSize(1)
+            it("collects a RuleSetProvider") {
+                val items = subject.run(code)
+                assertThat(items).hasSize(1)
+            }
+
+            it("has one rule") {
+                val items = subject.run(code)
+                val provider = items[0]
+                assertThat(provider.rules).hasSize(1)
+                assertThat(provider.rules[0]).isEqualTo(ruleName)
+            }
+
+            it("has correct name") {
+                val items = subject.run(code)
+                val provider = items[0]
+                assertThat(provider.name).isEqualTo(ruleSetId)
+            }
+
+            it("has correct description") {
+                val items = subject.run(code)
+                val provider = items[0]
+                assertThat(provider.description).isEqualTo(description)
+            }
+
+            it("is active") {
+                val items = subject.run(code)
+                val provider = items[0]
+                assertThat(provider.active).isTrue()
+            }
         }
 
-        it("has one rule") {
-            val items = subject.run(code)
-            val provider = items[0]
-            assertThat(provider.rules).hasSize(1)
-            assertThat(provider.rules[0]).isEqualTo(ruleName)
-        }
-
-        it("has correct name") {
-            val items = subject.run(code)
-            val provider = items[0]
-            assertThat(provider.name).isEqualTo(ruleSetId)
-        }
-
-        it("has correct description") {
-            val items = subject.run(code)
-            val provider = items[0]
-            assertThat(provider.description).isEqualTo(description)
-        }
-
-        it("is active") {
-            val items = subject.run(code)
-            val provider = items[0]
-            assertThat(provider.active).isTrue()
-        }
-    }
-
-    given("an inactive RuleSetProvider") {
-        val description = "This is a description"
-        val ruleSetId = "test"
-        val ruleName = "TestRule"
-        val code = """
+        context("an inactive RuleSetProvider") {
+            val description = "This is a description"
+            val ruleSetId = "test"
+            val ruleName = "TestRule"
+            val code = """
 			package foo
 
 			/**
@@ -152,17 +152,17 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 			}
 		"""
 
-        it("is not active") {
-            val items = subject.run(code)
-            val provider = items[0]
-            assertThat(provider.active).isFalse()
+            it("is not active") {
+                val items = subject.run(code)
+                val provider = items[0]
+                assertThat(provider.active).isFalse()
+            }
         }
-    }
 
-    given("a RuleSetProvider with missing name") {
-        val description = "This is a description"
-        val ruleName = "TestRule"
-        val code = """
+        context("a RuleSetProvider with missing name") {
+            val description = "This is a description"
+            val ruleName = "TestRule"
+            val code = """
 			package foo
 
 			/**
@@ -177,16 +177,16 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 			}
 		"""
 
-        it("throws an exception") {
-            assertThatExceptionOfType(InvalidDocumentationException::class.java)
-                    .isThrownBy { subject.run(code) }
+            it("throws an exception") {
+                assertThatExceptionOfType(InvalidDocumentationException::class.java)
+                        .isThrownBy { subject.run(code) }
+            }
         }
-    }
 
-    given("a RuleSetProvider with missing description") {
-        val ruleSetId = "test"
-        val ruleName = "TestRule"
-        val code = """
+        context("a RuleSetProvider with missing description") {
+            val ruleSetId = "test"
+            val ruleName = "TestRule"
+            val code = """
 			package foo
 
 			class TestProvider: RuleSetProvider {
@@ -200,15 +200,15 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 			}
 		"""
 
-        it("throws an exception") {
-            assertThatExceptionOfType(InvalidDocumentationException::class.java)
-                    .isThrownBy { subject.run(code) }
+            it("throws an exception") {
+                assertThatExceptionOfType(InvalidDocumentationException::class.java)
+                        .isThrownBy { subject.run(code) }
+            }
         }
-    }
 
-    given("a RuleSetProvider with no rules") {
-        val ruleSetId = "test"
-        val code = """
+        context("a RuleSetProvider with no rules") {
+            val ruleSetId = "test"
+            val code = """
 			package foo
 
 			class TestProvider: RuleSetProvider {
@@ -220,18 +220,18 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 			}
 		"""
 
-        it("throws an exception") {
-            assertThatExceptionOfType(InvalidDocumentationException::class.java)
-                    .isThrownBy { subject.run(code) }
+            it("throws an exception") {
+                assertThatExceptionOfType(InvalidDocumentationException::class.java)
+                        .isThrownBy { subject.run(code) }
+            }
         }
-    }
 
-    given("a correct RuleSetProvider class with full parameters") {
-        val description = "This is a description"
-        val ruleSetId = "test"
-        val ruleName = "TestRule"
-        val secondRuleName = "SecondRule"
-        val code = """
+        context("a correct RuleSetProvider class with full parameters") {
+            val description = "This is a description"
+            val ruleSetId = "test"
+            val ruleName = "TestRule"
+            val secondRuleName = "SecondRule"
+            val code = """
 			package foo
 
 			/**
@@ -251,9 +251,10 @@ class RuleSetProviderCollectorSpec : SubjectSpek<RuleSetProviderCollector>({
 			}
 		"""
 
-        it("collects multiple rules") {
-            val items = subject.run(code)
-            assertThat(items[0].rules).containsExactly(ruleName, secondRuleName)
+            it("collects multiple rules") {
+                val items = subject.run(code)
+                assertThat(items[0].rules).containsExactly(ruleName, secondRuleName)
+            }
         }
     }
 })

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/ConfigPrinterSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/ConfigPrinterSpec.kt
@@ -3,15 +3,14 @@ package io.gitlab.arturbosch.detekt.generator.printer
 import io.gitlab.arturbosch.detekt.generator.printer.rulesetpage.ConfigPrinter
 import io.gitlab.arturbosch.detekt.generator.util.createRuleSetPage
 import io.gitlab.arturbosch.detekt.test.resource
-import java.io.File
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.io.File
 
 class ConfigPrinterSpec : Spek({
 
-    given("a config to print") {
+    describe("Config printer") {
 
         it("prints the correct yaml format") {
             val ruleSetList = listOf(createRuleSetPage())

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RuleSetPagePrinterSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RuleSetPagePrinterSpec.kt
@@ -3,16 +3,14 @@ package io.gitlab.arturbosch.detekt.generator.printer
 import io.gitlab.arturbosch.detekt.generator.printer.rulesetpage.RuleSetPagePrinter
 import io.gitlab.arturbosch.detekt.generator.util.createRuleSetPage
 import io.gitlab.arturbosch.detekt.test.resource
-import java.io.File
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.io.File
 
 class RuleSetPagePrinterSpec : Spek({
 
-    given("a config to print") {
-
+    describe("Ruleset page printer") {
         it("prints the correct markdown format") {
             val markdownString = RuleSetPagePrinter.print(createRuleSetPage())
             val expectedMarkdownString = File(resource("/RuleSet.md")).readText()

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -31,7 +31,7 @@ version = "1.0.0-RC13"
 
 val detektGradleVersion: String by project
 val jcommanderVersion: String by project
-val spekVersion = "1.2.1"
+val spekVersion = "2.0.0"
 val junitPlatformVersion = "1.3.2"
 val assertjVersion = "3.11.1"
 
@@ -40,10 +40,9 @@ dependencies {
 
     testImplementation(kotlin("reflect"))
     testImplementation("org.assertj:assertj-core:$assertjVersion")
-    testImplementation("org.jetbrains.spek:spek-api:$spekVersion")
-    testImplementation("org.jetbrains.spek:spek-subject-extension:$spekVersion")
+    testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
+    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }
 
 gradlePlugin {
@@ -107,11 +106,10 @@ val generateDefaultDetektVersionFile: Task by tasks.creating {
     doFirst {
         defaultDetektVersionFile.parentFile.mkdirs()
         defaultDetektVersionFile.writeText("""
-			package io.gitlab.arturbosch.detekt
+            package io.gitlab.arturbosch.detekt
 
-			internal const val DEFAULT_DETEKT_VERSION = "$version"
-			"""
-                .trimIndent()
+            internal const val DEFAULT_DETEKT_VERSION = "$version"
+            """.trimIndent()
         )
     }
 }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslTest.kt
@@ -2,9 +2,8 @@ package io.gitlab.arturbosch.detekt
 
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Markus Schwarz

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -4,9 +4,8 @@ import io.gitlab.arturbosch.detekt.DslTestBuilder.Companion.groovy
 import io.gitlab.arturbosch.detekt.DslTestBuilder.Companion.kotlin
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Marvin Ramin

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleTest.kt
@@ -4,9 +4,8 @@ import io.gitlab.arturbosch.detekt.DslTestBuilder.Companion.groovy
 import io.gitlab.arturbosch.detekt.DslTestBuilder.Companion.kotlin
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 const val SOURCE_DIRECTORY = "src/main/java"
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/GenerateConfigTaskTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/GenerateConfigTaskTest.kt
@@ -2,9 +2,8 @@ package io.gitlab.arturbosch.detekt
 
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class GenerateConfigTaskTest : Spek({
     describe("The generate config task of the Detekt Gradle plugin") {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorTest.kt
@@ -3,9 +3,8 @@ package io.gitlab.arturbosch.detekt
 import io.gitlab.arturbosch.detekt.DslTestBuilder.Companion.kotlin
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * Tests that run the Detekt Gradle Plugins tasks multiple times to check for correct

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
 
     testImplementation("org.reflections:reflections:$reflectionsVersion")
     testImplementation(project(":detekt-test"))
+    testImplementation(kotlin("reflect"))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
+    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/CommonSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/CommonSpec.kt
@@ -1,24 +1,22 @@
 package io.gitlab.arturbosch.detekt.rules
 
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.rules.style.WildcardImport
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
-class CommonSpec : SubjectSpek<Rule>({
-    subject { WildcardImport() }
-    val file = compileForTest(Case.Default.path())
+class CommonSpec : Spek({
+    val subject by memoized { WildcardImport() }
 
     describe("running specified rule") {
         it("should detect one finding") {
-            subject.lint(file.text)
+            val file = compileForTest(Case.Default.path())
+            subject.lint(file)
             assertThat(subject.findings).hasSize(1)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RuleProviderTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RuleProviderTest.kt
@@ -13,76 +13,79 @@ import io.gitlab.arturbosch.detekt.rules.providers.NamingProvider
 import io.gitlab.arturbosch.detekt.rules.providers.PerformanceProvider
 import io.gitlab.arturbosch.detekt.rules.providers.PotentialBugProvider
 import io.gitlab.arturbosch.detekt.rules.providers.StyleGuideProvider
-import java.lang.reflect.Modifier
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
 import org.reflections.Reflections
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.lang.reflect.Modifier
 
 class RuleProviderTest : Spek({
 
-    it("commentSmellProvider") {
-        RuleProviderAssert(
-                CommentSmellProvider(),
-                "io.gitlab.arturbosch.detekt.rules.documentation",
-                Rule::class.java)
-                .assert()
-    }
+    describe("Rule Provider") {
 
-    it("complexityProvider") {
-        RuleProviderAssert(
-                ComplexityProvider(),
-                "io.gitlab.arturbosch.detekt.rules.complexity",
-                Rule::class.java)
-                .assert()
-    }
+        it("commentSmellProvider") {
+            RuleProviderAssert(
+                    CommentSmellProvider(),
+                    "io.gitlab.arturbosch.detekt.rules.documentation",
+                    Rule::class.java)
+                    .assert()
+        }
 
-    it("emptyCodeProvider") {
-        RuleProviderAssert(
-                EmptyCodeProvider(),
-                "io.gitlab.arturbosch.detekt.rules.empty",
-                Rule::class.java)
-                .assert()
-    }
+        it("complexityProvider") {
+            RuleProviderAssert(
+                    ComplexityProvider(),
+                    "io.gitlab.arturbosch.detekt.rules.complexity",
+                    Rule::class.java)
+                    .assert()
+        }
 
-    it("exceptionsProvider") {
-        RuleProviderAssert(
-                ExceptionsProvider(),
-                "io.gitlab.arturbosch.detekt.rules.exceptions",
-                Rule::class.java)
-                .assert()
-    }
+        it("emptyCodeProvider") {
+            RuleProviderAssert(
+                    EmptyCodeProvider(),
+                    "io.gitlab.arturbosch.detekt.rules.empty",
+                    Rule::class.java)
+                    .assert()
+        }
 
-    it("namingProvider") {
-        RuleProviderAssert(
-                NamingProvider(),
-                "io.gitlab.arturbosch.detekt.rules.naming",
-                Rule::class.java)
-                .assert()
-    }
+        it("exceptionsProvider") {
+            RuleProviderAssert(
+                    ExceptionsProvider(),
+                    "io.gitlab.arturbosch.detekt.rules.exceptions",
+                    Rule::class.java)
+                    .assert()
+        }
 
-    it("performanceProvider") {
-        RuleProviderAssert(
-                PerformanceProvider(),
-                "io.gitlab.arturbosch.detekt.rules.performance",
-                Rule::class.java)
-                .assert()
-    }
+        it("namingProvider") {
+            RuleProviderAssert(
+                    NamingProvider(),
+                    "io.gitlab.arturbosch.detekt.rules.naming",
+                    Rule::class.java)
+                    .assert()
+        }
 
-    it("potentialBugProvider") {
-        RuleProviderAssert(
-                PotentialBugProvider(),
-                "io.gitlab.arturbosch.detekt.rules.bugs",
-                Rule::class.java)
-                .assert()
-    }
+        it("performanceProvider") {
+            RuleProviderAssert(
+                    PerformanceProvider(),
+                    "io.gitlab.arturbosch.detekt.rules.performance",
+                    Rule::class.java)
+                    .assert()
+        }
 
-    it("styleGuideProvider") {
-        RuleProviderAssert(
-                StyleGuideProvider(),
-                "io.gitlab.arturbosch.detekt.rules.style",
-                Rule::class.java)
-                .assert()
+        it("potentialBugProvider") {
+            RuleProviderAssert(
+                    PotentialBugProvider(),
+                    "io.gitlab.arturbosch.detekt.rules.bugs",
+                    Rule::class.java)
+                    .assert()
+        }
+
+        it("styleGuideProvider") {
+            RuleProviderAssert(
+                    StyleGuideProvider(),
+                    "io.gitlab.arturbosch.detekt.rules.style",
+                    Rule::class.java)
+                    .assert()
+        }
     }
 })
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RunRuleSetWithRuleFiltersSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RunRuleSetWithRuleFiltersSpec.kt
@@ -11,9 +11,8 @@ import io.gitlab.arturbosch.detekt.test.compileForTest
 import io.gitlab.arturbosch.detekt.test.loadRuleSet
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
@@ -10,54 +10,57 @@ import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
 class SuppressingSpec : Spek({
 
-    it("all findings are suppressed on element levels") {
-        val ktFile = compileForTest(Case.SuppressedElements.path())
-        val ruleSet = RuleSet("Test", listOf(LongMethod(), LongParameterList(), ComplexCondition()))
-        val findings = ruleSet.accept(ktFile)
-        findings.forEach {
-            println(it.compact())
+    describe("Rule suppression") {
+
+        it("all findings are suppressed on element levels") {
+            val ktFile = compileForTest(Case.SuppressedElements.path())
+            val ruleSet = RuleSet("Test", listOf(LongMethod(), LongParameterList(), ComplexCondition()))
+            val findings = ruleSet.accept(ktFile)
+            findings.forEach {
+                println(it.compact())
+            }
+            assertThat(findings).hasSize(0)
         }
-        assertThat(findings).hasSize(0)
-    }
 
-    it("all findings are suppressed on file levels") {
-        val ktFile = compileForTest(Case.SuppressedElementsByFile.path())
-        val ruleSet = RuleSet("Test", listOf(LongMethod(), LongParameterList(), ComplexCondition()))
-        val findings = ruleSet.accept(ktFile)
-        findings.forEach {
-            println(it.compact())
+        it("all findings are suppressed on file levels") {
+            val ktFile = compileForTest(Case.SuppressedElementsByFile.path())
+            val ruleSet = RuleSet("Test", listOf(LongMethod(), LongParameterList(), ComplexCondition()))
+            val findings = ruleSet.accept(ktFile)
+            findings.forEach {
+                println(it.compact())
+            }
+            assertThat(findings).hasSize(0)
         }
-        assertThat(findings).hasSize(0)
-    }
 
-    it("all findings are suppressed on class levels") {
-        val ktFile = compileForTest(Case.SuppressedElementsByClass.path())
-        val ruleSet = RuleSet("Test", listOf(LongMethod(), LongParameterList(), ComplexCondition()))
-        val findings = ruleSet.accept(ktFile)
-        findings.forEach {
-            println(it.compact())
+        it("all findings are suppressed on class levels") {
+            val ktFile = compileForTest(Case.SuppressedElementsByClass.path())
+            val ruleSet = RuleSet("Test", listOf(LongMethod(), LongParameterList(), ComplexCondition()))
+            val findings = ruleSet.accept(ktFile)
+            findings.forEach {
+                println(it.compact())
+            }
+            assertThat(findings).hasSize(0)
         }
-        assertThat(findings).hasSize(0)
-    }
 
-    it("should suppress TooManyFunctionsRule on class level") {
-        val findings = TooManyFunctions(
-                TestConfig(mapOf("thresholdInClass" to "0"))).lint(Case.SuppressedElementsByClass.path())
+        it("should suppress TooManyFunctionsRule on class level") {
+            val findings = TooManyFunctions(
+                    TestConfig(mapOf("thresholdInClass" to "0"))).lint(Case.SuppressedElementsByClass.path())
 
-        assertThat(findings).isEmpty()
-    }
+            assertThat(findings).isEmpty()
+        }
 
-    it("should suppress StringLiteralDuplication on class level") {
-        val findings = StringLiteralDuplication().lint(Case.SuppressStringLiteralDuplication.path())
+        it("should suppress StringLiteralDuplication on class level") {
+            val findings = StringLiteralDuplication().lint(Case.SuppressStringLiteralDuplication.path())
 
-        assertThat(findings).isEmpty()
+            assertThat(findings).isEmpty()
+        }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpressionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpressionSpec.kt
@@ -3,17 +3,16 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
-class DuplicateCaseInWhenExpressionSpec : SubjectSpek<DuplicateCaseInWhenExpression>({
-    subject { DuplicateCaseInWhenExpression(Config.empty) }
+class DuplicateCaseInWhenExpressionSpec : Spek({
+	val subject by memoized { DuplicateCaseInWhenExpression(Config.empty) }
 
-    given("several when expressions") {
+	describe("Duplicate Case In When Expression rule") {
 
         it("reports duplicated label in when") {
             val code = """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
@@ -4,14 +4,13 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class EqualsAlwaysReturnsTrueOrFalseSpec : SubjectSpek<EqualsAlwaysReturnsTrueOrFalse>({
-    subject { EqualsAlwaysReturnsTrueOrFalse(Config.empty) }
+class EqualsAlwaysReturnsTrueOrFalseSpec : Spek({
+	val subject by memoized { EqualsAlwaysReturnsTrueOrFalse(Config.empty) }
 
-    given("several classes overriding the equals() method") {
+	describe("Equals Always Returns True Or False rule") {
 
         it("reports equals() methods") {
             assertThat(subject.lint(Case.EqualsAlwaysReturnsTrueOrFalsePositive.path())).hasSize(6)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
@@ -3,63 +3,65 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
-class EqualsWithHashCodeExistSpec : SubjectSpek<EqualsWithHashCodeExist>({
-    subject { EqualsWithHashCodeExist(Config.empty) }
+class EqualsWithHashCodeExistSpec : Spek({
+    val subject by memoized { EqualsWithHashCodeExist(Config.empty) }
 
-    given("some classes with equals() and hashCode() functions") {
+    describe("Equals With Hash Code Exist rule") {
 
-        it("reports hashCode() without equals() function") {
-            val code = """
+        context("some classes with equals() and hashCode() functions") {
+
+            it("reports hashCode() without equals() function") {
+                val code = """
 				class A {
 					override fun hashCode(): Int { return super.hashCode() }
 				}"""
-            assertThat(subject.lint(code)).hasSize(1)
-        }
+                assertThat(subject.lint(code)).hasSize(1)
+            }
 
-        it("reports equals() without hashCode() function") {
-            val code = """
+            it("reports equals() without hashCode() function") {
+                val code = """
 				class A {
 					override fun equals(other: Any?): Boolean { return super.equals(other) }
 				}"""
-            assertThat(subject.lint(code)).hasSize(1)
-        }
+                assertThat(subject.lint(code)).hasSize(1)
+            }
 
-        it("does not report equals() with hashCode() function") {
-            val code = """
+            it("does not report equals() with hashCode() function") {
+                val code = """
 				class A {
 					override fun equals(other: Any?): Boolean { return super.equals(other) }
 					override fun hashCode(): Int { return super.hashCode() }
 				}"""
-            assertThat(subject.lint(code)).isEmpty()
-        }
+                assertThat(subject.lint(code)).isEmpty()
+            }
 
-        it("does not report when using kotlin.Any?") {
-            val code = """
+            it("does not report when using kotlin.Any?") {
+                val code = """
 				class A {
 					override fun equals(other: kotlin.Any?): Boolean { return super.equals(other) }
 					override fun hashCode(): Int { return super.hashCode() }
 				}"""
-            assertThat(subject.lint(code)).isEmpty()
+                assertThat(subject.lint(code)).isEmpty()
+            }
         }
-    }
 
-    given("a data class") {
+        context("a data class") {
 
-        it("does not report equals() or hashcode() violation") {
-            val code = """
+            it("does not report equals() or hashcode() violation on data class") {
+                val code = """
 				data class EqualsData(val i: Int) {
 					override fun equals(other: Any?): Boolean {
 						return super.equals(other)
 					}
 				}"""
-            assertThat(subject.lint(code)).hasSize(0)
+                assertThat(subject.lint(code)).hasSize(0)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCallSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCallSpec.kt
@@ -3,14 +3,13 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class ExplicitGarbageCollectionCallSpec : SubjectSpek<ExplicitGarbageCollectionCall>({
-    subject { ExplicitGarbageCollectionCall(Config.empty) }
+class ExplicitGarbageCollectionCallSpec : Spek({
+    val subject by memoized { ExplicitGarbageCollectionCall(Config.empty) }
 
-    given("several garbage collector calls") {
+    describe("ExplicitGarbageCollectionCall rule") {
 
         it("reports garbage collector calls") {
             val code = """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRangeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRangeSpec.kt
@@ -3,12 +3,11 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class InvalidRangeSpec : SubjectSpek<InvalidRange>({
-    subject { InvalidRange(Config.empty) }
+class InvalidRangeSpec : Spek({
+    val subject by memoized { InvalidRange(Config.empty) }
 
     describe("check for loop conditions") {
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethodSpec.kt
@@ -3,14 +3,13 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class IteratorHasNextCallsNextMethodSpec : SubjectSpek<IteratorHasNextCallsNextMethod>({
-    subject { IteratorHasNextCallsNextMethod() }
+class IteratorHasNextCallsNextMethodSpec : Spek({
+    val subject by memoized { IteratorHasNextCallsNextMethod() }
 
-    given("some iterator classes with a hasNext() method which calls next() method") {
+    describe("IteratorHasNextCallsNextMethod rule") {
 
         it("reports wrong iterator implementation") {
             val path = Case.IteratorImplPositive.path()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementExceptionSpec.kt
@@ -3,14 +3,13 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class IteratorNotThrowingNoSuchElementExceptionSpec : SubjectSpek<IteratorNotThrowingNoSuchElementException>({
-    subject { IteratorNotThrowingNoSuchElementException() }
+class IteratorNotThrowingNoSuchElementExceptionSpec : Spek({
+    val subject by memoized { IteratorNotThrowingNoSuchElementException() }
 
-    given("two iterator classes which next() method do not throw a NoSuchElementException") {
+    describe("IteratorNotThrowingNoSuchElementException rule") {
 
         it("reports invalid next() implementations") {
             val path = Case.IteratorImplPositive.path()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
@@ -2,16 +2,15 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
-import java.util.regex.PatternSyntaxException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.regex.PatternSyntaxException
 
 class LateinitUsageSpec : Spek({
 
-    given("a kt file with lateinit usages") {
+    describe("LateinitUsage rule") {
         val code = """
 			package foo
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
@@ -3,14 +3,13 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class UnconditionalJumpStatementInLoopSpec : SubjectSpek<UnconditionalJumpStatementInLoop>({
-    subject { UnconditionalJumpStatementInLoop() }
+class UnconditionalJumpStatementInLoopSpec : Spek({
+    val subject by memoized { UnconditionalJumpStatementInLoop() }
 
-    given("several jump statements in loops") {
+    describe("UnconditionalJumpStatementInLoop rule") {
 
         it("reports unconditional jumps") {
             val path = Case.UnconditionalJumpStatementInLoopPositive.path()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCodeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCodeSpec.kt
@@ -4,14 +4,13 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class UnreachableCodeSpec : SubjectSpek<UnreachableCode>({
-    subject { UnreachableCode(Config.empty) }
+class UnreachableCodeSpec : Spek({
+    val subject by memoized { UnreachableCode(Config.empty) }
 
-    given("several unreachable statements") {
+    describe("UnreachableCode rule") {
 
         it("reports unreachable code") {
             val path = Case.UnreachableCode.path()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableTypeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableTypeSpec.kt
@@ -2,15 +2,14 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Ivan Balaksha
  */
-class UnsafeCallOnNullableTypeSpec : SubjectSpek<UnsafeCallOnNullableType>({
-    subject { UnsafeCallOnNullableType() }
+class UnsafeCallOnNullableTypeSpec : Spek({
+    val subject by memoized { UnsafeCallOnNullableType() }
 
     describe("check all variants of safe/unsafe calls on nullable types") {
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
@@ -2,15 +2,14 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Ivan Balaksha
  */
-class UnsafeCastSpec : SubjectSpek<UnsafeCast>({
-    subject { UnsafeCast() }
+class UnsafeCastSpec : Spek({
+    val subject by memoized { UnsafeCast() }
 
     describe("check safe and unsafe casts") {
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
@@ -2,12 +2,11 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class UselessPostfixExpressionSpec : SubjectSpek<UselessPostfixExpression>({
-    subject { UselessPostfixExpression() }
+class UselessPostfixExpressionSpec : Spek({
+    val subject by memoized { UselessPostfixExpression() }
 
     describe("check several types of postfix increments") {
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameterSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameterSpec.kt
@@ -3,14 +3,13 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class WrongEqualsTypeParameterSpec : SubjectSpek<WrongEqualsTypeParameter>({
-    subject { WrongEqualsTypeParameter(Config.empty) }
+class WrongEqualsTypeParameterSpec : Spek({
+    val subject by memoized { WrongEqualsTypeParameter(Config.empty) }
 
-    given("an equals method") {
+    describe("WrongEqualsTypeParameter rule") {
 
         it("uses Any? as parameter") {
             val code = """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexConditionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexConditionSpec.kt
@@ -2,16 +2,15 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
 class ComplexConditionSpec : Spek({
 
-    given("some complex conditions") {
+    describe("ComplexCondition rule") {
 
         val code = """
 			val a = if (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5)) { 42 } else { 24 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
@@ -4,15 +4,14 @@ import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class ComplexInterfaceSpec : SubjectSpek<ComplexInterface>({
+class ComplexInterfaceSpec : Spek({
 
-    subject { ComplexInterface(threshold = THRESHOLD) }
+    val subject by memoized { ComplexInterface(threshold = THRESHOLD) }
 
-    given("several interface declarations") {
+    describe("ComplexInterface rule") {
 
         val path = Case.ComplexInterfacePositive.path()
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
@@ -6,60 +6,60 @@ import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.isThresholded
 import io.gitlab.arturbosch.detekt.test.lint
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
 class ComplexMethodSpec : Spek({
+	describe("ComplexMethod rule") {
 
-    given("a complex method") {
+        context("a complex method") {
 
-        it("finds one complex method") {
-            val subject = ComplexMethod()
-            subject.lint(Case.ComplexClass.path())
+            it("finds one complex method") {
+                val subject = ComplexMethod()
+                subject.lint(Case.ComplexClass.path())
 
-            assertThat(subject.findings).hasSourceLocations(SourceLocation(3, 1))
+                assertThat(subject.findings).hasSourceLocations(SourceLocation(3, 1))
 
-            assertThat(subject.findings.first())
-                    .isThresholded()
-                    .withValue(20)
-                    .withThreshold(10)
-        }
-    }
-
-    given("several complex methods") {
-
-        val path = Case.ComplexMethods.path()
-
-        it("does not report complex methods with a single when expression") {
-            val config = TestConfig(mapOf(
-                    ComplexMethod.IGNORE_SIMPLE_WHEN_ENTRIES to "1.0",
-                    ComplexMethod.IGNORE_SINGLE_WHEN_EXPRESSION to "true"))
-            val subject = ComplexMethod(config, threshold = 4)
-
-            assertThat(subject.lint(path)).hasSourceLocations(SourceLocation(42, 1))
+                assertThat(subject.findings.first())
+                        .isThresholded()
+                        .withValue(20)
+                        .withThreshold(10)
+            }
         }
 
-        it("reports all complex methods") {
-            val config = TestConfig(mapOf(ComplexMethod.IGNORE_SIMPLE_WHEN_ENTRIES to "1.0"))
-            val subject = ComplexMethod(config, threshold = 4)
+        context("several complex methods") {
 
-            assertThat(subject.lint(path)).hasSourceLocations(
-                    SourceLocation(5, 1),
-                    SourceLocation(14, 1),
-                    SourceLocation(24, 1),
-                    SourceLocation(34, 1),
-                    SourceLocation(42, 1)
-            )
-        }
+            val path = Case.ComplexMethods.path()
 
-        it("does not trip for a reasonable amount of simple when entries when ignoreSimpleWhenEntries is true") {
-            val config = TestConfig(mapOf(ComplexMethod.IGNORE_SIMPLE_WHEN_ENTRIES to "true"))
-            val subject = ComplexMethod(config)
-            val code = """
+            it("does not report complex methods with a single when expression") {
+                val config = TestConfig(mapOf(
+                        ComplexMethod.IGNORE_SIMPLE_WHEN_ENTRIES to "1.0",
+                        ComplexMethod.IGNORE_SINGLE_WHEN_EXPRESSION to "true"))
+                val subject = ComplexMethod(config, threshold = 4)
+
+                assertThat(subject.lint(path)).hasSourceLocations(SourceLocation(42, 1))
+            }
+
+            it("reports all complex methods") {
+                val config = TestConfig(mapOf(ComplexMethod.IGNORE_SIMPLE_WHEN_ENTRIES to "1.0"))
+                val subject = ComplexMethod(config, threshold = 4)
+
+                assertThat(subject.lint(path)).hasSourceLocations(
+                        SourceLocation(5, 1),
+                        SourceLocation(14, 1),
+                        SourceLocation(24, 1),
+                        SourceLocation(34, 1),
+                        SourceLocation(42, 1)
+                )
+            }
+
+            it("does not trip for a reasonable amount of simple when entries when ignoreSimpleWhenEntries is true") {
+                val config = TestConfig(mapOf(ComplexMethod.IGNORE_SIMPLE_WHEN_ENTRIES to "true"))
+                val subject = ComplexMethod(config)
+                val code = """
 				internal fun Map<String, Any>.asBundle(): Bundle {
 					val bundle = Bundle(size)
 
@@ -83,14 +83,14 @@ class ComplexMethodSpec : Spek({
 				}
 			""".trimIndent()
 
-            val findings = subject.lint(code)
-            assertThat(findings).isEmpty()
+                val findings = subject.lint(code)
+                assertThat(findings).isEmpty()
+            }
         }
-    }
 
-    given("function containing object literal with many overridden functions") {
+        context("function containing object literal with many overridden functions") {
 
-        val code = """
+            val code = """
 			fun f(): List<Any> {
 				return object : List<Any> {
 					override val size: Int get() = TODO("not implemented")
@@ -136,10 +136,11 @@ class ComplexMethodSpec : Spek({
 					}
 				}
 			}
-		""".trimIndent()
+			""".trimIndent()
 
-        it("should not count these overridden functions to base functions complexity") {
-            assertThat(ComplexMethod().lint(code)).isEmpty()
+            it("should not count these overridden functions to base functions complexity") {
+                assertThat(ComplexMethod().lint(code)).isEmpty()
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpressionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpressionSpec.kt
@@ -4,19 +4,18 @@ import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Ivan Balaksha
  * @author schalkms
  */
-class LabeledExpressionSpec : SubjectSpek<LabeledExpression>({
+class LabeledExpressionSpec : Spek({
 
-    subject { LabeledExpression() }
+    val subject by memoized { LabeledExpression() }
 
-    given("several labeled expressions") {
+    describe("LabeledExpression rule") {
 
         it("reports these labels") {
             subject.lint(Case.LabeledExpressionPositive.path())

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
@@ -3,9 +3,8 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethodSpec.kt
@@ -3,16 +3,15 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
-class LongMethodSpec : SubjectSpek<LongMethod>({
+class LongMethodSpec : Spek({
 
-    subject { LongMethod(threshold = 5) }
+    val subject by memoized { LongMethod(threshold = 5) }
 
     describe("nested functions can be long") {
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -3,18 +3,17 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
-class LongParameterListSpec : SubjectSpek<LongParameterList>({
+class LongParameterListSpec : Spek({
 
-    subject { LongParameterList() }
+    val subject by memoized { LongParameterList() }
 
-    given("function with parameters") {
+    describe("LongParameterList rule") {
 
         it("reports too long parameter list") {
             val code = "fun long(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) {}"

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
@@ -3,53 +3,55 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class MethodOverloadingSpec : SubjectSpek<MethodOverloading>({
+class MethodOverloadingSpec : Spek({
 
-    subject { MethodOverloading(threshold = 3) }
+    val subject by memoized { MethodOverloading(threshold = 3) }
 
-    given("several overloaded methods") {
+    describe("MethodOverloading rule") {
 
-        val findings = subject.lint(Case.OverloadedMethods.path())
+        context("several overloaded methods") {
 
-        it("reports overloaded methods which exceed the threshold") {
-            assertThat(findings.size).isEqualTo(3)
-        }
+            val findings = subject.lint(Case.OverloadedMethods.path())
 
-        it("reports the correct method name") {
-            val expected = "The method 'overloadedMethod' is overloaded 3 times."
-            assertThat(findings[0].message).isEqualTo(expected)
-        }
+            it("reports overloaded methods which exceed the threshold") {
+                assertThat(findings.size).isEqualTo(3)
+            }
 
-        it("does not report overloaded methods which do not exceed the threshold") {
-            subject.lint("""
+            it("reports the correct method name") {
+                val expected = "The method 'overloadedMethod' is overloaded 3 times."
+                assertThat(findings[0].message).isEqualTo(expected)
+            }
+
+            it("does not report overloaded methods which do not exceed the threshold") {
+                subject.lint("""
 				class Test {
 					fun x() { }
 					fun x(i: Int) { }
 				}""")
-            assertThat(subject.findings.size).isZero()
+                assertThat(subject.findings.size).isZero()
+            }
         }
-    }
 
-    given("several overloaded extensions functions") {
+        context("several overloaded extensions functions") {
 
-        it("does not report extension methods with a different receiver") {
-            subject.lint("""
+            it("does not report extension methods with a different receiver") {
+                subject.lint("""
 				fun Boolean.foo() {}
 				fun Int.foo() {}
 				fun Long.foo() {}""")
-            assertThat(subject.findings.size).isZero()
-        }
+                assertThat(subject.findings.size).isZero()
+            }
 
-        it("reports extension methods with the same receiver") {
-            subject.lint("""
+            it("reports extension methods with the same receiver") {
+                subject.lint("""
 				fun Int.foo() {}
 				fun Int.foo(i: Int) {}
 				fun Int.foo(i: String) {}""")
-            assertThat(subject.findings.size).isEqualTo(1)
+                assertThat(subject.findings.size).isEqualTo(1)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
@@ -4,16 +4,15 @@ import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
-class NestedBlockDepthSpec : SubjectSpek<NestedBlockDepth>({
+class NestedBlockDepthSpec : Spek({
 
-    subject { NestedBlockDepth(threshold = 4) }
+    val subject by memoized { NestedBlockDepth(threshold = 4) }
 
     describe("nested classes are also considered") {
         it("should detect only the nested large class") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
@@ -3,41 +3,40 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
-import java.util.regex.PatternSyntaxException
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.assertj.core.api.Java6Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
-import org.jetbrains.spek.subject.dsl.SubjectProviderDsl
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.regex.PatternSyntaxException
 
-class StringLiteralDuplicationSpec : SubjectSpek<StringLiteralDuplication>({
+class StringLiteralDuplicationSpec : Spek({
 
-    subject { StringLiteralDuplication() }
+    val subject by memoized { StringLiteralDuplication() }
 
-    given("many hardcoded strings") {
+    describe("StringLiteralDuplication rule") {
 
-        it("reports 3 equal hardcoded strings") {
-            val code = """
+        context("many hardcoded strings") {
+
+            it("reports 3 equal hardcoded strings") {
+                val code = """
 				class Duplication {
 					var s1 = "lorem"
 					fun f(s: String = "lorem") {
 						s1.equals("lorem")
 					}
 				}"""
-            assertCodeFindings(code, 1)
+                assertThat(subject.lint(code)).hasSize(1)
+            }
+
+            it("does not report 2 equal hardcoded strings") {
+                val code = """val str = "lorem" + "lorem" + "ipsum""""
+                assertThat(subject.lint(code)).hasSize(0)
+            }
         }
 
-        it("does not report 2 equal hardcoded strings") {
-            val code = """val str = "lorem" + "lorem" + "ipsum""""
-            assertCodeFindings(code, 0)
-        }
-    }
+        context("strings in annotations") {
 
-    given("strings in annotations") {
-
-        val code = """
+            val code = """
 		@Suppress("unused")
 		class A
 		@Suppress("unused")
@@ -46,91 +45,88 @@ class StringLiteralDuplicationSpec : SubjectSpek<StringLiteralDuplication>({
 		class C
 		""""
 
-        it("does not report strings in annotations") {
-            assertCodeFindings(code, 0)
-        }
+            it("does not report strings in annotations") {
+                assertThat(subject.lint(code)).hasSize(0)
+            }
 
-        it("reports strings in annotations according to config") {
-            val config = TestConfig(mapOf(StringLiteralDuplication.IGNORE_ANNOTATION to "false"))
-            assertFindingWithConfig(code, config, 1)
-        }
-    }
-
-    given("strings with less than 5 characters") {
-
-        val code = """val str = "amet" + "amet" + "amet""""
-
-        it("does not report strings with 4 characters") {
-            assertCodeFindings(code, 0)
-        }
-
-        it("reports string with 4 characters") {
-            val config = TestConfig(mapOf(StringLiteralDuplication.EXCLUDE_SHORT_STRING to "false"))
-            assertFindingWithConfig(code, config, 1)
-        }
-    }
-
-    given("strings with values to match for the regex") {
-
-        val regexTestingCode = """
-				val str1 = "lorem" + "lorem" + "lorem"
-				val str2 = "ipsum" + "ipsum" + "ipsum"
-			"""
-
-        it("does not report lorem or ipsum according to config in regex") {
-            val code = """
-				val str1 = "lorem" + "lorem" + "lorem"
-				val str2 = "ipsum" + "ipsum" + "ipsum"
-			"""
-            val config = TestConfig(mapOf(StringLiteralDuplication.IGNORE_STRINGS_REGEX to "(lorem|ipsum)"))
-            assertFindingWithConfig(code, config, 0)
-        }
-
-        it("should not fail with invalid regex when disabled") {
-            val configValues = mapOf(
-                    "active" to "false",
-                    StringLiteralDuplication.IGNORE_STRINGS_REGEX to "*lorem"
-            )
-            val config = TestConfig(configValues)
-            assertFindingWithConfig(regexTestingCode, config, 0)
-        }
-
-        it("should fail with invalid regex") {
-            val config = TestConfig(mapOf(StringLiteralDuplication.IGNORE_STRINGS_REGEX to "*lorem"))
-            assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
-                StringLiteralDuplication(config).lint(regexTestingCode)
+            it("reports strings in annotations according to config") {
+                val config = TestConfig(mapOf(StringLiteralDuplication.IGNORE_ANNOTATION to "false"))
+                assertFindingWithConfig(code, config, 1)
             }
         }
-    }
 
-    describe("saves string literal references") {
+        context("strings with less than 5 characters") {
 
-        it("reports 3 locations for 'lorem'") {
-            val code = """
+            val code = """val str = "amet" + "amet" + "amet""""
+
+            it("does not report strings with 4 characters") {
+                assertThat(subject.lint(code)).hasSize(0)
+            }
+
+            it("reports string with 4 characters") {
+                val config = TestConfig(mapOf(StringLiteralDuplication.EXCLUDE_SHORT_STRING to "false"))
+                assertFindingWithConfig(code, config, 1)
+            }
+        }
+
+        context("strings with values to match for the regex") {
+
+            val regexTestingCode = """
+				val str1 = "lorem" + "lorem" + "lorem"
+				val str2 = "ipsum" + "ipsum" + "ipsum"
+			"""
+
+            it("does not report lorem or ipsum according to config in regex") {
+                val code = """
+				val str1 = "lorem" + "lorem" + "lorem"
+				val str2 = "ipsum" + "ipsum" + "ipsum"
+			"""
+                val config = TestConfig(mapOf(StringLiteralDuplication.IGNORE_STRINGS_REGEX to "(lorem|ipsum)"))
+                assertFindingWithConfig(code, config, 0)
+            }
+
+            it("should not fail with invalid regex when disabled") {
+                val configValues = mapOf(
+                        "active" to "false",
+                        StringLiteralDuplication.IGNORE_STRINGS_REGEX to "*lorem"
+                )
+                val config = TestConfig(configValues)
+                assertFindingWithConfig(regexTestingCode, config, 0)
+            }
+
+            it("should fail with invalid regex") {
+                val config = TestConfig(mapOf(StringLiteralDuplication.IGNORE_STRINGS_REGEX to "*lorem"))
+                assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
+                    StringLiteralDuplication(config).lint(regexTestingCode)
+                }
+            }
+        }
+
+        describe("saves string literal references") {
+
+            it("reports 3 locations for 'lorem'") {
+                val code = """
 				class Duplication {
 					var s1 = "lorem"
 					fun f(s: String = "lorem") {
 						s1.equals("lorem")
 					}
 				}"""
-            val finding = subject.lint(code)[0]
-            val locations = finding.references.map { it.location } + finding.entity.location
-            assertThat(locations).hasSize(3)
+                val finding = subject.lint(code)[0]
+                val locations = finding.references.map { it.location } + finding.entity.location
+                assertThat(locations).hasSize(3)
+            }
         }
-    }
 
-    describe("multiline strings with string interpolation") {
+        describe("multiline strings with string interpolation") {
 
-        it("does not report duplicated parts in multiline strings") {
-            val path = Case.MultilineStringLiteralDuplication.path()
-            assertThat(subject.lint(path)).hasSize(0)
+            it("does not report duplicated parts in multiline strings") {
+                val path = Case.MultilineStringLiteralDuplication.path()
+                assertThat(subject.lint(path)).hasSize(0)
+            }
         }
     }
 })
-
-private fun SubjectProviderDsl<StringLiteralDuplication>.assertCodeFindings(code: String, expected: Int) {
-    assertThat(subject.lint(code)).hasSize(expected)
-}
 
 private fun assertFindingWithConfig(code: String, config: TestConfig, expected: Int) {
     val findings = StringLiteralDuplication(config).lint(code)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
@@ -4,9 +4,8 @@ import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethodSpec.kt
@@ -2,18 +2,17 @@ package io.gitlab.arturbosch.detekt.rules.documentation
 
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  * @author schalkms
  */
-class CommentOverPrivateMethodSpec : SubjectSpek<CommentOverPrivateFunction>({
-    subject { CommentOverPrivateFunction() }
+class CommentOverPrivateMethodSpec : Spek({
+    val subject by memoized { CommentOverPrivateFunction() }
 
-    given("some methods with comments") {
+    describe("CommentOverPrivateFunction rule") {
 
         it("reports private method with a comment") {
             val code = """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivatePropertiesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivatePropertiesSpec.kt
@@ -2,18 +2,17 @@ package io.gitlab.arturbosch.detekt.rules.documentation
 
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  * @author schalkms
  */
-class CommentOverPrivatePropertiesSpec : SubjectSpek<CommentOverPrivateProperty>({
-    subject { CommentOverPrivateProperty() }
+class CommentOverPrivatePropertiesSpec : Spek({
+    val subject by memoized { CommentOverPrivateProperty() }
 
-    given("some properties with comments") {
+    describe("CommentOverPrivateProperty rule") {
 
         it("reports private property with a comment") {
             val code = """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
@@ -2,85 +2,87 @@ package io.gitlab.arturbosch.detekt.rules.documentation
 
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Marvin Ramin
  * @author schalkms
  */
-class EndOfSentenceFormatSpec : SubjectSpek<KDocStyle>({
-    subject { KDocStyle() }
+class EndOfSentenceFormatSpec : Spek({
+    val subject by memoized { KDocStyle() }
 
-    it("reports invalid KDoc endings on classes") {
-        val code = """
+    describe("KDocStyle rule") {
+
+        it("reports invalid KDoc endings on classes") {
+            val code = """
 			/** Some doc */
 			class Test {
 			}
 			"""
-        assertThat(subject.compileAndLint(code)).hasSize(1)
-    }
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
 
-    it("reports invalid KDoc endings on objects") {
-        val code = """
+        it("reports invalid KDoc endings on objects") {
+            val code = """
 			/** Some doc */
 			object Test {
 			}
 			"""
-        assertThat(subject.compileAndLint(code)).hasSize(1)
-    }
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
 
-    it("reports invalid KDoc endings on properties") {
-        val code = """
+        it("reports invalid KDoc endings on properties") {
+            val code = """
 			class Test {
 			 	/** Some doc */
 				val test = 3
 			}
 			"""
-        assertThat(subject.compileAndLint(code)).hasSize(1)
-    }
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
 
-    it("reports invalid KDoc endings on top-level functions") {
-        val code = """
+        it("reports invalid KDoc endings on top-level functions") {
+            val code = """
 			/** Some doc */
 			fun test() = 3
 			"""
-        assertThat(subject.compileAndLint(code)).hasSize(1)
-    }
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
 
-    it("reports invalid KDoc endings on functions") {
-        val code = """
+        it("reports invalid KDoc endings on functions") {
+            val code = """
 			class Test {
 			 	/** Some doc */
 				fun test() = 3
 			}
 			"""
-        assertThat(subject.compileAndLint(code)).hasSize(1)
-    }
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
 
-    it("reports invalid KDoc endings") {
-        val code = """
+        it("reports invalid KDoc endings") {
+            val code = """
 			class Test {
 			 	/** Some doc-- */
 				fun test() = 3
 			}
 			"""
-        assertThat(subject.compileAndLint(code)).hasSize(1)
-    }
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
 
-    it("reports invalid KDoc endings in block") {
-        val code = """
+        it("reports invalid KDoc endings in block") {
+            val code = """
 			/**
 			 * Something off abc@@
 			 */
 			class Test {
 			}
 			"""
-        assertThat(subject.compileAndLint(code)).hasSize(1)
-    }
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
 
-    it("does not validate first sentence KDoc endings in a multi sentence comment") {
-        val code = """
+        it("does not validate first sentence KDoc endings in a multi sentence comment") {
+            val code = """
 			/**
 			 * This sentence is correct.
 			 *
@@ -89,22 +91,22 @@ class EndOfSentenceFormatSpec : SubjectSpek<KDocStyle>({
 			class Test {
 			}
 			"""
-        assertThat(subject.compileAndLint(code)).isEmpty()
-    }
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
 
-    it("does not report KDoc which doesn't contain any real sentence") {
-        val code = """
+        it("does not report KDoc which doesn't contain any real sentence") {
+            val code = """
 			/**
 			 * @author Someone
 			 */
 			class Test {
 			}
 			"""
-        assertThat(subject.compileAndLint(code)).isEmpty()
-    }
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
 
-    it("does not report KDoc which doesn't contain any real sentence but many tags") {
-        val code = """
+        it("does not report KDoc which doesn't contain any real sentence but many tags") {
+            val code = """
 			/**
 			 * @configuration this - just an example (default: 150)
 			 *
@@ -115,11 +117,11 @@ class EndOfSentenceFormatSpec : SubjectSpek<KDocStyle>({
 			class Test {
 			}
 			"""
-        assertThat(subject.compileAndLint(code)).isEmpty()
-    }
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
 
-    it("does not report KDoc which doesn't contain any real sentence but html tags") {
-        val code = """
+        it("does not report KDoc which doesn't contain any real sentence but html tags") {
+            val code = """
 			/**
 			 *
 			 * <noncompliant>
@@ -135,44 +137,44 @@ class EndOfSentenceFormatSpec : SubjectSpek<KDocStyle>({
 			class Test {
 			}
 			"""
-        assertThat(subject.compileAndLint(code)).isEmpty()
-    }
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
 
-    it("does not report KDoc ending with periods") {
-        val code = """
+        it("does not report KDoc ending with periods") {
+            val code = """
 			/**
 			 * Something correct.
 			 */
 			class Test {
 			}
 			"""
-        assertThat(subject.compileAndLint(code)).isEmpty()
-    }
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
 
-    it("does not report KDoc ending with questionmarks") {
-        val code = """
+        it("does not report KDoc ending with questionmarks") {
+            val code = """
 			/**
 			 * Something correct?
 			 */
 			class Test {
 			}
 			"""
-        assertThat(subject.compileAndLint(code)).isEmpty()
-    }
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
 
-    it("does not report KDoc ending with exclamation marks") {
-        val code = """
+        it("does not report KDoc ending with exclamation marks") {
+            val code = """
 			/**
 			 * Something correct!
 			 */
 			class Test {
 			}
 			"""
-        assertThat(subject.compileAndLint(code)).isEmpty()
-    }
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
 
-    it("does not report URLs in comments") {
-        val code = """
+        it("does not report URLs in comments") {
+            val code = """
 			/** http://www.google.com */
 			class Test1 {
 			}
@@ -182,6 +184,7 @@ class EndOfSentenceFormatSpec : SubjectSpek<KDocStyle>({
 			class Test2 {
 			}
 			"""
-        assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -3,15 +3,15 @@ package io.gitlab.arturbosch.detekt.rules.documentation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  * @author schalkms
  */
-class UndocumentedPublicClassSpec : SubjectSpek<UndocumentedPublicClass>({
-    subject { UndocumentedPublicClass() }
+class UndocumentedPublicClassSpec : Spek({
+    val subject by memoized { UndocumentedPublicClass() }
 
     val inner = """
 			/** Some doc */
@@ -54,64 +54,66 @@ class UndocumentedPublicClassSpec : SubjectSpek<UndocumentedPublicClass>({
     val privateClass = "private class TestNested {}"
     val internalClass = "internal class TestNested {}"
 
-    it("should report inner classes by default") {
-        assertThat(subject.compileAndLint(inner)).hasSize(1)
-    }
+    describe("UndocumentedPublicClass rule") {
 
-    it("should report inner object by default") {
-        assertThat(subject.compileAndLint(innerObject)).hasSize(1)
-    }
+        it("should report inner classes by default") {
+            assertThat(subject.compileAndLint(inner)).hasSize(1)
+        }
 
-    it("should report inner interfaces by default") {
-        assertThat(subject.compileAndLint(innerInterface)).hasSize(1)
-    }
+        it("should report inner object by default") {
+            assertThat(subject.compileAndLint(innerObject)).hasSize(1)
+        }
 
-    it("should report nested classes by default") {
-        assertThat(subject.compileAndLint(nested)).hasSize(1)
-    }
+        it("should report inner interfaces by default") {
+            assertThat(subject.compileAndLint(innerInterface)).hasSize(1)
+        }
 
-    it("should report explicit public nested classes by default") {
-        assertThat(subject.compileAndLint(nestedPublic)).hasSize(1)
-    }
+        it("should report nested classes by default") {
+            assertThat(subject.compileAndLint(nested)).hasSize(1)
+        }
 
-    it("should not report internal classes") {
-        assertThat(subject.compileAndLint(internalClass)).hasSize(0)
-    }
+        it("should report explicit public nested classes by default") {
+            assertThat(subject.compileAndLint(nestedPublic)).hasSize(1)
+        }
 
-    it("should not report private classes") {
-        assertThat(subject.compileAndLint(privateClass)).hasSize(0)
-    }
+        it("should not report internal classes") {
+            assertThat(subject.compileAndLint(internalClass)).hasSize(0)
+        }
 
-    it("should not report nested private classes") {
-        assertThat(subject.compileAndLint(nestedPrivate)).hasSize(0)
-    }
+        it("should not report private classes") {
+            assertThat(subject.compileAndLint(privateClass)).hasSize(0)
+        }
 
-    it("should not report inner classes when turned off") {
-        val findings = UndocumentedPublicClass(TestConfig(mapOf(UndocumentedPublicClass.SEARCH_IN_INNER_CLASS to "false"))).compileAndLint(inner)
-        assertThat(findings).isEmpty()
-    }
+        it("should not report nested private classes") {
+            assertThat(subject.compileAndLint(nestedPrivate)).hasSize(0)
+        }
 
-    it("should not report inner objects when turned off") {
-        val findings = UndocumentedPublicClass(TestConfig(mapOf(UndocumentedPublicClass.SEARCH_IN_INNER_OBJECT to "false"))).compileAndLint(innerObject)
-        assertThat(findings).isEmpty()
-    }
+        it("should not report inner classes when turned off") {
+            val findings = UndocumentedPublicClass(TestConfig(mapOf(UndocumentedPublicClass.SEARCH_IN_INNER_CLASS to "false"))).compileAndLint(inner)
+            assertThat(findings).isEmpty()
+        }
 
-    it("should not report inner interfaces when turned off") {
-        val findings = UndocumentedPublicClass(TestConfig(mapOf(UndocumentedPublicClass.SEARCH_IN_INNER_INTERFACE to "false"))).compileAndLint(innerInterface)
-        assertThat(findings).isEmpty()
-    }
+        it("should not report inner objects when turned off") {
+            val findings = UndocumentedPublicClass(TestConfig(mapOf(UndocumentedPublicClass.SEARCH_IN_INNER_OBJECT to "false"))).compileAndLint(innerObject)
+            assertThat(findings).isEmpty()
+        }
 
-    it("should not report nested classes when turned off") {
-        val findings = UndocumentedPublicClass(TestConfig(mapOf(UndocumentedPublicClass.SEARCH_IN_NESTED_CLASS to "false"))).compileAndLint(nested)
-        assertThat(findings).isEmpty()
-    }
+        it("should not report inner interfaces when turned off") {
+            val findings = UndocumentedPublicClass(TestConfig(mapOf(UndocumentedPublicClass.SEARCH_IN_INNER_INTERFACE to "false"))).compileAndLint(innerInterface)
+            assertThat(findings).isEmpty()
+        }
 
-    it("should report missing doc over object declaration") {
-        assertThat(subject.compileAndLint("object o")).hasSize(1)
-    }
+        it("should not report nested classes when turned off") {
+            val findings = UndocumentedPublicClass(TestConfig(mapOf(UndocumentedPublicClass.SEARCH_IN_NESTED_CLASS to "false"))).compileAndLint(nested)
+            assertThat(findings).isEmpty()
+        }
 
-    it("should not report for documented public object") {
-        val code = """
+        it("should report missing doc over object declaration") {
+            assertThat(subject.compileAndLint("object o")).hasSize(1)
+        }
+
+        it("should not report for documented public object") {
+            val code = """
 			/**
 			 * Class docs not being recognized.
 			 */
@@ -127,11 +129,11 @@ class UndocumentedPublicClassSpec : SubjectSpek<UndocumentedPublicClass>({
 			}
 		"""
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
-    }
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
 
-    it("should not report for anonymous objects") {
-        val code = """
+        it("should not report for anonymous objects") {
+            val code = """
 			fun main(args: Array<String>) {
 				val value = object : Iterator<Int> {
         		    override fun hasNext() = true
@@ -140,26 +142,27 @@ class UndocumentedPublicClassSpec : SubjectSpek<UndocumentedPublicClass>({
 			}
 		"""
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
-    }
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
 
-    it("should report for enum classes") {
-        val code = """
+        it("should report for enum classes") {
+            val code = """
 		    enum class Enum {
 				CONSTANT
 			}
 		"""
-        assertThat(subject.compileAndLint(code)).hasSize(1)
-    }
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
 
-    it("should not report for enum constants") {
-        val code = """
+        it("should not report for enum constants") {
+            val code = """
 			/** Some doc */
 			enum class Enum {
 				CONSTANT
 			}
 		"""
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
@@ -2,18 +2,17 @@ package io.gitlab.arturbosch.detekt.rules.documentation
 
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  * @author schalkms
  */
-class UndocumentedPublicFunctionSpec : SubjectSpek<UndocumentedPublicFunction>({
-    subject { UndocumentedPublicFunction() }
+class UndocumentedPublicFunctionSpec : Spek({
+    val subject by memoized { UndocumentedPublicFunction() }
 
-    given("several functions") {
+    describe("UndocumentedPublicFunction rule") {
 
         it("reports undocumented public functions") {
             val code = """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/CommentInsideBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/CommentInsideBlockSpec.kt
@@ -4,8 +4,8 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtBlockExpression
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Karol Wrótniak
@@ -19,13 +19,16 @@ class CommentInsideBlockSpec : Spek({
 
     val subject = NotConfiguredEmptyRule()
 
-    it("does not find comment inside an empty block") {
-        val findings = subject.lint("{/*comment*/}")
-        assertThat(findings).isEmpty()
-    }
+    describe("NotConfiguredEmptyRule rule") {
 
-    it("finds comments inside block") {
-        val findings = subject.lint("{}")
-        assertThat(findings).hasSize(1)
+        it("does not find comment inside an empty block") {
+            val findings = subject.lint("{/*comment*/}")
+            assertThat(findings).isEmpty()
+        }
+
+        it("finds comments inside block") {
+            val findings = subject.lint("{}")
+            assertThat(findings).hasSize(1)
+        }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocksMultiRuleSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocksMultiRuleSpec.kt
@@ -6,16 +6,15 @@ import io.gitlab.arturbosch.detekt.test.compileForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
-class EmptyBlocksMultiRuleSpec : SubjectSpek<EmptyBlocks>({
+class EmptyBlocksMultiRuleSpec : Spek({
 
-    subject { EmptyBlocks() }
+    val subject by memoized { EmptyBlocks() }
 
     val file = compileForTest(Case.Empty.path())
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
@@ -3,26 +3,22 @@ package io.gitlab.arturbosch.detekt.rules.empty
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Egor Neliuba
  */
-class EmptyClassBlockSpec : SubjectSpek<EmptyClassBlock>({
+class EmptyClassBlockSpec : Spek({
 
-    subject { EmptyClassBlock(Config.empty) }
+    val subject by memoized { EmptyClassBlock(Config.empty) }
 
-    given("a class with an empty body") {
+    describe("EmptyClassBlock rule") {
 
         it("flags the empty body") {
             val findings = subject.lint("class SomeClass {}")
             assertThat(findings).hasSize(1)
         }
-    }
-
-    given("an object with an empty body") {
 
         it("flags the object if it is of a non-anonymous class") {
             val findings = subject.lint("object SomeObject {}")

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
@@ -6,11 +6,11 @@ import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import io.gitlab.arturbosch.detekt.test.lint
-import java.util.regex.PatternSyntaxException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.regex.PatternSyntaxException
 
 /**
  * @author Artur Bosch
@@ -24,12 +24,14 @@ class EmptyCodeSpec : Spek({
 				}
 			}"""
 
-    it("findsEmptyCatch") {
-        test { EmptyCatchBlock(Config.empty) }
-    }
+    describe("EmptyCatchBlock rule") {
 
-    it("findsEmptyNestedCatch") {
-        val code = """
+        it("findsEmptyCatch") {
+            test { EmptyCatchBlock(Config.empty) }
+        }
+
+        it("findsEmptyNestedCatch") {
+            val code = """
 			fun f() {
 				try {
                 } catch (ignore: IOException) {
@@ -38,99 +40,100 @@ class EmptyCodeSpec : Spek({
 					}
 				}
 			}"""
-        assertThat(EmptyCatchBlock(Config.empty).lint(code)).hasSize(1)
-    }
+            assertThat(EmptyCatchBlock(Config.empty).lint(code)).hasSize(1)
+        }
 
-    it("doesNotReportIgnoredOrExpectedException") {
-        val code = """
+        it("doesNotReportIgnoredOrExpectedException") {
+            val code = """
 			fun f() {
 				try {
                 } catch (ignore: IOException) {
 				} catch (expected: Exception) {
 				}
 			}"""
-        assertThat(EmptyCatchBlock(Config.empty).lint(code)).isEmpty()
-    }
+            assertThat(EmptyCatchBlock(Config.empty).lint(code)).isEmpty()
+        }
 
-    it("doesNotReportEmptyCatchWithConfig") {
-        val code = """
+        it("doesNotReportEmptyCatchWithConfig") {
+            val code = """
 			fun f() {
 				try {
 				} catch (foo: MyException) {
 				}
 			}"""
-        val config = TestConfig(mapOf(EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "foo"))
-        assertThat(EmptyCatchBlock(config).lint(code)).isEmpty()
-    }
+            val config = TestConfig(mapOf(EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "foo"))
+            assertThat(EmptyCatchBlock(config).lint(code)).isEmpty()
+        }
 
-    it("findsEmptyFinally") {
-        test { EmptyFinallyBlock(Config.empty) }
-    }
+        it("findsEmptyFinally") {
+            test { EmptyFinallyBlock(Config.empty) }
+        }
 
-    it("findsEmptyIf") {
-        test { EmptyIfBlock(Config.empty) }
-    }
+        it("findsEmptyIf") {
+            test { EmptyIfBlock(Config.empty) }
+        }
 
-    it("findsEmptyElse") {
-        test { EmptyElseBlock(Config.empty) }
-    }
+        it("findsEmptyElse") {
+            test { EmptyElseBlock(Config.empty) }
+        }
 
-    it("findsEmptyFor") {
-        test { EmptyForBlock(Config.empty) }
-    }
+        it("findsEmptyFor") {
+            test { EmptyForBlock(Config.empty) }
+        }
 
-    it("findsEmptyWhile") {
-        test { EmptyWhileBlock(Config.empty) }
-    }
+        it("findsEmptyWhile") {
+            test { EmptyWhileBlock(Config.empty) }
+        }
 
-    it("findsEmptyDoWhile") {
-        test { EmptyDoWhileBlock(Config.empty) }
-    }
+        it("findsEmptyDoWhile") {
+            test { EmptyDoWhileBlock(Config.empty) }
+        }
 
-    it("findsEmptyFun") {
-        test { EmptyFunctionBlock(Config.empty) }
-    }
+        it("findsEmptyFun") {
+            test { EmptyFunctionBlock(Config.empty) }
+        }
 
-    it("findsEmptyClass") {
-        test { EmptyClassBlock(Config.empty) }
-    }
+        it("findsEmptyClass") {
+            test { EmptyClassBlock(Config.empty) }
+        }
 
-    it("findsEmptyWhen") {
-        test { EmptyWhenBlock(Config.empty) }
-    }
+        it("findsEmptyWhen") {
+            test { EmptyWhenBlock(Config.empty) }
+        }
 
-    it("findsEmptyInit") {
-        test { EmptyInitBlock(Config.empty) }
-    }
+        it("findsEmptyInit") {
+            test { EmptyInitBlock(Config.empty) }
+        }
 
-    it("findsOneEmptySecondaryConstructor") {
-        test { EmptySecondaryConstructor(Config.empty) }
-    }
+        it("findsOneEmptySecondaryConstructor") {
+            test { EmptySecondaryConstructor(Config.empty) }
+        }
 
-    it("findsEmptyDefaultConstructor") {
-        val rule = EmptyDefaultConstructor(Config.empty)
-        val text = compileForTest(Case.EmptyDefaultConstructorPositive.path()).text
-        assertThat(rule.lint(text)).hasSize(2)
-    }
+        it("findsEmptyDefaultConstructor") {
+            val rule = EmptyDefaultConstructor(Config.empty)
+            val text = compileForTest(Case.EmptyDefaultConstructorPositive.path()).text
+            assertThat(rule.lint(text)).hasSize(2)
+        }
 
-    it("doesNotFindEmptyDefaultConstructor") {
-        val rule = EmptyDefaultConstructor(Config.empty)
-        val text = compileForTest(Case.EmptyDefaultConstructorNegative.path()).text
-        assertThat(rule.lint(text)).isEmpty()
-    }
+        it("doesNotFindEmptyDefaultConstructor") {
+            val rule = EmptyDefaultConstructor(Config.empty)
+            val text = compileForTest(Case.EmptyDefaultConstructorNegative.path()).text
+            assertThat(rule.lint(text)).isEmpty()
+        }
 
-    it("doesNotFailWithInvalidRegexWhenDisabled") {
-        val configValues = mapOf("active" to "false",
-                EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "*foo")
-        val config = TestConfig(configValues)
-        assertThat(EmptyCatchBlock(config).lint(regexTestingCode)).isEmpty()
-    }
+        it("doesNotFailWithInvalidRegexWhenDisabled") {
+            val configValues = mapOf("active" to "false",
+                    EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "*foo")
+            val config = TestConfig(configValues)
+            assertThat(EmptyCatchBlock(config).lint(regexTestingCode)).isEmpty()
+        }
 
-    it("doesFailWithInvalidRegex") {
-        val configValues = mapOf(EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "*foo")
-        val config = TestConfig(configValues)
-        assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
-            EmptyCatchBlock(config).lint(regexTestingCode)
+        it("doesFailWithInvalidRegex") {
+            val configValues = mapOf(EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "*foo")
+            val config = TestConfig(configValues)
+            assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
+                EmptyCatchBlock(config).lint(regexTestingCode)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyConstructorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyConstructorSpec.kt
@@ -3,16 +3,18 @@ package io.gitlab.arturbosch.detekt.rules.empty
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
 class EmptyConstructorSpec : Spek({
 
-    it("should not report empty constructors for annotation classes with expect or actual keyword - #1362") {
-        val code = """
+    describe("EmptyDefaultConstructor rule") {
+
+        it("should not report empty constructors for annotation classes with expect or actual keyword - #1362") {
+            val code = """
 			expect annotation class NeedsConstructor()
 			actual annotation class NeedsConstructor actual constructor()
 
@@ -20,8 +22,9 @@ class EmptyConstructorSpec : Spek({
 			fun annotatedFunction() = Unit
 		""".trimIndent()
 
-        val findings = EmptyDefaultConstructor(Config.empty).lint(code)
+            val findings = EmptyDefaultConstructor(Config.empty).lint(code)
 
-        assertThat(findings).isEmpty()
+            assertThat(findings).isEmpty()
+        }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
@@ -4,18 +4,17 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
-class EmptyFunctionBlockSpec : SubjectSpek<EmptyFunctionBlock>({
+class EmptyFunctionBlockSpec : Spek({
 
-    subject { EmptyFunctionBlock(Config.empty) }
+    val subject by memoized { EmptyFunctionBlock(Config.empty) }
 
-    given("some functions") {
+    describe("EmptyFunctionBlock rule") {
 
         it("should flag function with protected modifier") {
             val code = "protected fun stuff() {}"
@@ -34,30 +33,30 @@ class EmptyFunctionBlockSpec : SubjectSpek<EmptyFunctionBlock>({
 				}"""
             assertThat(subject.lint(code)).hasSize(1)
         }
-    }
 
-    given("some overridden functions") {
+        context("some overridden functions") {
 
-        val code = """
-				fun empty() {}
+            val code = """
+					fun empty() {}
 
-				override fun stuff1() {}
+					override fun stuff1() {}
 
-				override fun stuff2() {
-					TODO("Implement this")
-				}
+					override fun stuff2() {
+						TODO("Implement this")
+					}
 
-				override fun stuff3() {
-					// this is necessary...
-				}"""
+					override fun stuff3() {
+						// this is necessary...
+					}"""
 
-        it("should flag empty block in overridden function") {
-            assertThat(subject.lint(code)).hasSize(2)
-        }
+            it("should flag empty block in overridden function") {
+                assertThat(subject.lint(code)).hasSize(2)
+            }
 
-        it("should not flag overridden functions") {
-            val config = TestConfig(mapOf(EmptyFunctionBlock.IGNORE_OVERRIDDEN_FUNCTIONS to "true"))
-            assertThat(EmptyFunctionBlock(config).lint(code)).hasSize(1)
+            it("should not flag overridden functions") {
+                val config = TestConfig(mapOf(EmptyFunctionBlock.IGNORE_OVERRIDDEN_FUNCTIONS to "true"))
+                assertThat(EmptyFunctionBlock(config).lint(code)).hasSize(1)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlockSpec.kt
@@ -4,18 +4,17 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
-class EmptyIfBlockSpec : SubjectSpek<EmptyIfBlock>({
+class EmptyIfBlockSpec : Spek({
 
-    subject { EmptyIfBlock(Config.empty) }
+    val subject by memoized { EmptyIfBlock(Config.empty) }
 
-    given("several empty if statements") {
+    describe("EmptyIfBlock rule") {
 
         it("reports positive cases") {
             val path = Case.EmptyIfPositive.path()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
@@ -4,18 +4,17 @@ import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class ExceptionRaisedInUnexpectedLocationSpec : SubjectSpek<ExceptionRaisedInUnexpectedLocation>({
-    subject {
+class ExceptionRaisedInUnexpectedLocationSpec : Spek({
+    val subject by memoized {
         ExceptionRaisedInUnexpectedLocation(
                 TestConfig(mapOf(ExceptionRaisedInUnexpectedLocation.METHOD_NAMES to "toString,hashCode,equals,finalize"))
         )
     }
 
-    given("methods which throw exceptions") {
+    describe("ExceptionRaisedInUnexpectedLocation rule") {
 
         it("reports methods raising an unexpected exception") {
             val path = Case.ExceptionRaisedInMethodsPositive.path()
@@ -26,16 +25,13 @@ class ExceptionRaisedInUnexpectedLocationSpec : SubjectSpek<ExceptionRaisedInUne
             val path = Case.ExceptionRaisedInMethodsNegative.path()
             assertThat(subject.lint(path)).hasSize(0)
         }
-    }
-
-    given("a configuration with a custom method") {
 
         it("reports the configured method") {
             val config = TestConfig(mapOf(ExceptionRaisedInUnexpectedLocation.METHOD_NAMES to "toDo,todo2"))
             val findings = ExceptionRaisedInUnexpectedLocation(config).lint("""
-				fun toDo() {
-					throw IllegalStateException()
-				}""")
+			fun toDo() {
+				throw IllegalStateException()
+			}""")
             assertThat(findings).hasSize(1)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
@@ -2,14 +2,13 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class InstanceOfCheckForExceptionSpec : SubjectSpek<InstanceOfCheckForException>({
-    subject { InstanceOfCheckForException() }
+class InstanceOfCheckForExceptionSpec : Spek({
+    val subject by memoized { InstanceOfCheckForException() }
 
-    given("several catch blocks") {
+    describe("InstanceOfCheckForException rule") {
 
         it("has is and as checks") {
             val code = """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclarationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclarationSpec.kt
@@ -2,41 +2,37 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class NotImplementedDeclarationSpec : SubjectSpek<NotImplementedDeclaration>({
-    subject { NotImplementedDeclaration() }
+class NotImplementedDeclarationSpec : Spek({
+    val subject by memoized { NotImplementedDeclaration() }
 
-    given("throwing NotImplementedError declarations") {
+    describe("NotImplementedDeclaration rule") {
 
         it("reports NotImplementedErrors") {
             val code = """
-				fun f() {
-					if (1 == 1) throw NotImplementedError()
-					throw NotImplementedError()
-				}"""
+			fun f() {
+				if (1 == 1) throw NotImplementedError()
+				throw NotImplementedError()
+			}"""
             assertThat(subject.lint(code)).hasSize(2)
         }
-    }
-
-    given("several TODOs") {
 
         it("reports TODO method calls") {
             val code = """
-				fun f() {
-					TODO("not implemented")
-					TODO()
-				}"""
+			fun f() {
+				TODO("not implemented")
+				TODO()
+			}"""
             assertThat(subject.lint(code)).hasSize(2)
         }
 
         it("does not report TODO comments") {
             val code = """
-				fun f() {
-					// TODO
-				}"""
+			fun f() {
+				// TODO
+			}"""
             assertThat(subject.lint(code)).hasSize(0)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTraceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTraceSpec.kt
@@ -2,28 +2,29 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class PrintStackTraceSpec : SubjectSpek<PrintStackTrace>({
-    subject { PrintStackTrace() }
+class PrintStackTraceSpec : Spek({
+    val subject by memoized { PrintStackTrace() }
 
-    given("catch clauses with printStacktrace methods") {
+    describe("PrintStackTrace") {
 
-        it("prints a stacktrace") {
-            val code = """
+        context("catch clauses with printStacktrace methods") {
+
+            it("prints a stacktrace") {
+                val code = """
 				fun x() {
 					try {
 					} catch (e: Exception) {
 						e.printStackTrace()
 					}
 				}"""
-            assertThat(subject.lint(code)).hasSize(1)
-        }
+                assertThat(subject.lint(code)).hasSize(1)
+            }
 
-        it("does not print a stacktrace") {
-            val code = """
+            it("does not print a stacktrace") {
+                val code = """
 				fun x() {
 					try {
 					} catch (e: Exception) {
@@ -32,19 +33,20 @@ class PrintStackTraceSpec : SubjectSpek<PrintStackTrace>({
 						printStackTrace()
 					}
 				}"""
-            assertThat(subject.lint(code)).hasSize(0)
+                assertThat(subject.lint(code)).hasSize(0)
+            }
         }
-    }
 
-    given("a stacktrace printed by a thread") {
+        context("a stacktrace printed by a thread") {
 
-        it("prints one") {
-            val code = """
+            it("prints one") {
+                val code = """
 				fun x() {
 					Thread.dumpStack()
-					Foo.dumpStack()
+					UnusedPrivateMemberPositiveObject.Foo.dumpStack()
 				}"""
-            assertThat(subject.lint(code)).hasSize(1)
+                assertThat(subject.lint(code)).hasSize(1)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtExceptionSpec.kt
@@ -3,14 +3,13 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class RethrowCaughtExceptionSpec : SubjectSpek<RethrowCaughtException>({
-    subject { RethrowCaughtException() }
+class RethrowCaughtExceptionSpec : Spek({
+    val subject by memoized { RethrowCaughtException() }
 
-    given("multiple caught exceptions") {
+    describe("RethrowCaughtException rule") {
 
         it("reports caught exceptions which are rethrown") {
             val path = Case.RethrowCaughtExceptionPositive.path()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
@@ -2,15 +2,16 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class ReturnFromFinallySpec : SubjectSpek<ReturnFromFinally>({
-    subject { ReturnFromFinally() }
+class ReturnFromFinallySpec : Spek({
+    val subject by memoized { ReturnFromFinally() }
 
-    given("a finally block with a return statement") {
-        val code = """
+    describe("ReturnFromFinally rule") {
+
+        context("a finally block with a return statement") {
+            val code = """
 			fun x() {
 				try {
 				} finally {
@@ -19,14 +20,14 @@ class ReturnFromFinallySpec : SubjectSpek<ReturnFromFinally>({
 			}
 		"""
 
-        it("should report") {
-            val findings = subject.lint(code)
-            Assertions.assertThat(findings).hasSize(1)
+            it("should report") {
+                val findings = subject.lint(code)
+                Assertions.assertThat(findings).hasSize(1)
+            }
         }
-    }
 
-    given("a finally block with no return statement") {
-        val code = """
+        context("a finally block with no return statement") {
+            val code = """
 			fun x() {
 				try {
 				} finally {
@@ -34,14 +35,14 @@ class ReturnFromFinallySpec : SubjectSpek<ReturnFromFinally>({
 			}
 		"""
 
-        it("should not report") {
-            val findings = subject.lint(code)
-            Assertions.assertThat(findings).hasSize(0)
+            it("should not report") {
+                val findings = subject.lint(code)
+                Assertions.assertThat(findings).hasSize(0)
+            }
         }
-    }
 
-    given("a finally block with a nested return statement") {
-        val code = """
+        context("a finally block with a nested return statement") {
+            val code = """
 			fun x() {
 				try {
 				} finally {
@@ -52,14 +53,14 @@ class ReturnFromFinallySpec : SubjectSpek<ReturnFromFinally>({
 			}
 		"""
 
-        it("should report") {
-            val findings = subject.lint(code)
-            Assertions.assertThat(findings).hasSize(1)
+            it("should report") {
+                val findings = subject.lint(code)
+                Assertions.assertThat(findings).hasSize(1)
+            }
         }
-    }
 
-    given("a finally block with a return in an inner function") {
-        val code = """
+        context("a finally block with a return in an inner function") {
+            val code = """
 			fun x() {
 				try {
 				} finally {
@@ -71,9 +72,10 @@ class ReturnFromFinallySpec : SubjectSpek<ReturnFromFinally>({
 			}
 		"""
 
-        it("should not report") {
-            val findings = subject.lint(code)
-            Assertions.assertThat(findings).hasSize(0)
+            it("should not report") {
+                val findings = subject.lint(code)
+                Assertions.assertThat(findings).hasSize(0)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -4,17 +4,16 @@ import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author schalkms
  */
-class SwallowedExceptionSpec : SubjectSpek<SwallowedException>({
-    subject { SwallowedException() }
+class SwallowedExceptionSpec : Spek({
+    val subject by memoized { SwallowedException() }
 
-    given("several catch blocks") {
+    describe("SwallowedException rule") {
 
         it("reports swallowed exceptions") {
             assertThat(subject.lint(Case.SwallowedExceptionPositive.path())).hasSize(5)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinallySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinallySpec.kt
@@ -2,14 +2,13 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class ThrowingExceptionFromFinallySpec : SubjectSpek<ThrowingExceptionFromFinally>({
-    subject { ThrowingExceptionFromFinally() }
+class ThrowingExceptionFromFinallySpec : Spek({
+    val subject by memoized { ThrowingExceptionFromFinally() }
 
-    given("some finally blocks") {
+    describe("ThrowingExceptionFromFinally rule") {
 
         it("should report a throw expression") {
             val code = """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
@@ -2,14 +2,13 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class ThrowingExceptionInMainSpec : SubjectSpek<ThrowingExceptionInMain>({
-    subject { ThrowingExceptionInMain() }
+class ThrowingExceptionInMainSpec : Spek({
+    val subject by memoized { ThrowingExceptionInMain() }
 
-    given("some main methods") {
+    describe("ThrowingExceptionInMain rule") {
 
         it("has a runnable main method which throws an exception") {
             val code = "fun main(args: Array<String>) { throw new IOException() }"

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
@@ -3,46 +3,48 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class ThrowingExceptionsWithoutMessageOrCauseSpec : SubjectSpek<ThrowingExceptionsWithoutMessageOrCause>({
-    subject {
+class ThrowingExceptionsWithoutMessageOrCauseSpec : Spek({
+    val subject by memoized{
         ThrowingExceptionsWithoutMessageOrCause(
                 TestConfig(mapOf(ThrowingExceptionsWithoutMessageOrCause.EXCEPTIONS to "IllegalArgumentException"))
         )
     }
 
-    given("several exception calls") {
+    describe("ThrowingExceptionsWithoutMessageOrCause rule") {
 
-        val code = """
+        context("several exception calls") {
+
+            val code = """
 				fun x() {
 					IllegalArgumentException(IllegalArgumentException())
 					IllegalArgumentException("foo")
 					throw IllegalArgumentException()
 				}"""
 
-        it("reports calls to the default constructor") {
-            assertThat(subject.lint(code)).hasSize(2)
+            it("reports calls to the default constructor") {
+                assertThat(subject.lint(code)).hasSize(2)
+            }
+
+            it("does not report calls to the default constructor with empty configuration") {
+                val config = TestConfig(mapOf(ThrowingExceptionsWithoutMessageOrCause.EXCEPTIONS to ""))
+                val findings = ThrowingExceptionsWithoutMessageOrCause(config).lint(code)
+                assertThat(findings).hasSize(0)
+            }
         }
 
-        it("does not report calls to the default constructor with empty configuration") {
-            val config = TestConfig(mapOf(ThrowingExceptionsWithoutMessageOrCause.EXCEPTIONS to ""))
-            val findings = ThrowingExceptionsWithoutMessageOrCause(config).lint(code)
-            assertThat(findings).hasSize(0)
-        }
-    }
+        context("a test code which asserts an exception") {
 
-    given("a test code which asserts an exception") {
-
-        it("does not report a call to this exception") {
-            val code = """
+            it("does not report a call to this exception") {
+                val code = """
 				fun test() {
 					assertThatIllegalArgumentException().isThrownBy { }
 				}
 			"""
-            assertThat(subject.lint(code)).isEmpty()
+                assertThat(subject.lint(code)).isEmpty()
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
@@ -2,15 +2,16 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class ThrowingNewInstanceOfSameExceptionSpec : SubjectSpek<ThrowingNewInstanceOfSameException>({
-    subject { ThrowingNewInstanceOfSameException() }
+class ThrowingNewInstanceOfSameExceptionSpec : Spek({
+    val subject by memoized { ThrowingNewInstanceOfSameException() }
 
-    given("a catch block which rethrows a new instance of the caught exception") {
-        val code = """
+    describe("ThrowingNewInstanceOfSameException rule") {
+
+        context("a catch block which rethrows a new instance of the caught exception") {
+            val code = """
 			fun x() {
 				try {
 				} catch (e: IllegalStateException) {
@@ -19,14 +20,14 @@ class ThrowingNewInstanceOfSameExceptionSpec : SubjectSpek<ThrowingNewInstanceOf
 			}
 		"""
 
-        it("should report") {
-            val findings = subject.lint(code)
-            Assertions.assertThat(findings).hasSize(1)
+            it("should report") {
+                val findings = subject.lint(code)
+                Assertions.assertThat(findings).hasSize(1)
+            }
         }
-    }
 
-    given("a catch block which rethrows a new instance of another exception") {
-        val code = """
+        context("a catch block which rethrows a new instance of another exception") {
+            val code = """
 			fun x() {
 				try {
 				} catch (e: IllegalStateException) {
@@ -35,14 +36,14 @@ class ThrowingNewInstanceOfSameExceptionSpec : SubjectSpek<ThrowingNewInstanceOf
 			}
 		"""
 
-        it("should not report") {
-            val findings = subject.lint(code)
-            Assertions.assertThat(findings).hasSize(0)
+            it("should not report") {
+                val findings = subject.lint(code)
+                Assertions.assertThat(findings).hasSize(0)
+            }
         }
-    }
 
-    given("a catch block which throws a new instance of the same exception type without wrapping the caught exception") {
-        val code = """
+        context("a catch block which throws a new instance of the same exception type without wrapping the caught exception") {
+            val code = """
 			fun x() {
 				try {
 				} catch (e: IllegalStateException) {
@@ -51,9 +52,10 @@ class ThrowingNewInstanceOfSameExceptionSpec : SubjectSpek<ThrowingNewInstanceOf
 			}
 		"""
 
-        it("should not report") {
-            val findings = subject.lint(code)
-            Assertions.assertThat(findings).hasSize(0)
+            it("should not report") {
+                val findings = subject.lint(code)
+                Assertions.assertThat(findings).hasSize(0)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
@@ -4,12 +4,11 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
-import java.util.regex.PatternSyntaxException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.regex.PatternSyntaxException
 
 class TooGenericExceptionCaughtSpec : Spek({
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionSpec.kt
@@ -6,18 +6,21 @@ import io.gitlab.arturbosch.detekt.rules.providers.ExceptionsProvider
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class TooGenericExceptionSpec : Spek({
 
-    it("should not report any as all catch exception rules are deactivated") {
-        val config = YamlConfig.loadResource(resource("deactivated-exceptions.yml").toURL())
-        val ruleSet = ExceptionsProvider().buildRuleset(config)
-        val file = compileForTest(Case.TooGenericExceptions.path())
+    describe("TooGenericException rule") {
 
-        val findings = ruleSet?.accept(file)
+        it("should not report any as all catch exception rules are deactivated") {
+            val config = YamlConfig.loadResource(resource("deactivated-exceptions.yml").toURL())
+            val ruleSet = ExceptionsProvider().buildRuleset(config)
+            val file = compileForTest(Case.TooGenericExceptions.path())
 
-        assertThat(findings).hasSize(0)
+            val findings = ruleSet?.accept(file)
+
+            assertThat(findings).hasSize(0)
+        }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrownSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrownSpec.kt
@@ -5,9 +5,8 @@ import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
@@ -2,9 +2,8 @@ package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -2,9 +2,8 @@ package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenNameSpec.kt
@@ -3,13 +3,12 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class ForbiddenNameSpec : Spek({
 
-    given("forbidden naming rules") {
+    describe("ForbiddenClassName rule") {
         it("should report classes with forbidden names") {
             val code = """
 				class TestManager {} // violation

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -4,8 +4,8 @@ import io.gitlab.arturbosch.detekt.test.TEST_FILENAME
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
@@ -14,60 +14,63 @@ class FunctionNamingSpec : Spek({
 
     val fileName = TEST_FILENAME
 
-    it("allows FunctionName as alias for suppressing") {
-        val code = """
+    describe("FunctionNaming rule") {
+
+        it("allows FunctionName as alias for suppressing") {
+            val code = """
 			@Suppress("FunctionName")
 			fun MY_FUN() = TODO()
 		"""
-        assertThat(FunctionNaming().lint(code)).isEmpty()
-    }
+            assertThat(FunctionNaming().lint(code)).isEmpty()
+        }
 
-    it("ignores functions in classes matching excludeClassPattern") {
-        val code = """
+        it("ignores functions in classes matching excludeClassPattern") {
+            val code = """
 			class WhateverTest {
 				fun SHOULD_NOT_BE_FLAGGED() = TODO()
 			}
 		"""
-        val config = TestConfig(mapOf("excludeClassPattern" to ".*Test$"))
-        assertThat(FunctionNaming(config).lint(code)).isEmpty()
-    }
+            val config = TestConfig(mapOf("excludeClassPattern" to ".*Test$"))
+            assertThat(FunctionNaming(config).lint(code)).isEmpty()
+        }
 
-    it("flags functions inside functions") {
-        val code = """
+        it("flags functions inside functions") {
+            val code = """
 			override fun shouldNotBeFlagged() {
 				fun SHOULD_BE_FLAGGED() { }
 			}
 		"""
-        assertThat(FunctionNaming().lint(code)).hasLocationStrings(
-                "'fun SHOULD_BE_FLAGGED() { }' at (2,2) in /$fileName"
-        )
-    }
+            assertThat(FunctionNaming().lint(code)).hasLocationStrings(
+                    "'fun SHOULD_BE_FLAGGED() { }' at (2,2) in /$fileName"
+            )
+        }
 
-    it("ignores overridden functions by default") {
-        val code = """
+        it("ignores overridden functions by default") {
+            val code = """
 			override fun SHOULD_NOT_BE_FLAGGED() = TODO()
 		"""
-        assertThat(FunctionNaming().lint(code)).isEmpty()
-    }
+            assertThat(FunctionNaming().lint(code)).isEmpty()
+        }
 
-    it("flags functions with bad names inside overridden functions by default") {
-        val code = """
+        it("flags functions with bad names inside overridden functions by default") {
+            val code = """
 			override fun SHOULD_NOT_BE_FLAGGED() {
 				fun SHOULD_BE_FLAGGED() {}
 			}
 		"""
-        assertThat(FunctionNaming().lint(code)).hasLocationStrings(
-                "'fun SHOULD_BE_FLAGGED() {}' at (2,2) in /$fileName"
-        )
-    }
+            assertThat(FunctionNaming().lint(code)).hasLocationStrings(
+                    "'fun SHOULD_BE_FLAGGED() {}' at (2,2) in /$fileName"
+            )
+        }
 
-    it("doesn't ignore overridden functions if ignoreOverridden is false") {
-        val code = """
+        it("doesn't ignore overridden functions if ignoreOverridden is false") {
+            val code = """
 			override fun SHOULD_BE_FLAGGED() = TODO()
 		"""
-        val config = TestConfig(mapOf("ignoreOverridden" to "false"))
-        assertThat(FunctionNaming(config).lint(code)).hasLocationStrings(
-                "'override fun SHOULD_BE_FLAGGED() = TODO()' at (1,1) in /$fileName"
-        )
+            val config = TestConfig(mapOf("ignoreOverridden" to "false"))
+            assertThat(FunctionNaming(config).lint(code)).hasLocationStrings(
+                    "'override fun SHOULD_BE_FLAGGED() = TODO()' at (1,1) in /$fileName"
+            )
+        }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
@@ -3,155 +3,157 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
 internal class MatchingDeclarationNameSpec : Spek({
 
-    given("compliant test cases") {
+    describe("MatchingDeclarationName rule") {
 
-        it("should pass for object declaration") {
-            val ktFile = compileContentForTest("object O")
-            ktFile.name = "O.kt"
-            val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
+        context("compliant test cases") {
 
-        it("should pass for class declaration") {
-            val ktFile = compileContentForTest("class C")
-            ktFile.name = "C.kt"
-            val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
+            it("should pass for object declaration") {
+                val ktFile = compileContentForTest("object O")
+                ktFile.name = "O.kt"
+                val findings = MatchingDeclarationName().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should pass for interface declaration") {
-            val ktFile = compileContentForTest("interface I")
-            ktFile.name = "I.kt"
-            val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
+            it("should pass for class declaration") {
+                val ktFile = compileContentForTest("class C")
+                ktFile.name = "C.kt"
+                val findings = MatchingDeclarationName().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should pass for enum declaration") {
-            val ktFile = compileContentForTest("""
+            it("should pass for interface declaration") {
+                val ktFile = compileContentForTest("interface I")
+                ktFile.name = "I.kt"
+                val findings = MatchingDeclarationName().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should pass for enum declaration") {
+                val ktFile = compileContentForTest("""
 				enum class E {
 					ONE, TWO, THREE
 				}
 			""")
-            ktFile.name = "E.kt"
-            val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
+                ktFile.name = "E.kt"
+                val findings = MatchingDeclarationName().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should pass for multiple declaration") {
-            val ktFile = compileContentForTest("""
+            it("should pass for multiple declaration") {
+                val ktFile = compileContentForTest("""
 				class C
 				object O
 				fun a() = 5
 			""")
-            ktFile.name = "MultiDeclarations.kt"
-            val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
+                ktFile.name = "MultiDeclarations.kt"
+                val findings = MatchingDeclarationName().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should pass for class declaration with utility functions") {
-            val ktFile = compileContentForTest("""
+            it("should pass for class declaration with utility functions") {
+                val ktFile = compileContentForTest("""
 				class C
 				fun a() = 5
 				fun C.b() = 5
 			""")
-            ktFile.name = "C.kt"
-            val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
+                ktFile.name = "C.kt"
+                val findings = MatchingDeclarationName().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should pass for private class declaration") {
-            val ktFile = compileContentForTest("""
+            it("should pass for private class declaration") {
+                val ktFile = compileContentForTest("""
 				private class C
 				fun a() = 5
 			""")
-            ktFile.name = "b.kt"
-            val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
+                ktFile.name = "b.kt"
+                val findings = MatchingDeclarationName().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should pass for a class with a typealias") {
-            val code = """
+            it("should pass for a class with a typealias") {
+                val code = """
 				typealias Foo = FooImpl
 
 				class FooImpl {}"""
-            val ktFile = compileContentForTest(code)
-            ktFile.name = "Foo.kt"
-            val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-    }
-
-    given("non-compliant test cases") {
-
-        it("should not pass for object declaration") {
-            val ktFile = compileContentForTest("object O")
-            ktFile.name = "Objects.kt"
-            val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasLocationStrings("'object O' at (1,1) in /Objects.kt")
+                val ktFile = compileContentForTest(code)
+                ktFile.name = "Foo.kt"
+                val findings = MatchingDeclarationName().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
         }
 
-        it("should not pass for class declaration") {
-            val ktFile = compileContentForTest("class C")
-            ktFile.name = "Classes.kt"
-            val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasLocationStrings("'class C' at (1,1) in /Classes.kt")
-        }
+        context("non-compliant test cases") {
 
-        it("should not pass for class declaration with utility functions") {
-            val ktFile = compileContentForTest("""
+            it("should not pass for object declaration") {
+                val ktFile = compileContentForTest("object O")
+                ktFile.name = "Objects.kt"
+                val findings = MatchingDeclarationName().lint(ktFile)
+                assertThat(findings).hasLocationStrings("'object O' at (1,1) in /Objects.kt")
+            }
+
+            it("should not pass for class declaration") {
+                val ktFile = compileContentForTest("class C")
+                ktFile.name = "Classes.kt"
+                val findings = MatchingDeclarationName().lint(ktFile)
+                assertThat(findings).hasLocationStrings("'class C' at (1,1) in /Classes.kt")
+            }
+
+            it("should not pass for class declaration with utility functions") {
+                val ktFile = compileContentForTest("""
 				class C
 				fun a() = 5
 				fun C.b() = 5
 			""")
-            ktFile.name = "ClassUtils.kt"
-            val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasLocationStrings("""'
+                ktFile.name = "ClassUtils.kt"
+                val findings = MatchingDeclarationName().lint(ktFile)
+                assertThat(findings).hasLocationStrings("""'
 				class C
 				fun a() = 5
 				fun C.b() = 5
 			' at (1,1) in /ClassUtils.kt""", trimIndent = true)
-        }
+            }
 
-        it("should not pass for interface declaration") {
-            val ktFile = compileContentForTest("interface I")
-            ktFile.name = "Not_I.kt"
-            val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasLocationStrings("'interface I' at (1,1) in /Not_I.kt")
-        }
+            it("should not pass for interface declaration") {
+                val ktFile = compileContentForTest("interface I")
+                ktFile.name = "Not_I.kt"
+                val findings = MatchingDeclarationName().lint(ktFile)
+                assertThat(findings).hasLocationStrings("'interface I' at (1,1) in /Not_I.kt")
+            }
 
-        it("should not pass for enum declaration") {
-            val ktFile = compileContentForTest("""
+            it("should not pass for enum declaration") {
+                val ktFile = compileContentForTest("""
 				enum class NOT_E {
 					ONE, TWO, THREE
 				}
 			""")
-            ktFile.name = "E.kt"
-            val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasLocationStrings("""'
+                ktFile.name = "E.kt"
+                val findings = MatchingDeclarationName().lint(ktFile)
+                assertThat(findings).hasLocationStrings("""'
 				enum class NOT_E {
 					ONE, TWO, THREE
 				}
 			' at (1,1) in /E.kt""", trimIndent = true)
-        }
+            }
 
-        it("should not pass for a typealias with a different name") {
-            val code = """
+            it("should not pass for a typealias with a different name") {
+                val code = """
 				typealias Bar = FooImpl
 
 				class FooImpl {}"""
-            val ktFile = compileContentForTest(code)
-            ktFile.name = "Foo.kt"
-            val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasSize(1)
+                val ktFile = compileContentForTest(code)
+                ktFile.name = "Foo.kt"
+                val findings = MatchingDeclarationName().lint(ktFile)
+                assertThat(findings).hasSize(1)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
@@ -5,39 +5,41 @@ import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class MemberNameEqualsClassNameSpec : SubjectSpek<MemberNameEqualsClassName>({
-    subject { MemberNameEqualsClassName(Config.empty) }
+class MemberNameEqualsClassNameSpec : Spek({
+    val subject by memoized { MemberNameEqualsClassName(Config.empty) }
 
-    given("some classes with methods which don't have the same name") {
+    describe("MemberNameEqualsClassName rule") {
 
-        it("reports methods which are not named after the class") {
-            val path = Case.MemberNameEqualsClassNameNegative.path()
-            assertThat(subject.lint(path)).hasSize(0)
-        }
-    }
+        context("some classes with methods which don't have the same name") {
 
-    given("some classes with methods which have the same name") {
-
-        val path = Case.MemberNameEqualsClassNamePositive.path()
-        val findings = subject.lint(path)
-
-        it("reports methods which are named after the class") {
-            assertThat(findings).hasSize(8)
+            it("reports methods which are not named after the class") {
+                val path = Case.MemberNameEqualsClassNameNegative.path()
+                assertThat(subject.lint(path)).hasSize(0)
+            }
         }
 
-        it("reports methods which are named after the class object") {
-            val objectFindings = findings.filter { it.message.contains("object") }
-            assertThat(objectFindings).hasSize(2)
-        }
+        context("some classes with methods which have the same name") {
 
-        it("reports methods which are named after the class object including overridden functions") {
-            val config = TestConfig(mapOf("ignoreOverriddenFunction" to "false"))
-            val rule = MemberNameEqualsClassName(config)
-            assertThat(rule.lint(path)).hasSize(9)
+            val path = Case.MemberNameEqualsClassNamePositive.path()
+            val findings = subject.lint(path)
+
+            it("reports methods which are named after the class") {
+                assertThat(findings).hasSize(8)
+            }
+
+            it("reports methods which are named after the class object") {
+                val objectFindings = findings.filter { it.message.contains("object") }
+                assertThat(objectFindings).hasSize(2)
+            }
+
+            it("reports methods which are named after the class object including overridden functions") {
+                val config = TestConfig(mapOf("ignoreOverriddenFunction" to "false"))
+                val rule = MemberNameEqualsClassName(config)
+                assertThat(rule.lint(path)).hasSize(9)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternTest.kt
@@ -2,11 +2,11 @@ package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
-import java.util.regex.PatternSyntaxException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.regex.PatternSyntaxException
 
 class NamingConventionCustomPatternTest : Spek({
 
@@ -61,9 +61,11 @@ class NamingConventionCustomPatternTest : Spek({
 				fun MYFun() {}
 			}"""
 
-    it("shouldUseCustomNameForMethodAndClass") {
-        val rule = NamingRules(testConfig)
-        assertThat(rule.lint("""
+    describe("NamingRules rule") {
+
+        it("shouldUseCustomNameForMethodAndClass") {
+            val rule = NamingRules(testConfig)
+            assertThat(rule.lint("""
             class aBbD{
                 fun `name with back ticks`(){
                   val `123var` = ""
@@ -74,66 +76,66 @@ class NamingConventionCustomPatternTest : Spek({
                 }
             }
         """)).isEmpty()
-    }
+        }
 
-    it("shouldUseCustomNameForConstant") {
-        val rule = NamingRules(testConfig)
-        assertThat(rule.lint("""
+        it("shouldUseCustomNameForConstant") {
+            val rule = NamingRules(testConfig)
+            assertThat(rule.lint("""
             class aBbD{
                 companion object {
                   const val lowerCaseConst = ""
                 }
             }
         """)).isEmpty()
-    }
+        }
 
-    it("shouldUseCustomNameForEnum") {
-        val rule = NamingRules(testConfig)
-        assertThat(rule.lint("""
+        it("shouldUseCustomNameForEnum") {
+            val rule = NamingRules(testConfig)
+            assertThat(rule.lint("""
             class aBbD{
                 enum class aBbD {
                     enum1, enum2
                 }
             }
         """)).isEmpty()
-    }
-
-    it("shouldUseCustomNameForPackage") {
-        val rule = NamingRules(testConfig)
-        assertThat(rule.lint("package package_1")).isEmpty()
-    }
-
-    it("shouldExcludeClassesFromVariableNaming") {
-        val code = """
-			class Bar {
-				val MYVar = 3
-			}
-
-			object Foo {
-				val MYVar = 3
-			}"""
-        val config = TestConfig(mapOf(VariableNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar"))
-        assertThat(VariableNaming(config).lint(code)).isEmpty()
-    }
-
-    it("shouldNotFailWithInvalidRegexWhenDisabledVariableNaming") {
-        val configValues = mapOf(
-                "active" to "false",
-                VariableNaming.EXCLUDE_CLASS_PATTERN to "*Foo"
-        )
-        val config = TestConfig(configValues)
-        assertThat(VariableNaming(config).lint(excludeClassPatternVariableRegexCode)).isEmpty()
-    }
-
-    it("shouldFailWithInvalidRegexVariableNaming") {
-        val config = TestConfig(mapOf(VariableNaming.EXCLUDE_CLASS_PATTERN to "*Foo"))
-        assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
-            VariableNaming(config).lint(excludeClassPatternVariableRegexCode)
         }
-    }
 
-    it("shouldExcludeClassesFromFunctionNaming") {
-        val code = """
+        it("shouldUseCustomNameForPackage") {
+            val rule = NamingRules(testConfig)
+            assertThat(rule.lint("package package_1")).isEmpty()
+        }
+
+        it("shouldExcludeClassesFromVariableNaming") {
+            val code = """
+			class Bar {
+				val MYVar = 3
+			}
+
+			object Foo {
+				val MYVar = 3
+			}"""
+            val config = TestConfig(mapOf(VariableNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar"))
+            assertThat(VariableNaming(config).lint(code)).isEmpty()
+        }
+
+        it("shouldNotFailWithInvalidRegexWhenDisabledVariableNaming") {
+            val configValues = mapOf(
+                    "active" to "false",
+                    VariableNaming.EXCLUDE_CLASS_PATTERN to "*Foo"
+            )
+            val config = TestConfig(configValues)
+            assertThat(VariableNaming(config).lint(excludeClassPatternVariableRegexCode)).isEmpty()
+        }
+
+        it("shouldFailWithInvalidRegexVariableNaming") {
+            val config = TestConfig(mapOf(VariableNaming.EXCLUDE_CLASS_PATTERN to "*Foo"))
+            assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
+                VariableNaming(config).lint(excludeClassPatternVariableRegexCode)
+            }
+        }
+
+        it("shouldExcludeClassesFromFunctionNaming") {
+            val code = """
 			class Bar {
 				fun MYFun() {}
 			}
@@ -141,23 +143,24 @@ class NamingConventionCustomPatternTest : Spek({
 			object Foo {
 				fun MYFun() {}
 			}"""
-        val config = TestConfig(mapOf(FunctionNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar"))
-        assertThat(FunctionNaming(config).lint(code)).isEmpty()
-    }
+            val config = TestConfig(mapOf(FunctionNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar"))
+            assertThat(FunctionNaming(config).lint(code)).isEmpty()
+        }
 
-    it("shouldNotFailWithInvalidRegexWhenDisabledFunctionNaming") {
-        val configRules = mapOf(
-                "active" to "false",
-                FunctionNaming.EXCLUDE_CLASS_PATTERN to "*Foo"
-        )
-        val config = TestConfig(configRules)
-        assertThat(FunctionNaming(config).lint(excludeClassPatternFunctionRegexCode)).isEmpty()
-    }
+        it("shouldNotFailWithInvalidRegexWhenDisabledFunctionNaming") {
+            val configRules = mapOf(
+                    "active" to "false",
+                    FunctionNaming.EXCLUDE_CLASS_PATTERN to "*Foo"
+            )
+            val config = TestConfig(configRules)
+            assertThat(FunctionNaming(config).lint(excludeClassPatternFunctionRegexCode)).isEmpty()
+        }
 
-    it("shouldFailWithInvalidRegexFunctionNaming") {
-        val config = TestConfig(mapOf(FunctionNaming.EXCLUDE_CLASS_PATTERN to "*Foo"))
-        assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
-            FunctionNaming(config).lint(excludeClassPatternFunctionRegexCode)
+        it("shouldFailWithInvalidRegexFunctionNaming") {
+            val config = TestConfig(mapOf(FunctionNaming.EXCLUDE_CLASS_PATTERN to "*Foo"))
+            assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
+                FunctionNaming(config).lint(excludeClassPatternFunctionRegexCode)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
@@ -3,83 +3,85 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class NamingConventionLengthSpec : SubjectSpek<NamingRules>({
+class NamingConventionLengthSpec : Spek({
 
-    subject { NamingRules() }
+    val subject by memoized { NamingRules() }
 
-    it("should not report underscore variable names") {
-        val code = "val (_, status) = getResult()"
-        subject.lint(code)
-        assertThat(subject.findings).isEmpty()
-    }
+    describe("NamingRules rule") {
 
-    it("should not report a variable with single letter name") {
-        val code = "private val a = 3"
-        subject.lint(code)
-        assertThat(subject.findings).hasSize(0)
-    }
-
-    describe("VariableMinLength rule with a custom minimum length") {
-
-        val variableMinLength = VariableMinLength(TestConfig(mapOf(VariableMinLength.MINIMUM_VARIABLE_NAME_LENGTH to "2")))
-
-        it("reports a very short variable name") {
-            val code = "private val a = 3"
-            assertThat(variableMinLength.lint(code)).hasSize(1)
+        it("should not report underscore variable names") {
+            val code = "val (_, status) = getResult()"
+            subject.lint(code)
+            assertThat(subject.findings).isEmpty()
         }
 
-        it("does not report a variable with only a single underscore") {
-            val code = """
+        it("should not report a variable with single letter name") {
+            val code = "private val a = 3"
+            subject.lint(code)
+            assertThat(subject.findings).hasSize(0)
+        }
+
+        context("VariableMinLength rule with a custom minimum length") {
+
+            val variableMinLength = VariableMinLength(TestConfig(mapOf(VariableMinLength.MINIMUM_VARIABLE_NAME_LENGTH to "2")))
+
+            it("reports a very short variable name") {
+                val code = "private val a = 3"
+                assertThat(variableMinLength.lint(code)).hasSize(1)
+            }
+
+            it("does not report a variable with only a single underscore") {
+                val code = """
 			class C {
 				val prop: (Int) -> Unit = { _ -> Unit }
 			}"""
-            assertThat(variableMinLength.lint(code)).hasSize(0)
+                assertThat(variableMinLength.lint(code)).hasSize(0)
+            }
         }
-    }
 
-    it("should not report a variable with 64 letters") {
-        val code = "private val varThatIsExactly64LettersLongWhichYouMightNotWantToBelieveInLolz = 3"
-        subject.lint(code)
-        assertThat(subject.findings).hasSize(0)
-    }
+        it("should not report a variable with 64 letters") {
+            val code = "private val varThatIsExactly64LettersLongWhichYouMightNotWantToBelieveInLolz = 3"
+            subject.lint(code)
+            assertThat(subject.findings).hasSize(0)
+        }
 
-    it("should report a variable name that is too long") {
-        val code = "private val thisVariableIsDefinitelyWayTooLongLongerThanEverythingAndShouldBeMuchShorter = 3"
-        subject.lint(code)
-        assertThat(subject.findings).hasSize(1)
-    }
+        it("should report a variable name that is too long") {
+            val code = "private val thisVariableIsDefinitelyWayTooLongLongerThanEverythingAndShouldBeMuchShorter = 3"
+            subject.lint(code)
+            assertThat(subject.findings).hasSize(1)
+        }
 
-    it("should not report a variable name that is okay") {
-        val code = "private val thisOneIsCool = 3"
-        subject.lint(code)
-        assertThat(subject.findings).isEmpty()
-    }
+        it("should not report a variable name that is okay") {
+            val code = "private val thisOneIsCool = 3"
+            subject.lint(code)
+            assertThat(subject.findings).isEmpty()
+        }
 
-    it("should report a function name that is too short") {
-        val code = "private fun a = 3"
-        subject.lint(code)
-        assertThat(subject.findings).hasSize(1)
-    }
+        it("should report a function name that is too short") {
+            val code = "private fun a = 3"
+            subject.lint(code)
+            assertThat(subject.findings).hasSize(1)
+        }
 
-    it("should report a function name that is too long") {
-        val code = "private fun thisFunctionIsDefinitelyWayTooLongAndShouldBeMuchShorter = 3"
-        subject.lint(code)
-        assertThat(subject.findings).hasSize(1)
-    }
+        it("should report a function name that is too long") {
+            val code = "private fun thisFunctionIsDefinitelyWayTooLongAndShouldBeMuchShorter = 3"
+            subject.lint(code)
+            assertThat(subject.findings).hasSize(1)
+        }
 
-    it("should not report a function name that is okay") {
-        val code = "private fun three = 3"
-        subject.lint(code)
-        assertThat(subject.findings).isEmpty()
-    }
+        it("should not report a function name that is okay") {
+            val code = "private fun three = 3"
+            subject.lint(code)
+            assertThat(subject.findings).isEmpty()
+        }
 
-    it("should not report a function name that begins with a backtick, capitals, and spaces") {
-        val code = "private fun `Hi bye` = 3"
-        subject.lint(code)
-        assertThat(subject.findings).isEmpty()
+        it("should not report a function name that begins with a backtick, capitals, and spaces") {
+            val code = "private fun `Hi bye` = 3"
+            subject.lint(code)
+            assertThat(subject.findings).isEmpty()
+        }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
@@ -4,15 +4,14 @@ import io.gitlab.arturbosch.detekt.test.TEST_FILENAME
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class NamingRulesSpec : SubjectSpek<NamingRules>({
+class NamingRulesSpec : Spek({
 
     val fileName = TEST_FILENAME
 
-    subject { NamingRules() }
+    val subject by memoized { NamingRules() }
 
     describe("properties in classes") {
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -5,17 +5,16 @@ import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class ObjectPropertyNamingSpec : SubjectSpek<ObjectPropertyNaming>({
-
-    subject { ObjectPropertyNaming() }
+class ObjectPropertyNamingSpec : Spek({
 
     val fileName = TEST_FILENAME
 
     describe("constants in object declarations") {
+
+        val subject by memoized { ObjectPropertyNaming() }
 
         it("should not detect public constants complying to the naming rules") {
             val code = compileContentForTest("""
@@ -66,6 +65,8 @@ class ObjectPropertyNamingSpec : SubjectSpek<ObjectPropertyNaming>({
     }
 
     describe("constants in companion object") {
+
+        val subject by memoized { ObjectPropertyNaming() }
 
         it("should not detect public constants complying to the naming rules") {
             val code = compileContentForTest("""
@@ -126,6 +127,8 @@ class ObjectPropertyNamingSpec : SubjectSpek<ObjectPropertyNaming>({
     }
 
     describe("variables in objects") {
+
+        val subject by memoized { ObjectPropertyNaming() }
 
         it("should not detect public constants complying to the naming rules") {
             val code = compileContentForTest("""

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
@@ -2,24 +2,27 @@ package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class PackageNamingSpec : SubjectSpek<PackageNaming>({
+class PackageNamingSpec : Spek({
 
-    it("should find a uppercase package name") {
-        assertThat(NamingRules().lint("package FOO.BAR")).hasSize(1)
-    }
+    describe("PackageNaming rule") {
 
-    it("should find a upper camel case package name") {
-        assertThat(NamingRules().lint("package Foo.Bar")).hasSize(1)
-    }
+        it("should find a uppercase package name") {
+            assertThat(NamingRules().lint("package FOO.BAR")).hasSize(1)
+        }
 
-    it("should find a camel case package name") {
-        assertThat(NamingRules().lint("package fOO.bAR")).hasSize(1)
-    }
+        it("should find a upper camel case package name") {
+            assertThat(NamingRules().lint("package Foo.Bar")).hasSize(1)
+        }
 
-    it("should check an valid package name") {
-        assertThat(NamingRules().lint("package foo.bar")).isEmpty()
+        it("should find a camel case package name") {
+            assertThat(NamingRules().lint("package fOO.bAR")).hasSize(1)
+        }
+
+        it("should check an valid package name") {
+            assertThat(NamingRules().lint("package foo.bar")).isEmpty()
+        }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ParameterNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ParameterNamingSpec.kt
@@ -3,9 +3,8 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Mickele Moriconi

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
@@ -3,13 +3,12 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class TopLevelPropertyNamingSpec : SubjectSpek<TopLevelPropertyNaming>({
+class TopLevelPropertyNamingSpec : Spek({
 
-    subject { TopLevelPropertyNaming() }
+    val subject by memoized { TopLevelPropertyNaming() }
 
     describe("constants on top level") {
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
@@ -1,17 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.performance
 
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author elaydis
  */
-class ArrayPrimitiveSpec : SubjectSpek<ArrayPrimitive>({
-    subject { ArrayPrimitive() }
+class ArrayPrimitiveSpec : Spek({
+    val subject by memoized { ArrayPrimitive() }
 
     describe("one function parameter") {
         it("is an array of primitive type") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
@@ -2,14 +2,15 @@ package io.gitlab.arturbosch.detekt.rules.performance
 
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class ForEachOnRangeSpec : Spek({
 
-    given("a kt file with using a forEach on a range") {
-        val code = """
+    describe("ForEachOnRange rule") {
+
+        context("a kt file with using a forEach on a range") {
+            val code = """
 			fun test() {
 				(1..10).forEach {
 					println(it)
@@ -26,27 +27,27 @@ class ForEachOnRangeSpec : Spek({
 			}
 		"""
 
-        it("should report the forEach usage") {
-            val findings = ForEachOnRange().compileAndLint(code)
-            assertThat(findings).hasSize(4)
+            it("should report the forEach usage") {
+                val findings = ForEachOnRange().compileAndLint(code)
+                assertThat(findings).hasSize(4)
+            }
         }
-    }
 
-    given("a kt file with using any other method on a range") {
-        val code = """
+        context("a kt file with using any other method on a range") {
+            val code = """
 			fun test() {
 				(1..10).isEmpty()
 			}
 		"""
 
-        it("should report not report any issues") {
-            val findings = ForEachOnRange().compileAndLint(code)
-            assertThat(findings).isEmpty()
+            it("should report not report any issues") {
+                val findings = ForEachOnRange().compileAndLint(code)
+                assertThat(findings).isEmpty()
+            }
         }
-    }
 
-    given("a kt file with using a forEach on a list") {
-        val code = """
+        context("a kt file with using a forEach on a list") {
+            val code = """
 			fun test() {
 				listOf(1, 2, 3).forEach {
 					println(it)
@@ -54,9 +55,10 @@ class ForEachOnRangeSpec : Spek({
 			}
 		"""
 
-        it("should report not report any issues") {
-            val findings = ForEachOnRange().compileAndLint(code)
-            assertThat(findings).isEmpty()
+            it("should report not report any issues") {
+                val findings = ForEachOnRange().compileAndLint(code)
+                assertThat(findings).isEmpty()
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
@@ -2,16 +2,15 @@ package io.gitlab.arturbosch.detekt.rules.performance
 
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Ivan Balaksha
  * @author schalkms
  */
-class SpreadOperatorSpec : SubjectSpek<SpreadOperator>({
-    subject { SpreadOperator() }
+class SpreadOperatorSpec : Spek({
+    val subject by memoized { SpreadOperator() }
 
     describe("test vararg cases") {
         it("as vararg") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiationSpec.kt
@@ -2,14 +2,14 @@ package io.gitlab.arturbosch.detekt.rules.performance
 
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author schalkms
  */
-class UnnecessaryTemporaryInstantiationSpec : SubjectSpek<UnnecessaryTemporaryInstantiation>({
-    subject { UnnecessaryTemporaryInstantiation() }
+class UnnecessaryTemporaryInstantiationSpec : Spek({
+    val subject by memoized { UnnecessaryTemporaryInstantiation() }
 
     describe("temporary instantiation for conversion") {
         val code = "val i = Integer(1).toString()"

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatementsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatementsSpec.kt
@@ -4,14 +4,13 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class CollapsibleIfStatementsSpec : SubjectSpek<CollapsibleIfStatements>({
-    subject { CollapsibleIfStatements(Config.empty) }
+class CollapsibleIfStatementsSpec : Spek({
+    val subject by memoized { CollapsibleIfStatements(Config.empty) }
 
-    given("multiple if statements") {
+    describe("CollapsibleIfStatements rule") {
 
         it("reports if statements which can be merged") {
             val path = Case.CollapsibleIfsPositive.path()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctionsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctionsSpec.kt
@@ -4,18 +4,17 @@ import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Ivan Balaksha
  */
 
-class DataClassContainsFunctionsSpec : SubjectSpek<DataClassContainsFunctions>({
-    subject { DataClassContainsFunctions() }
+class DataClassContainsFunctionsSpec : Spek({
+    val subject by memoized { DataClassContainsFunctions() }
 
-    given("several data classes") {
+    describe("DataClassContainsFunctions rule") {
 
         val path = Case.DataClassContainsFunctionsPositive.path()
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCallSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCallSpec.kt
@@ -3,14 +3,13 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class EqualsNullCallSpec : SubjectSpek<EqualsNullCall>({
-    subject { EqualsNullCall(Config.empty) }
+class EqualsNullCallSpec : Spek({
+    val subject by memoized { EqualsNullCall(Config.empty) }
 
-    given("an equals method with a parameter") {
+    describe("EqualsNullCall rule") {
 
         it("with null as parameter") {
             val code = """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLineSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLineSpec.kt
@@ -3,16 +3,15 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class EqualsOnSignatureLineSpec : SubjectSpek<EqualsOnSignatureLine>({
-    subject { EqualsOnSignatureLine(Config.empty) }
+class EqualsOnSignatureLineSpec : Spek({
+    val subject by memoized { EqualsOnSignatureLine(Config.empty) }
 
-    given("a function") {
+    describe("EqualsOnSignatureLine rule") {
 
-        given("with expression syntax and without a return type") {
+        context("with expression syntax and without a return type") {
             it("reports when the equals is on a new line") {
                 val findings = subject.lint("""
 				fun foo()
@@ -32,7 +31,7 @@ class EqualsOnSignatureLineSpec : SubjectSpek<EqualsOnSignatureLine>({
             }
         }
 
-        given("with expression syntax and with a return type") {
+        context("with expression syntax and with a return type") {
             it("reports when the equals is on a new line") {
                 val findings = subject.lint("""
 				fun one(): Int
@@ -86,7 +85,7 @@ class EqualsOnSignatureLineSpec : SubjectSpek<EqualsOnSignatureLine>({
             }
         }
 
-        given("with expression syntax and with a where clause") {
+        context("with expression syntax and with a where clause") {
             it("reports when the equals is on a new line") {
                 val findings = subject.lint("""
 				fun <V> one(): Int where V : Number

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
@@ -3,16 +3,14 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.api.dsl.on
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class ExplicitItLambdaParameterSpec : SubjectSpek<ExplicitItLambdaParameter>({
-    subject { ExplicitItLambdaParameter(Config.empty) }
+class ExplicitItLambdaParameterSpec : Spek({
+    val subject by memoized { ExplicitItLambdaParameter(Config.empty) }
 
-    given("lambda with single parameter") {
-        on("single parameter with name `it` declared explicitly") {
+    describe("ExplicitItLambdaParameter rule") {
+        context("single parameter lambda with name `it` declared explicitly") {
             it("reports when parameter type is not declared") {
                 val findings = subject.lint("""
 				fun f() {
@@ -28,7 +26,7 @@ class ExplicitItLambdaParameterSpec : SubjectSpek<ExplicitItLambdaParameter>({
                 assertThat(findings).hasSize(1)
             }
         }
-        on("no parameter declared explicitly") {
+        context("no parameter declared explicitly") {
             it("does not report implicit `it` parameter usage") {
                 val findings = subject.lint("""
 				fun f() {
@@ -39,9 +37,8 @@ class ExplicitItLambdaParameterSpec : SubjectSpek<ExplicitItLambdaParameter>({
                 assertThat(findings).isEmpty()
             }
         }
-    }
-    given("some code using lambdas with (slightly) better style guidelines") {
-        on("multiple parameters one of which with name `it` declared explicitly") {
+
+        context("multiple parameters one of which with name `it` declared explicitly") {
             it("reports when parameter types are not declared") {
                 val findings = subject.lint("""
 				fun f() {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
@@ -4,38 +4,39 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
-class ExpressionBodySyntaxSpec : SubjectSpek<ExpressionBodySyntax>({
-    subject { ExpressionBodySyntax(Config.empty) }
+class ExpressionBodySyntaxSpec : Spek({
+    val subject by memoized { ExpressionBodySyntax(Config.empty) }
 
-    given("several return statements") {
+    describe("ExpressionBodySyntax rule") {
 
-        it("reports constant return") {
-            assertThat(subject.lint("""
+        context("several return statements") {
+
+            it("reports constant return") {
+                assertThat(subject.lint("""
 				fun stuff(): Int {
 					return 5
 				}
 			"""
-            )).hasSize(1)
-        }
+                )).hasSize(1)
+            }
 
-        it("reports return statement with method chain") {
-            assertThat(subject.lint("""
+            it("reports return statement with method chain") {
+                assertThat(subject.lint("""
 				fun stuff(): Int {
 					return moreStuff().getStuff().stuffStuff()
 				}
 			"""
-            )).hasSize(1)
-        }
+                )).hasSize(1)
+            }
 
-        it("reports return statements with conditionals") {
-            assertThat(subject.lint("""
+            it("reports return statements with conditionals") {
+                assertThat(subject.lint("""
 				fun stuff(): Int {
 					return if (true) return 5 else return 3
 				}
@@ -43,40 +44,40 @@ class ExpressionBodySyntaxSpec : SubjectSpek<ExpressionBodySyntax>({
 					return try { return 5 } catch (e: Exception) { return 3 }
 				}
 			""")).hasSize(2)
-        }
+            }
 
-        it("does not report multiple if statements") {
-            assertThat(subject.lint("""
+            it("does not report multiple if statements") {
+                assertThat(subject.lint("""
 				fun stuff(): Int {
 					if (true) return true
 					return false
 				}
 			""")).isEmpty()
+            }
         }
-    }
 
-    given("several return statements with multiline method chain") {
+        context("several return statements with multiline method chain") {
 
-        val code = """
+            val code = """
 			fun stuff(): Int {
 				return moreStuff()
 					.getStuff()
 					.stuffStuff()
 			}"""
 
-        it("does not report with the default configuration") {
-            assertThat(subject.lint(code)).isEmpty()
+            it("does not report with the default configuration") {
+                assertThat(subject.lint(code)).isEmpty()
+            }
+
+            it("reports with includeLineWrapping = true configuration") {
+                val config = TestConfig(mapOf(ExpressionBodySyntax.INCLUDE_LINE_WRAPPING to "true"))
+                assertThat(ExpressionBodySyntax(config).lint(code)).hasSize(1)
+            }
         }
 
-        it("reports with includeLineWrapping = true configuration") {
-            val config = TestConfig(mapOf(ExpressionBodySyntax.INCLUDE_LINE_WRAPPING to "true"))
-            assertThat(ExpressionBodySyntax(config).lint(code)).hasSize(1)
-        }
-    }
+        context("several return statements with multiline when expression") {
 
-    given("several return statements with multiline when expression") {
-
-        val code = """
+            val code = """
 			fun stuff(val arg: Int): Int {
 				return when(arg) {
 					0 -> 0
@@ -84,31 +85,32 @@ class ExpressionBodySyntaxSpec : SubjectSpek<ExpressionBodySyntax>({
 				}
 			}"""
 
-        it("does not report with the default configuration") {
-            assertThat(subject.lint(code)).isEmpty()
+            it("does not report with the default configuration") {
+                assertThat(subject.lint(code)).isEmpty()
+            }
+
+            it("reports with includeLineWrapping = true configuration") {
+                val config = TestConfig(mapOf(ExpressionBodySyntax.INCLUDE_LINE_WRAPPING to "true"))
+                assertThat(ExpressionBodySyntax(config).lint(code)).hasSize(1)
+            }
         }
 
-        it("reports with includeLineWrapping = true configuration") {
-            val config = TestConfig(mapOf(ExpressionBodySyntax.INCLUDE_LINE_WRAPPING to "true"))
-            assertThat(ExpressionBodySyntax(config).lint(code)).hasSize(1)
-        }
-    }
+        context("several return statements with multiline if expression") {
 
-    given("several return statements with multiline if expression") {
-
-        val code = """
+            val code = """
 			fun stuff(val arg: Int): Int {
 				return if (arg == 0) 0
 				else 1
 			}"""
 
-        it("does not report with the default configuration") {
-            assertThat(subject.lint(code)).isEmpty()
-        }
+            it("does not report with the default configuration") {
+                assertThat(subject.lint(code)).isEmpty()
+            }
 
-        it("reports with includeLineWrapping = true configuration") {
-            val config = TestConfig(mapOf(ExpressionBodySyntax.INCLUDE_LINE_WRAPPING to "true"))
-            assertThat(ExpressionBodySyntax(config).lint(code)).hasSize(1)
+            it("reports with includeLineWrapping = true configuration") {
+                val config = TestConfig(mapOf(ExpressionBodySyntax.INCLUDE_LINE_WRAPPING to "true"))
+                assertThat(ExpressionBodySyntax(config).lint(code)).hasSize(1)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -3,9 +3,8 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Java6Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class ForbiddenCommentSpec : Spek({
 
@@ -18,65 +17,68 @@ class ForbiddenCommentSpec : Spek({
     val stopShipColon = "// STOPSHIP: I need to fix this."
     val stopShip = "// STOPSHIP I need to fix this."
 
-    given("the default values are configured") {
+    describe("ForbiddenComment rule") {
 
-        it("should report TODO: usages") {
-            val findings = ForbiddenComment().lint(todoColon)
-            assertThat(findings).hasSize(1)
+        context("the default values are configured") {
+
+            it("should report TODO: usages") {
+                val findings = ForbiddenComment().lint(todoColon)
+                assertThat(findings).hasSize(1)
+            }
+
+            it("should not report TODO usages") {
+                val findings = ForbiddenComment().lint(todo)
+                assertThat(findings).hasSize(0)
+            }
+
+            it("should report FIXME: usages") {
+                val findings = ForbiddenComment().lint(fixmeColon)
+                assertThat(findings).hasSize(1)
+            }
+
+            it("should not report FIXME usages") {
+                val findings = ForbiddenComment().lint(fixme)
+                assertThat(findings).hasSize(0)
+            }
+
+            it("should report STOPSHIP: usages") {
+                val findings = ForbiddenComment().lint(stopShipColon)
+                assertThat(findings).hasSize(1)
+            }
+
+            it("should not report STOPSHIP usages") {
+                val findings = ForbiddenComment().lint(stopShip)
+                assertThat(findings).hasSize(0)
+            }
         }
 
-        it("should not report TODO usages") {
-            val findings = ForbiddenComment().lint(todo)
-            assertThat(findings).hasSize(0)
-        }
+        context("custom default values are configured") {
+            val banana = "// Banana."
 
-        it("should report FIXME: usages") {
-            val findings = ForbiddenComment().lint(fixmeColon)
-            assertThat(findings).hasSize(1)
-        }
+            it("should not report TODO: usages") {
+                val findings = ForbiddenComment(TestConfig(mapOf(ForbiddenComment.VALUES to "Banana"))).lint(todoColon)
+                assertThat(findings).hasSize(0)
+            }
 
-        it("should not report FIXME usages") {
-            val findings = ForbiddenComment().lint(fixme)
-            assertThat(findings).hasSize(0)
-        }
+            it("should not report FIXME: usages") {
+                val findings = ForbiddenComment(TestConfig(mapOf(ForbiddenComment.VALUES to "Banana"))).lint(fixmeColon)
+                assertThat(findings).hasSize(0)
+            }
 
-        it("should report STOPSHIP: usages") {
-            val findings = ForbiddenComment().lint(stopShipColon)
-            assertThat(findings).hasSize(1)
-        }
+            it("should not report STOPME: usages") {
+                val findings = ForbiddenComment(TestConfig(mapOf(ForbiddenComment.VALUES to "Banana"))).lint(stopShipColon)
+                assertThat(findings).hasSize(0)
+            }
 
-        it("should not report STOPSHIP usages") {
-            val findings = ForbiddenComment().lint(stopShip)
-            assertThat(findings).hasSize(0)
-        }
-    }
+            it("should report Banana usages") {
+                val findings = ForbiddenComment(TestConfig(mapOf(ForbiddenComment.VALUES to "Banana"))).lint(banana)
+                assertThat(findings).hasSize(1)
+            }
 
-    given("custom default values are configured") {
-        val banana = "// Banana."
-
-        it("should not report TODO: usages") {
-            val findings = ForbiddenComment(TestConfig(mapOf(ForbiddenComment.VALUES to "Banana"))).lint(todoColon)
-            assertThat(findings).hasSize(0)
-        }
-
-        it("should not report FIXME: usages") {
-            val findings = ForbiddenComment(TestConfig(mapOf(ForbiddenComment.VALUES to "Banana"))).lint(fixmeColon)
-            assertThat(findings).hasSize(0)
-        }
-
-        it("should not report STOPME: usages") {
-            val findings = ForbiddenComment(TestConfig(mapOf(ForbiddenComment.VALUES to "Banana"))).lint(stopShipColon)
-            assertThat(findings).hasSize(0)
-        }
-
-        it("should report Banana usages") {
-            val findings = ForbiddenComment(TestConfig(mapOf(ForbiddenComment.VALUES to "Banana"))).lint(banana)
-            assertThat(findings).hasSize(1)
-        }
-
-        it("should report Banana usages regardless of case sensitive") {
-            val findings = ForbiddenComment(TestConfig(mapOf(ForbiddenComment.VALUES to "bAnAnA"))).lint(banana)
-            assertThat(findings).hasSize(1)
+            it("should report Banana usages regardless of case sensitive") {
+                val findings = ForbiddenComment(TestConfig(mapOf(ForbiddenComment.VALUES to "bAnAnA"))).lint(banana)
+                assertThat(findings).hasSize(1)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -3,12 +3,11 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Java6Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class ForbiddenImportSpec : Spek({
-    given("a file with imports") {
+    describe("ForbiddenImport rule") {
         val code = """
 			package foo
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
@@ -2,12 +2,11 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Java6Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class ForbiddenVoidSpec : Spek({
-    given("some Void usage") {
+    describe("ForbiddenVoid rule") {
         it("should report all Void type usage") {
             val code = """
 				lateinit var c: () -> Void

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
@@ -4,14 +4,13 @@ import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class FunctionOnlyReturningConstantSpec : SubjectSpek<FunctionOnlyReturningConstant>({
-    subject { FunctionOnlyReturningConstant() }
+class FunctionOnlyReturningConstantSpec : Spek({
+    val subject by memoized { FunctionOnlyReturningConstant() }
 
-    given("some functions which return constants") {
+    describe("FunctionOnlyReturningConstant rule - positive cases") {
 
         val path = Case.FunctionReturningConstantPositive.path()
 
@@ -33,7 +32,7 @@ class FunctionOnlyReturningConstantSpec : SubjectSpek<FunctionOnlyReturningConst
         }
     }
 
-    given("some functions which do not return constants") {
+    describe("FunctionOnlyReturningConstant rule - negative cases") {
 
         it("does not report functions which do not return constants") {
             val path = Case.FunctionReturningConstantNegative.path()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
@@ -4,14 +4,13 @@ import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class LoopWithTooManyJumpStatementsSpec : SubjectSpek<LoopWithTooManyJumpStatements>({
-    subject { LoopWithTooManyJumpStatements() }
+class LoopWithTooManyJumpStatementsSpec : Spek({
+    val subject by memoized { LoopWithTooManyJumpStatements() }
 
-    given("loops with multiple break or continue statements") {
+    describe("LoopWithTooManyJumpStatements rule") {
 
         val path = Case.LoopWithTooManyJumpStatementsPositive.path()
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -7,260 +7,261 @@ import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class MagicNumberSpec : Spek({
 
     val fileName = TEST_FILENAME
 
-    given("a float of 1") {
-        val ktFile = compileContentForTest("val myFloat = 1.0f")
+    describe("Magic Number rule") {
 
-        it("should not be reported by default") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).isEmpty()
+        context("a float of 1") {
+            val ktFile = compileContentForTest("val myFloat = 1.0f")
+
+            it("should not be reported by default") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should be reported when ignoredNumbers is empty") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
+                assertThat(findings).hasLocationStrings("'1.0f' at (1,15) in /$fileName")
+            }
         }
 
-        it("should be reported when ignoredNumbers is empty") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-            assertThat(findings).hasLocationStrings("'1.0f' at (1,15) in /$fileName")
-        }
-    }
+        context("a const float of 1") {
+            val ktFile = compileContentForTest("const val MY_FLOAT = 1.0f")
 
-    given("a const float of 1") {
-        val ktFile = compileContentForTest("const val MY_FLOAT = 1.0f")
+            it("should not be reported by default") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should not be reported by default") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-
-        it("should not be reported when ignoredNumbers is empty") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-    }
-
-    given("an integer of 1") {
-        val ktFile = compileContentForTest("val myInt = 1")
-
-        it("should not be reported by default") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).isEmpty()
+            it("should not be reported when ignoredNumbers is empty") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
         }
 
-        it("should be reported when ignoredNumbers is empty") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-            assertThat(findings).hasLocationStrings("'1' at (1,13) in /$fileName")
-        }
-    }
+        context("an integer of 1") {
+            val ktFile = compileContentForTest("val myInt = 1")
 
-    given("a const integer of 1") {
-        val ktFile = compileContentForTest("const val MY_INT = 1")
+            it("should not be reported by default") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should not be reported by default") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-
-        it("should not be reported when ignoredNumbers is empty") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-    }
-
-    given("a long of 1") {
-        val ktFile = compileContentForTest("val myLong = 1L")
-
-        it("should not be reported by default") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).isEmpty()
+            it("should be reported when ignoredNumbers is empty") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
+                assertThat(findings).hasLocationStrings("'1' at (1,13) in /$fileName")
+            }
         }
 
-        it("should be reported when ignoredNumbers is empty") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-            assertThat(findings).hasLocationStrings("'1L' at (1,14) in /$fileName")
-        }
-    }
+        context("a const integer of 1") {
+            val ktFile = compileContentForTest("const val MY_INT = 1")
 
-    given("a long of -1") {
-        val ktFile = compileContentForTest("val myLong = -1L")
+            it("should not be reported by default") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should not be reported by default") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-
-        it("should be reported when ignoredNumbers is empty") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-            assertThat(findings).hasLocationStrings("'1L' at (1,15) in /$fileName")
-        }
-    }
-
-    given("a long of -2") {
-        val ktFile = compileContentForTest("val myLong = -2L")
-
-        it("should be reported by default") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).hasLocationStrings("'2L' at (1,15) in /$fileName")
+            it("should not be reported when ignoredNumbers is empty") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
         }
 
-        it("should be ignored when ignoredNumbers contains it verbatim") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "-2L"))).lint(ktFile)
-            assertThat(findings).isEmpty()
+        context("a long of 1") {
+            val ktFile = compileContentForTest("val myLong = 1L")
+
+            it("should not be reported by default") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should be reported when ignoredNumbers is empty") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
+                assertThat(findings).hasLocationStrings("'1L' at (1,14) in /$fileName")
+            }
         }
 
-        it("should be ignored when ignoredNumbers contains it as floating point") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "-2f"))).lint(ktFile)
-            assertThat(findings).isEmpty()
+        context("a long of -1") {
+            val ktFile = compileContentForTest("val myLong = -1L")
+
+            it("should not be reported by default") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should be reported when ignoredNumbers is empty") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
+                assertThat(findings).hasLocationStrings("'1L' at (1,15) in /$fileName")
+            }
         }
 
-        it("should not be ignored when ignoredNumbers contains 2 but not -2") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "1,2,3,-1,0"))).lint(ktFile)
-            assertThat(findings).hasLocationStrings("'2L' at (1,15) in /$fileName")
-        }
-    }
+        context("a long of -2") {
+            val ktFile = compileContentForTest("val myLong = -2L")
 
-    given("a const long of 1") {
-        val ktFile = compileContentForTest("const val MY_LONG = 1L")
+            it("should be reported by default") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).hasLocationStrings("'2L' at (1,15) in /$fileName")
+            }
 
-        it("should not be reported by default") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
+            it("should be ignored when ignoredNumbers contains it verbatim") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "-2L"))).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should not be reported when ignoredNumbers is empty") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-    }
+            it("should be ignored when ignoredNumbers contains it as floating point") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "-2f"))).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
 
-    given("a double of 1") {
-        val ktFile = compileContentForTest("val myDouble = 1.0")
-
-        it("should not be reported by default") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).isEmpty()
+            it("should not be ignored when ignoredNumbers contains 2 but not -2") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "1,2,3,-1,0"))).lint(ktFile)
+                assertThat(findings).hasLocationStrings("'2L' at (1,15) in /$fileName")
+            }
         }
 
-        it("should be reported when ignoredNumbers is empty") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-            assertThat(findings).hasLocationStrings("'1.0' at (1,16) in /$fileName")
-        }
-    }
+        context("a const long of 1") {
+            val ktFile = compileContentForTest("const val MY_LONG = 1L")
 
-    given("a const double of 1") {
-        val ktFile = compileContentForTest("const val MY_DOUBLE = 1.0")
+            it("should not be reported by default") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should not be reported by default") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-
-        it("should not be reported when ignoredNumbers is empty") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-    }
-
-    given("a hex of 1") {
-        val ktFile = compileContentForTest("val myHex = 0x1")
-
-        it("should not be reported by default") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).isEmpty()
+            it("should not be reported when ignoredNumbers is empty") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
         }
 
-        it("should be reported when ignoredNumbers is empty") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-            assertThat(findings).hasLocationStrings("'0x1' at (1,13) in /$fileName")
-        }
-    }
+        context("a double of 1") {
+            val ktFile = compileContentForTest("val myDouble = 1.0")
 
-    given("a const hex of 1") {
-        val ktFile = compileContentForTest("const val MY_HEX = 0x1")
+            it("should not be reported by default") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should not be reported by default") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-
-        it("should not be reported when ignoredNumbers is empty") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-    }
-
-    given("an integer of 300") {
-        val ktFile = compileContentForTest("val myInt = 300")
-
-        it("should not be reported when ignoredNumbers contains 300") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "300"))).lint(ktFile)
-            assertThat(findings).isEmpty()
+            it("should be reported when ignoredNumbers is empty") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
+                assertThat(findings).hasLocationStrings("'1.0' at (1,16) in /$fileName")
+            }
         }
 
-        it("should not be reported when ignoredNumbers contains a floating point 300") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "300.0"))).lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-    }
+        context("a const double of 1") {
+            val ktFile = compileContentForTest("const val MY_DOUBLE = 1.0")
 
-    given("a binary literal") {
-        val ktFile = compileContentForTest("val myBinary = 0b01001")
+            it("should not be reported by default") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should not be reported") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).hasSize(1)
-        }
-
-        it("should not be reported when ignoredNumbers contains a binary literal 0b01001") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "0b01001"))).lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-    }
-
-    given("an integer literal with underscores") {
-        val ktFile = compileContentForTest("val myInt = 100_000")
-
-        it("should be reported by default") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).hasLocationStrings("'100_000' at (1,13) in /$fileName")
+            it("should not be reported when ignoredNumbers is empty") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
         }
 
-        it("should not be reported when ignored verbatim") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "100_000"))).lint(ktFile)
-            assertThat(findings).isEmpty()
+        context("a hex of 1") {
+            val ktFile = compileContentForTest("val myHex = 0x1")
+
+            it("should not be reported by default") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should be reported when ignoredNumbers is empty") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
+                assertThat(findings).hasLocationStrings("'0x1' at (1,13) in /$fileName")
+            }
         }
 
-        it("should not be reported when ignored with different underscores") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "10_00_00"))).lint(ktFile)
-            assertThat(findings).isEmpty()
+        context("a const hex of 1") {
+            val ktFile = compileContentForTest("const val MY_HEX = 0x1")
+
+            it("should not be reported by default") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should not be reported when ignoredNumbers is empty") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
         }
 
-        it("should not be reported when ignored without underscores") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "100000"))).lint(ktFile)
-            assertThat(findings).isEmpty()
+        context("an integer of 300") {
+            val ktFile = compileContentForTest("val myInt = 300")
+
+            it("should not be reported when ignoredNumbers contains 300") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "300"))).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should not be reported when ignoredNumbers contains a floating point 300") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "300.0"))).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
         }
-    }
 
-    given("an if statement with magic numbers") {
-        val ktFile = compileContentForTest("val myInt = if (5 < 6) 7 else 8")
+        context("a binary literal") {
+            val ktFile = compileContentForTest("val myBinary = 0b01001")
 
-        it("should be reported") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).hasLocationStrings(
-                    "'5' at (1,17) in /$fileName",
-                    "'6' at (1,21) in /$fileName",
-                    "'7' at (1,24) in /$fileName",
-                    "'8' at (1,31) in /$fileName"
-            )
+            it("should not be reported") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).hasSize(1)
+            }
+
+            it("should not be reported when ignoredNumbers contains a binary literal 0b01001") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "0b01001"))).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
         }
-    }
 
-    given("a when statement with magic numbers") {
-        val ktFile = compileContentForTest("""
+        context("an integer literal with underscores") {
+            val ktFile = compileContentForTest("val myInt = 100_000")
+
+            it("should be reported by default") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).hasLocationStrings("'100_000' at (1,13) in /$fileName")
+            }
+
+            it("should not be reported when ignored verbatim") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "100_000"))).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should not be reported when ignored with different underscores") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "10_00_00"))).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should not be reported when ignored without underscores") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "100000"))).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+        }
+
+        context("an if statement with magic numbers") {
+            val ktFile = compileContentForTest("val myInt = if (5 < 6) 7 else 8")
+
+            it("should be reported") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).hasLocationStrings(
+                        "'5' at (1,17) in /$fileName",
+                        "'6' at (1,21) in /$fileName",
+                        "'7' at (1,24) in /$fileName",
+                        "'8' at (1,31) in /$fileName"
+                )
+            }
+        }
+
+        context("a when statement with magic numbers") {
+            val ktFile = compileContentForTest("""
 			fun test(x: Int) {
 				when (x) {
 					5 -> return 5
@@ -270,95 +271,95 @@ class MagicNumberSpec : Spek({
 			}
 		""".trimMargin())
 
-        it("should be reported") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).hasLocationStrings(
-                    "'5' at (3,6) in /$fileName",
-                    "'5' at (3,18) in /$fileName",
-                    "'4' at (4,6) in /$fileName",
-                    "'4' at (4,18) in /$fileName",
-                    "'3' at (5,6) in /$fileName",
-                    "'3' at (5,18) in /$fileName"
-            )
+            it("should be reported") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).hasLocationStrings(
+                        "'5' at (3,6) in /$fileName",
+                        "'5' at (3,18) in /$fileName",
+                        "'4' at (4,6) in /$fileName",
+                        "'4' at (4,18) in /$fileName",
+                        "'3' at (5,6) in /$fileName",
+                        "'3' at (5,18) in /$fileName"
+                )
+            }
         }
-    }
 
-    given("a method containing variables with magic numbers") {
-        val ktFile = compileContentForTest("""
+        context("a method containing variables with magic numbers") {
+            val ktFile = compileContentForTest("""
 			fun test(x: Int) {
 				val i = 5
 			}
 		""".trimMargin())
 
-        it("should be reported") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).hasLocationStrings("'5' at (2,13) in /$fileName")
+            it("should be reported") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).hasLocationStrings("'5' at (2,13) in /$fileName")
+            }
         }
-    }
 
-    given("a boolean value") {
-        val ktFile = compileContentForTest("""
+        context("a boolean value") {
+            val ktFile = compileContentForTest("""
 			fun test() : Boolean {
 				return true;
 			}
 		""".trimMargin())
 
-        it("should not be reported") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-    }
-
-    given("a non-numeric constant expression") {
-        val ktFile = compileContentForTest("val surprise = true")
-
-        it("should not be reported") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-    }
-
-    given("a float of 0.5") {
-        val ktFile = compileContentForTest("val test = 0.5f")
-
-        it("should be reported by default") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).hasLocationStrings("'0.5f' at (1,12) in /$fileName")
-        }
-
-        it("should not be reported when ignoredNumbers contains it") {
-            val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ".5"))).lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-    }
-
-    given("a magic number number in a constructor call") {
-
-        it("should report") {
-            val code = "val file = File(42)"
-            val findings = MagicNumber().lint(code)
-            assertThat(findings).hasSize(1)
-        }
-    }
-
-    given("an invalid ignoredNumber") {
-
-        it("throws a NumberFormatException") {
-            assertThatExceptionOfType(NumberFormatException::class.java).isThrownBy {
-                MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "banana")))
+            it("should not be reported") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).isEmpty()
             }
         }
-    }
 
-    given("an empty ignoredNumber") {
+        context("a non-numeric constant expression") {
+            val ktFile = compileContentForTest("val surprise = true")
 
-        it("doesn't throw an exception") {
-            MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "")))
+            it("should not be reported") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
         }
-    }
 
-    given("ignoring properties") {
-        val ktFile = compileContentForTest("""
+        context("a float of 0.5") {
+            val ktFile = compileContentForTest("val test = 0.5f")
+
+            it("should be reported by default") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).hasLocationStrings("'0.5f' at (1,12) in /$fileName")
+            }
+
+            it("should not be reported when ignoredNumbers contains it") {
+                val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ".5"))).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+        }
+
+        context("a magic number number in a constructor call") {
+
+            it("should report") {
+                val code = "val file = File(42)"
+                val findings = MagicNumber().lint(code)
+                assertThat(findings).hasSize(1)
+            }
+        }
+
+        context("an invalid ignoredNumber") {
+
+            it("throws a NumberFormatException") {
+                assertThatExceptionOfType(NumberFormatException::class.java).isThrownBy {
+                    MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "banana")))
+                }
+            }
+        }
+
+        context("an empty ignoredNumber") {
+
+            it("doesn't throw an exception") {
+                MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "")))
+            }
+        }
+
+        context("ignoring properties") {
+            val ktFile = compileContentForTest("""
 			@Magic(number = 69)
 			class A {
 				val boringNumber = 42
@@ -375,46 +376,46 @@ class MagicNumberSpec : Spek({
 			}
 		""".trimMargin())
 
-        it("should report all without ignore flags") {
-            val config = TestConfig(
-                    mapOf(
-                            MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-                            MagicNumber.IGNORE_ANNOTATION to "false",
-                            MagicNumber.IGNORE_HASH_CODE to "false",
-                            MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-                            MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                    )
-            )
+            it("should report all without ignore flags") {
+                val config = TestConfig(
+                        mapOf(
+                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+                                MagicNumber.IGNORE_ANNOTATION to "false",
+                                MagicNumber.IGNORE_HASH_CODE to "false",
+                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                        )
+                )
 
-            val findings = MagicNumber(config).lint(ktFile)
-            assertThat(findings).hasLocationStrings(
-                    "'69' at (1,20) in /$fileName",
-                    "'42' at (3,24) in /$fileName",
-                    "'93871' at (4,33) in /$fileName",
-                    "'7328672' at (7,23) in /$fileName",
-                    "'43' at (11,35) in /$fileName",
-                    "'93872' at (12,40) in /$fileName"
-            )
+                val findings = MagicNumber(config).lint(ktFile)
+                assertThat(findings).hasLocationStrings(
+                        "'69' at (1,20) in /$fileName",
+                        "'42' at (3,24) in /$fileName",
+                        "'93871' at (4,33) in /$fileName",
+                        "'7328672' at (7,23) in /$fileName",
+                        "'43' at (11,35) in /$fileName",
+                        "'93872' at (12,40) in /$fileName"
+                )
+            }
+
+            it("should not report any issues with all ignore flags") {
+                val config = TestConfig(
+                        mapOf(
+                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
+                                MagicNumber.IGNORE_ANNOTATION to "true",
+                                MagicNumber.IGNORE_HASH_CODE to "true",
+                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
+                        )
+                )
+
+                val findings = MagicNumber(config).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
         }
 
-        it("should not report any issues with all ignore flags") {
-            val config = TestConfig(
-                    mapOf(
-                            MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-                            MagicNumber.IGNORE_ANNOTATION to "true",
-                            MagicNumber.IGNORE_HASH_CODE to "true",
-                            MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-                            MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
-                    )
-            )
-
-            val findings = MagicNumber(config).lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-    }
-
-    given("magic numbers in companion object property assignments") {
-        val ktFile = compileContentForTest("""
+        context("magic numbers in companion object property assignments") {
+            val ktFile = compileContentForTest("""
 			class A {
 
 				companion object {
@@ -424,102 +425,102 @@ class MagicNumberSpec : Spek({
 			}
 		""".trimMargin())
 
-        it("should not report any issues by default") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).isEmpty()
+            it("should not report any issues by default") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should not report any issues when ignoring properties but not constants nor companion objects") {
+                val config = TestConfig(
+                        mapOf(
+                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
+                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                        )
+                )
+
+                val findings = MagicNumber(config).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should not report any issues when ignoring properties and constants but not companion objects") {
+                val config = TestConfig(
+                        mapOf(
+                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
+                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                        )
+                )
+
+                val findings = MagicNumber(config).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should not report any issues when ignoring properties, constants and companion objects") {
+                val config = TestConfig(
+                        mapOf(
+                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
+                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
+                        )
+                )
+
+                val findings = MagicNumber(config).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should not report any issues when ignoring companion objects but not properties and constants") {
+                val config = TestConfig(
+                        mapOf(
+                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
+                        )
+                )
+
+                val findings = MagicNumber(config).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should report property when ignoring constants but not properties and companion objects") {
+                val config = TestConfig(
+                        mapOf(
+                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                        )
+                )
+
+                val findings = MagicNumber(config).lint(ktFile)
+                assertThat(findings).hasLocationStrings("'43' at (4,35) in /$fileName")
+            }
+
+            it("should report property and constant when not ignoring properties, constants nor companion objects") {
+                val config = TestConfig(
+                        mapOf(
+                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                        )
+                )
+
+                val findings = MagicNumber(config).lint(ktFile)
+                assertThat(findings).hasLocationStrings("'43' at (4,35) in /$fileName", "'93872' at (5,40) in /$fileName")
+            }
         }
 
-        it("should not report any issues when ignoring properties but not constants nor companion objects") {
-            val config = TestConfig(
-                    mapOf(
-                            MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-                            MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-                            MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                    )
-            )
+        context("a property without number") {
+            val ktFile = compileContentForTest("private var pair: Pair<String, Int>? = null")
 
-            val findings = MagicNumber(config).lint(ktFile)
-            assertThat(findings).isEmpty()
+            it("should not lead to a crash #276") {
+                val findings = MagicNumber().lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
         }
 
-        it("should not report any issues when ignoring properties and constants but not companion objects") {
-            val config = TestConfig(
-                    mapOf(
-                            MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-                            MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-                            MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                    )
-            )
-
-            val findings = MagicNumber(config).lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-
-        it("should not report any issues when ignoring properties, constants and companion objects") {
-            val config = TestConfig(
-                    mapOf(
-                            MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-                            MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-                            MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
-                    )
-            )
-
-            val findings = MagicNumber(config).lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-
-        it("should not report any issues when ignoring companion objects but not properties and constants") {
-            val config = TestConfig(
-                    mapOf(
-                            MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-                            MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-                            MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
-                    )
-            )
-
-            val findings = MagicNumber(config).lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-
-        it("should report property when ignoring constants but not properties and companion objects") {
-            val config = TestConfig(
-                    mapOf(
-                            MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-                            MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-                            MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                    )
-            )
-
-            val findings = MagicNumber(config).lint(ktFile)
-            assertThat(findings).hasLocationStrings("'43' at (4,35) in /$fileName")
-        }
-
-        it("should report property and constant when not ignoring properties, constants nor companion objects") {
-            val config = TestConfig(
-                    mapOf(
-                            MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-                            MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-                            MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                    )
-            )
-
-            val findings = MagicNumber(config).lint(ktFile)
-            assertThat(findings).hasLocationStrings("'43' at (4,35) in /$fileName", "'93872' at (5,40) in /$fileName")
-        }
-    }
-
-    given("a property without number") {
-        val ktFile = compileContentForTest("private var pair: Pair<String, Int>? = null")
-
-        it("should not lead to a crash #276") {
-            val findings = MagicNumber().lint(ktFile)
-            assertThat(findings).isEmpty()
-        }
-    }
-
-    given("ignoring named arguments") {
-        given("in constructor invocation") {
-            fun code(numberString: String) = compileContentForTest("""
+        context("ignoring named arguments") {
+            context("in constructor invocation") {
+                fun code(numberString: String) = compileContentForTest("""
 				data class Model(
 						val someVal: Int,
 						val other: String = "default"
@@ -528,50 +529,50 @@ class MagicNumberSpec : Spek({
 				var model = Model(someVal = $numberString)
 			""")
 
-            it("should not ignore int by default") {
-                assertThat(MagicNumber().lint(code("53"))).hasSize(1)
-            }
+                it("should not ignore int by default") {
+                    assertThat(MagicNumber().lint(code("53"))).hasSize(1)
+                }
 
-            it("should not ignore float by default") {
-                assertThat(MagicNumber().lint(code("53f"))).hasSize(1)
-            }
+                it("should not ignore float by default") {
+                    assertThat(MagicNumber().lint(code("53f"))).hasSize(1)
+                }
 
-            it("should not ignore binary by default") {
-                assertThat(MagicNumber().lint(code("0b01001"))).hasSize(1)
-            }
+                it("should not ignore binary by default") {
+                    assertThat(MagicNumber().lint(code("0b01001"))).hasSize(1)
+                }
 
-            it("should ignore integer with underscores") {
-                assertThat(MagicNumber().lint(code("101_000"))).hasSize(1)
-            }
+                it("should ignore integer with underscores") {
+                    assertThat(MagicNumber().lint(code("101_000"))).hasSize(1)
+                }
 
-            it("should ignore numbers when 'ignoreNamedArgument' is set to true") {
-                val rule = MagicNumber(TestConfig(mapOf("ignoreNamedArgument" to "true")))
-                assertThat(rule.lint(code("53"))).isEmpty()
-            }
+                it("should ignore numbers when 'ignoreNamedArgument' is set to true") {
+                    val rule = MagicNumber(TestConfig(mapOf("ignoreNamedArgument" to "true")))
+                    assertThat(rule.lint(code("53"))).isEmpty()
+                }
 
-            it("should ignore named arguments in inheritance - #992") {
-                val code = """
+                it("should ignore named arguments in inheritance - #992") {
+                    val code = """
 					abstract class A(n: Int)
 
 					object B : A(n = 5)
 				""".trimIndent()
-                val rule = MagicNumber(TestConfig(mapOf("ignoreNamedArgument" to "true")))
-                assertThat(rule.lint(code)).isEmpty()
+                    val rule = MagicNumber(TestConfig(mapOf("ignoreNamedArgument" to "true")))
+                    assertThat(rule.lint(code)).isEmpty()
+                }
+
+                it("should ignore named arguments in parameter annotations - #1115") {
+                    val code =
+                            "@JvmStatic fun setCustomDimension(@IntRange(from = 0, to = 19) index: Int, value: String?) {}"
+                    MagicNumber(TestConfig(mapOf("ignoreNamedArgument" to "true")))
+                            .lint(code)
+                            .assert()
+                            .isEmpty()
+                }
             }
 
-            it("should ignore named arguments in parameter annotations - #1115") {
-                val code =
-                        "@JvmStatic fun setCustomDimension(@IntRange(from = 0, to = 19) index: Int, value: String?) {}"
-                MagicNumber(TestConfig(mapOf("ignoreNamedArgument" to "true")))
-                        .lint(code)
-                        .assert()
-                        .isEmpty()
-            }
-        }
+            context("Issue#659 - false-negative reporting on unnamed argument when ignore is true") {
 
-        given("Issue#659 - false-negative reporting on unnamed argument when ignore is true") {
-
-            fun code(numberString: String) = compileContentForTest("""
+                fun code(numberString: String) = compileContentForTest("""
 				data class Model(
 						val someVal: Int,
 						val other: String = "default"
@@ -580,112 +581,113 @@ class MagicNumberSpec : Spek({
 				var model = Model($numberString)
 			""")
 
-            it("should detect the argument") {
-                val rule = MagicNumber(TestConfig(mapOf("ignoreNamedArgument" to "true")))
-                assertThat(rule.lint(code("53"))).hasSize(1)
+                it("should detect the argument") {
+                    val rule = MagicNumber(TestConfig(mapOf("ignoreNamedArgument" to "true")))
+                    assertThat(rule.lint(code("53"))).hasSize(1)
+                }
             }
-        }
 
-        given("in function invocation") {
-            fun code(number: Number) = compileContentForTest("""
+            context("in function invocation") {
+                fun code(number: Number) = compileContentForTest("""
 				fun tested(someVal: Int, other: String = "default")
 
 				tested(someVal = $number)
 			""")
-            it("should ignore int by default") {
-                assertThat(MagicNumber().lint(code(53))).isEmpty()
-            }
+                it("should ignore int by default") {
+                    assertThat(MagicNumber().lint(code(53))).isEmpty()
+                }
 
-            it("should ignore float by default") {
-                assertThat(MagicNumber().lint(code(53f))).isEmpty()
-            }
+                it("should ignore float by default") {
+                    assertThat(MagicNumber().lint(code(53f))).isEmpty()
+                }
 
-            it("should ignore binary by default") {
-                assertThat(MagicNumber().lint(code(0b01001))).isEmpty()
-            }
+                it("should ignore binary by default") {
+                    assertThat(MagicNumber().lint(code(0b01001))).isEmpty()
+                }
 
-            it("should ignore integer with underscores") {
-                assertThat(MagicNumber().lint(code(101_000))).isEmpty()
+                it("should ignore integer with underscores") {
+                    assertThat(MagicNumber().lint(code(101_000))).isEmpty()
+                }
             }
-        }
-        given("in enum constructor argument") {
-            val ktFile = compileContentForTest("""
+            context("in enum constructor argument") {
+                val ktFile = compileContentForTest("""
 				enum class Bag(id: Int) {
 					SMALL(1),
 					EXTRA_LARGE(5)
 				}
 			""")
-            it("should be reported by default") {
-                assertThat(MagicNumber().lint(ktFile)).hasSize(1)
+                it("should be reported by default") {
+                    assertThat(MagicNumber().lint(ktFile)).hasSize(1)
+                }
+                it("numbers when 'ignoreEnums' is set to true") {
+                    val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_ENUMS to "true")))
+                    assertThat(rule.lint(ktFile)).isEmpty()
+                }
             }
-            it("numbers when 'ignoreEnums' is set to true") {
-                val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_ENUMS to "true")))
-                assertThat(rule.lint(ktFile)).isEmpty()
-            }
-        }
-        given("in enum constructor as named argument") {
-            val ktFile = compileContentForTest("""
+            context("in enum constructor as named argument") {
+                val ktFile = compileContentForTest("""
 				enum class Bag(id: Int) {
 					SMALL(id = 1),
 					EXTRA_LARGE(id = 5)
 				}
 			""")
-            it("should be reported by default") {
-                assertThat(MagicNumber().lint(ktFile)).hasSize(1)
-            }
-            it("numbers when 'ignoreEnums' is set to true") {
-                val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_ENUMS to "true")))
-                assertThat(rule.lint(ktFile)).isEmpty()
+                it("should be reported by default") {
+                    assertThat(MagicNumber().lint(ktFile)).hasSize(1)
+                }
+                it("numbers when 'ignoreEnums' is set to true") {
+                    val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_ENUMS to "true")))
+                    assertThat(rule.lint(ktFile)).isEmpty()
+                }
             }
         }
-    }
 
-    given("functions with and without braces which return values") {
+        context("functions with and without braces which return values") {
 
-        it("does not report functions that always returns a constant value") {
-            val code = """
+            it("does not report functions that always returns a constant value") {
+                val code = """
 				fun x() = 9
 				fun y() { return 9 }"""
-            assertThat(MagicNumber().lint(code)).isEmpty()
-        }
+                assertThat(MagicNumber().lint(code)).isEmpty()
+            }
 
-        it("reports functions that does not return a constant value") {
-            val code = """
+            it("reports functions that does not return a constant value") {
+                val code = """
 				fun x() = 9 + 1
 				fun y(): Int { return 9 + 1 }"""
-            assertThat(MagicNumber().lint(code)).hasSize(2)
-        }
-    }
-
-    given("in-class declaration with default parameters") {
-
-        it("reports no finding") {
-            val code = compileContentForTest("class SomeClassWithDefault(val defaultValue: Int = 10)")
-            assertThat(MagicNumber().lint(code)).isEmpty()
+                assertThat(MagicNumber().lint(code)).hasSize(2)
+            }
         }
 
-        it("reports no finding for an explicit declaration") {
-            val code = compileContentForTest("class SomeClassWithDefault constructor(val defaultValue: Int = 10)")
-            assertThat(MagicNumber().lint(code)).isEmpty()
+        context("in-class declaration with default parameters") {
+
+            it("reports no finding") {
+                val code = compileContentForTest("class SomeClassWithDefault(val defaultValue: Int = 10)")
+                assertThat(MagicNumber().lint(code)).isEmpty()
+            }
+
+            it("reports no finding for an explicit declaration") {
+                val code = compileContentForTest("class SomeClassWithDefault constructor(val defaultValue: Int = 10)")
+                assertThat(MagicNumber().lint(code)).isEmpty()
+            }
         }
-    }
 
-    given("default parameters in secondary constructor") {
+        context("default parameters in secondary constructor") {
 
-        it("reports no finding") {
-            val code = compileContentForTest("""
+            it("reports no finding") {
+                val code = compileContentForTest("""
 				class SomeClassWithDefault {
 					constructor(val defaultValue: Int = 10) { }
 				}""")
-            assertThat(MagicNumber().lint(code)).isEmpty()
+                assertThat(MagicNumber().lint(code)).isEmpty()
+            }
         }
-    }
 
-    given("default parameters in function") {
+        context("default parameters in function") {
 
-        it("reports no finding") {
-            val code = compileContentForTest("fun f(p: Int = 100)")
-            assertThat(MagicNumber().lint(code)).isEmpty()
+            it("reports no finding") {
+                val code = compileContentForTest("fun f(p: Int = 100)")
+                assertThat(MagicNumber().lint(code)).isEmpty()
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -5,47 +5,48 @@ import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class MaxLineLengthSpec : Spek({
 
-    given("a kt file with some long lines") {
-        val file = compileForTest(Case.MaxLineLength.path())
-        val lines = file.text.splitToSequence("\n")
-        val fileContent = KtFileContent(file, lines)
+    describe("MaxLineLength rule") {
 
-        it("should report no errors when maxLineLength is set to 200") {
-            val rule = MaxLineLength(TestConfig(mapOf("maxLineLength" to "200")))
+        context("a kt file with some long lines") {
+            val file = compileForTest(Case.MaxLineLength.path())
+            val lines = file.text.splitToSequence("\n")
+            val fileContent = KtFileContent(file, lines)
 
-            rule.visit(fileContent)
-            assertThat(rule.findings).isEmpty()
+            it("should report no errors when maxLineLength is set to 200") {
+                val rule = MaxLineLength(TestConfig(mapOf("maxLineLength" to "200")))
+
+                rule.visit(fileContent)
+                assertThat(rule.findings).isEmpty()
+            }
+
+            it("should report all errors with default maxLineLength") {
+                val rule = MaxLineLength()
+
+                rule.visit(fileContent)
+                assertThat(rule.findings).hasSize(3)
+            }
         }
 
-        it("should report all errors with default maxLineLength") {
-            val rule = MaxLineLength()
+        context("a kt file with long but suppressed lines") {
+            val file = compileForTest(Case.MaxLineLengthSuppressed.path())
+            val lines = file.text.splitToSequence("\n")
+            val fileContent = KtFileContent(file, lines)
 
-            rule.visit(fileContent)
-            assertThat(rule.findings).hasSize(3)
+            it("should not report as lines are suppressed") {
+                val rule = MaxLineLength()
+
+                rule.visit(fileContent)
+                assertThat(rule.findings).isEmpty()
+            }
         }
-    }
 
-    given("a kt file with long but suppressed lines") {
-        val file = compileForTest(Case.MaxLineLengthSuppressed.path())
-        val lines = file.text.splitToSequence("\n")
-        val fileContent = KtFileContent(file, lines)
-
-        it("should not report as lines are suppressed") {
-            val rule = MaxLineLength()
-
-            rule.visit(fileContent)
-            assertThat(rule.findings).isEmpty()
-        }
-    }
-
-    given("a kt file with a long package name and long import statements") {
-        val code = """
+        context("a kt file with a long package name and long import statements") {
+            val code = """
 			package anIncrediblyLongAndComplexPackageNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
 
 			import anIncrediblyLongAndComplexImportNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
@@ -54,81 +55,81 @@ class MaxLineLengthSpec : Spek({
 			}
 		"""
 
-        val file = compileContentForTest(code)
-        val lines = file.text.splitToSequence("\n")
-        val fileContent = KtFileContent(file, lines)
+            val file = compileContentForTest(code)
+            val lines = file.text.splitToSequence("\n")
+            val fileContent = KtFileContent(file, lines)
 
-        it("should not report the package statement and import statements by default") {
-            val rule = MaxLineLength(TestConfig(mapOf(
-                    "maxLineLength" to "60"
-            )))
+            it("should not report the package statement and import statements by default") {
+                val rule = MaxLineLength(TestConfig(mapOf(
+                        "maxLineLength" to "60"
+                )))
 
-            rule.visit(fileContent)
-            assertThat(rule.findings).isEmpty()
+                rule.visit(fileContent)
+                assertThat(rule.findings).isEmpty()
+            }
+
+            it("should report the package statement and import statements if they're enabled") {
+                val rule = MaxLineLength(TestConfig(mapOf(
+                        "maxLineLength" to "60",
+                        "excludePackageStatements" to "false",
+                        "excludeImportStatements" to "false"
+                )))
+
+                rule.visit(fileContent)
+                assertThat(rule.findings).hasSize(2)
+            }
+
+            it("should not report anything if both package and import statements are disabled") {
+                val rule = MaxLineLength(TestConfig(mapOf(
+                        "maxLineLength" to "60",
+                        "excludePackageStatements" to "true",
+                        "excludeImportStatements" to "true"
+                )))
+
+                rule.visit(fileContent)
+                assertThat(rule.findings).isEmpty()
+            }
         }
 
-        it("should report the package statement and import statements if they're enabled") {
-            val rule = MaxLineLength(TestConfig(mapOf(
-                    "maxLineLength" to "60",
-                    "excludePackageStatements" to "false",
-                    "excludeImportStatements" to "false"
-            )))
+        context("a kt file with a long package name, long import statements, a long line and long comments") {
+            val file = compileForTest(Case.MaxLineLengthWithLongComments.path())
+            val lines = file.text.splitToSequence("\n")
+            val fileContent = KtFileContent(file, lines)
 
-            rule.visit(fileContent)
-            assertThat(rule.findings).hasSize(2)
+            it("should report the package statement, import statements, line and comments by default") {
+                val rule = MaxLineLength(TestConfig(mapOf(
+                        "maxLineLength" to "60"
+                )))
+
+                rule.visit(fileContent)
+                assertThat(rule.findings).hasSize(8)
+            }
+
+            it("should report the package statement, import statements, line and comments if they're enabled") {
+                val rule = MaxLineLength(TestConfig(mapOf(
+                        "maxLineLength" to "60",
+                        "excludePackageStatements" to "false",
+                        "excludeImportStatements" to "false",
+                        "excludeCommentStatements" to "false"
+                )))
+
+                rule.visit(fileContent)
+                assertThat(rule.findings).hasSize(8)
+            }
+
+            it("should not report comments if they're disabled") {
+                val rule = MaxLineLength(TestConfig(mapOf(
+                        "maxLineLength" to "60",
+                        "excludeCommentStatements" to "true"
+                )))
+
+                rule.visit(fileContent)
+                assertThat(rule.findings).hasSize(5)
+            }
         }
 
-        it("should not report anything if both package and import statements are disabled") {
-            val rule = MaxLineLength(TestConfig(mapOf(
-                    "maxLineLength" to "60",
-                    "excludePackageStatements" to "true",
-                    "excludeImportStatements" to "true"
-            )))
-
-            rule.visit(fileContent)
-            assertThat(rule.findings).isEmpty()
-        }
-    }
-
-    given("a kt file with a long package name, long import statements, a long line and long comments") {
-        val file = compileForTest(Case.MaxLineLengthWithLongComments.path())
-        val lines = file.text.splitToSequence("\n")
-        val fileContent = KtFileContent(file, lines)
-
-        it("should report the package statement, import statements, line and comments by default") {
-            val rule = MaxLineLength(TestConfig(mapOf(
-                    "maxLineLength" to "60"
-            )))
-
-            rule.visit(fileContent)
-            assertThat(rule.findings).hasSize(8)
-        }
-
-        it("should report the package statement, import statements, line and comments if they're enabled") {
-            val rule = MaxLineLength(TestConfig(mapOf(
-                    "maxLineLength" to "60",
-                    "excludePackageStatements" to "false",
-                    "excludeImportStatements" to "false",
-                    "excludeCommentStatements" to "false"
-            )))
-
-            rule.visit(fileContent)
-            assertThat(rule.findings).hasSize(8)
-        }
-
-        it("should not report comments if they're disabled") {
-            val rule = MaxLineLength(TestConfig(mapOf(
-                    "maxLineLength" to "60",
-                    "excludeCommentStatements" to "true"
-            )))
-
-            rule.visit(fileContent)
-            assertThat(rule.findings).hasSize(5)
-        }
-    }
-
-    given("a kt file with a long package name, long import statements and a long line") {
-        val code = """
+        context("a kt file with a long package name, long import statements and a long line") {
+            val code = """
 			package anIncrediblyLongAndComplexPackageNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
 
 			import anIncrediblyLongAndComplexImportNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
@@ -138,53 +139,54 @@ class MaxLineLengthSpec : Spek({
 			}
 		""".trim()
 
-        val file = compileContentForTest(code)
-        val lines = file.text.splitToSequence("\n")
-        val fileContent = KtFileContent(file, lines)
+            val file = compileContentForTest(code)
+            val lines = file.text.splitToSequence("\n")
+            val fileContent = KtFileContent(file, lines)
 
-        it("should only the function line by default") {
-            val rule = MaxLineLength(TestConfig(mapOf(
-                    "maxLineLength" to "60"
-            )))
+            it("should only the function line by default") {
+                val rule = MaxLineLength(TestConfig(mapOf(
+                        "maxLineLength" to "60"
+                )))
 
-            rule.visit(fileContent)
-            assertThat(rule.findings).hasSize(1)
-        }
+                rule.visit(fileContent)
+                assertThat(rule.findings).hasSize(1)
+            }
 
-        it("should report the package statement, import statements and line if they're not excluded") {
-            val rule = MaxLineLength(TestConfig(mapOf(
-                    "maxLineLength" to "60",
-                    "excludePackageStatements" to "false",
-                    "excludeImportStatements" to "false"
-            )))
+            it("should report the package statement, import statements and line if they're not excluded") {
+                val rule = MaxLineLength(TestConfig(mapOf(
+                        "maxLineLength" to "60",
+                        "excludePackageStatements" to "false",
+                        "excludeImportStatements" to "false"
+                )))
 
-            rule.visit(fileContent)
-            assertThat(rule.findings).hasSize(3)
-        }
+                rule.visit(fileContent)
+                assertThat(rule.findings).hasSize(3)
+            }
 
-        it("should report only method if both package and import statements are disabled") {
-            val rule = MaxLineLength(TestConfig(mapOf(
-                    "maxLineLength" to "60",
-                    "excludePackageStatements" to "true",
-                    "excludeImportStatements" to "true"
-            )))
+            it("should report only method if both package and import statements are disabled") {
+                val rule = MaxLineLength(TestConfig(mapOf(
+                        "maxLineLength" to "60",
+                        "excludePackageStatements" to "true",
+                        "excludeImportStatements" to "true"
+                )))
 
-            rule.visit(fileContent)
-            assertThat(rule.findings).hasSize(1)
-        }
+                rule.visit(fileContent)
+                assertThat(rule.findings).hasSize(1)
+            }
 
-        it("should report correct line and column for function with excessive length") {
-            val rule = MaxLineLength(TestConfig(mapOf(
-                    "maxLineLength" to "60",
-                    "excludePackageStatements" to "true",
-                    "excludeImportStatements" to "true"
-            )))
+            it("should report correct line and column for function with excessive length") {
+                val rule = MaxLineLength(TestConfig(mapOf(
+                        "maxLineLength" to "60",
+                        "excludePackageStatements" to "true",
+                        "excludeImportStatements" to "true"
+                )))
 
-            rule.visit(fileContent)
-            assertThat(rule.findings).hasSize(1)
-            val findingSource = rule.findings[0].location.source
-            assertThat(findingSource.line).isEqualTo(6)
-            assertThat(findingSource.column).isEqualTo(5)
+                rule.visit(fileContent)
+                assertThat(rule.findings).hasSize(1)
+                val findingSource = rule.findings[0].location.source
+                assertThat(findingSource.line).isEqualTo(6)
+                assertThat(findingSource.column).isEqualTo(5)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
@@ -3,45 +3,46 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class MayBeConstSpec : SubjectSpek<MayBeConst>({
+class MayBeConstSpec : Spek({
 
-    subject { MayBeConst() }
+    val subject by memoized { MayBeConst() }
 
-    given("some valid constants") {
-        it("is a valid constant") {
-            val code = """const val X = 42"""
-            subject.lint(code)
-            assertThat(subject.findings).isEmpty()
-        }
+    describe("MayBeConst rule") {
 
-        it("is const vals in object") {
-            val code = """
+        context("some valid constants") {
+            it("is a valid constant") {
+                val code = """const val X = 42"""
+                subject.lint(code)
+                assertThat(subject.findings).isEmpty()
+            }
+
+            it("is const vals in object") {
+                val code = """
 				object Test {
 					const val TEST = "Test"
 				}
 				"""
-            subject.lint(code)
-            assertThat(subject.findings).isEmpty()
-        }
+                subject.lint(code)
+                assertThat(subject.findings).isEmpty()
+            }
 
-        it("isconst vals in companion objects") {
-            val code = """
+            it("isconst vals in companion objects") {
+                val code = """
 				class Test {
 					companion object {
 						const val B = 1
 					}
 				}
 				"""
-            subject.lint(code)
-            assertThat(subject.findings).isEmpty()
-        }
+                subject.lint(code)
+                assertThat(subject.findings).isEmpty()
+            }
 
-        it("does not report const vals that use other const vals") {
-            val code = """
+            it("does not report const vals that use other const vals") {
+                val code = """
 				const val a = 0
 
 				class Test {
@@ -51,73 +52,73 @@ class MayBeConstSpec : SubjectSpek<MayBeConst>({
 					}
 				}
 				"""
-            subject.lint(code)
-            assertThat(subject.findings).isEmpty()
-        }
+                subject.lint(code)
+                assertThat(subject.findings).isEmpty()
+            }
 
-        it("does not report none const val candidates") {
-            val code = """
+            it("does not report none const val candidates") {
+                val code = """
 				const val a = 0
 				val p = Pair(a, a + a)
 				val p2 = emptyList<Int>().plus(a)
 				"""
-            subject.lint(code)
-            assertThat(subject.findings).isEmpty()
+                subject.lint(code)
+                assertThat(subject.findings).isEmpty()
+            }
         }
-    }
 
-    given("some vals that could be constants") {
-        it("is a simple val") {
-            val code = """
+        context("some vals that could be constants") {
+            it("is a simple val") {
+                val code = """
 				val x = 1
 				"""
-            subject.lint(code)
-            assertThat(subject.findings).hasSize(1)
-        }
+                subject.lint(code)
+                assertThat(subject.findings).hasSize(1)
+            }
 
-        it("is a simple JvmField val") {
-            val code = """
+            it("is a simple JvmField val") {
+                val code = """
 				@JvmField val x = 1
 				"""
-            subject.lint(code)
-            assertThat(subject.findings).hasSize(1)
-        }
+                subject.lint(code)
+                assertThat(subject.findings).hasSize(1)
+            }
 
-        it("is a field in an object") {
-            val code = """
+            it("is a field in an object") {
+                val code = """
 				object Test {
     				@JvmField val test = "Test"
 				}
 				"""
-            subject.lint(code)
-            assertThat(subject.findings).hasSize(1)
-        }
+                subject.lint(code)
+                assertThat(subject.findings).hasSize(1)
+            }
 
-        it("reports vals in companion objects") {
-            val code = """
+            it("reports vals in companion objects") {
+                val code = """
 				class Test {
 					companion object {
 						val b = 1
 					}
 				}
 				"""
-            subject.lint(code)
-            assertThat(subject.findings).hasSize(1)
+                subject.lint(code)
+                assertThat(subject.findings).hasSize(1)
+            }
         }
-    }
 
-    given("vals that can be constants but detekt doesn't handle yet") {
-        it("is a constant binary expression") {
-            val code = """
+        context("vals that can be constants but detekt doesn't handle yet") {
+            it("is a constant binary expression") {
+                val code = """
 				const val one = 1
 				val two = one * 2
 				"""
-            subject.lint(code)
-            assertThat(subject.findings).hasSize(1)
-        }
+                subject.lint(code)
+                assertThat(subject.findings).hasSize(1)
+            }
 
-        it("is a constant binary expression in a companion object") {
-            val code = """
+            it("is a constant binary expression in a companion object") {
+                val code = """
 				class Test {
 					companion object {
 						const val one = 1
@@ -125,30 +126,30 @@ class MayBeConstSpec : SubjectSpek<MayBeConst>({
 					}
 				}
 				"""
-            subject.lint(code)
-            assertThat(subject.findings).hasSize(1)
-        }
+                subject.lint(code)
+                assertThat(subject.findings).hasSize(1)
+            }
 
-        it("is a nested constant binary expression") {
-            val code = """
+            it("is a nested constant binary expression") {
+                val code = """
 				const val one = 1
 				val two = one * 2 + 1
 				"""
-            subject.lint(code)
-            assertThat(subject.findings).hasSize(1)
-        }
+                subject.lint(code)
+                assertThat(subject.findings).hasSize(1)
+            }
 
-        it("is a nested constant parenthesised expression") {
-            val code = """
+            it("is a nested constant parenthesised expression") {
+                val code = """
 				const val one = 1
 				val two = one * (2 + 1)
 				"""
-            subject.lint(code)
-            assertThat(subject.findings).hasSize(1)
-        }
+                subject.lint(code)
+                assertThat(subject.findings).hasSize(1)
+            }
 
-        it("reports vals that use other const vals") {
-            val code = """
+            it("reports vals that use other const vals") {
+                val code = """
 				const val a = 0
 
 				class Test {
@@ -158,67 +159,67 @@ class MayBeConstSpec : SubjectSpek<MayBeConst>({
 					}
 				}
 				"""
-            subject.lint(code)
-            assertThat(subject.findings).hasSize(1)
-        }
+                subject.lint(code)
+                assertThat(subject.findings).hasSize(1)
+            }
 
-        it("reports concatenated string vals") {
-            val code = """
+            it("reports concatenated string vals") {
+                val code = """
 				private const val A = "a"
 				private val B = A + "b"
 				"""
-            subject.lint(code)
-            assertThat(subject.findings).hasSize(1)
-        }
-    }
-
-    given("vals that cannot be constants") {
-        it("does not report arrays") {
-            val code = "val arr = arrayOf(\"a\", \"b\")"
-            subject.lint(code)
-            assertThat(subject.findings).isEmpty()
+                subject.lint(code)
+                assertThat(subject.findings).hasSize(1)
+            }
         }
 
-        it("is a var") {
-            val code = "var test = 1"
-            subject.lint(code)
-            assertThat(subject.findings).isEmpty()
-        }
+        context("vals that cannot be constants") {
+            it("does not report arrays") {
+                val code = "val arr = arrayOf(\"a\", \"b\")"
+                subject.lint(code)
+                assertThat(subject.findings).isEmpty()
+            }
 
-        it("has a getter") {
-            val code = "val withGetter get() = 42"
-            subject.lint(code)
-            assertThat(subject.findings).isEmpty()
-        }
+            it("is a var") {
+                val code = "var test = 1"
+                subject.lint(code)
+                assertThat(subject.findings).isEmpty()
+            }
 
-        it("is initialized to null") {
-            val code = "val test = null"
-            subject.lint(code)
-            assertThat(subject.findings).isEmpty()
-        }
+            it("has a getter") {
+                val code = "val withGetter get() = 42"
+                subject.lint(code)
+                assertThat(subject.findings).isEmpty()
+            }
 
-        it("is a JvmField in a class") {
-            val code = """
+            it("is initialized to null") {
+                val code = "val test = null"
+                subject.lint(code)
+                assertThat(subject.findings).isEmpty()
+            }
+
+            it("is a JvmField in a class") {
+                val code = """
 				class Test {
 					@JvmField val a = 3
 				}
 			""".trimMargin()
-            subject.lint(code)
-            assertThat(subject.findings).isEmpty()
-        }
+                subject.lint(code)
+                assertThat(subject.findings).isEmpty()
+            }
 
-        it("has some annotation") {
-            val code = """
+            it("has some annotation") {
+                val code = """
 				annotation class A
 
 				@A val a = 55
 			""".trimMargin()
-            subject.lint(code)
-            assertThat(subject.findings).isEmpty()
-        }
+                subject.lint(code)
+                assertThat(subject.findings).isEmpty()
+            }
 
-        it("overrides something") {
-            val code = """
+            it("overrides something") {
+                val code = """
 				interface Base {
 					val property: Int
 				}
@@ -227,28 +228,29 @@ class MayBeConstSpec : SubjectSpek<MayBeConst>({
 					override val property = 1
 				}
 			""".trimMargin()
-            subject.lint(code)
-            assertThat(subject.findings).isEmpty()
+                subject.lint(code)
+                assertThat(subject.findings).isEmpty()
+            }
+
+            it("does not detect just a dollar as interpolation") {
+                val code = """ val hasDollar = "$" """
+                subject.lint(code)
+                assertThat(subject.findings).hasSize(1)
+            }
+
+            it("does not report interpolated strings") {
+                subject.lint(Case.MayBeConstNegative.path())
+                assertThat(subject.findings).isEmpty()
+            }
         }
 
-        it("does not detect just a dollar as interpolation") {
-            val code = """ val hasDollar = "$" """
-            subject.lint(code)
-            assertThat(subject.findings).hasSize(1)
-        }
+        context("some const val candidates in nested objects") {
 
-        it("does not report interpolated strings") {
-            subject.lint(Case.MayBeConstNegative.path())
-            assertThat(subject.findings).isEmpty()
-        }
-    }
-
-    given("some const val candidates in nested objects") {
-
-        it("reports the const val candidates") {
-            val path = Case.ConstInObjects.path()
-            subject.lint(path)
-            assertThat(subject.findings).hasSize(3)
+            it("reports the const val candidates") {
+                val path = Case.ConstInObjects.path()
+                subject.lint(path)
+                assertThat(subject.findings).hasSize(3)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
@@ -4,93 +4,95 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class ModifierOrderSpec : SubjectSpek<ModifierOrder>({
-    subject { ModifierOrder(Config.empty) }
+class ModifierOrderSpec : Spek({
+    val subject by memoized { ModifierOrder(Config.empty) }
 
-    given("kt classes with modifiers") {
-        val bad1 = "data internal class Test(val test: String)"
-        val bad2 = "actual private class Test(val test: String)"
-        val bad3 = "annotation expect class Test"
+    describe("ModifierOrder rule") {
 
-        it("should report incorrectly ordered modifiers") {
-            assertThat(subject.lint(bad1)).hasSize(1)
-            assertThat(subject.lint(bad2)).hasSize(1)
-            assertThat(subject.lint(bad3)).hasSize(1)
+        context("kt classes with modifiers") {
+            val bad1 = "data internal class Test(val test: String)"
+            val bad2 = "actual private class Test(val test: String)"
+            val bad3 = "annotation expect class Test"
+
+            it("should report incorrectly ordered modifiers") {
+                assertThat(subject.lint(bad1)).hasSize(1)
+                assertThat(subject.lint(bad2)).hasSize(1)
+                assertThat(subject.lint(bad3)).hasSize(1)
+            }
+
+            it("does not report correctly ordered modifiers") {
+                assertThat(subject.lint("internal data class Test")).isEmpty()
+                assertThat(subject.lint("private actual class Test(val test: String)")).isEmpty()
+                assertThat(subject.lint("expect annotation class Test")).isEmpty()
+            }
+
+            it("should not report issues if inactive") {
+                val rule = ModifierOrder(TestConfig(mapOf("active" to "false")))
+                assertThat(rule.lint(bad1)).isEmpty()
+                assertThat(rule.lint(bad2)).isEmpty()
+                assertThat(rule.lint(bad3)).isEmpty()
+            }
         }
 
-        it("does not report correctly ordered modifiers") {
-            assertThat(subject.lint("internal data class Test")).isEmpty()
-            assertThat(subject.lint("private actual class Test(val test: String)")).isEmpty()
-            assertThat(subject.lint("expect annotation class Test")).isEmpty()
+        context("a kt parameter with modifiers") {
+
+            it("should report wrongly ordered modifiers") {
+                val code = "lateinit internal private val test: String"
+                assertThat(subject.lint(code)).hasSize(1)
+            }
+
+            it("should not report correctly ordered modifiers") {
+                val code = "private internal lateinit val test: String"
+                assertThat(subject.lint(code)).isEmpty()
+            }
         }
 
-        it("should not report issues if inactive") {
-            val rule = ModifierOrder(TestConfig(mapOf("active" to "false")))
-            assertThat(rule.lint(bad1)).isEmpty()
-            assertThat(rule.lint(bad2)).isEmpty()
-            assertThat(rule.lint(bad3)).isEmpty()
-        }
-    }
+        context("an overridden function") {
 
-    given("a kt parameter with modifiers") {
-
-        it("should report wrongly ordered modifiers") {
-            val code = "lateinit internal private val test: String"
-            assertThat(subject.lint(code)).hasSize(1)
-        }
-
-        it("should not report correctly ordered modifiers") {
-            val code = "private internal lateinit val test: String"
-            assertThat(subject.lint(code)).isEmpty()
-        }
-    }
-
-    given("an overridden function") {
-
-        it("should report incorrectly ordered modifiers") {
-            val code = """
+            it("should report incorrectly ordered modifiers") {
+                val code = """
 				abstract class Test {
 					override open fun test() {}
 				}"""
-            assertThat(subject.lint(code)).hasSize(1)
-        }
+                assertThat(subject.lint(code)).hasSize(1)
+            }
 
-        it("should not report correctly ordered modifiers") {
-            val code = """
+            it("should not report correctly ordered modifiers") {
+                val code = """
 				abstract class Test {
 					override fun test() {}
 				}"""
-            assertThat(subject.lint(code)).isEmpty()
-        }
-    }
-
-    given("a tailrec function") {
-
-        it("should report incorrectly ordered modifiers") {
-            val code = "tailrec private fun findFixPoint(x: Double = 1.0): Double"
-            assertThat(subject.lint(code)).hasSize(1)
+                assertThat(subject.lint(code)).isEmpty()
+            }
         }
 
-        it("should not report correctly ordered modifiers") {
-            val code = "private tailrec fun findFixPoint(x: Double = 1.0): Double"
-            assertThat(subject.lint(code)).isEmpty()
+        context("a tailrec function") {
+
+            it("should report incorrectly ordered modifiers") {
+                val code = "tailrec private fun findFixPoint(x: Double = 1.0): Double"
+                assertThat(subject.lint(code)).hasSize(1)
+            }
+
+            it("should not report correctly ordered modifiers") {
+                val code = "private tailrec fun findFixPoint(x: Double = 1.0): Double"
+                assertThat(subject.lint(code)).isEmpty()
+            }
         }
-    }
 
-    given("a vararg argument") {
+        context("a vararg argument") {
 
-        it("should report incorrectly ordered modifiers") {
-            val code = "fun foo(vararg private val strings: String) {}"
-            assertThat(subject.lint(code)).hasSize(1)
-        }
+            it("should report incorrectly ordered modifiers") {
+                val code = "fun foo(vararg private val strings: String) {}"
+                assertThat(subject.lint(code)).hasSize(1)
+            }
 
-        it("should not report correctly ordered modifiers") {
-            val code = "fun foo(private vararg val strings: String) {}"
-            assertThat(subject.lint(code)).isEmpty()
+            it("should not report correctly ordered modifiers") {
+                val code = "fun foo(private vararg val strings: String) {}"
+                assertThat(subject.lint(code)).isEmpty()
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibilitySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibilitySpec.kt
@@ -3,14 +3,13 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class NestedClassesVisibilitySpec : SubjectSpek<NestedClassesVisibility>({
-    subject { NestedClassesVisibility() }
+class NestedClassesVisibilitySpec : Spek({
+    val subject by memoized { NestedClassesVisibility() }
 
-    given("several nested classes") {
+    describe("NestedClassesVisibility rule") {
 
         it("reports public nested classes") {
             assertThat(subject.lint(Case.NestedClassVisibilityPositive.path())).hasSize(6)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
@@ -3,27 +3,23 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class NewLineAtEndOfFileSpec : SubjectSpek<NewLineAtEndOfFile>({
-    subject { NewLineAtEndOfFile() }
+class NewLineAtEndOfFileSpec : Spek({
+    val subject by memoized { NewLineAtEndOfFile() }
 
-    given("a kt file containing new space at end") {
-        it("should not flag it") {
+    describe("NewLineAtEndOfFile rule") {
+
+        it("should not flag a kt file containing new space at end") {
             assertThat(subject.lint(Case.NewLineAtEndOfFile.path())).hasSize(0)
         }
-    }
 
-    given("a kt file not containing new space at end") {
-        it("should flag it") {
+        it("should flag a kt file not containing new space at end") {
             assertThat(subject.lint("class Test")).hasSize(1)
         }
-    }
 
-    given("an empty kt file") {
-        it("should not flag it") {
+        it("should not flag an empty kt file") {
             assertThat(subject.lint(Case.EmptyKtFile.path())).hasSize(0)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabsSpec.kt
@@ -1,38 +1,27 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileForTest
-import java.nio.file.Path
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
-import org.jetbrains.spek.subject.dsl.SubjectProviderDsl
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class NoTabsSpec : SubjectSpek<NoTabs>({
+class NoTabsSpec : Spek({
 
-    subject { NoTabs() }
+    val subject by memoized { NoTabs() }
 
-    given("a line that contains a tab") {
+    describe("NoTabs rule") {
 
-        it("should flag it") {
-            val path = Case.NoTabsPositive.path()
-            assertThat(lint(path)).hasSize(5)
+        it("should flag a line that contains a tab") {
+            val file = compileForTest(Case.NoTabsPositive.path())
+            subject.findTabs(file)
+            assertThat(subject.findings).hasSize(5)
         }
-    }
 
-    given("a line that does not contain a tab") {
-
-        it("should not flag it") {
-            val path = Case.NoTabsNegative.path()
-            assertThat(lint(path)).hasSize(0)
+        it("should not flag a line that does not contain a tab") {
+            val file = compileForTest(Case.NoTabsNegative.path())
+            subject.findTabs(file)
+            assertThat(subject.findings).hasSize(0)
         }
     }
 })
-
-private fun SubjectProviderDsl<NoTabs>.lint(path: Path): List<Finding> {
-    val file = compileForTest(path)
-    subject.findTabs(file)
-    return subject.findings
-}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeywordSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeywordSpec.kt
@@ -2,12 +2,11 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class OptionalAbstractKeywordSpec : SubjectSpek<OptionalAbstractKeyword>({
-    subject { OptionalAbstractKeyword() }
+class OptionalAbstractKeywordSpec : Spek({
+    val subject by memoized { OptionalAbstractKeyword() }
 
     describe("some abstract keyword definitions are checked for optionality") {
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBracesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBracesSpec.kt
@@ -2,12 +2,11 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class OptionalWhenBracesSpec : SubjectSpek<OptionalWhenBraces>({
-    subject { OptionalWhenBraces() }
+class OptionalWhenBracesSpec : Spek({
+    val subject by memoized { OptionalWhenBraces() }
 
     describe("check optional braces in when expression") {
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
@@ -4,12 +4,11 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class ProtectedMemberInFinalClassSpec : SubjectSpek<ProtectedMemberInFinalClass>({
-    subject { ProtectedMemberInFinalClass(Config.empty) }
+class ProtectedMemberInFinalClassSpec : Spek({
+    val subject by memoized { ProtectedMemberInFinalClass(Config.empty) }
 
     describe("check all variants of protected visibility modifier in final class") {
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
@@ -2,12 +2,11 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class RedundantVisibilityModifierRuleSpec : SubjectSpek<RedundantVisibilityModifierRule>({
-    subject { RedundantVisibilityModifierRule() }
+class RedundantVisibilityModifierRuleSpec : Spek({
+    val subject by memoized { RedundantVisibilityModifierRule() }
     describe("check all cases") {
         it("check overridden function of abstract class w/ public modifier") {
             val code = """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -3,14 +3,15 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Java6Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class ReturnCountSpec : Spek({
 
-    given("a file with 3 returns") {
-        val code = """
+    describe("ReturnCount rule") {
+
+        context("a file with 3 returns") {
+            val code = """
 			fun test(x: Int): Int {
 				when (x) {
 					5 -> return 5
@@ -20,24 +21,24 @@ class ReturnCountSpec : Spek({
 			}
 		"""
 
-        it("should get flagged by default") {
-            val findings = ReturnCount().lint(code)
-            assertThat(findings).hasSize(1)
+            it("should get flagged by default") {
+                val findings = ReturnCount().lint(code)
+                assertThat(findings).hasSize(1)
+            }
+
+            it("should not get flagged when max value is 3") {
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "3"))).lint(code)
+                assertThat(findings).hasSize(0)
+            }
+
+            it("should get flagged when max value is 1") {
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "1"))).lint(code)
+                assertThat(findings).hasSize(1)
+            }
         }
 
-        it("should not get flagged when max value is 3") {
-            val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "3"))).lint(code)
-            assertThat(findings).hasSize(0)
-        }
-
-        it("should get flagged when max value is 1") {
-            val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "1"))).lint(code)
-            assertThat(findings).hasSize(1)
-        }
-    }
-
-    given("a file with 2 returns") {
-        val code = """
+        context("a file with 2 returns") {
+            val code = """
 			fun test(x: Int): Int {
 				when (x) {
 					5 -> return 5
@@ -46,24 +47,24 @@ class ReturnCountSpec : Spek({
 			}
 		"""
 
-        it("should not get flagged by default") {
-            val findings = ReturnCount().lint(code)
-            assertThat(findings).hasSize(0)
+            it("should not get flagged by default") {
+                val findings = ReturnCount().lint(code)
+                assertThat(findings).hasSize(0)
+            }
+
+            it("should not get flagged when max value is 2") {
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
+                assertThat(findings).hasSize(0)
+            }
+
+            it("should get flagged when max value is 1") {
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "1"))).lint(code)
+                assertThat(findings).hasSize(1)
+            }
         }
 
-        it("should not get flagged when max value is 2") {
-            val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
-            assertThat(findings).hasSize(0)
-        }
-
-        it("should get flagged when max value is 1") {
-            val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "1"))).lint(code)
-            assertThat(findings).hasSize(1)
-        }
-    }
-
-    given("a function is ignored") {
-        val code = """
+        context("a function is ignored") {
+            val code = """
     		fun test(x: Int): Int {
 				when (x) {
 					5 -> return 5
@@ -73,17 +74,17 @@ class ReturnCountSpec : Spek({
 			}
 		"""
 
-        it("should not get flagged") {
-            val findings = ReturnCount(TestConfig(mapOf(
-                    ReturnCount.MAX to "2",
-                    ReturnCount.EXCLUDED_FUNCTIONS to "test")
-            )).lint(code)
-            assertThat(findings).isEmpty()
+            it("should not get flagged") {
+                val findings = ReturnCount(TestConfig(mapOf(
+                        ReturnCount.MAX to "2",
+                        ReturnCount.EXCLUDED_FUNCTIONS to "test")
+                )).lint(code)
+                assertThat(findings).isEmpty()
+            }
         }
-    }
 
-    given("a subset of functions are ignored") {
-        val code = """
+        context("a subset of functions are ignored") {
+            val code = """
     		fun test1(x: Int): Int {
 				when (x) {
 					5 -> return 5
@@ -109,17 +110,17 @@ class ReturnCountSpec : Spek({
 			}
 		"""
 
-        it("should flag none of the ignored functions") {
-            val findings = ReturnCount(TestConfig(mapOf(
-                    ReturnCount.MAX to "2",
-                    ReturnCount.EXCLUDED_FUNCTIONS to "test1,test2")
-            )).lint(code)
-            assertThat(findings).hasSize(1)
+            it("should flag none of the ignored functions") {
+                val findings = ReturnCount(TestConfig(mapOf(
+                        ReturnCount.MAX to "2",
+                        ReturnCount.EXCLUDED_FUNCTIONS to "test1,test2")
+                )).lint(code)
+                assertThat(findings).hasSize(1)
+            }
         }
-    }
 
-    given("a function with inner object") {
-        val code = """
+        context("a function with inner object") {
+            val code = """
 			fun test(x: Int): Int {
 				val a = object {
 					fun test2(x: Int): Int {
@@ -136,14 +137,14 @@ class ReturnCountSpec : Spek({
 			}
     	"""
 
-        it("should not get flag when returns is in inner object") {
-            val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
-            assertThat(findings).hasSize(0)
+            it("should not get flag when returns is in inner object") {
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
+                assertThat(findings).hasSize(0)
+            }
         }
-    }
 
-    given("a function with 2 inner object") {
-        val code = """
+        context("a function with 2 inner object") {
+            val code = """
 			fun test(x: Int): Int {
 				val a = object {
 					fun test2(x: Int): Int {
@@ -168,14 +169,14 @@ class ReturnCountSpec : Spek({
 			}
     	"""
 
-        it("should not get flag when returns is in inner object") {
-            val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
-            assertThat(findings).hasSize(0)
+            it("should not get flag when returns is in inner object") {
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
+                assertThat(findings).hasSize(0)
+            }
         }
-    }
 
-    given("a function with 2 inner object and exceeded max") {
-        val code = """
+        context("a function with 2 inner object and exceeded max") {
+            val code = """
 			fun test(x: Int): Int {
 				val a = object {
 					fun test2(x: Int): Int {
@@ -202,15 +203,15 @@ class ReturnCountSpec : Spek({
 			}
     	"""
 
-        it("should get flagged when returns is in inner object") {
-            val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
-            assertThat(findings).hasSize(1)
+            it("should get flagged when returns is in inner object") {
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
+                assertThat(findings).hasSize(1)
+            }
         }
-    }
 
-    given("function with multiple labeled return statements") {
+        context("function with multiple labeled return statements") {
 
-        val code = """
+            val code = """
 			fun readUsers(name: String): Flowable<User> {
 			return userDao.read(name)
 				.flatMap {
@@ -220,24 +221,25 @@ class ReturnCountSpec : Spek({
     		}
 		""".trimIndent()
 
-        it("should not count labeled returns from lambda by default") {
-            val findings = ReturnCount().lint(code)
-            assertThat(findings).isEmpty()
-        }
+            it("should not count labeled returns from lambda by default") {
+                val findings = ReturnCount().lint(code)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should count labeled returns from lambda when activated") {
-            val findings = ReturnCount(
-                    TestConfig(mapOf("excludeReturnFromLambda" to "false"))).lint(code)
-            assertThat(findings).hasSize(1)
-        }
+            it("should count labeled returns from lambda when activated") {
+                val findings = ReturnCount(
+                        TestConfig(mapOf("excludeReturnFromLambda" to "false"))).lint(code)
+                assertThat(findings).hasSize(1)
+            }
 
-        it("should be empty when labeled returns are de-activated") {
-            val findings = ReturnCount(
-                    TestConfig(mapOf(
-                            "excludeLabeled" to "true",
-                            "excludeReturnFromLambda" to "false"
-                    ))).lint(code)
-            assertThat(findings).isEmpty()
+            it("should be empty when labeled returns are de-activated") {
+                val findings = ReturnCount(
+                        TestConfig(mapOf(
+                                "excludeLabeled" to "true",
+                                "excludeReturnFromLambda" to "false"
+                        ))).lint(code)
+                assertThat(findings).isEmpty()
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCastSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCastSpec.kt
@@ -2,14 +2,13 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class SafeCastSpec : SubjectSpek<SafeCast>({
-    subject { SafeCast() }
+class SafeCastSpec : Spek({
+    val subject by memoized { SafeCast() }
 
-    given("some cast expressions") {
+    describe("SafeCast rule") {
 
         it("reports negated expression") {
             val code = """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
@@ -4,14 +4,13 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class SerialVersionUIDInSerializableClassSpec : SubjectSpek<SerialVersionUIDInSerializableClass>({
-    subject { SerialVersionUIDInSerializableClass(Config.empty) }
+class SerialVersionUIDInSerializableClassSpec : Spek({
+    val subject by memoized { SerialVersionUIDInSerializableClass(Config.empty) }
 
-    given("several serializable classes") {
+    describe("SerialVersionUIDInSerializableClass rule") {
 
         it("reports serializable classes which do not implement the serialVersionUID correctly") {
             assertThat(subject.lint(Case.SerializablePositive.path())).hasSize(5)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
@@ -3,68 +3,66 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
-import org.jetbrains.spek.subject.dsl.SubjectProviderDsl
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class SpacingBetweenPackageAndImportsSpec : SubjectSpek<SpacingBetweenPackageAndImports>({
-    subject { SpacingBetweenPackageAndImports(Config.empty) }
+class SpacingBetweenPackageAndImportsSpec : Spek({
+    val subject by memoized { SpacingBetweenPackageAndImports(Config.empty) }
 
-    given("several package and import declarations") {
+    describe("SpacingBetweenPackageAndImports rule") {
 
         it("has no blank lines violation") {
             val code = "package test\n\nimport a.b\n\nclass A {}"
-            assertCodeWithoutViolation(code)
+            assertThat(subject.lint(code)).hasSize(0)
         }
 
         it("has a package and import declaration") {
             val code = "package test\n\nimport a.b"
-            assertCodeWithoutViolation(code)
+            assertThat(subject.lint(code)).hasSize(0)
         }
 
         it("has no import declaration") {
             val code = "package test\n\nclass A {}"
-            assertCodeWithoutViolation(code)
+            assertThat(subject.lint(code)).hasSize(0)
         }
 
         it("has no package declaration") {
             val code = "import a.b\n\nclass A {}"
-            assertCodeWithoutViolation(code)
+            assertThat(subject.lint(code)).hasSize(0)
         }
 
         it("has no package and import declaration") {
             val code = "class A {}"
-            assertCodeWithoutViolation(code)
+            assertThat(subject.lint(code)).hasSize(0)
         }
 
         it("has a comment declaration") {
             val code = "import a.b\n\n// a comment"
-            assertCodeWithoutViolation(code)
+            assertThat(subject.lint(code)).hasSize(0)
         }
 
         it("is an empty kt file") {
-            assertCodeWithoutViolation("")
+            assertThat(subject.lint("")).hasSize(0)
         }
 
         it("has code on new line") {
             val code = "package test\nimport a.b\nclass A {}"
-            assertCodeViolation(code, 2)
+            assertThat(subject.lint(code)).hasSize(2)
         }
 
         it("has code with spaces") {
             val code = "package test; import a.b; class A {}"
-            assertCodeViolation(code, 2)
+            assertThat(subject.lint(code)).hasSize(2)
         }
 
         it("has two many blank lines") {
             val code = "package test\n\n\nimport a.b\n\n\nclass A {}"
-            assertCodeViolation(code, 2)
+            assertThat(subject.lint(code)).hasSize(2)
         }
 
         it("has package declarations in same line") {
             val code = "package test;import a.b;class A {}"
-            assertCodeViolation(code, 2)
+            assertThat(subject.lint(code)).hasSize(2)
         }
 
         it("should be valid") {
@@ -76,7 +74,7 @@ class SpacingBetweenPackageAndImportsSpec : SubjectSpek<SpacingBetweenPackageAnd
 
 				class MyClass { }
 				"""
-            assertCodeViolation(code, 0)
+            assertThat(subject.lint(code)).hasSize(0)
         }
 
         it("has no class") {
@@ -86,15 +84,7 @@ class SpacingBetweenPackageAndImportsSpec : SubjectSpek<SpacingBetweenPackageAnd
 				import android.util.Log
 				import java.util.concurrent.TimeUnit
 				"""
-            assertCodeViolation(code, 0)
+            assertThat(subject.lint(code)).hasSize(0)
         }
     }
 })
-
-private fun SubjectProviderDsl<SpacingBetweenPackageAndImports>.assertCodeViolation(code: String, size: Int) {
-    assertThat(subject.lint(code)).hasSize(size)
-}
-
-private fun SubjectProviderDsl<SpacingBetweenPackageAndImports>.assertCodeWithoutViolation(code: String) {
-    assertThat(subject.lint(code)).hasSize(0)
-}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
@@ -4,14 +4,12 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class ThrowsCountSpec : SubjectSpek<ThrowsCount>({
-    subject { ThrowsCount(Config.empty) }
+class ThrowsCountSpec : Spek({
 
-    given("several methods which throw exceptions") {
+    describe("ThrowsCount rule") {
 
         val code = """
 			fun f1(x: Int) {
@@ -38,15 +36,21 @@ class ThrowsCountSpec : SubjectSpek<ThrowsCount>({
 			}
 		"""
 
-        it("reports violation by default") {
-            val findings = subject.lint(code)
-            assertThat(findings).hasSize(1)
+        context("default config") {
+            val subject = ThrowsCount(Config.empty)
+
+            it("reports violation by default") {
+                assertThat(subject.lint(code)).hasSize(1)
+            }
         }
 
-        it("does not report for configuration max parameter") {
+        context("max count == 3") {
             val config = TestConfig(mapOf(ThrowsCount.MAX to "3"))
             val subject = ThrowsCount(config)
-            assertThat(subject.lint(code)).hasSize(0)
+
+            it("does not report for configuration max parameter") {
+                assertThat(subject.lint(code)).hasSize(0)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
@@ -3,35 +3,37 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class TrailingWhitespaceSpec : Spek({
 
-    given("a kt file that contains lines that end with a whitespace") {
-        val rule = TrailingWhitespace()
-        val file = compileForTest(Case.TrailingWhitespacePositive.path())
-        val lines = file.text.splitToSequence("\n")
-        rule.visit(KtFileContent(file, lines))
+    describe("TrailingWhitespace rule") {
 
-        it("should flag it") {
-            assertThat(rule.findings).hasSize(7)
-        }
-
-        it("should report the correct source location for a comment with trailing whitespace") {
-            val findingSource = rule.findings[1].location.source
-            assertThat(findingSource.line).isEqualTo(5)
-            assertThat(findingSource.column).isEqualTo(1)
-        }
-    }
-
-    given("a kt file that does not contain lines that end with a whitespace") {
-
-        it("should not flag it") {
+        context("a kt file that contains lines that end with a whitespace") {
             val rule = TrailingWhitespace()
-            rule.visit(Case.TrailingWhitespaceNegative.getKtFileContent())
-            assertThat(rule.findings).hasSize(0)
+            val file = compileForTest(Case.TrailingWhitespacePositive.path())
+            val lines = file.text.splitToSequence("\n")
+            rule.visit(KtFileContent(file, lines))
+
+            it("should flag it") {
+                assertThat(rule.findings).hasSize(7)
+            }
+
+            it("should report the correct source location for a comment with trailing whitespace") {
+                val findingSource = rule.findings[1].location.source
+                assertThat(findingSource.line).isEqualTo(5)
+                assertThat(findingSource.column).isEqualTo(1)
+            }
+        }
+
+        context("a kt file that does not contain lines that end with a whitespace") {
+
+            it("should not flag it") {
+                val rule = TrailingWhitespace()
+                rule.visit(Case.TrailingWhitespaceNegative.getKtFileContent())
+                assertThat(rule.findings).hasSize(0)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -4,13 +4,12 @@ import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class UnderscoresInNumericLiteralsSpec : Spek({
 
-    given("an Int of 1000") {
+    describe("an Int of 1000") {
         val ktFile = compileContentForTest("val myInt = 1000")
 
         it("should be reported by default") {
@@ -26,7 +25,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    given("an Int of 1_000_000") {
+    describe("an Int of 1_000_000") {
         val ktFile = compileContentForTest("val myInt = 1_000_000")
 
         it("should not be reported") {
@@ -35,7 +34,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    given("a const Int of 1000000") {
+    describe("a const Int of 1000000") {
         val ktFile = compileContentForTest("const val myInt = 1000000")
 
         it("should be reported by default") {
@@ -51,7 +50,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    given("a Float of 1000f") {
+    describe("a Float of 1000f") {
         val ktFile = compileContentForTest("val myFloat = 1000f")
 
         it("should be reported by default") {
@@ -67,7 +66,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    given("a Float of -1000f") {
+    describe("a Float of -1000f") {
         val ktFile = compileContentForTest("val myFloat = -1000f")
 
         it("should be reported by default") {
@@ -83,7 +82,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    given("a Float of -1_000f") {
+    describe("a Float of -1_000f") {
         val ktFile = compileContentForTest("const val myFloat = -1_000f")
 
         it("should not be reported") {
@@ -92,7 +91,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    given("a Long of 1000000L") {
+    describe("a Long of 1000000L") {
         val ktFile = compileContentForTest("const val myLong = 1000000L")
 
         it("should be reported by default") {
@@ -108,7 +107,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    given("a Double of 1_000_000.00_000_000") {
+    describe("a Double of 1_000_000.00_000_000") {
         val ktFile = compileContentForTest("val myDouble = 1_000_000.00_000_000")
 
         it("should not be reported") {
@@ -117,7 +116,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    given("a function with default Int parameter value 1000") {
+    describe("a function with default Int parameter value 1000") {
         val ktFile = compileContentForTest("fun testFunction(testParam: Int = 1000) {}")
 
         it("should be reported by default") {
@@ -126,7 +125,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    given("an annotation with numeric literals 0 and 10") {
+    describe("an annotation with numeric literals 0 and 10") {
         val ktFile = compileContentForTest(
                 "fun setCustomDimension(@IntRange(from = 0, to = 10) index: Int, value: String?) {}"
         )
@@ -137,7 +136,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    given("an annotation with numeric literals 0 and 1000000") {
+    describe("an annotation with numeric literals 0 and 1000000") {
         val ktFile = compileContentForTest(
                 "fun setCustomDimension(@IntRange(from = 0, to = 1000000) index: Int, value: String?) {}"
         )
@@ -148,7 +147,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    given("an Int of 10_00_00") {
+    describe("an Int of 10_00_00") {
         val ktFile = compileContentForTest("const val myInt = 10_00_00")
 
         it("should be reported by default") {
@@ -164,7 +163,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    given("a binary Int of 0b1011") {
+    describe("a binary Int of 0b1011") {
         val ktFile = compileContentForTest("const val myBinInt = 0b1011")
 
         it("should not be reported") {
@@ -173,7 +172,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    given("a hexadecimal Int of 0x1facdf") {
+    describe("a hexadecimal Int of 0x1facdf") {
         val ktFile = compileContentForTest("const val myHexInt = 0x1facdf")
 
         it("should not be reported") {
@@ -182,7 +181,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    given("a property named serialVersionUID in an object that implements Serializable") {
+    describe("a property named serialVersionUID in an object that implements Serializable") {
         val ktFile = compileContentForTest("""
             object TestSerializable : Serializable {
                 private val serialVersionUID = 314159L
@@ -195,7 +194,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    given("a property named serialVersionUID in an object that does not implement Serializable") {
+    describe("a property named serialVersionUID in an object that does not implement Serializable") {
         val ktFile = compileContentForTest("""
             object TestSerializable {
                 private val serialVersionUID = 314159L

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -5,12 +5,11 @@ import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class UnnecessaryAbstractClassSpec : SubjectSpek<UnnecessaryAbstractClass>({
-    subject {
+class UnnecessaryAbstractClassSpec : Spek({
+    val subject by memoized {
         UnnecessaryAbstractClass(TestConfig(mapOf(
                 UnnecessaryAbstractClass.EXCLUDE_ANNOTATED_CLASSES to "jdk.nashorn.internal.ir.annotations.Ignore"
         )))
@@ -19,31 +18,34 @@ class UnnecessaryAbstractClassSpec : SubjectSpek<UnnecessaryAbstractClass>({
     val noConcreteMemberDescription = "An abstract class without a concrete member can be refactored to an interface."
     val noAbstractMemberDescription = "An abstract class without an abstract member can be refactored to a concrete class."
 
-    given("abstract classes with no abstract members") {
+    describe("UnnecessaryAbstractClass rule") {
 
-        val path = Case.UnnecessaryAbstractClassPositive.path()
-        val findings = subject.lint(path)
+        context("abstract classes with no abstract members") {
 
-        it("has no abstract member violation") {
-            assertThat(countViolationsWithDescription(findings, noAbstractMemberDescription)).isEqualTo(5)
+            val path = Case.UnnecessaryAbstractClassPositive.path()
+            val findings = subject.lint(path)
+
+            it("has no abstract member violation") {
+                assertThat(countViolationsWithDescription(findings, noAbstractMemberDescription)).isEqualTo(5)
+            }
+
+            it("has no concrete member violation") {
+                assertThat(countViolationsWithDescription(findings, noConcreteMemberDescription)).isEqualTo(1)
+            }
         }
 
-        it("has no concrete member violation") {
-            assertThat(countViolationsWithDescription(findings, noConcreteMemberDescription)).isEqualTo(1)
-        }
-    }
+        context("abstract classes with members") {
 
-    given("abstract classes with members") {
+            val path = Case.UnnecessaryAbstractClassNegative.path()
+            val findings = subject.lint(path)
 
-        val path = Case.UnnecessaryAbstractClassNegative.path()
-        val findings = subject.lint(path)
+            it("does not report no abstract member violation") {
+                assertThat(countViolationsWithDescription(findings, noAbstractMemberDescription)).isEqualTo(0)
+            }
 
-        it("does not report no abstract member violation") {
-            assertThat(countViolationsWithDescription(findings, noAbstractMemberDescription)).isEqualTo(0)
-        }
-
-        it("does not report no concrete member violation") {
-            assertThat(countViolationsWithDescription(findings, noConcreteMemberDescription)).isEqualTo(0)
+            it("does not report no concrete member violation") {
+                assertThat(countViolationsWithDescription(findings, noConcreteMemberDescription)).isEqualTo(0)
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -3,18 +3,19 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class UnnecessaryApplySpec : SubjectSpek<UnnecessaryApply>({
+class UnnecessaryApplySpec : Spek({
 
-    subject { UnnecessaryApply(Config.empty) }
+    val subject by memoized { UnnecessaryApply(Config.empty) }
 
-    given("unnecessary apply expressions that can be changed to ordinary method call") {
+    describe("UnnecessaryApply rule") {
 
-        it("reports an apply on non-nullable type") {
-            assertThat(subject.lint("""
+        context("unnecessary apply expressions that can be changed to ordinary method call") {
+
+            it("reports an apply on non-nullable type") {
+                assertThat(subject.lint("""
 				fun f() {
 					val a : Int = 0
 					a.apply {
@@ -22,10 +23,10 @@ class UnnecessaryApplySpec : SubjectSpek<UnnecessaryApply>({
 					}
 				}
 			""")).hasSize(1)
-        }
+            }
 
-        it("reports a false negative apply on nullable type") {
-            assertThat(subject.lint("""
+            it("reports a false negative apply on nullable type") {
+                assertThat(subject.lint("""
 				fun f() {
 					val a : Int? = null
 					// Resolution: we can't say here if plus is on 'this' or just a side effects when a is not null
@@ -34,10 +35,10 @@ class UnnecessaryApplySpec : SubjectSpek<UnnecessaryApply>({
 					}
 				}
 			""")).isEmpty()
-        }
+            }
 
-        it("does not report an apply with lambda block") {
-            assertThat(subject.lint("""
+            it("does not report an apply with lambda block") {
+                assertThat(subject.lint("""
 				fun f() {
 					val a : Int? = null
 					a.apply({
@@ -45,10 +46,10 @@ class UnnecessaryApplySpec : SubjectSpek<UnnecessaryApply>({
 					})
 				}
 			""")).isEmpty()
-        }
+            }
 
-        it("does report single statement in apply used as function argument") {
-            assertThat(subject.lint("""
+            it("does report single statement in apply used as function argument") {
+                assertThat(subject.lint("""
 				fun b(i : Int?) {
 				}
 				fun f() {
@@ -58,10 +59,10 @@ class UnnecessaryApplySpec : SubjectSpek<UnnecessaryApply>({
 					})
 				}
 			""")).isEmpty()
-        }
+            }
 
-        it("does not report applies with lambda body containing more than one statement") {
-            assertThat(subject.lint("""
+            it("does not report applies with lambda body containing more than one statement") {
+                assertThat(subject.lint("""
 				fun b(i : Int?) {
 				}
 				fun f() {
@@ -79,40 +80,40 @@ class UnnecessaryApplySpec : SubjectSpek<UnnecessaryApply>({
 						plus(2)
 					})
 				}""")).isEmpty()
+            }
         }
-    }
 
-    given("reported false positives - #1305") {
+        context("reported false positives - #1305") {
 
-        it("is used within an assignment expr itself") {
-            assertThat(subject.lint("""
+            it("is used within an assignment expr itself") {
+                assertThat(subject.lint("""
 				val content = Intent().apply { putExtra("", 1) }
 			""".trimIndent())).isEmpty()
-        }
+            }
 
-        it("is used as return type of extension function") {
-            assertThat(subject.lint("""
+            it("is used as return type of extension function") {
+                assertThat(subject.lint("""
 				fun setColor(color: Int) = apply { initialColor = color }
 			""".trimIndent())).isEmpty()
-        }
+            }
 
-        it("should not flag apply when assigning property on this") {
-            assertThat(subject.lint("""
+            it("should not flag apply when assigning property on this") {
+                assertThat(subject.lint("""
 				private val requestedInterval by lazy {
  				   MutableLiveData<Int>().apply { value = UsageFragment.INTERVAL_DAY }
 				}
 			""".trimIndent())).isEmpty()
-        }
+            }
 
-        it("should not report apply when using it after returning something") {
-            assertThat(subject.lint("""
+            it("should not report apply when using it after returning something") {
+                assertThat(subject.lint("""
 				inline class Money(var amount: Int)
 				fun returnMe = (Money(5)).apply { amount = 10 }
 			""".trimIndent())).isEmpty()
-        }
+            }
 
-        it("should not report apply usage inside safe chained expressions") {
-            assertThat(subject.lint("""
+            it("should not report apply usage inside safe chained expressions") {
+                assertThat(subject.lint("""
 				fun test() {
 					val arguments = listOf(1,2,3)
 					?.map { it * 2 }
@@ -120,6 +121,7 @@ class UnnecessaryApplySpec : SubjectSpek<UnnecessaryApply>({
 					?: listOf(0)
 				}
 			""".trimIndent())).isEmpty()
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
@@ -3,12 +3,11 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class UnnecessaryInheritanceSpec : SubjectSpek<UnnecessaryInheritance>({
-    subject { UnnecessaryInheritance(Config.empty) }
+class UnnecessaryInheritanceSpec : Spek({
+    val subject by memoized { UnnecessaryInheritance(Config.empty) }
 
     describe("check inherit classes") {
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -3,14 +3,13 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class UnnecessaryLetSpec : SubjectSpek<UnnecessaryLet>({
-    subject { UnnecessaryLet(Config.empty) }
+class UnnecessaryLetSpec : Spek({
+    val subject by memoized { UnnecessaryLet(Config.empty) }
 
-    given("some code using let expressions extensively") {
+    describe("UnnecessaryLet rule") {
         it("reports unnecessary lets that can be changed to ordinary method call") {
             val findings = subject.lint("""
 				fun f() {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -3,14 +3,13 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class UnnecessaryParenthesesSpec : SubjectSpek<UnnecessaryParentheses>({
-    subject { UnnecessaryParentheses(Config.empty) }
+class UnnecessaryParenthesesSpec : Spek({
+    val subject by memoized { UnnecessaryParentheses(Config.empty) }
 
-    given("parenthesized expressions") {
+    describe("UnnecessaryParentheses rule") {
 
         it("with unnecessary parentheses on val assignment") {
             val code = "val local = (5)"

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UntilInsteadOfRangeToSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UntilInsteadOfRangeToSpec.kt
@@ -3,14 +3,13 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class UntilInsteadOfRangeToSpec : SubjectSpek<UntilInsteadOfRangeTo>({
-    subject { UntilInsteadOfRangeTo(Config.empty) }
+class UntilInsteadOfRangeToSpec : Spek({
+    val subject by memoized { UntilInsteadOfRangeTo(Config.empty) }
 
-    given("several loops") {
+    describe("UntilInsteadOfRangeTo rule") {
 
         it("reports for '..'") {
             val code = """
@@ -45,9 +44,6 @@ class UntilInsteadOfRangeToSpec : SubjectSpek<UntilInsteadOfRangeTo>({
 				}"""
             assertThat(subject.lint(code)).hasSize(0)
         }
-    }
-
-    given("several binary expressions") {
 
         it("reports for '..'") {
             val code = "val r = 0 .. 10 - 1"

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
@@ -3,9 +3,8 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Shyiko
@@ -13,10 +12,10 @@ import org.jetbrains.spek.subject.SubjectSpek
  * @author Mauin
  * @author schalkms
  */
-class UnusedImportsSpec : SubjectSpek<UnusedImports>({
-    subject { UnusedImports(Config.empty) }
+class UnusedImportsSpec : Spek({
+    val subject by memoized { UnusedImports(Config.empty) }
 
-    given("some import statements") {
+    describe("UnusedImports rule") {
 
         it("does not report infix operators") {
             assertThat(subject.lint("""
@@ -145,11 +144,8 @@ class UnusedImportsSpec : SubjectSpek<UnusedImports>({
                 assertThat(this).isEmpty()
             }
         }
-    }
 
-    given("some import statements referenced by KDoc @see") {
-
-        it("does not report see annotation linking to class") {
+        it("does not report KDoc @see annotation linking to class") {
             val code = """
 				import tasks.success
 
@@ -162,7 +158,7 @@ class UnusedImportsSpec : SubjectSpek<UnusedImports>({
             assertThat(subject.lint(code)).isEmpty()
         }
 
-        it("does not report see annotation linking to class with description") {
+        it("does not report KDoc @see annotation linking to class with description") {
             val code = """
 				import tasks.success
 
@@ -175,7 +171,7 @@ class UnusedImportsSpec : SubjectSpek<UnusedImports>({
             assertThat(subject.lint(code)).isEmpty()
         }
 
-        it("reports see annotation that does not link to class") {
+        it("reports KDoc @see annotation that does not link to class") {
             val code = """
 				import tasks.success
 
@@ -188,7 +184,7 @@ class UnusedImportsSpec : SubjectSpek<UnusedImports>({
             assertThat(subject.lint(code)).hasSize(1)
         }
 
-        it("reports see annotation that links after description") {
+        it("reports KDoc @see annotation that links after description") {
             val code = """
 				import tasks.success
 
@@ -200,9 +196,6 @@ class UnusedImportsSpec : SubjectSpek<UnusedImports>({
 
             assertThat(subject.lint(code)).hasSize(1)
         }
-    }
-
-    given("some import statements with KDoc") {
 
         it("does not report imports in KDoc") {
             val code = """
@@ -218,11 +211,8 @@ class UnusedImportsSpec : SubjectSpek<UnusedImports>({
 
             assertThat(subject.lint(code)).isEmpty()
         }
-    }
 
-    given("imports with aliases") {
-
-        it("should not report import as unused because the alias is used") {
+        it("should not report import alias as unused when the alias is used") {
             val code = """
 				import test.forEach as foreach
 				fun foo() = listOf().iterator().foreach {}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
@@ -2,16 +2,14 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class UnusedPrivateClassSpec : SubjectSpek<UnusedPrivateClass>({
+class UnusedPrivateClassSpec : Spek({
 
-    subject { UnusedPrivateClass() }
+    val subject by memoized { UnusedPrivateClass() }
 
-    given("top level interfaces") {
+    describe("top level interfaces") {
         it("should report them if not used") {
             val code = """
 				private interface Foo
@@ -26,7 +24,7 @@ class UnusedPrivateClassSpec : SubjectSpek<UnusedPrivateClass>({
             }
         }
 
-        given("top level private classes") {
+        describe("top level private classes") {
 
             it("should report them if not used") {
                 val code = """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -3,16 +3,15 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
-import java.util.regex.PatternSyntaxException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.regex.PatternSyntaxException
 
-class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
+class UnusedPrivateMemberSpec : Spek({
 
-    subject { UnusedPrivateMember() }
+    val subject by memoized { UnusedPrivateMember() }
 
     val regexTestingCode = """
 				class Test {
@@ -25,7 +24,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
 				}
 				"""
 
-    given("cases file with different findings") {
+    describe("cases file with different findings") {
 
         it("positive cases file") {
             assertThat(subject.lint(Case.UnusedPrivateMemberPositive.path())).hasSize(13)
@@ -36,7 +35,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("interface functions") {
+    describe("interface functions") {
 
         it("should not report parameters in interface functions") {
             val code = """
@@ -49,7 +48,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("external functions") {
+    describe("external functions") {
 
         it("should not report parameters in external functions") {
             val code = "external fun foo(bar: String)"
@@ -57,7 +56,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("overridden functions") {
+    describe("overridden functions") {
 
         it("should not report parameters in not private functions") {
             val code = """
@@ -73,7 +72,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("classes accessing constants from companion objects") {
+    describe("classes accessing constants from companion objects") {
 
         it("should not report used constants") {
             val code = """
@@ -92,7 +91,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("several classes with properties") {
+    describe("several classes with properties") {
 
         it("reports an unused member") {
             val code = """
@@ -164,7 +163,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("several classes with properties and local properties") {
+    describe("several classes with properties and local properties") {
 
         it("reports an unused member") {
             val code = """
@@ -209,7 +208,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("loop iterators") {
+    describe("loop iterators") {
 
         it("should not depend on evaluation order of functions or properties") {
             val code = """
@@ -289,7 +288,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("properties used to initialize other properties") {
+    describe("properties used to initialize other properties") {
 
         it("does not report properties used by other properties") {
             val code = """
@@ -319,7 +318,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("function parameters") {
+    describe("function parameters") {
         it("reports single parameters if they are unused") {
             val code = """
 			class Test {
@@ -391,7 +390,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("top level function parameters") {
+    describe("top level function parameters") {
         it("reports single parameters if they are unused") {
             val code = """
 			fun function(unusedParameter: Int): Int {
@@ -443,7 +442,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("unused private functions") {
+    describe("unused private functions") {
         it("does not report used private functions") {
             val code = """
 			class Test {
@@ -471,7 +470,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("private functions only used by unused private functions") {
+    describe("private functions only used by unused private functions") {
 
         it("reports the non called private function") {
             val code = """
@@ -490,7 +489,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("unused class declarations which are allowed") {
+    describe("unused class declarations which are allowed") {
 
         it("does not report the unused private property") {
             val code = """
@@ -509,7 +508,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("nested class declarations") {
+    describe("nested class declarations") {
 
         it("reports unused nested private property") {
             val code = """
@@ -533,7 +532,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("parameters in primary constructors") {
+    describe("parameters in primary constructors") {
         it("reports unused private property") {
             val code = """
 				class Test(private val unused: Any)
@@ -604,7 +603,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("error messages") {
+    describe("error messages") {
         it("are specific for function parameters") {
             val code = """
 				fun foo(unused: Int){}
@@ -640,7 +639,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("suppress unused parameter warning annotations") {
+    describe("suppress unused parameter warning annotations") {
         it("does not report annotated parameters") {
             val code = """
 				fun foo(@Suppress("UNUSED_PARAMETER") unused: String){}
@@ -724,7 +723,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("suppress unused property warning annotations") {
+    describe("suppress unused property warning annotations") {
         it("does not report annotated private constructor properties") {
             val code = """
 				class Test(@Suppress("unused") private val foo: String) {}
@@ -862,7 +861,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("suppress unused function warning annotations") {
+    describe("suppress unused function warning annotations") {
         it("does not report annotated private functions") {
             val code = """
 				@Suppress("unused")
@@ -927,7 +926,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("main methods") {
+    describe("main methods") {
 
         it("does not report the args parameter of the main function inside an object") {
             val code = """
@@ -952,7 +951,7 @@ class UnusedPrivateMemberSpec : SubjectSpek<UnusedPrivateMember>({
         }
     }
 
-    given("operators") {
+    describe("operators") {
 
         it("does not report used plus operator - #1354") {
             val code = """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -5,18 +5,17 @@ import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Ivan Balaksha
  */
-class UseDataClassSpec : SubjectSpek<UseDataClass>({
+class UseDataClassSpec : Spek({
 
-    subject { UseDataClass(Config.empty) }
+    val subject by memoized { UseDataClass(Config.empty) }
 
-    given("several classes") {
+    describe("UseDataClass rule") {
 
         it("reports potential data classes") {
             assertThat(subject.lint(Case.UseDataClassPositive.path())).hasSize(5)
@@ -27,15 +26,10 @@ class UseDataClassSpec : SubjectSpek<UseDataClass>({
         }
 
         it("does not report inline classes") {
-            assertThat(subject.lint(
-                    """inline class A(val x: Int)"""
-            )).isEmpty()
+            assertThat(subject.lint("inline class A(val x: Int)")).isEmpty()
         }
-    }
 
-    given("a class with an annotation which is ignored") {
-
-        it("does not report a potential data class") {
+        it("does not report a potential data class when class has an annotation which is ignored") {
             val code = """
 				import kotlin.SinceKotlin
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructorSpec.kt
@@ -4,40 +4,40 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class UtilityClassWithPublicConstructorSpec : SubjectSpek<UtilityClassWithPublicConstructor>({
+class UtilityClassWithPublicConstructorSpec : Spek({
 
-    subject { UtilityClassWithPublicConstructor(Config.empty) }
+    val subject by memoized { UtilityClassWithPublicConstructor(Config.empty) }
+    describe("UtilityClassWithPublicConstructor rule") {
 
-    given("several UtilityClassWithPublicConstructor rule violations") {
+        context("several UtilityClassWithPublicConstructor rule violations") {
 
-        val findings = subject.lint(Case.UtilityClassesPositive.path())
+            val findings = subject.lint(Case.UtilityClassesPositive.path())
 
-        it("reports utility classes with a public constructor") {
-            assertThat(findings).hasSize(6)
+            it("reports utility classes with a public constructor") {
+                assertThat(findings).hasSize(6)
+            }
+
+            it("reports utility classes which are marked as open") {
+                val count = findings.count { it.message.contains("The utility class OpenUtilityClass should be final.") }
+                assertThat(count).isEqualTo(1)
+            }
         }
 
-        it("reports utility classes which are marked as open") {
-            val count = findings.count { it.message.contains("The utility class OpenUtilityClass should be final.") }
-            assertThat(count).isEqualTo(1)
+        context("several classes which adhere to the UtilityClassWithPublicConstructor rule") {
+
+            it("does not report given classes") {
+                val findings = subject.lint(Case.UtilityClassesNegative.path())
+                assertThat(findings).isEmpty()
+            }
         }
-    }
 
-    given("several classes which adhere to the UtilityClassWithPublicConstructor rule") {
+        context("annotations class") {
 
-        it("does not report given classes") {
-            val findings = subject.lint(Case.UtilityClassesNegative.path())
-            assertThat(findings).isEmpty()
-        }
-    }
-
-    given("annotations class") {
-
-        it("should not get triggered for utility class") {
-            val code = """
+            it("should not get triggered for utility class") {
+                val code = """
 				@Retention(AnnotationRetention.SOURCE)
 				@StringDef(
 					Gender.MALE,
@@ -50,7 +50,8 @@ class UtilityClassWithPublicConstructorSpec : SubjectSpek<UtilityClassWithPublic
 					}
 				}
 			""".trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
+                assertThat(subject.lint(code)).isEmpty()
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -2,15 +2,14 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class VarCouldBeValSpec : SubjectSpek<VarCouldBeVal>({
+class VarCouldBeValSpec : Spek({
 
-    subject { VarCouldBeVal() }
+    val subject by memoized { VarCouldBeVal() }
 
-    given("local declarations in functions") {
+    describe("local declarations in functions") {
 
         it("does not report variables that are re-assigned") {
             val code = """
@@ -123,7 +122,7 @@ class VarCouldBeValSpec : SubjectSpek<VarCouldBeVal>({
         }
     }
 
-    given("this-prefixed properties - #1257") {
+    describe("this-prefixed properties - #1257") {
 
         it("finds unused field and local") {
             val code = """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -4,14 +4,15 @@ import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class WildcardImportSpec : Spek({
 
-    given("a kt file with wildcard imports") {
-        val code = """
+    describe("WildcardImport rule") {
+
+        context("a kt file with wildcard imports") {
+            val code = """
 			package test
 
 			import io.gitlab.arturbosch.detekt.*
@@ -21,46 +22,46 @@ class WildcardImportSpec : Spek({
 			}
 		"""
 
-        val file = compileContentForTest(code).text
+            val file = compileContentForTest(code).text
 
-        it("should not report anything when the rule is turned off") {
-            val rule = WildcardImport(TestConfig(mapOf("active" to "false")))
+            it("should not report anything when the rule is turned off") {
+                val rule = WildcardImport(TestConfig(mapOf("active" to "false")))
 
-            val findings = rule.lint(file)
-            assertThat(findings).isEmpty()
+                val findings = rule.lint(file)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should report all wildcard imports") {
+                val rule = WildcardImport()
+
+                val findings = rule.lint(file)
+                assertThat(findings).hasSize(2)
+            }
+
+            it("should not report excluded wildcard imports") {
+                val rule = WildcardImport(TestConfig(mapOf("excludeImports" to "test.test.*")))
+
+                val findings = rule.lint(file)
+                assertThat(findings).hasSize(1)
+            }
+
+            it("should not report excluded wildcard imports when multiple are excluded") {
+                val rule = WildcardImport(TestConfig(mapOf("excludeImports" to "test.test.*, io.gitlab.arturbosch.detekt")))
+
+                val findings = rule.lint(file)
+                assertThat(findings).isEmpty()
+            }
+
+            it("ignores excludes that are not matching") {
+                val rule = WildcardImport(TestConfig(mapOf("excludeImports" to "other.test.*")))
+
+                val findings = rule.lint(file)
+                assertThat(findings).hasSize(2)
+            }
         }
 
-        it("should report all wildcard imports") {
-            val rule = WildcardImport()
-
-            val findings = rule.lint(file)
-            assertThat(findings).hasSize(2)
-        }
-
-        it("should not report excluded wildcard imports") {
-            val rule = WildcardImport(TestConfig(mapOf("excludeImports" to "test.test.*")))
-
-            val findings = rule.lint(file)
-            assertThat(findings).hasSize(1)
-        }
-
-        it("should not report excluded wildcard imports when multiple are excluded") {
-            val rule = WildcardImport(TestConfig(mapOf("excludeImports" to "test.test.*, io.gitlab.arturbosch.detekt")))
-
-            val findings = rule.lint(file)
-            assertThat(findings).isEmpty()
-        }
-
-        it("ignores excludes that are not matching") {
-            val rule = WildcardImport(TestConfig(mapOf("excludeImports" to "other.test.*")))
-
-            val findings = rule.lint(file)
-            assertThat(findings).hasSize(2)
-        }
-    }
-
-    given("a kt file with no wildcard imports") {
-        val code = """
+        context("a kt file with no wildcard imports") {
+            val code = """
 			package test
 
 			import test.Test
@@ -69,9 +70,10 @@ class WildcardImportSpec : Spek({
 			}
 		"""
 
-        it("should not report any issues") {
-            val findings = WildcardImport().lint(code)
-            assertThat(findings).isEmpty()
+            it("should not report any issues") {
+                val findings = WildcardImport().lint(code)
+                assertThat(findings).isEmpty()
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/ConditionalPathVisitorTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/ConditionalPathVisitorTest.kt
@@ -3,25 +3,28 @@ package io.gitlab.arturbosch.detekt.rules.style.optional
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
 class ConditionalPathVisitorTest : Spek({
 
-    it("pathCount") {
-        var counter = 0
+    describe("ConditionalPathVisitor") {
 
-        val visitor = ConditionalPathVisitor {
-            counter++
+        it("pathCount") {
+            var counter = 0
+
+            val visitor = ConditionalPathVisitor {
+                counter++
+            }
+
+            val ktFile = compileForTest(Case.ConditionalPath.path())
+
+            ktFile.accept(visitor)
+
+            assertThat(counter).isEqualTo(5)
         }
-
-        val ktFile = compileForTest(Case.ConditionalPath.path())
-
-        ktFile.accept(visitor)
-
-        assertThat(counter).isEqualTo(5)
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
@@ -4,14 +4,13 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class MandatoryBracesIfStatementsSpec : SubjectSpek<MandatoryBracesIfStatements>({
-    subject { MandatoryBracesIfStatements(Config.empty) }
+class MandatoryBracesIfStatementsSpec : Spek({
+    val subject by memoized { MandatoryBracesIfStatements(Config.empty) }
 
-    given("if statements") {
+    describe("MandatoryBracesIfStatements rule") {
 
         it("reports multi-line if statements should have braces") {
             val path = Case.MandatoryBracesIfStatementsPositive.path()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -3,19 +3,20 @@ package io.gitlab.arturbosch.detekt.rules.style.optional
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
-class OptionalUnitSpec : SubjectSpek<OptionalUnit>({
-    subject { OptionalUnit(Config.empty) }
+class OptionalUnitSpec : Spek({
+    val subject by memoized { OptionalUnit(Config.empty) }
 
-    given("several functions which return Unit") {
+    describe("OptionalUnit rule") {
 
-        val code = """
+        context("several functions which return Unit") {
+
+            val code = """
 				fun returnsUnit1(): Unit {
 					fun returnsUnitNested(): Unit {
 						return Unit
@@ -25,32 +26,32 @@ class OptionalUnitSpec : SubjectSpek<OptionalUnit>({
 
 				fun returnsUnit2() = Unit
 			"""
-        val findings = subject.lint(code)
+            val findings = subject.lint(code)
 
-        it("should report functions returning Unit") {
-            assertThat(findings).hasSize(3)
-        }
+            it("should report functions returning Unit") {
+                assertThat(findings).hasSize(3)
+            }
 
-        it("should report the correct violation message") {
-            findings.forEach {
-                assertThat(it.message).endsWith(
-                        " defines a return type of Unit. This is unnecessary and can safely be removed.")
+            it("should report the correct violation message") {
+                findings.forEach {
+                    assertThat(it.message).endsWith(
+                            " defines a return type of Unit. This is unnecessary and can safely be removed.")
+                }
             }
         }
-    }
 
-    given("an overridden function which returns Unit") {
+        context("an overridden function which returns Unit") {
 
-        it("should not report Unit return type in overridden function") {
-            val code = "override fun returnsUnit2() = Unit"
-            val findings = subject.lint(code)
-            assertThat(findings).isEmpty()
+            it("should not report Unit return type in overridden function") {
+                val code = "override fun returnsUnit2() = Unit"
+                val findings = subject.lint(code)
+                assertThat(findings).isEmpty()
+            }
         }
-    }
 
-    given("several lone Unit statements") {
+        context("several lone Unit statements") {
 
-        val code = """
+            val code = """
 				fun returnsNothing() {
 					Unit
 					val i: (Int) -> Unit = { _ -> Unit }
@@ -65,23 +66,23 @@ class OptionalUnitSpec : SubjectSpek<OptionalUnit>({
 					}
 				}
 			"""
-        val findings = subject.lint(code)
+            val findings = subject.lint(code)
 
-        it("should report lone Unit statement") {
-            assertThat(findings).hasSize(4)
-        }
+            it("should report lone Unit statement") {
+                assertThat(findings).hasSize(4)
+            }
 
-        it("should report the correct violation message") {
-            findings.forEach {
-                assertThat(it.message).isEqualTo("A single Unit expression is unnecessary and can safely be removed")
+            it("should report the correct violation message") {
+                findings.forEach {
+                    assertThat(it.message).isEqualTo("A single Unit expression is unnecessary and can safely be removed")
+                }
             }
         }
-    }
 
-    given("several Unit references") {
+        context("several Unit references") {
 
-        it("should not report Unit reference") {
-            val findings = subject.lint("""
+            it("should not report Unit reference") {
+                val findings = subject.lint("""
 				fun returnsNothing(u: Unit, us: () -> String) {
 					val u1 = u is Unit
 					val u2: Unit = Unit
@@ -90,19 +91,20 @@ class OptionalUnitSpec : SubjectSpek<OptionalUnit>({
 					val i: (Int) -> Unit = { _ -> }
 				}
 			""")
-            assertThat(findings).isEmpty()
+                assertThat(findings).isEmpty()
+            }
         }
-    }
 
-    given("a default interface implementation") {
-        it("should not report Unit as part of default interface implementations") {
-            val code = """
+        context("a default interface implementation") {
+            it("should not report Unit as part of default interface implementations") {
+                val code = """
                 interface Foo {
                     fun onMapClicked(point: Point?) = Unit
                 }
             """
-            val findings = subject.lint(code)
-            assertThat(findings).isEmpty()
+                val findings = subject.lint(code)
+                assertThat(findings).isEmpty()
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntaxSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntaxSpec.kt
@@ -4,14 +4,13 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions
-import org.jetbrains.spek.api.dsl.given
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
-class PreferToOverPairSyntaxSpec : SubjectSpek<PreferToOverPairSyntax>({
-    subject { PreferToOverPairSyntax(Config.empty) }
+class PreferToOverPairSyntaxSpec : Spek({
+    val subject by memoized { PreferToOverPairSyntax(Config.empty) }
 
-    given("pair objects") {
+    describe("PreferToOverPairSyntax rule") {
 
         it("reports if pair is created using pair constructor") {
             val path = Case.PreferToOverPairSyntaxPositive.path()

--- a/detekt-sample-extensions/build.gradle.kts
+++ b/detekt-sample-extensions/build.gradle.kts
@@ -9,9 +9,8 @@ dependencies {
 
     testImplementation("io.gitlab.arturbosch.detekt:detekt-test:$usedDetektVersion")
     testImplementation("org.assertj:assertj-core:$assertjVersion")
-    testImplementation("org.jetbrains.spek:spek-api:$spekVersion")
-    testImplementation("org.jetbrains.spek:spek-subject-extension:$spekVersion")
+    testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
+    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/TooManyFunctionsSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/TooManyFunctionsSpec.kt
@@ -3,16 +3,15 @@ package io.gitlab.arturbosch.detekt.sample.extensions
 import io.gitlab.arturbosch.detekt.sample.extensions.rules.TooManyFunctions
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.subject.SubjectSpek
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
-class TooManyFunctionsSpec : SubjectSpek<TooManyFunctions>({
+class TooManyFunctionsSpec : Spek({
 
-    subject { TooManyFunctions() }
+    val subject by memoized { TooManyFunctions() }
 
     describe("a simple test") {
 

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessorSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessorSpec.kt
@@ -3,16 +3,18 @@ package io.gitlab.arturbosch.detekt.sample.extensions.processors
 import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
 class NumberOfLoopsProcessorSpec : Spek({
 
-    it("should expect two loops") {
-        val code = """
+    describe("Number of Loops sample rule") {
+
+        it("should expect two loops") {
+            val code = """
 			fun main() {
 				for (i in 0..10) {
 					while (i < 5) {
@@ -22,10 +24,11 @@ class NumberOfLoopsProcessorSpec : Spek({
 			}
 		"""
 
-        val ktFile = compileContentForTest(code)
-        ktFile.accept(DetektVisitor())
-        NumberOfLoopsProcessor().onProcess(ktFile)
+            val ktFile = compileContentForTest(code)
+            ktFile.accept(DetektVisitor())
+            NumberOfLoopsProcessor().onProcess(ktFile)
 
-        assertThat(ktFile.getUserData(NumberOfLoopsProcessor.numberOfLoopsKey)).isEqualTo(2)
+            assertThat(ktFile.getUserData(NumberOfLoopsProcessor.numberOfLoopsKey)).isEqualTo(2)
+        }
     }
 })

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorTest.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorTest.kt
@@ -8,25 +8,28 @@ import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import org.assertj.core.api.Assertions
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.util.keyFMap.KeyFMap
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 /**
  * @author Artur Bosch
  */
 class QualifiedNameProcessorTest : Spek({
 
-    it("fqNamesOfTestFiles") {
-        val ktFile = compileContentForTest(code)
-        val processor = QualifiedNameProcessor()
-        processor.onProcess(ktFile)
-        processor.onFinish(listOf(ktFile), result)
+    describe("QualifiedNameProcessor") {
 
-        val data = result.getData(fqNamesKey)
-        Assertions.assertThat(data).contains(
-                "io.gitlab.arturbosch.detekt.sample.Foo",
-                "io.gitlab.arturbosch.detekt.sample.Bar",
-                "io.gitlab.arturbosch.detekt.sample.Bla")
+        it("fqNamesOfTestFiles") {
+            val ktFile = compileContentForTest(code)
+            val processor = QualifiedNameProcessor()
+            processor.onProcess(ktFile)
+            processor.onFinish(listOf(ktFile), result)
+
+            val data = result.getData(fqNamesKey)
+            Assertions.assertThat(data).contains(
+                    "io.gitlab.arturbosch.detekt.sample.Foo",
+                    "io.gitlab.arturbosch.detekt.sample.Bar",
+                    "io.gitlab.arturbosch.detekt.sample.Bla")
+        }
     }
 })
 

--- a/detekt-watcher/build.gradle.kts
+++ b/detekt-watcher/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     implementation(project(":detekt-core"))
     testImplementation(project(":detekt-test"))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion")
+    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }
 
 tasks.withType<ShadowJar> {

--- a/detekt-watcher/src/test/kotlin/io/gitlab/arturbosch/detekt/watcher/DetektServiceSpec.kt
+++ b/detekt-watcher/src/test/kotlin/io/gitlab/arturbosch/detekt/watcher/DetektServiceSpec.kt
@@ -14,9 +14,8 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.WatchEvent.Kind
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
 
 class DetektServiceSpec : Spek({
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 detektVersion=1.0.0-RC13
 usedDetektVersion=1.0.0-RC13
 ktlintVersion=0.30.0
-spekVersion=1.2.1
+spekVersion=2.0.0
 junitPlatformVersion=1.4.0
 yamlVersion=1.23
 jcommanderVersion=1.74

--- a/reports/baseline.xml
+++ b/reports/baseline.xml
@@ -2,7 +2,7 @@
 <SmellBaseline>
   <Blacklist timestamp="1540322472112"></Blacklist>
   <Whitelist timestamp="1549734024500">
-    <ID>LargeClass:UnusedPrivateMemberSpec.kt$UnusedPrivateMemberSpec : SubjectSpek</ID>
+    <ID>LargeClass:UnusedPrivateMemberSpec.kt$UnusedPrivateMemberSpec : Spek</ID>
     <ID>MaxLineLength:BaselineFacade.kt$BaselineFacade$val blackFiltered = whiteFiltered.filterNot { finding -&gt; listings.second.ids.contains(finding.baselineId) }</ID>
     <ID>MaxLineLength:ComplexityReportGenerator.kt$ComplexityReportGenerator.Factory$fun create(detektion: Detektion): ComplexityReportGenerator</ID>
     <ID>MaxLineLength:Config.kt$io.gitlab.arturbosch.detekt.api.Config.kt</ID>


### PR DESCRIPTION
Update to Spek 2. Mostly straightforward, except:

* `subject` extension was removed. Followed these instruction to convert: https://spekframework.org/migration/#subjects
* `context` and `it` are not allowed in the root scope of a test, so wrapped in `describe` where appropriate
* converting existing tests that used `given` to the new `given`, `on`, `it` style was going to be a bit of work, so in these cases changed to `describe` instead