### PR TITLE
Show friendlier error when wrong type used for a config parameter

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -63,7 +63,7 @@ internal object EmptyConfig : Config {
  */
 abstract class BaseConfig : Config {
 
-    protected open fun valueOrDefaultInternal(result: Any?, default: Any): Any {
+    protected open fun valueOrDefaultInternal(key: String, result: Any?, default: Any): Any {
         return try {
             if (result != null) {
                 when (result) {
@@ -74,9 +74,9 @@ abstract class BaseConfig : Config {
                 default
             }
         } catch (e: ClassCastException) {
-            throw IllegalArgumentException("Type of value $result does not match the type of default value $default!")
+            throw IllegalArgumentException("Value \"$result\" set for config parameter '$key' is not of required type ${default::class.simpleName}.")
         } catch (e: NumberFormatException) {
-            throw IllegalArgumentException("Type of value $result does not match the type of default value $default!", e)
+            throw IllegalArgumentException("Value \"$result\" set for config parameter '$key' is not of required type ${default::class.simpleName}.", e)
         }
     }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/YamlConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/YamlConfig.kt
@@ -22,7 +22,7 @@ class YamlConfig internal constructor(val properties: Map<String, Any>) : BaseCo
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T {
         val result = properties[key]
-        return valueOrDefaultInternal(result, default) as T
+        return valueOrDefaultInternal(key, result, default) as T
     }
 
     override fun <T : Any> valueOrNull(key: String): T? {

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
@@ -12,12 +12,12 @@ open class TestConfig(private val values: Map<String, String> = mutableMapOf()) 
 
     override fun <T : Any> valueOrDefault(key: String, default: T) = when (key) {
         "active" -> getActiveValue(default) as T
-        else -> valueOrDefaultInternal(values[key], default) as T
+        else -> valueOrDefaultInternal(key, values[key], default) as T
     }
 
     private fun <T : Any> getActiveValue(default: T): Any {
         val active = values["active"]
-        return if (active != null) valueOrDefaultInternal(active, default) else true
+        return if (active != null) valueOrDefaultInternal("active", active, default) else true
     }
 
     override fun <T : Any> valueOrNull(key: String): T? = when (key) {


### PR DESCRIPTION
Fixes #1498, but doesn't show the full path to the incorrectly set config parameter (e.g. if a threshold is set to a String instead of an Int, only shows "threshold" and not "path.to.threshold").

I couldn't see a simple way to provide the full path due to the way the configs are set throughout detekt-rules, but happy if someone else can pick this up and continue with it.

Example output:
`Value "two" set for config parameter 'threshold' is not of required type Int.`