### PR TITLE
Ignore enums in ProtectedMemberInFinalClass rule - #1489

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
@@ -58,7 +58,8 @@ class ProtectedMemberInFinalClass(config: Config = Config.empty) : Rule(config) 
         val isNotAbstract = !klass.isAbstract()
         val isFinal = !klass.isOpen()
         val isNotSealed = !klass.isSealed()
-        return isNotAbstract && isFinal && isNotSealed
+        val isNotEnum = !klass.isEnum()
+        return isNotAbstract && isFinal && isNotSealed && isNotEnum
     }
 
     internal inner class DeclarationVisitor : DetektVisitor() {

--- a/detekt-rules/src/test/resources/cases/ProtectedMemberInFinalClassNegative.kt
+++ b/detekt-rules/src/test/resources/cases/ProtectedMemberInFinalClassNegative.kt
@@ -27,4 +27,7 @@ sealed class SealedClass {
     protected fun a() {}
 }
 
-
+enum class EnumClass {
+    ;
+    protected fun foo() {}
+}


### PR DESCRIPTION
closes #1489 