### PR TITLE
Fix deprecation warnings

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -58,7 +58,7 @@ open class Detekt : DefaultTask() {
     @InputFile
     @Optional
     @PathSensitive(PathSensitivity.RELATIVE)
-    var baseline: RegularFileProperty = createNewInputFile()
+    var baseline: RegularFileProperty = project.fileProperty()
 
     @InputFiles
     @Optional
@@ -158,5 +158,4 @@ open class Detekt : DefaultTask() {
         DetektInvoker.invokeCli(project, arguments.toList(), debugProp.getOrElse(false))
     }
 
-    private fun createNewInputFile() = project.fileProperty()
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.extensions.DetektReports
+import io.gitlab.arturbosch.detekt.internal.fileProperty
 import io.gitlab.arturbosch.detekt.invoke.BaselineArgument
 import io.gitlab.arturbosch.detekt.invoke.BuildUponDefaultConfigArgument
 import io.gitlab.arturbosch.detekt.invoke.ConfigArgument
@@ -57,7 +58,7 @@ open class Detekt : DefaultTask() {
     @InputFile
     @Optional
     @PathSensitive(PathSensitivity.RELATIVE)
-    var baseline: RegularFileProperty = project.layout.fileProperty()
+    var baseline: RegularFileProperty = createNewInputFile()
 
     @InputFiles
     @Optional
@@ -156,4 +157,6 @@ open class Detekt : DefaultTask() {
 
         DetektInvoker.invokeCli(project, arguments.toList(), debugProp.getOrElse(false))
     }
+
+    private fun createNewInputFile() = project.fileProperty()
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt
 
+import io.gitlab.arturbosch.detekt.internal.fileProperty
 import io.gitlab.arturbosch.detekt.invoke.BaselineArgument
 import io.gitlab.arturbosch.detekt.invoke.BuildUponDefaultConfigArgument
 import io.gitlab.arturbosch.detekt.invoke.ConfigArgument
@@ -41,7 +42,7 @@ open class DetektCreateBaselineTask : DefaultTask() {
 
     @OutputFile
     @PathSensitive(PathSensitivity.RELATIVE)
-    var baseline: RegularFileProperty = project.layout.fileProperty()
+    var baseline: RegularFileProperty = project.fileProperty()
 
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.extensions
 
+import io.gitlab.arturbosch.detekt.internal.fileProperty
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
@@ -25,7 +26,7 @@ class DetektReport(val type: DetektReportType, private val project: Project) {
     }
 
     private fun getTargetFile(reportsDir: File): RegularFile {
-        val prop = project.layout.fileProperty()
+        val prop = project.fileProperty()
         val customDestination = destination
         if (customDestination != null)
             prop.set(customDestination)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/GradleCompat.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/GradleCompat.kt
@@ -1,0 +1,13 @@
+package io.gitlab.arturbosch.detekt.internal
+
+import org.gradle.api.Project
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.util.GradleVersion
+
+fun Project.fileProperty(): RegularFileProperty {
+    return if (GradleVersion.current() < GradleVersion.version("5.0")) {
+        objects.fileProperty()
+    } else {
+        layout.fileProperty()
+    }
+}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/GradleCompat.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/GradleCompat.kt
@@ -6,8 +6,8 @@ import org.gradle.util.GradleVersion
 
 fun Project.fileProperty(): RegularFileProperty {
     return if (GradleVersion.current() < GradleVersion.version("5.0")) {
-        objects.fileProperty()
-    } else {
         layout.fileProperty()
+    } else {
+        objects.fileProperty()
     }
 }


### PR DESCRIPTION
As pointed out by @jw-fielmann the gradle compat helper was just using the inverted logic to determine the correct method. So I partially reverted the commit by @3flex, changed the logic and everything worked.

Closes #1307 