### PR TITLE
AssertJ housekeeping

### DIFF
--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.api
 
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
-import org.assertj.core.api.Java6Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigAssert.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigAssert.kt
@@ -3,8 +3,8 @@ package io.gitlab.arturbosch.detekt.cli
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.YamlConfig
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
 import org.reflections.Reflections
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
@@ -29,7 +29,7 @@ class ConfigAssert(
         for (ruleClass in ruleClasses) {
             val ymlDeclaration = ymlDeclarations.filter { it.key == ruleClass.simpleName }
             if (ymlDeclaration.keys.size != 1) {
-                Assertions.fail<String>("${ruleClass.simpleName} rule is not correctly defined in $CONFIG_FILE")
+                fail<String>("${ruleClass.simpleName} rule is not correctly defined in $CONFIG_FILE")
             }
 
             @Suppress("UNCHECKED_CAST")
@@ -48,7 +48,7 @@ class ConfigAssert(
         for (ymlOption in filter) {
             val configField = configFields.singleOrNull { ymlOption.key == it.get(null) }
             if (configField == null) {
-                Assertions.fail<String>("${ymlOption.key} option for ${ruleClass.simpleName} rule is not correctly " +
+                fail<String>("${ymlOption.key} option for ${ruleClass.simpleName} rule is not correctly " +
                         "defined")
             }
         }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/FileProcessorLocatorTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/FileProcessorLocatorTest.kt
@@ -4,8 +4,8 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.core.FileProcessorLocator
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.test.resource
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
 import org.reflections.Reflections
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -28,7 +28,7 @@ class FileProcessorLocatorTest : Spek({
             assertThat(processorClasses).isNotEmpty
             processorClasses
                     .filter { clazz -> processors.firstOrNull { clazz == it.javaClass } == null }
-                    .forEach { Assertions.fail("$it processor is not loaded by the FileProcessorLocator") }
+                    .forEach { fail("$it processor is not loaded by the FileProcessorLocator") }
         }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
@@ -13,7 +13,7 @@ import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.cli.CliArgs
 import io.gitlab.arturbosch.detekt.test.resource
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtClass
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -43,7 +43,7 @@ class SingleRuleRunnerSpec : Spek({
 
 class TestConsoleReport : ConsoleReport() {
     override fun render(detektion: Detektion): String? {
-        Assertions.assertThat(detektion.findings).hasSize(1)
+        assertThat(detektion.findings).hasSize(1)
         return "I've run!"
     }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/RuleSetLocatorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/RuleSetLocatorTest.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
 import org.reflections.Reflections
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -19,7 +19,7 @@ class RuleSetLocatorTest : Spek({
             assertThat(providerClasses).isNotEmpty
             providerClasses
                     .filter { clazz -> providers.firstOrNull { it.javaClass == clazz } == null }
-                    .forEach { Assertions.fail("$it rule set is not loaded by the RuleSetLocator") }
+                    .forEach { fail("$it rule set is not loaded by the RuleSetLocator") }
         }
     }
 })

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/KtFileCountVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/KtFileCountVisitorTest.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.core.processors
 
 import io.gitlab.arturbosch.detekt.core.path
 import io.gitlab.arturbosch.detekt.test.compileForTest
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtFile
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -18,7 +18,7 @@ class KtFileCountVisitorTest : Spek({
             val count = files
                     .map { getData(it) }
                     .sum()
-            Assertions.assertThat(count).isEqualTo(2)
+            assertThat(count).isEqualTo(2)
         }
     }
 })

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/LOCVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/LOCVisitorTest.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.core.processors
 
 import io.gitlab.arturbosch.detekt.core.path
 import io.gitlab.arturbosch.detekt.test.compileForTest
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -15,7 +15,7 @@ class LOCVisitorTest : Spek({
                 accept(LOCVisitor())
                 getUserData(linesKey)
             }
-            Assertions.assertThat(loc).isEqualTo(8)
+            assertThat(loc).isEqualTo(8)
         }
     }
 })

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/PackageCountVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/PackageCountVisitorTest.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.core.processors
 
 import io.gitlab.arturbosch.detekt.core.path
 import io.gitlab.arturbosch.detekt.test.compileForTest
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtFile
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -19,7 +19,7 @@ class PackageCountVisitorTest : Spek({
                     .map { getData(it) }
                     .distinct()
                     .count()
-            Assertions.assertThat(count).isEqualTo(2)
+            assertThat(count).isEqualTo(2)
         }
     }
 })

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/SLOCVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/SLOCVisitorTest.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.core.processors
 
 import io.gitlab.arturbosch.detekt.core.path
 import io.gitlab.arturbosch.detekt.test.compileForTest
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -15,7 +15,7 @@ class SLOCVisitorTest : Spek({
                 accept(SLOCVisitor())
                 getUserData(sourceLinesKey)
             }
-            Assertions.assertThat(loc).isEqualTo(3)
+            assertThat(loc).isEqualTo(3)
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RunRuleSetWithRuleFiltersSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RunRuleSetWithRuleFiltersSpec.kt
@@ -9,7 +9,6 @@ import io.gitlab.arturbosch.detekt.rules.style.WildcardImport
 import io.gitlab.arturbosch.detekt.rules.style.optional.OptionalUnit
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import io.gitlab.arturbosch.detekt.test.loadRuleSet
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -28,8 +27,8 @@ class RunRuleSetWithRuleFiltersSpec : Spek({
 
         it("filters WildcardImport, runs OptionalUnit") {
             val findings = ruleSet.accept(defaultFile, setOf("WildcardImport"))
-            Assertions.assertThat(findings).allMatch { it.id != "WildcardImport" }
-            Assertions.assertThat(findings).anySatisfy { it.id != "OptionalUnit" }
+            assertThat(findings).allMatch { it.id != "WildcardImport" }
+            assertThat(findings).anySatisfy { it.id != "OptionalUnit" }
         }
     }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
@@ -2,8 +2,8 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.assertj.core.api.Java6Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.util.regex.PatternSyntaxException

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -22,7 +22,7 @@ class ReturnFromFinallySpec : Spek({
 
             it("should report") {
                 val findings = subject.lint(code)
-                Assertions.assertThat(findings).hasSize(1)
+                assertThat(findings).hasSize(1)
             }
         }
 
@@ -37,7 +37,7 @@ class ReturnFromFinallySpec : Spek({
 
             it("should not report") {
                 val findings = subject.lint(code)
-                Assertions.assertThat(findings).hasSize(0)
+                assertThat(findings).hasSize(0)
             }
         }
 
@@ -55,7 +55,7 @@ class ReturnFromFinallySpec : Spek({
 
             it("should report") {
                 val findings = subject.lint(code)
-                Assertions.assertThat(findings).hasSize(1)
+                assertThat(findings).hasSize(1)
             }
         }
 
@@ -74,7 +74,7 @@ class ReturnFromFinallySpec : Spek({
 
             it("should not report") {
                 val findings = subject.lint(code)
-                Assertions.assertThat(findings).hasSize(0)
+                assertThat(findings).hasSize(0)
             }
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -22,7 +22,7 @@ class ThrowingNewInstanceOfSameExceptionSpec : Spek({
 
             it("should report") {
                 val findings = subject.lint(code)
-                Assertions.assertThat(findings).hasSize(1)
+                assertThat(findings).hasSize(1)
             }
         }
 
@@ -38,7 +38,7 @@ class ThrowingNewInstanceOfSameExceptionSpec : Spek({
 
             it("should not report") {
                 val findings = subject.lint(code)
-                Assertions.assertThat(findings).hasSize(0)
+                assertThat(findings).hasSize(0)
             }
         }
 
@@ -54,7 +54,7 @@ class ThrowingNewInstanceOfSameExceptionSpec : Spek({
 
             it("should not report") {
                 val findings = subject.lint(code)
-                Assertions.assertThat(findings).hasSize(0)
+                assertThat(findings).hasSize(0)
             }
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCallSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCallSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -16,7 +16,7 @@ class EqualsNullCallSpec : Spek({
 				fun x(a: String) {
 					a.equals(null)
 				}"""
-            Assertions.assertThat(subject.lint(code).size).isEqualTo(1)
+            assertThat(subject.lint(code).size).isEqualTo(1)
         }
 
         it("with nested equals(null) call as parameter") {
@@ -24,7 +24,7 @@ class EqualsNullCallSpec : Spek({
 				fun x(a: String, b: String) {
 					a.equals(b.equals(null))
 				}"""
-            Assertions.assertThat(subject.lint(code).size).isEqualTo(1)
+            assertThat(subject.lint(code).size).isEqualTo(1)
         }
 
         it("with non-nullable parameter") {
@@ -32,7 +32,7 @@ class EqualsNullCallSpec : Spek({
 				fun x(a: String, b: String) {
 					a.equals(b)
 				}"""
-            Assertions.assertThat(subject.lint(code).size).isEqualTo(0)
+            assertThat(subject.lint(code).size).isEqualTo(0)
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Java6Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Java6Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Java6Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Java6Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntaxSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntaxSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style.optional
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -14,12 +14,12 @@ class PreferToOverPairSyntaxSpec : Spek({
 
         it("reports if pair is created using pair constructor") {
             val path = Case.PreferToOverPairSyntaxPositive.path()
-            Assertions.assertThat(subject.lint(path)).hasSize(5)
+            assertThat(subject.lint(path)).hasSize(5)
         }
 
         it("does not report if it is created using the to syntax ") {
             val path = Case.PreferToOverPairSyntaxNegative.path()
-            Assertions.assertThat(subject.lint(path)).hasSize(0)
+            assertThat(subject.lint(path)).hasSize(0)
         }
     }
 })

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorTest.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorTest.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.util.keyFMap.KeyFMap
 import org.spekframework.spek2.Spek
@@ -25,7 +25,7 @@ class QualifiedNameProcessorTest : Spek({
             processor.onFinish(listOf(ktFile), result)
 
             val data = result.getData(fqNamesKey)
-            Assertions.assertThat(data).contains(
+            assertThat(data).contains(
                     "io.gitlab.arturbosch.detekt.sample.Foo",
                     "io.gitlab.arturbosch.detekt.sample.Bar",
                     "io.gitlab.arturbosch.detekt.sample.Bla")

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.api.AbstractListAssert
-import org.assertj.core.internal.Objects
+import org.assertj.core.util.Objects.areEqual
 
 fun assertThat(findings: List<Finding>) = FindingsAssert(findings)
 
@@ -44,11 +44,6 @@ class FindingsAssert(actual: List<Finding>) :
                 .sortedWith(compareBy({ it.line }, { it.column }))
 
         areEqual(actualSources.toList(), expectedSources.toList())
-    }
-
-    private fun <T> areEqual(actual: List<T>, expected: List<T>) {
-        Objects.instance()
-                .assertEqual(writableAssertionInfo, actual, expected)
     }
 }
 

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.test
 
 import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
 import org.assertj.core.api.AbstractAssert
-import org.assertj.core.internal.Objects
 
 fun assertThat(thresholdedCodeSmell: ThresholdedCodeSmell) = ThresholdedCodeSmellAssert(thresholdedCodeSmell)
 
@@ -19,14 +18,14 @@ class ThresholdedCodeSmellAssert(actual: ThresholdedCodeSmell?) :
 
     fun withValue(expected: Int) = hasValue(expected).let { this }
 
-    private val objects = Objects.instance()
-
     @Suppress("UnsafeCast") // False positive, see issue #1137
     fun hasValue(expected: Int) {
         isNotNull
 
         val smell = actual as ThresholdedCodeSmell
-        objects.assertEqual(writableAssertionInfo, smell.value, expected)
+        if (expected != smell.value) {
+            failWithMessage("Expected value to be <%s> but was <%s>", expected, smell.value)
+        }
     }
 
     fun withThreshold(expected: Int) = hasThreshold(expected).let { this }
@@ -36,6 +35,8 @@ class ThresholdedCodeSmellAssert(actual: ThresholdedCodeSmell?) :
         isNotNull
 
         val smell = actual as ThresholdedCodeSmell
-        objects.assertEqual(writableAssertionInfo, smell.threshold, expected)
+        if (expected != smell.threshold) {
+            failWithMessage("Expected threshold to be <%s> but was <%s>", expected, smell.threshold)
+        }
     }
 }


### PR DESCRIPTION
* replace `import org.assertj.core.api.Java6Assertions.assertThat` with `import org.assertj.core.api.Assertions.assertThat`
* Add static import of `import org.assertj.core.api.Assertions.assertThat` and `import org.assertj.core.api.Assertions.fail` where missing
* Tidies the two custom assertion types so they don't use AssertJ's internal API