### PR TITLE
Exit process with specific code when detekt finds code issues

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.cli
 
 import com.beust.jcommander.JCommander
 import com.beust.jcommander.ParameterException
+import kotlin.system.exitProcess
 
 inline fun <reified T : Args> parseArguments(args: Array<String>): Pair<T, JCommander> {
     val cli = T::class.java.declaredConstructors.firstOrNull()?.newInstance() as? T
@@ -22,7 +23,7 @@ inline fun <reified T : Args> parseArguments(args: Array<String>): Pair<T, JComm
 
     if (cli.help) {
         jCommander.usage()
-        System.exit(0)
+        exitProcess(0)
     }
 
     return cli to jCommander
@@ -38,5 +39,5 @@ fun JCommander.failWithErrorMessages(messages: Iterable<String?>) {
     }
     println()
     this.usage()
-    System.exit(-1)
+    exitProcess(1)
 }

--- a/docs/pages/gettingstarted/cli.md
+++ b/docs/pages/gettingstarted/cli.md
@@ -12,6 +12,14 @@ summary:
 2. `gradle build`
 3. `java -jar detekt-cli/build/libs/detekt-cli-[version]-all.jar [parameters]*`
 
+detekt will exit with one of the following exit codes:
+
+| Exit code | Description                                                                                     |
+|-----------|-------------------------------------------------------------------------------------------------|
+| 0         | detekt ran normally and maxIssues or failThreshold count was not reached in BuildFailureReport. |
+| 1         | An unexpected error occurred                                                                    |
+| 2         | maxIssues or failThreshold count was reached in BuildFailureReport.                             |
+
 The following parameters are shown when `--help` is entered.
 
 ```


### PR DESCRIPTION
Closes #1493 

detekt will exit with one of the following exit codes:

| Exit code | Description                                                                                     |
|-----------|-------------------------------------------------------------------------------------------------|
| 0         | detekt ran normally and maxIssues or failThreshold count was not reached in BuildFailureReport. |
| 1         | An unexpected error occurred                                                                    |
| 2         | maxIssues or failThreshold count was reached in BuildFailureReport.                             |