### PR TITLE
Enable Kotlin's progressive compilation mode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -137,6 +137,7 @@ subprojects {
         kotlinOptions.jvmTarget = "1.8"
         // https://youtrack.jetbrains.com/issue/KT-24946
         kotlinOptions.freeCompilerArgs = listOf(
+            "-progressive",
             "-Xskip-runtime-version-check",
             "-Xdisable-default-scripting-plugin",
             "-Xuse-experimental=kotlin.Experimental"


### PR DESCRIPTION
Forces certain compiler bug fixes to be applied between major Kotlin releases.

This may mean a Kotlin point release update will require code changes, but changes would only be required if they lead to safer code.

See here for more details: https://kotlinlang.org/docs/reference/whatsnew13.html#progressive-mode