### PR TITLE
Remove project cache dir workaround from tests

### DIFF
--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -205,7 +205,7 @@ internal class DetektTaskDslTest : Spek({
 
                     val config = """
 						|detekt {
-						|	input = files("${"$"}projectDir")
+						|	input = files("${"$"}projectDir/src")
 						|	filters = ".*/test/.*"
 						|}
 						"""
@@ -270,7 +270,7 @@ internal class DetektTaskDslTest : Spek({
 					|task detektFailFast(type: io.gitlab.arturbosch.detekt.Detekt) {
 					|	description = "Runs a failfast detekt build."
 					|
-					|	input = files("${"$"}projectDir")
+					|	input = files("${"$"}projectDir/src")
 					|	config = files("config.yml")
 					|	debug = true
 					|	parallel = true
@@ -303,7 +303,7 @@ internal class DetektTaskDslTest : Spek({
 					|task<io.gitlab.arturbosch.detekt.Detekt>("detektFailFast") {
 					|	description = "Runs a failfast detekt build."
 					|
-					|	input = files("${"$"}projectDir")
+					|	input = files("${"$"}projectDir/src")
 					|	config = files("config.yml")
 					|	debug = true
 					|	parallel = true

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleTest.kt
@@ -318,7 +318,7 @@ internal class DetektTaskMultiModuleTest : Spek({
 
             val detektConfig: String = """
 				|detekt {
-				|	input = files("${"$"}projectDir")
+				|	input = files("${"$"}projectDir/src", "${"$"}projectDir/child1/src", "${"$"}projectDir/child2/src")
 				|	filters = ".*build.gradle.kts"
 				|}
 				""".trimMargin()

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
@@ -14,7 +14,6 @@ class DslGradleRunner(
 ) {
 
     private val rootDir: File = createTempDir(prefix = "applyPlugin")
-    private val cacheDir = createTempDir(prefix = "cache")
     private val randomString = UUID.randomUUID().toString()
 
     private val settingsContent = """
@@ -80,10 +79,7 @@ class DslGradleRunner(
 
     fun runTasksAndCheckResult(vararg tasks: String, doAssert: DslGradleRunner.(BuildResult) -> Unit) {
 
-        // Using a custom "project-cache-dir" to avoid a Gradle error on Windows
-        val cacheArgs = listOf("--project-cache-dir", cacheDir.absolutePath, "--build-cache")
-
-        val args = listOf("--stacktrace", "--info") + cacheArgs + tasks
+        val args = listOf("--stacktrace", "--info", "--build-cache") + tasks
         val result = GradleRunner.create()
                 .withProjectDir(rootDir)
                 .withPluginClasspath()


### PR DESCRIPTION
This was originally removed in #929 but brought back at some point.

Will see if it passes in CI, if not, will investigate.