### PR TITLE
Enable local build cache for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk:
   - openjdk8
   - openjdk11
 script:
-  - ./gradlew build -PwarningsAsErrors=true
+  - ./gradlew build --build-cache -PwarningsAsErrors=true
   - ./gradlew shadowJar
   - java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar --help
   - java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar -i . --baseline ./reports/baseline.xml -f ".*/resources/.*,.*/build/.*" -c ./detekt-cli/src/main/resources/default-detekt-config.yml,./reports/failfast.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
   - gradlew.bat --version
 
 build_script:
-  - gradlew build -PwarningsAsErrors=true
+  - gradlew build --build-cache -PwarningsAsErrors=true
   - gradlew installShadowDist
   - detekt-cli\build\install\detekt-cli-shadow\bin\detekt-cli --help
 


### PR DESCRIPTION
This should greatly decrease the overall build time for subsequent CI builds.

Will require monitoring in the near term to make sure it's working properly. If there's build instability then this should be reverted and root cause investigated.