### PR TITLE
Configure build-scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,14 @@ matrix:
       osx_image: xcode10.2
 install: true
 script:
-  - ./gradlew build --build-cache -PwarningsAsErrors=true
+  - ./gradlew build --build-cache -PwarningsAsErrors=true --scan
   - ./gradlew shadowJar
   - java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar --help
   - java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar -i . --baseline ./reports/baseline.xml -ex "**/resources/**,**/detekt*/build/**" -c ./detekt-cli/src/main/resources/default-detekt-config.yml,./reports/failfast.yml
   - ./gradlew verifyGeneratorOutput
 after_success:
   - .buildscript/deploy_snapshot.sh
-  - ./gradlew rootJacocoTestReport
+  - ./gradlew rootJacocoTestReport --scan
   - bash <(curl -s https://codecov.io/bash)
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.Date
 
 plugins {
+    id("com.gradle.build-scan") version "2.2.1"
     kotlin("jvm") version "1.3.31"
     id("com.jfrog.bintray") version "1.8.4"
     id("com.github.ben-manes.versions") version "0.21.0"
@@ -15,6 +16,11 @@ plugins {
     id("io.gitlab.arturbosch.detekt")
     id("org.jetbrains.dokka") version "0.9.18"
     jacoco
+}
+
+buildScan {
+    termsOfServiceUrl   = "https://gradle.com/terms-of-service"
+    termsOfServiceAgree = "yes"
 }
 
 tasks.wrapper {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.Date
 
 plugins {
-    id("com.gradle.build-scan") version "2.2.1"
+    id("com.gradle.build-scan") version "2.3"
     kotlin("jvm") version "1.3.31"
     id("com.jfrog.bintray") version "1.8.4"
     id("com.github.ben-manes.versions") version "0.21.0"


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.