### PR TITLE
Disable rules that ktlint disables by default

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,12 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.jfrog.bintray.gradle.BintrayExtension
 import io.gitlab.arturbosch.detekt.Detekt
-import java.util.Date
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.util.GFileUtils
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.util.Date
 
 plugins {
     kotlin("jvm") version "1.3.21"

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/YamlConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/YamlConfig.kt
@@ -1,10 +1,10 @@
 package io.gitlab.arturbosch.detekt.api
 
+import org.yaml.snakeyaml.Yaml
 import java.io.BufferedReader
 import java.net.URL
 import java.nio.file.Files
 import java.nio.file.Path
-import org.yaml.snakeyaml.Yaml
 
 /**
  * Config implementation using the yaml format. SubConfigurations can return sub maps according to the

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/Compiler.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/Compiler.kt
@@ -1,11 +1,11 @@
 package io.gitlab.arturbosch.detekt.api
 
-import java.io.File
-import java.net.URI
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.KtFile
+import java.io.File
+import java.net.URI
 
 /**
  * @author Artur Bosch

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFormat.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFormat.kt
@@ -1,11 +1,11 @@
 package io.gitlab.arturbosch.detekt.cli.baseline
 
+import org.xml.sax.SAXParseException
 import java.nio.file.Files
 import java.nio.file.Path
 import javax.xml.parsers.SAXParserFactory
 import javax.xml.stream.XMLStreamException
 import javax.xml.stream.XMLStreamWriter
-import org.xml.sax.SAXParseException
 
 /**
  * @author Artur Bosch

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineHandler.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineHandler.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.cli.baseline
 
-import java.time.Instant
 import org.xml.sax.Attributes
 import org.xml.sax.helpers.DefaultHandler
+import java.time.Instant
 
 /**
  * @author Artur Bosch

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -214,8 +214,7 @@ formatting:
     active: true
     autoCorrect: true
   ImportOrdering:
-    active: true
-    autoCorrect: true
+    active: false
   Indentation:
     active: true
     autoCorrect: true
@@ -237,7 +236,7 @@ formatting:
     active: true
     autoCorrect: true
   NoItParamInMultilineLambda:
-    active: true
+    active: false
   NoLineBreakAfterElse:
     active: true
     autoCorrect: true

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigAssert.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigAssert.kt
@@ -3,11 +3,11 @@ package io.gitlab.arturbosch.detekt.cli
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.YamlConfig
-import java.lang.reflect.Field
-import java.lang.reflect.Modifier
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.reflections.Reflections
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
 
 class ConfigAssert(
     private val config: Config,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
@@ -5,8 +5,8 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import java.nio.file.Path
 import org.jetbrains.kotlin.psi.KtFile
+import java.nio.file.Path
 
 /**
  * @author Artur Bosch

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektor.kt
@@ -5,8 +5,8 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import java.util.concurrent.ExecutorService
 import org.jetbrains.kotlin.psi.KtFile
+import java.util.concurrent.ExecutorService
 
 /**
  * @author Artur Bosch

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Junk.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Junk.kt
@@ -1,13 +1,13 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.Finding
+import org.jetbrains.kotlin.psi.KtFile
 import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.HashMap
 import java.util.stream.Collectors
 import java.util.stream.Stream
-import org.jetbrains.kotlin.psi.KtFile
 
 /**
  * @author Artur Bosch

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
@@ -1,13 +1,13 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.psiProject
-import java.nio.file.Path
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
 import org.jetbrains.kotlin.com.intellij.testFramework.LightVirtualFile
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.KtFile
+import java.nio.file.Path
 
 /**
  * @author Artur Bosch

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
@@ -1,11 +1,11 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.Notification
-import java.nio.file.Files
-import java.nio.file.Path
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.fileClasses.javaFileFacadeFqName
 import org.jetbrains.kotlin.psi.KtFile
+import java.nio.file.Files
+import java.nio.file.Path
 
 /**
  * @author Artur Bosch

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.core
 
+import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Files
 import java.nio.file.Path
-import org.jetbrains.kotlin.psi.KtFile
 
 /**
  * @author Artur Bosch

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/TestPattern.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/TestPattern.kt
@@ -3,9 +3,9 @@ package io.gitlab.arturbosch.detekt.core
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleId
 import io.gitlab.arturbosch.detekt.core.TestPattern.Companion.TEST_PATTERN_SUB_CONFIG
+import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
 import java.nio.file.Paths
-import org.jetbrains.kotlin.psi.KtFile
 
 /**
  * @author Artur Bosch

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KT.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KT.kt
@@ -10,9 +10,9 @@ import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.test.resource
+import org.jetbrains.kotlin.psi.KtClassOrObject
 import java.nio.file.Path
 import java.nio.file.Paths
-import org.jetbrains.kotlin.psi.KtClassOrObject
 
 /**
  * @author Artur Bosch

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
@@ -7,8 +7,6 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
  *
- * @active since v1.0.0
- * @autoCorrect since v1.0.0
  * @author Artur Bosch
  */
 class ImportOrdering(config: Config) : FormattingRule(config) {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoItParamInMultilineLambda.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoItParamInMultilineLambda.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
  *
- * @active since v1.0.0
  * @author Artur Bosch
  */
 class NoItParamInMultilineLambda(config: Config) : FormattingRule(config) {

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
@@ -2,9 +2,9 @@ package io.gitlab.arturbosch.detekt.formatting
 
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import io.gitlab.arturbosch.detekt.test.resource
+import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import java.io.File
 import java.nio.file.Paths
-import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 
 /**
  * @author Artur Bosch

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Main.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Main.kt
@@ -5,8 +5,8 @@ package io.gitlab.arturbosch.detekt.generator
 import io.gitlab.arturbosch.detekt.cli.failWithErrorMessages
 import io.gitlab.arturbosch.detekt.cli.parseArguments
 import io.gitlab.arturbosch.detekt.core.isFile
-import java.nio.file.Files
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
+import java.nio.file.Files
 
 /**
  * @author Marvin Ramin

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -9,7 +9,6 @@ import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidCodeExa
 import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidDocumentationException
 import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidIssueDeclaration
 import io.gitlab.arturbosch.detekt.rules.empty.EmptyRule
-import java.lang.reflect.Modifier
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
@@ -17,6 +16,7 @@ import org.jetbrains.kotlin.psi.KtSuperTypeList
 import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.psiUtil.containingClass
 import org.jetbrains.kotlin.psi.psiUtil.getSuperNames
+import java.lang.reflect.Modifier
 
 /**
  * @author Marvin Ramin

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -15,7 +15,6 @@ import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
 import io.gitlab.arturbosch.detekt.invoke.PluginsArgument
 import io.gitlab.arturbosch.detekt.invoke.XmlReportArgument
-import java.io.File
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
@@ -37,6 +36,7 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.gradle.language.base.plugins.LifecycleBasePlugin
+import java.io.File
 
 /**
  * @author Artur Bosch

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -1,10 +1,10 @@
 package io.gitlab.arturbosch.detekt.extensions
 
-import java.io.File
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.plugins.quality.CodeQualityExtension
+import java.io.File
 
 /**
  * @author Artur Bosch

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
@@ -1,10 +1,10 @@
 package io.gitlab.arturbosch.detekt.extensions
 
 import io.gitlab.arturbosch.detekt.internal.fileProperty
-import java.io.File
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
+import java.io.File
 
 class DetektReport(val type: DetektReportType, private val project: Project) {
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt
 
-import java.io.File
-import java.util.UUID
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
+import java.io.File
+import java.util.UUID
 
 class DslGradleRunner(
     val projectLayout: ProjectLayout,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/IsPartOfUtils.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/IsPartOfUtils.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.rules
 
-import kotlin.reflect.KClass
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtStringTemplateEntry
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
+import kotlin.reflect.KClass
 
 /**
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/LinesOfCode.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/LinesOfCode.kt
@@ -1,7 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules
 
-import java.util.ArrayDeque
-import kotlin.reflect.KClass
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
@@ -21,6 +19,8 @@ import org.jetbrains.kotlin.kdoc.psi.impl.KDocSection
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocTag
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
+import java.util.ArrayDeque
+import kotlin.reflect.KClass
 
 fun ASTNode.tokenSequence(skipTreesOf: Set<KClass<out PsiElement>>): Sequence<ASTNode> = sequence {
     val queue = ArrayDeque<ASTNode>()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
@@ -9,11 +9,11 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.isEqualsFunction
 import io.gitlab.arturbosch.detekt.rules.isHashCodeFunction
-import java.util.ArrayDeque
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import java.util.ArrayDeque
 
 /**
  * When a class overrides the equals() method it should also override the hashCode() method.

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -10,10 +10,10 @@ import io.gitlab.arturbosch.detekt.api.ThresholdRule
 import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
 import io.gitlab.arturbosch.detekt.rules.linesOfCode
 import io.gitlab.arturbosch.detekt.rules.parentOfType
-import java.util.IdentityHashMap
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.utils.addToStdlib.flattenTo
+import java.util.IdentityHashMap
 
 /**
  * This rule reports large classes. Classes should generally have one responsibility. Large classes can indicate that

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -10,10 +10,10 @@ import io.gitlab.arturbosch.detekt.api.ThresholdRule
 import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
 import io.gitlab.arturbosch.detekt.rules.linesOfCode
 import io.gitlab.arturbosch.detekt.rules.parentOfType
-import java.util.IdentityHashMap
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.utils.addToStdlib.flattenTo
+import java.util.IdentityHashMap
 
 /**
  * Methods should have one responsibility. Long methods can indicate that a method handles too many cases at once.

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -10,7 +10,6 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.isConstant
 import io.gitlab.arturbosch.detekt.rules.isHashCodeFunction
 import io.gitlab.arturbosch.detekt.rules.isPartOf
-import java.util.Locale
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
@@ -28,6 +27,7 @@ import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
+import java.util.Locale
 
 /**
  * This rule detects and reports usages of magic numbers in the code. Prefer defining constants with clear names

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
-import java.util.Arrays
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.lexer.KtTokens.ABSTRACT_KEYWORD
 import org.jetbrains.kotlin.lexer.KtTokens.ACTUAL_KEYWORD
@@ -36,6 +35,7 @@ import org.jetbrains.kotlin.lexer.KtTokens.TAILREC_KEYWORD
 import org.jetbrains.kotlin.lexer.KtTokens.VARARG_KEYWORD
 import org.jetbrains.kotlin.psi.KtModifierList
 import org.jetbrains.kotlin.psi.psiUtil.allChildren
+import java.util.Arrays
 
 /**
  * This rule reports cases in the code where modifiers are not in the correct order. The default modifier order is

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -8,10 +8,10 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.safeAs
-import java.util.Locale
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtProperty
+import java.util.Locale
 
 /**
  * This rule detects and reports decimal base 10 numeric literals above a certain length that should be underscore

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
@@ -8,13 +8,13 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.safeAs
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.contract
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
 /**
  * `apply` expressions are used frequently, but sometimes their usage should be replaced with

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEngine.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEngine.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.test
 
-import javax.script.ScriptEngineManager
-import javax.script.ScriptException
 import org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback
 import org.jetbrains.kotlin.script.jsr223.KotlinJsr223JvmLocalScriptEngine
+import javax.script.ScriptEngineManager
+import javax.script.ScriptException
 
 /**
  * The object to create the Kotlin script engine for code compilation.

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
@@ -1,11 +1,11 @@
 package io.gitlab.arturbosch.detekt.test
 
 import io.gitlab.arturbosch.detekt.core.KtCompiler
-import java.nio.file.Path
-import java.nio.file.Paths
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.KtFile
+import java.nio.file.Path
+import java.nio.file.Paths
 
 /**
  * Test compiler extends kt compiler and adds ability to compile from text content.

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -4,9 +4,9 @@ import io.gitlab.arturbosch.detekt.api.BaseRule
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.test.KotlinScriptEngine.compile
-import java.nio.file.Path
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.psi.KtFile
+import java.nio.file.Path
 
 fun BaseRule.compileAndLint(@Language("kotlin") content: String): List<Finding> {
     compile(content)

--- a/detekt-watcher/src/test/kotlin/io/gitlab/arturbosch/detekt/watcher/DetektServiceSpec.kt
+++ b/detekt-watcher/src/test/kotlin/io/gitlab/arturbosch/detekt/watcher/DetektServiceSpec.kt
@@ -7,15 +7,14 @@ import io.gitlab.arturbosch.detekt.watcher.service.PathEvent
 import io.gitlab.arturbosch.detekt.watcher.service.WatchedDir
 import io.gitlab.arturbosch.detekt.watcher.state.Parameters
 import io.gitlab.arturbosch.detekt.watcher.state.State
-import java.io.ByteArrayOutputStream
-import java.io.PrintStream
-import java.lang.UnsupportedOperationException
-import java.nio.file.Files
-import java.nio.file.Paths
-import java.nio.file.WatchEvent.Kind
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.WatchEvent.Kind
 
 class DetektServiceSpec : Spek({
 


### PR DESCRIPTION
ktlint disables `ImportOrderingRule` and `NoItParamInMultilineLambdaRule` by default due to existing known issues:
* ImportOrderingRule is disabled "until it's clear how to reconcile difference in Intellij & Android Studio import layout"
* NoItParamInMultilineLambdaRule is disabled "until it's clear what to do in case of `import _.it`"

This brings detekt's config in line to reduce false positives being raised.

Also allows "Optimize imports" in IntelliJ/AS to work as expected, so have run that on the codebase as well.