### PR TITLE
Remove failFast from default-detekt-config.yml

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -1,5 +1,4 @@
 autoCorrect: true
-failFast: false
 
 test-pattern: # Configure exclusions for test sources
   active: true

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -64,7 +64,6 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
     private fun defaultGenericConfiguration(): String {
         return """
 			autoCorrect: true
-			failFast: false
 			""".trimIndent()
     }
 


### PR DESCRIPTION
`failFast` is now deprecated.