### PR TITLE
Load dependencies over HTTPS

### DIFF
--- a/scripts/get_analysis_projects.groovy
+++ b/scripts/get_analysis_projects.groovy
@@ -1,4 +1,4 @@
-@GrabResolver(name='detekt', root='http://dl.bintray.com/arturbosch/code-analysis/', m2Compatible='true')
+@GrabResolver(name='detekt', root='https://dl.bintray.com/arturbosch/code-analysis/', m2Compatible='true')
 @Grab('org.vcsreader:vcsreader:1.1.1')
 import org.vcsreader.VcsProject
 import org.vcsreader.vcs.VcsError


### PR DESCRIPTION
Fixes a security vulnerability where `get_analysis_projects.groovy` downloaded dependencies over HTTP instead of HTTPS.
