### PR TITLE
Travis: Skip default install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ jdk:
   - openjdk8
   - openjdk11
   - openjdk12
+install: true
 script:
   - ./gradlew build --build-cache -PwarningsAsErrors=true
   - ./gradlew shadowJar


### PR DESCRIPTION
Travis runs `./gradlew assemble` by default, which means any custom flags set (such as `--build-cache` and `-PwarningsAsErrors=true`) don't apply. Skipping the default install steps means the build will only start at the `./gradlew build` step in the `script` block.

Each AppVeyor build is now down to about 5-6 mins thanks to the build cache - this should bring the Travis build down to a similar level since the `--build-cache` flag will now apply to the `assemble` task.