### PR TITLE
Ignore local properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Alistair Sykes](https://github.com/alistairsykes) - Doc improvement
 - [Andrew Arnott](https://github.com/andrew-arnott) - UnusedPrivateMember improvement
 - [Tyler Wong](https://github.com/tylerbwong) - UnderscoresInNumericLiterals rule
+- [Daniele Conti](https://github.com/fourlastor) - ObjectPropertyNaming improvement
 
 ### Mentions
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
@@ -35,6 +35,10 @@ class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
     private val privatePropertyPattern by LazyRegex(PRIVATE_PROPERTY_PATTERN, "(_)?[A-Za-z][_A-Za-z0-9]*")
 
     override fun visitProperty(property: KtProperty) {
+        if (property.isLocal) {
+            return
+        }
+
         if (property.isConstant()) {
             handleConstant(property)
         } else {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -195,6 +195,25 @@ class ObjectPropertyNamingSpec : Spek({
             assertThat(subject.lint(code)).isEmpty()
         }
     }
+
+    describe("local properties") {
+        it("should not detect local properties") {
+            val config = TestConfig(mapOf(
+                ObjectPropertyNaming.PROPERTY_PATTERN to "valid"
+            ))
+            val subject = ObjectPropertyNaming(config)
+
+            val code = """
+                object O {
+                    fun foo() {
+                        val somethingElse = 1
+                    }
+                }
+            """
+
+            assertThat(subject.lint(code)).isEmpty()
+        }
+    }
 })
 
 abstract class NamingSnippet(private val isPrivate: Boolean, private val isConst: Boolean) {


### PR DESCRIPTION
Hello! I noticed that `ObjectPropertyNaming` would flag also local properties (val/vars inside functions inside an object).

I believe that wasn't an intended behaviour, and this addresses it excluding local properties when visiting an object.

If this was the intended behaviour, this could change to add tests to reflect it.