### PR TITLE
Fix compliant/noncompliant code example in OptionalWhenBraces

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBraces.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBraces.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  *
  * <noncompliant>
  * val i = 1
- * when (1) {
+ * when (i) {
  *     1 -> { println("one") } // unnecessary curly braces since there is only one statement
  *     else -> println("else")
  * }
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  *
  * <compliant>
  * val i = 1
- * when (1) {
+ * when (i) {
  *     1 -> println("one")
  *     else -> println("else")
  * }

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -610,7 +610,7 @@ This rule reports unnecessary braces in when expressions. These optional braces 
 
 ```kotlin
 val i = 1
-when (1) {
+when (i) {
     1 -> { println("one") } // unnecessary curly braces since there is only one statement
     else -> println("else")
 }
@@ -620,7 +620,7 @@ when (1) {
 
 ```kotlin
 val i = 1
-when (1) {
+when (i) {
     1 -> println("one")
     else -> println("else")
 }


### PR DESCRIPTION
Supersedes and closes #1486.

Fix compliant/noncompliant code example in OptionalWhenBraces.

Keeps the commit history intact for @ChrisZou's original commit.