### PR TITLE
Ensure IntelliJ is configured to use official Kotlin style

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,7 @@ kshVersion=0.1.1
 reflectionsVersion=0.9.11
 jacocoVersion=0.8.3
 
+kotlin.code.style=official
+
 systemProp.sonar.host.url=http://localhost:9000
 systemProp.detektVersion=detektVersion


### PR DESCRIPTION
Uses tip from https://kotlinlang.org/docs/reference/code-style-migration-guide.html#migration-to-a-new-code-style

https://github.com/arturbosch/detekt/commit/445ffb0c55b0b3af830cea363d42f1730d9642b3 reformatted the code base to use spaces instead of tabs for indentation, however there is still much code that is not formatted according to the latest Kotlin code style. This flag will ensure that new code edited in IntelliJ/Android Studio will adhere to the new style without modifying existing code.

If @arturbosch prefers I'll also add a commit that will have IntellIJ automatically migrate code to the official style.