### PR TITLE
Check cross-module coverage with Jacoco

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
   - ./gradlew verifyGeneratorOutput
 after_success:
   - .buildscript/deploy_snapshot.sh
-  - ./gradlew jacocoTestReport
+  - ./gradlew rootJacocoTestReport
   - bash <(curl -s https://codecov.io/bash)
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,16 +67,19 @@ subprojects {
         plugin("maven-publish")
         plugin("io.gitlab.arturbosch.detekt")
         plugin("org.jetbrains.dokka")
-        plugin("jacoco")
     }
 
-    val jacocoVersion: String by project
-    jacoco.toolVersion = jacocoVersion
+    if (project.name != "detekt-test") {
+        apply { plugin("jacoco") }
 
-    tasks.named<JacocoReport>("jacocoTestReport").configure {
-        reports.xml.isEnabled = true
-        reports.html.isEnabled = true
-        dependsOn(tasks.named("test"))
+        val jacocoVersion: String by project
+        jacoco.toolVersion = jacocoVersion
+
+        tasks.jacocoTestReport.configure {
+            reports.xml.isEnabled = false
+            reports.html.isEnabled = false
+            dependsOn(tasks.named("test"))
+        }
     }
 
     tasks.withType<Detekt> {
@@ -300,5 +303,26 @@ val detektAll by tasks.registering(Detekt::class) {
     reports {
         xml.enabled = false
         html.enabled = false
+    }
+}
+
+tasks.create<JacocoReport>("rootJacocoTestReport") {
+    val jacocoReportTasks =
+        subprojects
+            .filterNot { it.project.name == "detekt-test" }
+            .map { it.tasks["jacocoTestReport"] as? JacocoReport }
+    dependsOn(jacocoReportTasks)
+
+    val executionData = jacocoReportTasks.mapNotNull { it?.executionData }.toTypedArray()
+    executionData(executionData)
+    reports.xml.isEnabled = true
+    reports.xml.destination = file("$buildDir/reports/jacoco/jacocoRootReport.xml")
+
+    subprojects.forEach { testedProject ->
+        val sourceSets = testedProject.sourceSets
+        this@create.additionalSourceDirs.from(files(sourceSets.main.get().allSource.srcDirs))
+        this@create.sourceDirectories.from(files(sourceSets.main.get().allSource.srcDirs))
+        this@create.classDirectories.from(files(sourceSets.main.get().output))
+        this@create.dependsOn(testedProject.tasks.named("test"))
     }
 }


### PR DESCRIPTION
This allows for more thorough coverage checking - before this PR, coverage is only reported on a module based on the tests run in that module.

This PR shows coverage across modules, so tests run in detekt-core may cover additional lines in detekt-api which should be reported here.

This is probably still not quite 100% accurate but it shows a slightly better storage when it comes to test coverage.