### PR TITLE
Allow configuration to ignore magic number in ranges.

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -441,6 +441,7 @@ style:
     ignoreAnnotation: false
     ignoreNamedArgument: true
     ignoreEnums: false
+    ignoreRanges: false
   MandatoryBracesIfStatements:
     active: false
   MaxLineLength:

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -10,6 +10,7 @@ import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+@Suppress("LargeClass")
 class MagicNumberSpec : Spek({
 
     val fileName = TEST_FILENAME

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -363,6 +363,10 @@ declarations should be ignored
 
    whether magic numbers in enums should be ignored
 
+* `ignoreRanges` (default: `false`)
+
+   whether magic numbers in ranges should be ignored
+
 #### Noncompliant Code:
 
 ```kotlin


### PR DESCRIPTION
Closes #1368 

This allows the user to ignore magic numbers in ranges. By default these occurrences are reported.