### PR TITLE
Update Default acceptableDecimalLength for UnderscoresInNumericLiterals

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -491,7 +491,7 @@ style:
     active: false
   UnderscoresInNumericLiterals:
     active: false
-    acceptableDecimalLength: 4
+    acceptableDecimalLength: 5
   UnnecessaryAbstractClass:
     active: false
     excludeAnnotatedClasses: "dagger.Module"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -15,8 +15,9 @@ import org.jetbrains.kotlin.psi.KtProperty
 
 /**
  * This rule detects and reports decimal base 10 numeric literals above a certain length that should be underscore
- * separated for readability. For [Serializable] classes or objects, the field [serialVersionUID] is explicitly
- * ignored.
+ * separated for readability. Underscores that do not make groups of 3 digits are also reported even if their length is
+ * under the `acceptableDecimalLength`. For `Serializable` classes or objects, the field `serialVersionUID` is
+ * explicitly ignored.
  *
  * <noncompliant>
  * object Money {
@@ -31,7 +32,7 @@ import org.jetbrains.kotlin.psi.KtProperty
  * </compliant>
  *
  * @configuration acceptableDecimalLength - Length under which decimal base 10 literals are not required to have
- * underscores (default: 4)
+ * underscores (default: 5)
  *
  * @author Tyler Wong
  */
@@ -98,6 +99,6 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
         private const val BIN_PREFIX = "0b"
         private const val SERIALIZABLE = "Serializable"
         private const val SERIAL_UID_PROPERTY_NAME = "serialVersionUID"
-        private const val DEFAULT_ACCEPTABLE_DECIMAL_LENGTH = 4
+        private const val DEFAULT_ACCEPTABLE_DECIMAL_LENGTH = 5
     }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -75,7 +75,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
-        it("should not be reported if acceptableDecimalLength is 4") {
+        it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).lint(ktFile)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -13,16 +13,16 @@ class UnderscoresInNumericLiteralsSpec : Spek({
     given("an Int of 1000") {
         val ktFile = compileContentForTest("val myInt = 1000")
 
-        it("should be reported by default") {
+        it("should not be reported by default") {
             val findings = UnderscoresInNumericLiterals().lint(ktFile)
-            assertThat(findings).isNotEmpty
+            assertThat(findings).isEmpty()
         }
 
-        it("should not be reported if acceptableDecimalLength is 5") {
+        it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "5"))
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).lint(ktFile)
-            assertThat(findings).isEmpty()
+            assertThat(findings).isNotEmpty
         }
     }
 
@@ -54,36 +54,36 @@ class UnderscoresInNumericLiteralsSpec : Spek({
     given("a Float of 1000f") {
         val ktFile = compileContentForTest("val myFloat = 1000f")
 
-        it("should be reported by default") {
+        it("should not be reported by default") {
             val findings = UnderscoresInNumericLiterals().lint(ktFile)
-            assertThat(findings).isNotEmpty
+            assertThat(findings).isEmpty()
         }
 
-        it("should not be reported if acceptableDecimalLength is 5") {
+        it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "5"))
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).lint(ktFile)
-            assertThat(findings).isEmpty()
+            assertThat(findings).isNotEmpty
         }
     }
 
     given("a Float of -1000f") {
         val ktFile = compileContentForTest("val myFloat = -1000f")
 
-        it("should be reported by default") {
+        it("should not be reported by default") {
             val findings = UnderscoresInNumericLiterals().lint(ktFile)
-            assertThat(findings).isNotEmpty
+            assertThat(findings).isEmpty()
         }
 
-        it("should not be reported if acceptableDecimalLength is 5") {
+        it("should not be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "5"))
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).lint(ktFile)
-            assertThat(findings).isEmpty()
+            assertThat(findings).isNotEmpty
         }
     }
 
-    given("a Float of -1_000f") {
+    given("a constant Float of -1_000f") {
         val ktFile = compileContentForTest("const val myFloat = -1_000f")
 
         it("should not be reported") {
@@ -120,8 +120,15 @@ class UnderscoresInNumericLiteralsSpec : Spek({
     given("a function with default Int parameter value 1000") {
         val ktFile = compileContentForTest("fun testFunction(testParam: Int = 1000) {}")
 
-        it("should be reported by default") {
+        it("should not be reported by default") {
             val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+
+        it("should be reported if acceptableDecimalLength is 4") {
+            val findings = UnderscoresInNumericLiterals(
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
+            ).lint(ktFile)
             assertThat(findings).isNotEmpty
         }
     }
@@ -205,6 +212,22 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         it("should not be reported") {
             val findings = UnderscoresInNumericLiterals().lint(ktFile)
             assertThat(findings).isNotEmpty
+        }
+    }
+
+    given("an Int of 10000") {
+        val ktFile = compileContentForTest("val myInt = 10000")
+
+        it("should be reported by default") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isNotEmpty
+        }
+
+        it("should not be reported if acceptableDecimalLength is 6") {
+            val findings = UnderscoresInNumericLiterals(
+                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "6"))
+            ).lint(ktFile)
+            assertThat(findings).isEmpty()
         }
     }
 })

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -884,8 +884,9 @@ This rule reports lines that end with a whitespace.
 ### UnderscoresInNumericLiterals
 
 This rule detects and reports decimal base 10 numeric literals above a certain length that should be underscore
-separated for readability. For [Serializable] classes or objects, the field [serialVersionUID] is explicitly
-ignored.
+separated for readability. Underscores that do not make groups of 3 digits are also reported even if their length is
+under the `acceptableDecimalLength`. For `Serializable` classes or objects, the field `serialVersionUID` is
+explicitly ignored.
 
 **Severity**: Style
 
@@ -893,7 +894,7 @@ ignored.
 
 #### Configuration options:
 
-* `acceptableDecimalLength` (default: `4`)
+* `acceptableDecimalLength` (default: `5`)
 
    Length under which decimal base 10 literals are not required to have
 underscores


### PR DESCRIPTION
It's quite common to have numeric literals of length 4 that may represent ids (such as result codes in Android). Those don't become anymore readable if underscore separated so they shouldn't need to be. 

This bumps the default `acceptableDecimalLength` to 5 for the `UnderscoresInNumericLiterals` rule and also updates the documentation formatting and description.