### PR TITLE
Type and symbol resolving

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Andrew Ochsner](https://github.com/aochsner) - Updated Readme for `failFast` option
 - [Paul Merlin](https://github.com/eskatos) - Gradle build improvements
 - [Konstantin Aksenov](https://github.com/vacxe) - Coding improvement
-- [Matthew Haughton](https://github.com/3flex) - Started type resolution, Dependency updates, Coding + Documentation improvements
+- [Matthew Haughton](https://github.com/3flex) - Added type resolution, Dependency updates, Coding + Documentation improvements
 - [Janusz Bagiński](https://github.com/jbaginski) - Fixed line number reporting for MaxLineLengthRule 
 - [Mike Kobit](https://github.com/mkobit) - Gradle build improvements
 - [Philipp Hofmann](https://github.com/philipphofmann) - Readme improvements

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,10 +18,10 @@
 - Windows support!
 - `sonar-plugin` (has it's own space [here](https://github.com/arturbosch/sonar-kotlin))
 - Allow to exclude rules or rule sets for test sources
+- figure out how kotlinc/intellij does type and symbol resolution
 
 ## Beyond 1.0.0
 
-- figure out how kotlinc/intellij does type and symbol resolution
 - finish `FeatureEnvy` rule -> needs type resolution
 
 ## Ideas for new major versions

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/BaseRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/BaseRule.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.api
 
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * The type to use when referring to rule ids giving it more context then a String would.
@@ -24,12 +25,18 @@ abstract class BaseRule(
 ) : DetektVisitor(), Context by context {
 
     open val ruleId: RuleId = javaClass.simpleName
+    var bindingContext: BindingContext = BindingContext.EMPTY
 
     /**
      * Before starting visiting kotlin elements, a check is performed if this rule should be triggered.
      * Pre- and post-visit-hooks are executed before/after the visiting process.
+     * [BindingContext] holds the result of the semantic analysis of the source code by the Kotlin compiler. Rules that
+     * rely on symbols and types being resolved can use the BindingContext for this analysis. Note that detekt must
+     * receive the correct compile classpath for the code being analyzed otherwise the default value
+     * [BindingContext.EMPTY] will be used and it will not be possible for detekt to resolve types or symbols.
      */
-    fun visitFile(root: KtFile) {
+    fun visitFile(root: KtFile, bindingContext: BindingContext = BindingContext.EMPTY) {
+        this.bindingContext = bindingContext
         if (visitCondition(root)) {
             clearFindings()
             preVisit(root)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ProjectExtension.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ProjectExtension.kt
@@ -1,10 +1,13 @@
 package io.gitlab.arturbosch.detekt.api
 
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
+import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoots
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.cli.jvm.config.addJavaSourceRoots
+import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.com.intellij.openapi.extensions.ExtensionPoint
 import org.jetbrains.kotlin.com.intellij.openapi.extensions.Extensions
@@ -18,29 +21,58 @@ import org.jetbrains.kotlin.com.intellij.pom.impl.PomTransactionBase
 import org.jetbrains.kotlin.com.intellij.pom.tree.TreeAspect
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.TreeCopyHandler
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtPsiFactory
 import sun.reflect.ReflectionFactory
+import java.io.File
+import java.nio.file.Path
 
 /**
  * The initialized kotlin environment which is used to translate kotlin code to a Kotlin-AST.
  */
-val psiProject: Project = createKotlinCoreEnvironment()
+val psiProject: Project = createProject()
 
 /**
  * Allows to generate different kinds of [KtElement]'s.
  */
 val psiFactory: KtPsiFactory = KtPsiFactory(psiProject, false)
 
-private fun createKotlinCoreEnvironment(): Project {
+fun createKotlinCoreEnvironment(configuration: CompilerConfiguration = CompilerConfiguration()): KotlinCoreEnvironment {
     System.setProperty("idea.io.use.fallback", "true")
-    val configuration = CompilerConfiguration()
     configuration.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY,
             PrintingMessageCollector(System.err, MessageRenderer.PLAIN_FULL_PATHS, false))
     return KotlinCoreEnvironment.createForProduction(Disposer.newDisposable(),
-            configuration, EnvironmentConfigFiles.JVM_CONFIG_FILES).project.apply {
+        configuration, EnvironmentConfigFiles.JVM_CONFIG_FILES)
+}
+
+private fun createProject(configuration: CompilerConfiguration = CompilerConfiguration()): Project {
+    return createKotlinCoreEnvironment(configuration).project.apply {
         makeMutable(this as? MockProject ?: throw IllegalStateException(
                 "Unexpected Type for psi project. MockProject expected. Please report this!"))
+    }
+}
+
+fun createCompilerConfiguration(
+    classpath: List<String>,
+    pathsToAnalyze: List<Path>
+): CompilerConfiguration {
+
+    val javaFiles = pathsToAnalyze.flatMap { path ->
+        path.toFile().walk()
+            .filter { it.isFile && it.extension.equals("java", true) }
+            .toList()
+    }
+    val kotlinFiles = pathsToAnalyze.flatMap { path ->
+        path.toFile().walk()
+            .filter { it.isFile }
+            .filter { it.extension.equals("kt", true) || it.extension.equals("kts", true) }
+            .map { it.absolutePath }
+            .toList()
+    }
+
+    return CompilerConfiguration().apply {
+        addJavaSourceRoots(javaFiles)
+        addKotlinSourceRoots(kotlinFiles)
+        addJvmClasspathRoots(classpath.map { File(it) })
     }
 }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.api
 
 import io.gitlab.arturbosch.detekt.api.internal.validateIdentifier
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
 
 typealias RuleSetId = String
 
@@ -20,7 +21,10 @@ class RuleSet(val id: RuleSetId, val rules: List<BaseRule>) {
      * Visits given file with all rules of this rule set, returning a list
      * of all code smell findings.
      */
-    fun accept(file: KtFile): List<Finding> = rules.flatMap { it.visitFile(file); it.findings }
+    fun accept(file: KtFile, bindingContext: BindingContext = BindingContext.EMPTY): List<Finding> = rules.flatMap {
+        it.visitFile(file, bindingContext)
+        it.findings
+    }
 
     /**
      * Visits given file with all non-filtered rules of this rule set.
@@ -29,9 +33,16 @@ class RuleSet(val id: RuleSetId, val rules: List<BaseRule>) {
      *
      * A list of findings is returned for given [KtFile]
      */
-    fun accept(file: KtFile, ruleFilters: Set<RuleId>): List<Finding> =
-            rules.asSequence()
-                    .filterNot { it.ruleId in ruleFilters }
-                    .onEach { if (it is MultiRule) it.ruleFilters = ruleFilters }.toList()
-                    .flatMap { it.visitFile(file); it.findings }
+    fun accept(
+        file: KtFile,
+        ruleFilters: Set<RuleId>,
+        bindingContext: BindingContext = BindingContext.EMPTY
+    ): List<Finding> =
+        rules.asSequence()
+            .filterNot { it.ruleId in ruleFilters }
+            .onEach { if (it is MultiRule) it.ruleFilters = ruleFilters }.toList()
+            .flatMap {
+                it.visitFile(file, bindingContext)
+                it.findings
+            }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -23,6 +23,13 @@ class CliArgs : Args {
                     "These filters apply on relative paths from the project root.")
     var filters: String? = null // Using a converter for List<PathFilter> resulted in a ClassCastException
 
+    @Parameter(
+        names = ["--classpath", "-cp"],
+        required = false,
+        description = "EXPERIMENTAL: Compile Classpath of the project."
+    )
+    var classpath: String? = null
+
     @Parameter(names = ["--config", "-c"],
             description = "Path to the config file (path/to/config.yml). " +
                     "Multiple configuration files can be specified with ',' or ';' as separator.")

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -23,6 +23,8 @@ fun CliArgs.createPlugins(): List<Path> = plugins.letIfNonEmpty {
     MultipleExistingPathConverter().convert(this)
 }
 
+fun CliArgs.createClasspath(): List<String> = classpath.letIfNonEmpty { split(";") }
+
 private fun <T> String?.letIfNonEmpty(init: String.() -> List<T>): List<T> =
         if (this == null || this.isEmpty()) listOf() else this.init()
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.cli.runners
 
 import io.gitlab.arturbosch.detekt.cli.CliArgs
 import io.gitlab.arturbosch.detekt.cli.OutputFacade
+import io.gitlab.arturbosch.detekt.cli.createClasspath
 import io.gitlab.arturbosch.detekt.cli.createPathFilters
 import io.gitlab.arturbosch.detekt.cli.createPlugins
 import io.gitlab.arturbosch.detekt.cli.loadConfiguration
@@ -30,6 +31,7 @@ class Runner(private val arguments: CliArgs) : Executable {
         with(arguments) {
             val pathFilters = createPathFilters()
             val plugins = createPlugins()
+            val classpath = createClasspath()
             val config = loadConfiguration()
 
             return ProcessingSettings(
@@ -38,7 +40,9 @@ class Runner(private val arguments: CliArgs) : Executable {
                     pathFilters = pathFilters,
                     parallelCompilation = parallel,
                     excludeDefaultRuleSets = disableDefaultRuleSets,
-                    pluginPaths = plugins)
+                    pluginPaths = plugins,
+                    classpath = classpath
+            )
         }
     }
 }

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -514,6 +514,8 @@ style:
   UseDataClass:
     active: false
     excludeAnnotatedClasses: ""
+  UselessCallOnNotNull:
+    active: false
   UtilityClassWithPublicConstructor:
     active: false
   VarCouldBeVal:

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektor.kt
@@ -5,7 +5,17 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.createKotlinCoreEnvironment
+import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
+import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
+import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.cli.jvm.compiler.NoScopeRecordCliBindingTrace
+import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
+import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProviderFactory
 import java.util.concurrent.ExecutorService
 
 /**
@@ -21,12 +31,32 @@ class Detektor(
     private val executor: ExecutorService = settings.executorService
     private val logger = settings.errorPrinter
 
-    fun run(ktFiles: List<KtFile>): Map<RuleSetId, List<Finding>> = withExecutor(executor) {
+    fun run(
+        ktFiles: List<KtFile>,
+        environment: KotlinCoreEnvironment = createKotlinCoreEnvironment(),
+        resolveTypes: Boolean = false
+    ): Map<RuleSetId, List<Finding>> = withExecutor(executor) {
+        val bindingContext = if (resolveTypes) {
+            val analyzer = AnalyzerWithCompilerReport(
+                PrintingMessageCollector(System.out, MessageRenderer.PLAIN_FULL_PATHS, true),
+                environment.configuration.languageVersionSettings
+            )
+            analyzer.analyzeAndReport(ktFiles) {
+                TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(
+                    environment.project, ktFiles, NoScopeRecordCliBindingTrace(),
+                    environment.configuration, environment::createPackagePartProvider,
+                    ::FileBasedDeclarationProviderFactory
+                )
+            }
+            analyzer.analysisResult.bindingContext
+        } else {
+            BindingContext.EMPTY
+        }
 
         val futures = ktFiles.map { file ->
             runAsync {
                 processors.forEach { it.onProcess(file) }
-                file.analyze().apply {
+                file.analyze(bindingContext).apply {
                     processors.forEach { it.onProcessComplete(file, this) }
                 }
             }.exceptionally { error ->
@@ -48,7 +78,7 @@ class Detektor(
         result
     }
 
-    private fun KtFile.analyze(): Map<RuleSetId, List<Finding>> {
+    private fun KtFile.analyze(bindingContext: BindingContext): Map<RuleSetId, List<Finding>> {
         var ruleSets = providers.asSequence()
                 .mapNotNull { it.buildRuleset(config) }
                 .sortedBy { it.id }
@@ -57,9 +87,9 @@ class Detektor(
 
         return if (testPattern.isTestSource(this)) {
             ruleSets = ruleSets.filterNot { testPattern.matchesRuleSet(it.id) }
-            ruleSets.map { ruleSet -> ruleSet.id to ruleSet.accept(this, testPattern.excludingRules) }
+            ruleSets.map { ruleSet -> ruleSet.id to ruleSet.accept(this, testPattern.excludingRules, bindingContext) }
         } else {
-            ruleSets.map { ruleSet -> ruleSet.id to ruleSet.accept(this) }
+            ruleSets.map { ruleSet -> ruleSet.id to ruleSet.accept(this, bindingContext) }
         }.toMergedMap()
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -22,6 +22,7 @@ data class ProcessingSettings @JvmOverloads constructor(
     val parallelCompilation: Boolean = false,
     val excludeDefaultRuleSets: Boolean = false,
     val pluginPaths: List<Path> = emptyList(),
+    val classpath: List<String> = emptyList(),
     val executorService: ExecutorService = ForkJoinPool.commonPool(),
     val outPrinter: PrintStream = System.out,
     val errorPrinter: PrintStream = System.err
@@ -36,12 +37,13 @@ data class ProcessingSettings @JvmOverloads constructor(
         parallelCompilation: Boolean = false,
         excludeDefaultRuleSets: Boolean = false,
         pluginPaths: List<Path> = emptyList(),
+        classpath: List<String> = emptyList(),
         executorService: ExecutorService = ForkJoinPool.commonPool(),
         outPrinter: PrintStream = System.out,
         errorPrinter: PrintStream = System.err
     ) : this(
         listOf(inputPath), config, pathFilters, parallelCompilation,
-        excludeDefaultRuleSets, pluginPaths, executorService, outPrinter, errorPrinter
+        excludeDefaultRuleSets, pluginPaths, classpath, executorService, outPrinter, errorPrinter
     )
 
     init {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -40,6 +40,7 @@ import io.gitlab.arturbosch.detekt.rules.style.UnusedImports
 import io.gitlab.arturbosch.detekt.rules.style.UnusedPrivateClass
 import io.gitlab.arturbosch.detekt.rules.style.UnusedPrivateMember
 import io.gitlab.arturbosch.detekt.rules.style.UseDataClass
+import io.gitlab.arturbosch.detekt.rules.style.UselessCallOnNotNull
 import io.gitlab.arturbosch.detekt.rules.style.UtilityClassWithPublicConstructor
 import io.gitlab.arturbosch.detekt.rules.style.VarCouldBeVal
 import io.gitlab.arturbosch.detekt.rules.style.WildcardImport
@@ -103,6 +104,7 @@ class StyleGuideProvider : RuleSetProvider {
                 VarCouldBeVal(config),
                 ForbiddenVoid(config),
                 ExplicitItLambdaParameter(config),
+                UselessCallOnNotNull(config),
                 UnderscoresInNumericLiterals(config)
         ))
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
@@ -1,0 +1,87 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.resolve.calls.callUtil.getType
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
+import org.jetbrains.kotlin.types.TypeUtils
+
+/**
+ * The Kotlin stdlib provides some functions that are designed to operate on references that may be null. These
+ * functions can also be called on non-nullable references or on collections or sequences that are known to be empty -
+ * the calls are redundant in this case and can be removed or should be changed to a call that does not check whether
+ * the value is null or not.
+ *
+ * Rule adapted from Kotlin's IntelliJ plugin: https://github.com/JetBrains/kotlin/blob/f5d0a38629e7d2e7017ee645dc4d4bee60614e93/idea/src/org/jetbrains/kotlin/idea/inspections/collections/UselessCallOnNotNullInspection.kt
+ *
+ * <noncompliant>
+ * val testList = listOf("string").orEmpty()
+ * val testList2 = listOf("string").orEmpty().map { _ }
+ * val testString = ""?.isNullOrBlank()
+ * </noncompliant>
+ *
+ * <compliant>
+ * val testList = listOf("string")
+ * val testList2 = listOf("string").map { _ }
+ * val testString = ""?.isBlank()
+ * </compliant>
+ *
+ * @author Matthew Haughton
+ */
+class UselessCallOnNotNull(config: Config = Config.empty) : Rule(config) {
+    override val issue: Issue = Issue(
+        "UselessCallOnNotNull",
+        Severity.Performance,
+        "This call on non-null reference may be reduced or removed. Some calls are intended to be called on nullable " +
+                "collection or text types (e.g. String?). When this call is used on a reference to a non-null type " +
+                "(e.g. String) it is redundant and will have no effect, so it can be removed.",
+        Debt.FIVE_MINS
+    )
+
+    private val uselessFqNames = mapOf(
+        "kotlin.collections.orEmpty" to Conversion(),
+        "kotlin.sequences.orEmpty" to Conversion(),
+        "kotlin.text.orEmpty" to Conversion(),
+        "kotlin.text.isNullOrEmpty" to Conversion("isEmpty"),
+        "kotlin.text.isNullOrBlank" to Conversion("isBlank")
+    )
+
+    private val uselessNames = toShortFqNames(uselessFqNames.keys)
+
+    @Suppress("ReturnCount")
+    override fun visitQualifiedExpression(expression: KtQualifiedExpression) {
+        super.visitQualifiedExpression(expression)
+        if (bindingContext == BindingContext.EMPTY) return
+        val selector = expression.selectorExpression as? KtCallExpression ?: return
+        val calleeExpression = selector.calleeExpression ?: return
+        if (calleeExpression.text !in uselessNames) return
+
+        val resolvedCall = expression.getResolvedCall(bindingContext) ?: return
+        if (uselessFqNames.contains(resolvedCall.resultingDescriptor.fqNameOrNull()?.asString())) {
+            val safeExpression = expression as? KtSafeQualifiedExpression
+            val notNullType =
+                expression.receiverExpression.getType(bindingContext)?.let { TypeUtils.isNullableType(it) } == false
+            if (notNullType || safeExpression != null) {
+                report(CodeSmell(issue, Entity.from(expression), ""))
+            }
+        }
+    }
+
+    private companion object {
+        data class Conversion(val replacementName: String? = null)
+
+        private fun toShortFqNames(longNames: Set<String>): Set<String> {
+            return longNames.mapTo(mutableSetOf()) { fqName -> fqName.takeLastWhile { it != '.' } }
+        }
+    }
+}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
@@ -1,0 +1,71 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
+import io.gitlab.arturbosch.detekt.test.lintWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object UselessCallOnNotNullSpec : Spek({
+
+    val subject by memoized { UselessCallOnNotNull() }
+
+    lateinit var environment: KotlinCoreEnvironment
+
+    beforeEachTest {
+        environment = KtTestCompiler.createEnvironment()
+    }
+
+    describe("UselessCallOnNotNull rule") {
+        it("reports when calling orEmpty on a list") {
+            val code = """val testList = listOf("string").orEmpty()"""
+            assertThat(subject.lintWithContext(environment, code)).hasSize(1)
+        }
+
+        it("reports when calling orEmpty on a nullable list") {
+            val code = """val testList = listOf("string")?.orEmpty()"""
+            assertThat(subject.lintWithContext(environment, code)).hasSize(1)
+        }
+
+        it("reports when calling orEmpty in a chain") {
+            val code = """val testList = listOf("string").orEmpty().map { _ }"""
+            assertThat(subject.lintWithContext(environment, code)).hasSize(1)
+        }
+
+        it("reports when calling isNullOrBlank on a nullable type") {
+            val code = """val testString = ""?.isNullOrBlank()"""
+            assertThat(subject.lintWithContext(environment, code)).hasSize(1)
+        }
+
+        it("reports when calling isNullOrEmpty on a nullable type") {
+            val code = """val testString = ""?.isNullOrEmpty()"""
+            assertThat(subject.lintWithContext(environment, code)).hasSize(1)
+        }
+
+        it("reports when calling isNullOrEmpty on a string") {
+            val code = """val testString = "".isNullOrEmpty()"""
+            assertThat(subject.lintWithContext(environment, code)).hasSize(1)
+        }
+
+        it("reports when calling orEmpty on a string") {
+            val code = """val testString = "".orEmpty()"""
+            assertThat(subject.lintWithContext(environment, code)).hasSize(1)
+        }
+
+        it("reports when calling orEmpty on a sequence") {
+            val code = """val testSequence = listOf(1).asSequence().orEmpty()"""
+            assertThat(subject.lintWithContext(environment, code)).hasSize(1)
+        }
+
+        it("only reports on a Kotlin list") {
+            val code = """
+                |fun main() {
+                |    val javaList = Java().list.orEmpty()
+                |    val list = listOf(1, 2, 3).orEmpty()
+                |}
+            """.trimMargin()
+            assertThat(subject.lintWithContext(environment, code)).hasSize(1)
+        }
+    }
+})

--- a/detekt-test/build.gradle.kts
+++ b/detekt-test/build.gradle.kts
@@ -5,6 +5,6 @@ dependencies {
     implementation(kotlin("compiler-embeddable"))
     implementation(kotlin("script-util"))
 
-    implementation(project(":detekt-core"))
+    api(project(":detekt-core"))
     implementation("org.assertj:assertj-core:$assertjVersion")
 }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
@@ -1,9 +1,21 @@
 package io.gitlab.arturbosch.detekt.test
 
 import io.gitlab.arturbosch.detekt.core.KtCompiler
+import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.cli.jvm.compiler.NoScopeRecordCliBindingTrace
+import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
+import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoot
+import org.jetbrains.kotlin.com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
+import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProviderFactory
+import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -24,6 +36,33 @@ object KtTestCompiler : KtCompiler() {
                 KotlinLanguage.INSTANCE,
                 StringUtilRt.convertLineSeparators(content))
         return psiFile as? KtFile ?: throw IllegalStateException("kotlin file expected")
+    }
+
+    fun getContextForPaths(environment: KotlinCoreEnvironment, paths: List<KtFile>) =
+        TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(
+            environment.project, paths, NoScopeRecordCliBindingTrace(),
+            environment.configuration, environment::createPackagePartProvider, ::FileBasedDeclarationProviderFactory
+        ).bindingContext
+
+    fun createEnvironment(): KotlinCoreEnvironment {
+        val configuration = CompilerConfiguration()
+        configuration.put(CommonConfigurationKeys.MODULE_NAME, "test_module")
+        configuration.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
+
+        // Get the runtime location of stdlib jar and pass to the compiler so it's available to generate the
+        // BindingContext for rules under test.
+        val path = File(CharRange::class.java.protectionDomain.codeSource.location.path)
+        configuration.addJvmClasspathRoot(path)
+
+        return KotlinCoreEnvironment.createForTests(
+            TestDisposable(),
+            configuration,
+            EnvironmentConfigFiles.JVM_CONFIG_FILES
+        )
+    }
+
+    class TestDisposable : Disposable {
+        override fun dispose() { } // Don't want to dispose the test KotlinCoreEnvironment
     }
 }
 

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -5,7 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.test.KotlinScriptEngine.compile
 import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
 import java.nio.file.Path
 
 fun BaseRule.compileAndLint(@Language("kotlin") content: String): List<Finding> {
@@ -23,10 +25,19 @@ fun BaseRule.lint(path: Path): List<Finding> {
     return findingsAfterVisit(ktFile)
 }
 
+fun BaseRule.lintWithContext(environment: KotlinCoreEnvironment, content: String): List<Finding> {
+    val ktFile = KtTestCompiler.compileFromContent(content.trimIndent())
+    val bindingContext = KtTestCompiler.getContextForPaths(environment, listOf(ktFile))
+    return findingsAfterVisit(ktFile, bindingContext)
+}
+
 fun BaseRule.lint(ktFile: KtFile) = findingsAfterVisit(ktFile)
 
-private fun BaseRule.findingsAfterVisit(ktFile: KtFile): List<Finding> {
-    this.visitFile(ktFile)
+private fun BaseRule.findingsAfterVisit(
+    ktFile: KtFile,
+    bindingContext: BindingContext = BindingContext.EMPTY
+): List<Finding> {
+    this.visitFile(ktFile, bindingContext)
     return this.findings
 }
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -1150,6 +1150,35 @@ class DataClassCandidate(val i: Int) {
 data class DataClass(val i: Int, val i2: Int)
 ```
 
+### UselessCallOnNotNull
+
+The Kotlin stdlib provides some functions that are designed to operate on references that may be null. These
+functions can also be called on non-nullable references or on collections or sequences that are known to be empty -
+the calls are redundant in this case and can be removed or should be changed to a call that does not check whether
+the value is null or not.
+
+Rule adapted from Kotlin's IntelliJ plugin: https://github.com/JetBrains/kotlin/blob/f5d0a38629e7d2e7017ee645dc4d4bee60614e93/idea/src/org/jetbrains/kotlin/idea/inspections/collections/UselessCallOnNotNullInspection.kt
+
+**Severity**: Performance
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+val testList = listOf("string").orEmpty()
+val testList2 = listOf("string").orEmpty().map { _ }
+val testString = ""?.isNullOrBlank()
+```
+
+#### Compliant Code:
+
+```kotlin
+val testList = listOf("string")
+val testList2 = listOf("string").map { _ }
+val testString = ""?.isBlank()
+```
+
 ### UtilityClassWithPublicConstructor
 
 A class which only contains utility variables and functions with no concrete implementation can be refactored

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,4 @@ kotlin.code.style=official
 
 systemProp.sonar.host.url=http://localhost:9000
 systemProp.detektVersion=detektVersion
+systemProp.file.encoding=UTF-8


### PR DESCRIPTION
This PR adds type and symbol resolving for Kotlin code that targets the JVM, seeking early feedback. It's a WIP until at a minimum the following tests/features are added:

- [x] Make the functionality optional - it's slow, so want to disable by default unless a value passed to `--classpath` parameter
- [ ] Tests for the new functionality in a mixed Java/Kotlin codebase
- [x] Tests for the new `UselessCallOnNotNull` rule
- [x] Sharing compiler errors/warnings with the user (they are not currently shown, so user has to know that their code compiles before running detekt, otherwise there'll be an error)

Kotlin/JS and Kotlin/Native will not be in scope, so naturally won't look at MPP support either. Will tackle Gradle plugin integration in future but not as part of this PR.

To test, enable the `UselessCallOnNotNull` rule in the config file, add the following test file with a `kts` extension, then run with `--input path/to/testfile.kts --classpath path/to/kotlin-stdlib.jar --config path/to/config.yml`.
```kotlin
val nextTest = mutableListOf<String>().orEmpty()
```
The new rule will resolve the `orEmpty()` call to `kotlin.collections.orEmpty` which will trigger a detekt issue because the `orEmpty()` call is never needed on a not-null collection.

This is an updated version of #485, rebased and with a simplified implementation (and the intention to get it merged this time! :smile:).