### PR TITLE
Bugfix: Deprecation warning if using on Gradle >= 5.0

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/GradleCompat.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/GradleCompat.kt
@@ -5,7 +5,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.util.GradleVersion
 
 fun Project.fileProperty(): RegularFileProperty {
-    return if (GradleVersion.current() < GradleVersion.version("5.0")) {
+    return if (GradleVersion.current() >= GradleVersion.version("5.0")) {
         objects.fileProperty()
     } else {
         layout.fileProperty()


### PR DESCRIPTION
The given condition is wrong (see commit). If Gradle >=5.0 is found, it uses the deprecated method and vice versa. That leads to the message "Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0".