### PR TITLE
Silence dokka

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,7 +30,7 @@ automatically. The format of the KDoc should be as follows:
      * // add the compliant code example here
      * </compliant>
      *
-     * @configuration name - Description for the configuration option (default: "whatever should be the default")
+     * @configuration name - Description for the configuration option (default: `whatever should be the default`)
      *
      * @author name
      */

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -184,7 +184,7 @@ subprojects {
     }
 
     tasks.withType<DokkaTask> {
-        // suppresses undocumented classes but not dokka warnings https://github.com/Kotlin/dokka/issues/319
+        // suppresses undocumented classes but not dokka warnings https://github.com/Kotlin/dokka/issues/90
         reportUndocumented = false
         outputFormat = "javadoc"
         outputDirectory = "$buildDir/javadoc"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -184,8 +184,7 @@ subprojects {
     }
 
     tasks.withType<DokkaTask> {
-        // suppresses undocumented classes but not dokka warnings
-        // https://github.com/Kotlin/dokka/issues/229 && https://github.com/Kotlin/dokka/issues/319
+        // suppresses undocumented classes but not dokka warnings https://github.com/Kotlin/dokka/issues/319
         reportUndocumented = false
         outputFormat = "javadoc"
         outputDirectory = "$buildDir/javadoc"

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/BaseRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/BaseRule.kt
@@ -8,12 +8,12 @@ import org.jetbrains.kotlin.psi.KtFile
 typealias RuleId = String
 
 /**
- * Defines the visiting mechanism for [KtFile]'s.
+ * Defines the visiting mechanism for KtFile's.
  *
  * Custom rule implementations should actually use [Rule] as base class.
  *
  * The extraction of this class from [Rule] actually resulted from the need
- * of running many different checks on the same [KtFile] but within a single
+ * of running many different checks on the same KtFile but within a single
  * potential costly visiting process, see [MultiRule].
  *
  * This base rule class abstracts over single and multi rules and allows the

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
@@ -1,7 +1,5 @@
 package io.gitlab.arturbosch.detekt.api
 
-import org.jetbrains.kotlin.psi.KtFile
-
 /**
  * A context describes the storing and reporting mechanism of [Finding]'s inside a [Rule].
  * Additionally it handles suppression and aliases management.

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
@@ -6,8 +6,8 @@ import org.jetbrains.kotlin.psi.KtFile
  * A context describes the storing and reporting mechanism of [Finding]'s inside a [Rule].
  * Additionally it handles suppression and aliases management.
  *
- * The detekt engine retrieves the findings after each [KtFile] visit and resets the context
- * before the next [KtFile].
+ * The detekt engine retrieves the findings after each KtFile visit and resets the context
+ * before the next KtFile.
  *
  * @author Artur Bosch
  * @author Marvin Ramin

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
@@ -23,7 +23,7 @@ data class Entity(
 
     companion object {
         /**
-         * Factory function which retrieves all needed information from the [PsiElement] itself.
+         * Factory function which retrieves all needed information from the PsiElement itself.
          */
         fun from(element: PsiElement, offset: Int = 0): Entity {
             val name = element.searchName()

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ProjectExtension.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ProjectExtension.kt
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.com.intellij.pom.impl.PomTransactionBase
 import org.jetbrains.kotlin.com.intellij.pom.tree.TreeAspect
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.TreeCopyHandler
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtPsiFactory
 import sun.reflect.ReflectionFactory
 
@@ -28,7 +27,7 @@ import sun.reflect.ReflectionFactory
 val psiProject: Project = createKotlinCoreEnvironment()
 
 /**
- * Allows to generate different kinds of [KtElement]'s.
+ * Allows to generate different kinds of KtElement's.
  */
 val psiFactory: KtPsiFactory = KtPsiFactory(psiProject, false)
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
@@ -27,7 +27,7 @@ class RuleSet(val id: RuleSetId, val rules: List<BaseRule>) {
      * If a rule is a [MultiRule] the filters are passed to it via a setter
      * and later used to filter sub rules of the [MultiRule].
      *
-     * A list of findings is returned for given [KtFile]
+     * A list of findings is returned for given KtFile
      */
     fun accept(file: KtFile, ruleFilters: Set<RuleId>): List<Finding> =
             rules.asSequence()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
@@ -13,8 +13,8 @@ import io.gitlab.arturbosch.detekt.api.RuleSetProvider
  * to your gradle dependencies or reference the `detekt-formatting`-jar with the `--plugins` option
  * in the command line interface.
  *
- * @configuration android - if android style guides should be preferred (default: false)
- * @configuration autoCorrect - if rules should auto correct style violation (default: true)
+ * @configuration android - if android style guides should be preferred (default: `false`)
+ * @configuration autoCorrect - if rules should auto correct style violation (default: `true`)
  * @active since v1.0.0
  * @author Artur Bosch
  */

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
@@ -11,8 +11,8 @@ import io.gitlab.arturbosch.detekt.formatting.merge
 /**
  * See <a href="https://ktlint.github.io/#rule-indentation">ktlint-website</a> for documentation.
  *
- * @configuration indentSize - indentation size (default: 4)
- * @configuration continuationIndentSize - continuation indentation size (default: 4)
+ * @configuration indentSize - indentation size (default: `4`)
+ * @configuration continuationIndentSize - continuation indentation size (default: `4`)
  *
  * @active since v1.0.0
  * @autoCorrect since v1.0.0

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MaximumLineLength.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MaximumLineLength.kt
@@ -11,7 +11,7 @@ import io.gitlab.arturbosch.detekt.formatting.merge
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
  *
- * @configuration maxLineLength - maximum line length (default: 120)
+ * @configuration maxLineLength - maximum line length (default: `120`)
  *
  * @active since v1.0.0
  * @author Artur Bosch

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.merge
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
  *
- * @configuration indentSize - indentation size (default: 4)
+ * @configuration indentSize - indentation size (default: `4`)
  *
  * @active since v1.0.0
  * @autoCorrect since v1.0.0

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/KDocTags.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/KDocTags.kt
@@ -33,7 +33,7 @@ fun KDocTag.parseConfigTag(): Configuration {
 }
 
 private const val EXPECTED_CONFIGURATION_FORMAT =
-        "Expected format: @configuration {paramName} - {paramDescription} (default: {defaultValue})."
+        "Expected format: @configuration {paramName} - {paramDescription} (default: `{defaultValue}`)."
 
 fun KDocTag.isValidConfigurationTag(entity: String = "Rule"): Boolean {
     val content: String = getContent()
@@ -42,7 +42,7 @@ fun KDocTag.isValidConfigurationTag(entity: String = "Rule"): Boolean {
                 "[${containingFile.name}] $entity '$content' doesn't seem to contain a description.\n" +
                         EXPECTED_CONFIGURATION_FORMAT)
     }
-    if (!content.contains(configurationDefaultValueRegex)) {
+    if (content.substringAfter("`", "").substringBeforeLast("`", "").isBlank()) {
         val parameterName = content.substringBefore(" - ")
         throw InvalidDocumentationException(
                 "[${containingFile.name}] $entity '$parameterName' doesn't seem to contain a default value.\n" +
@@ -51,5 +51,5 @@ fun KDocTag.isValidConfigurationTag(entity: String = "Rule"): Boolean {
     return true
 }
 
-val configurationDefaultValueRegex = "\\(default: (.+)\\)".toRegex(RegexOption.DOT_MATCHES_ALL)
+val configurationDefaultValueRegex = "\\(default: `(.+)`\\)".toRegex(RegexOption.DOT_MATCHES_ALL)
 const val TAG_CONFIGURATION = "configuration"

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -267,7 +267,7 @@ class RuleCollectorSpec : Spek({
 
 				/**
 				 * $description
-				 * @configuration config - description (default: '[A-Z$]')
+				 * @configuration config - description (default: `'[A-Z$]'`)
 				 */
 				class $name: Rule {
 				}
@@ -287,14 +287,67 @@ class RuleCollectorSpec : Spek({
 
 				/**
 				 * $description
-				 * @configuration config - description (default: "")
-				 * @configuration config2 - description2 (default: "")
+				 * @configuration config - description (default: `""`)
+				 * @configuration config2 - description2 (default: `""`)
 				 */
 				class $name: Rule {
 				}
 			"""
             val items = subject.run(code)
             assertThat(items[0].configuration).hasSize(2)
+        }
+
+        it("doesn't have a default value") {
+            val name = "SomeRandomClass"
+            val description = "some description"
+            val code = """
+				package foo
+
+				/**
+				 * $description
+				 * @configuration config - description
+				 */
+				class $name: Rule {
+				}
+			"""
+            assertThatExceptionOfType(InvalidDocumentationException::class.java)
+                .isThrownBy { subject.run(code) }
+        }
+
+
+        it("has a blank default value") {
+            val name = "SomeRandomClass"
+            val description = "some description"
+            val code = """
+				package foo
+
+				/**
+				 * $description
+				 * @configuration config2 - description2 (default: ``)
+				 */
+				class $name: Rule {
+				}
+			"""
+            assertThatExceptionOfType(InvalidDocumentationException::class.java)
+                .isThrownBy { subject.run(code) }
+        }
+
+
+        it("has an incorrectly delimited default value") {
+            val name = "SomeRandomClass"
+            val description = "some description"
+            val code = """
+				package foo
+
+				/**
+				 * $description
+				 * @configuration config2 - description2 (default: true)
+				 */
+				class $name: Rule {
+				}
+			"""
+            assertThatExceptionOfType(InvalidDocumentationException::class.java)
+                .isThrownBy { subject.run(code) }
         }
 
         it("contains a misconfigured configuration option") {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -29,8 +29,8 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  * </noncompliant>
  *
  * @configuration excludeAnnotatedProperties - Allows you to provide a list of annotations that disable
- * this check. (default: "")
- * @configuration ignoreOnClassesPattern - Allows you to disable the rule for a list of classes (default: "")
+ * this check. (default: `""`)
+ * @configuration ignoreOnClassesPattern - Allows you to disable the rule for a list of classes (default: `""`)
  *
  * @author Marvin Ramin
  * @author Niklas Baudy

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
@@ -36,7 +36,7 @@ import org.jetbrains.kotlin.psi.KtWhileExpression
  * fun hasCorrectEnding() = return !str.endsWith("foo") && !str.endsWith("bar") && !str.endsWith("_")
  * </compliant>
  *
- * @configuration threshold - (default: 4)
+ * @configuration threshold - (default: `4`)
  *
  * @active since v1.0.0
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
@@ -23,8 +23,8 @@ import org.jetbrains.kotlin.psi.KtProperty
  * Large interfaces should be split into smaller interfaces which have a clear responsibility and are easier
  * to understand and implement.
  *
- * @configuration threshold - maximum amount of definitions in an interface (default: 10)
- * @configuration includeStaticDeclarations - whether static declarations should be included (default: false)
+ * @configuration threshold - maximum amount of definitions in an interface (default: `10`)
+ * @configuration includeStaticDeclarations - whether static declarations should be included (default: `false`)
  *
  * @author schalkms
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -20,10 +20,10 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  * Prefer splitting up complex methods into smaller methods that are in turn easier to understand.
  * Smaller methods can also be named much clearer which leads to improved readability of the code.
  *
- * @configuration threshold - MCC threshold for a method (default: 10)
+ * @configuration threshold - MCC threshold for a method (default: `10`)
  * @configuration ignoreSingleWhenExpression - Ignores a complex method if it only contains a single when expression.
- * (default: false)
- * @configuration ignoreSimpleWhenEntries - Whether to ignore simple (braceless) when entries. (default: false)
+ * (default: `false`)
+ * @configuration ignoreSimpleWhenEntries - Whether to ignore simple (braceless) when entries. (default: `false`)
  *
  * @active since v1.0.0
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
@@ -59,7 +59,7 @@ import org.jetbrains.kotlin.psi.psiUtil.parents
  * </compliant>
  *
  * @configuration ignoredLabels - allows to provide a list of label names which should be ignored by this rule
- * (default: "")
+ * (default: `""`)
  *
  * @author Ivan Balaksha
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -21,7 +21,7 @@ import java.util.IdentityHashMap
  * split up large classes into smaller classes. These smaller classes are then easier to understand and handle less
  * things.
  *
- * @configuration threshold - maximum size of a class (default: 600)
+ * @configuration threshold - maximum size of a class (default: `600`)
  *
  * @active since v1.0.0
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -21,7 +21,7 @@ import java.util.IdentityHashMap
  *
  * Extract parts of the functionality of long methods into separate, smaller methods.
  *
- * @configuration threshold - maximum lines in a method (default: 60)
+ * @configuration threshold - maximum lines in a method (default: `60`)
  *
  * @active since v1.0.0
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -15,8 +15,8 @@ import org.jetbrains.kotlin.psi.KtParameterList
 /**
  * Reports functions which have more parameters than a certain threshold (default: 6).
  *
- * @configuration threshold - maximum number of parameters (default: 6)
- * @configuration ignoreDefaultParameters - ignore parameters that have a default value (default: false)
+ * @configuration threshold - maximum number of parameters (default: `6`)
+ * @configuration ignoreDefaultParameters - ignore parameters that have a default value (default: `false`)
  *
  * @active since v1.0.0
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
  *
  * Refactor these methods and try to use optional parameters instead to prevent some of the overloading.
  *
- * @configuration threshold - (default: 6)
+ * @configuration threshold - (default: `6`)
  *
  * @author schalkms
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  *
  * Prefer extracting the nested code into well-named functions to make it easier to understand.
  *
- * @configuration threshold - maximum nesting depth (default: 4)
+ * @configuration threshold - maximum nesting depth (default: `4`)
  *
  * @active since v1.0.0
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
@@ -42,10 +42,10 @@ import org.jetbrains.kotlin.psi.KtStringTemplateExpression
  * }
  * </compliant>
  *
- * @configuration threshold - amount of duplications to trigger rule (default: 3)
- * @configuration ignoreAnnotation - if values in Annotations should be ignored (default: true)
- * @configuration excludeStringsWithLessThan5Characters - if short strings should be excluded (default: true)
- * @configuration ignoreStringsRegex - RegEx of Strings that should be ignored (default: '$^')
+ * @configuration threshold - amount of duplications to trigger rule (default: `3`)
+ * @configuration ignoreAnnotation - if values in Annotations should be ignored (default: `true`)
+ * @configuration excludeStringsWithLessThan5Characters - if short strings should be excluded (default: `true`)
+ * @configuration ignoreStringsRegex - RegEx of Strings that should be ignored (default: `'$^'`)
  *
  * @author schalkms
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -24,14 +24,14 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  * Too many functions indicate a violation of the single responsibility principle. Prefer extracting functionality
  * which clearly belongs together in separate parts of the code.
  *
- * @configuration thresholdInFiles - threshold in files (default: 11)
- * @configuration thresholdInClasses - threshold in classes (default: 11)
- * @configuration thresholdInInterfaces - threshold in interfaces (default: 11)
- * @configuration thresholdInObjects - threshold in objects (default: 11)
- * @configuration thresholdInEnums - threshold in enums (default: 11)
- * @configuration ignoreDeprecated - ignore deprecated functions (default: false)
- * @configuration ignorePrivate - ignore private functions (default: false)
- * @configuration ignoreOverridden - ignore overridden functions (default: false)
+ * @configuration thresholdInFiles - threshold in files (default: `11`)
+ * @configuration thresholdInClasses - threshold in classes (default: `11`)
+ * @configuration thresholdInInterfaces - threshold in interfaces (default: `11`)
+ * @configuration thresholdInObjects - threshold in objects (default: `11`)
+ * @configuration thresholdInEnums - threshold in enums (default: `11`)
+ * @configuration ignoreDeprecated - ignore deprecated functions (default: `false`)
+ * @configuration ignorePrivate - ignore private functions (default: `false`)
+ * @configuration ignoreOverridden - ignore overridden functions (default: `false`)
  *
  * @active since v1.0.0
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
@@ -30,7 +30,7 @@ class KDocStyle(config: Config = Config.empty) : MultiRule() {
  * It should end with proper punctuation or with a correct URL.
  *
  * @configuration endOfSentenceFormat - regular expression which should match the end of the first sentence in the KDoc
- * (default: ([.?!][ \t\n\r\f<])|([.?!]$))
+ * (default: `([.?!][ \t\n\r\f<])|([.?!]$)`)
  *
  *  @author Marvin Ramin
  *  @author schalkms

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -20,10 +20,10 @@ import org.jetbrains.kotlin.psi.KtObjectDeclaration
  * By default this rule also searches for nested and inner classes and objects. This default behavior can be changed
  * with the configuration options of this rule.
  *
- * @configuration searchInNestedClass - if nested classes should be searched (default: true)
- * @configuration searchInInnerClass - if inner classes should be searched (default: true)
- * @configuration searchInInnerObject - if inner objects should be searched (default: true)
- * @configuration searchInInnerInterface - if inner interfaces should be searched (default: true)
+ * @configuration searchInNestedClass - if nested classes should be searched (default: `true`)
+ * @configuration searchInInnerClass - if inner classes should be searched (default: `true`)
+ * @configuration searchInInnerObject - if inner objects should be searched (default: `true`)
+ * @configuration searchInInnerInterface - if inner interfaces should be searched (default: `true`)
  *
  * @author Artur Bosch
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.psi.KtCatchClause
  * Reports empty `catch` blocks. Empty blocks of code serve no purpose and should be removed.
  *
  * @configuration allowedExceptionNameRegex - ignores exception types which match this regex
- * (default: "^(_|(ignore|expected).*)")
+ * (default: `"^(_|(ignore|expected).*)"`)
  * @active since v1.0.0
  * @author Artur Bosch
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  * Reports empty functions. Empty blocks of code serve no purpose and should be removed.
  * This rule will not report functions overriding others.
  *
- * @configuration ignoreOverriddenFunctions - excludes overridden functions with an empty body (default: false)
+ * @configuration ignoreOverriddenFunctions - excludes overridden functions with an empty body (default: `false`)
  *
  * @active since v1.0.0
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  * </noncompliant>
  *
  * @configuration methodNames - methods which should not throw exceptions
- * (default: 'toString,hashCode,equals,finalize')
+ * (default: `'toString,hashCode,equals,finalize'`)
  *
  * @author schalkms
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -53,7 +53,7 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  * </compliant>
  *
  * @configuration ignoredExceptionTypes - exception types which should be ignored by this rule
- * (default: 'InterruptedException,NumberFormatException,ParseException,MalformedURLException')
+ * (default: `'InterruptedException,NumberFormatException,ParseException,MalformedURLException'`)
  *
  * @author schalkms
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
@@ -35,7 +35,7 @@ import org.jetbrains.kotlin.psi.KtCallExpression
  * </compliant>
  *
  * @configuration exceptions - exceptions which should not be thrown without message or cause
- * (default: 'IllegalArgumentException,IllegalStateException,IOException')
+ * (default: `'IllegalArgumentException,IllegalStateException,IOException'`)
  *
  * @author schalkms
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
@@ -36,16 +36,16 @@ import org.jetbrains.kotlin.psi.KtTypeReference
  * </compliant>
  *
  * @configuration exceptionNames - exceptions which are too generic and should not be caught
- * (default: - ArrayIndexOutOfBoundsException
+ * (default: `- ArrayIndexOutOfBoundsException
  *			 - Error
  *			 - Exception
  *			 - IllegalMonitorStateException
  *			 - NullPointerException
  *			 - IndexOutOfBoundsException
  *			 - RuntimeException
- *			 - Throwable)
+ *			 - Throwable`)
  * @configuration allowedExceptionNameRegex - ignores too generic exception types which match this regex
- * (default: "^(_|(ignore|expected).*)")
+ * (default: `"^(_|(ignore|expected).*)"`)
  * @active since v1.0.0
  * @author Artur Bosch
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
@@ -33,10 +33,10 @@ import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
  * </compliant>
  *
  * @configuration exceptionNames - exceptions which are too generic and should not be thrown
- * (default: - Error
+ * (default: `- Error
  * 			 - Exception
  *			 - Throwable
- * 			 - RuntimeException)
+ * 			 - RuntimeException`)
  *
  * @active since v1.0.0
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
 /**
  * Reports when class or object names which do not follow the specified naming convention are used.
  *
- * @configuration classPattern - naming pattern (default: '[A-Z$][a-zA-Z0-9$]*')
+ * @configuration classPattern - naming pattern (default: `'[A-Z$][a-zA-Z0-9$]*'`)
  * @active since v1.0.0
  * @author Marvin Ramin
  */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
@@ -16,9 +16,9 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 /**
  * Reports constructor parameter names which do not follow the specified naming convention are used.
  *
- * @configuration parameterPattern - naming pattern (default: '[a-z][A-Za-z0-9]*')
- * @configuration privateParameterPattern - naming pattern (default: '[a-z][A-Za-z0-9]*')
- * @configuration excludeClassPattern - ignores variables in classes which match this regex (default: '$^')
+ * @configuration parameterPattern - naming pattern (default: `'[a-z][A-Za-z0-9]*'`)
+ * @configuration privateParameterPattern - naming pattern (default: `'[a-z][A-Za-z0-9]*'`)
+ * @configuration excludeClassPattern - ignores variables in classes which match this regex (default: `'$^'`)
  *
  * @active since v1.0.0
  * @author Mickele Moriconi

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
 /**
  * Reports when enum names which do not follow the specified naming convention are used.
  *
- * @configuration enumEntryPattern - naming pattern (default: '^[A-Z][_a-zA-Z0-9]*')
+ * @configuration enumEntryPattern - naming pattern (default: `'^[A-Z][_a-zA-Z0-9]*'`)
  * @active since v1.0.0
  * @author Marvin Ramin
  */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
  * By default this rule does not report any classes.
  * Examples for forbidden names might be too generic class names like `...Manager`.
  *
- * @configuration forbiddenName - forbidden class names (default: '')
+ * @configuration forbiddenName - forbidden class names (default: `''`)
  * @author Marvin Ramin
  */
 class ForbiddenClassName(config: Config = Config.empty) : Rule(config) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLength.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 /**
  * Reports when very long function names are used.
  *
- * @configuration maximumFunctionNameLength - maximum name length (default: 30)
+ * @configuration maximumFunctionNameLength - maximum name length (default: `30`)
  * @author Marvin Ramin
  */
 class FunctionMaxLength(config: Config = Config.empty) : Rule(config) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLength.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 /**
  * Reports when very short function names are used.
  *
- * @configuration minimumFunctionNameLength - minimum name length (default: 3)
+ * @configuration minimumFunctionNameLength - minimum name length (default: `3`)
  * @author Marvin Ramin
  */
 class FunctionMinLength(config: Config = Config.empty) : Rule(config) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -16,9 +16,9 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 /**
  * Reports when function names which do not follow the specified naming convention are used.
  *
- * @configuration functionPattern - naming pattern (default: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$')
- * @configuration excludeClassPattern - ignores functions in classes which match this regex (default: '$^')
- * @configuration ignoreOverridden - ignores functions that have the override modifier (default: true)
+ * @configuration functionPattern - naming pattern (default: `'^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'`)
+ * @configuration excludeClassPattern - ignores functions in classes which match this regex (default: `'$^'`)
+ * @configuration ignoreOverridden - ignores functions that have the override modifier (default: `true`)
  *
  * @active since v1.0.0
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
@@ -16,10 +16,10 @@ import org.jetbrains.kotlin.psi.KtParameter
 /**
  * Reports function parameter names which do not follow the specified naming convention are used.
  *
- * @configuration parameterPattern - naming pattern (default: '[a-z][A-Za-z0-9]*')
- * @configuration excludeClassPattern - ignores variables in classes which match this regex (default: '$^')
+ * @configuration parameterPattern - naming pattern (default: `'[a-z][A-Za-z0-9]*'`)
+ * @configuration excludeClassPattern - ignores variables in classes which match this regex (default: `'$^'`)
  * @configuration ignoreOverriddenFunctions - ignores overridden functions with parameters not matching the pattern
- * (default: true)
+ * (default: `true`)
  *
  * @active since v1.0.0
  * @author Mickele Moriconi

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -47,7 +47,7 @@ import org.jetbrains.kotlin.util.collectionUtils.concat
  * }
  * </compliant>
  *
- * @configuration ignoreOverriddenFunction - if overridden functions should be ignored (default: true)
+ * @configuration ignoreOverriddenFunction - if overridden functions should be ignored (default: `true`)
  *
  * @author schalkms
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
@@ -16,9 +16,9 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 /**
  * Reports when property names inside objects which do not follow the specified naming convention are used.
  *
- * @configuration constantPattern - naming pattern (default: '[A-Za-z][_A-Za-z0-9]*')
- * @configuration propertyPattern - naming pattern (default: '[A-Za-z][_A-Za-z0-9]*')
- * @configuration privatePropertyPattern - naming pattern (default: '(_)?[A-Za-z][_A-Za-z0-9]*')
+ * @configuration constantPattern - naming pattern (default: `'[A-Za-z][_A-Za-z0-9]*'`)
+ * @configuration propertyPattern - naming pattern (default: `'[A-Za-z][_A-Za-z0-9]*'`)
+ * @configuration privatePropertyPattern - naming pattern (default: `'(_)?[A-Za-z][_A-Za-z0-9]*'`)
  * @active since v1.0.0
  * @author Marvin Ramin
  * @author schalkms

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
 /**
  * Reports when package names which do not follow the specified naming convention are used.
  *
- * @configuration packagePattern - naming pattern (default: '^[a-z]+(\.[a-z][A-Za-z0-9]*)*$')
+ * @configuration packagePattern - naming pattern (default: `'^[a-z]+(\.[a-z][A-Za-z0-9]*)*$'`)
  * @active since v1.0.0
  * @author Marvin Ramin
  */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
@@ -16,9 +16,9 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 /**
  * Reports when top level constant names which do not follow the specified naming convention are used.
  *
- * @configuration constantPattern - naming pattern (default: '[A-Z][_A-Z0-9]*')
- * @configuration propertyPattern - naming pattern (default: '[A-Za-z][_A-Za-z0-9]*')
- * @configuration privatePropertyPattern - naming pattern (default: '_?[A-Za-z][_A-Za-z0-9]*')
+ * @configuration constantPattern - naming pattern (default: `'[A-Z][_A-Z0-9]*'`)
+ * @configuration propertyPattern - naming pattern (default: `'[A-Za-z][_A-Za-z0-9]*'`)
+ * @configuration privatePropertyPattern - naming pattern (default: `'_?[A-Za-z][_A-Za-z0-9]*'`)
  *
  * @active since v1.0.0
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLength.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtProperty
 /**
  * Reports when very long variable names are used.
  *
- * @configuration maximumVariableNameLength - maximum name length (default: 64)
+ * @configuration maximumVariableNameLength - maximum name length (default: `64`)
  * @author Marvin Ramin
  */
 class VariableMaxLength(config: Config = Config.empty) : Rule(config) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLength.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
 /**
  * Reports when very short variable names are used.
  *
- * @configuration minimumVariableNameLength - maximum name length (default: 1)
+ * @configuration minimumVariableNameLength - maximum name length (default: `1`)
  * @author Marvin Ramin, Niklas Baudy
  */
 class VariableMinLength(config: Config = Config.empty) : Rule(config) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
@@ -18,10 +18,10 @@ import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
 /**
  * Reports when variable names which do not follow the specified naming convention are used.
  *
- * @configuration variablePattern - naming pattern (default: '[a-z][A-Za-z0-9]*')
- * @configuration privateVariablePattern - naming pattern (default: '(_)?[a-z][A-Za-z0-9]*')
- * @configuration excludeClassPattern - ignores variables in classes which match this regex (default: '$^')
- * @configuration ignoreOverridden - ignores member properties that have the override modifier (default: true)
+ * @configuration variablePattern - naming pattern (default: `'[a-z][A-Za-z0-9]*'`)
+ * @configuration privateVariablePattern - naming pattern (default: `'(_)?[a-z][A-Za-z0-9]*'`)
+ * @configuration excludeClassPattern - ignores variables in classes which match this regex (default: `'$^'`)
+ * @configuration ignoreOverridden - ignores member properties that have the override modifier (default: `true`)
  *
  * @active since v1.0.0
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  * }
  * </noncompliant>
  *
- * @configuration conversionFunctionPrefix - allowed conversion function names (default: 'to')
+ * @configuration conversionFunctionPrefix - allowed conversion function names (default: `'to'`)
  * @author Ivan Balaksha
  * @author schalkms
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlin.psi.KtReturnExpression
  * }
  * </compliant>
  *
- * @configuration includeLineWrapping - include return statements with line wraps in it (default: false)
+ * @configuration includeLineWrapping - include return statements with line wraps in it (default: `false`)
  *
  * @author Artur Bosch
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiComment
  * fun foo() { }
  * </noncompliant>
  *
- * @configuration values - forbidden comment strings (default: 'TODO:,FIXME:,STOPSHIP:')
+ * @configuration values - forbidden comment strings (default: `'TODO:,FIXME:,STOPSHIP:'`)
  *
  * @active since v1.0.0
  * @author Niklas Baudy

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  * import kotlin.SinceKotlin
  * </noncompliant>
  *
- * @configuration imports - imports which should not be used (default: '')
+ * @configuration imports - imports which should not be used (default: `''`)
  *
  * @author Niklas Baudy
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -29,8 +29,8 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  * const val constantString = "1"
  * </compliant>
  *
- * @configuration ignoreOverridableFunction - if overriden functions should be ignored (default: true)
- * @configuration excludedFunctions - excluded functions (default: 'describeContents')
+ * @configuration ignoreOverridableFunction - if overriden functions should be ignored (default: `true`)
+ * @configuration excludedFunctions - excluded functions (default: `'describeContents'`)
  * @author schalkms
  * @author Marvin Ramin
  */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.psi.KtLoopExpression
  * }
  * </noncompliant>
  *
- * @configuration maxJumpCount - maximum allowed jumps in a loop (default: 1)
+ * @configuration maxJumpCount - maximum allowed jumps in a loop (default: `1`)
  *
  * @author schalkms
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -63,21 +63,21 @@ import java.util.Locale
  * }
  * </compliant>
  *
- * @configuration ignoreNumbers - numbers which do not count as magic numbers (default: '-1,0,1,2')
+ * @configuration ignoreNumbers - numbers which do not count as magic numbers (default: `'-1,0,1,2'`)
  * @configuration ignoreHashCodeFunction - whether magic numbers in hashCode functions should be ignored
- * (default: true)
+ * (default: `true`)
  * @configuration ignorePropertyDeclaration - whether magic numbers in property declarations should be ignored
- * (default: false)
+ * (default: `false`)
  * @configuration ignoreConstantDeclaration - whether magic numbers in property declarations should be ignored
- * (default: true)
+ * (default: `true`)
  * @configuration ignoreCompanionObjectPropertyDeclaration - whether magic numbers in companion object
- * declarations should be ignored (default: true)
+ * declarations should be ignored (default: `true`)
  * @configuration ignoreAnnotation - whether magic numbers in annotations should be ignored
- * (default: false)
+ * (default: `false`)
  * @configuration ignoreNamedArgument - whether magic numbers in named arguments should be ignored
- * (default: true)
- * @configuration ignoreEnums - whether magic numbers in enums should be ignored (default: false)
- * @configuration ignoreRanges - whether magic numbers in ranges should be ignored (default: false)
+ * (default: `true`)
+ * @configuration ignoreEnums - whether magic numbers in enums should be ignored (default: `false`)
+ * @configuration ignoreRanges - whether magic numbers in ranges should be ignored (default: `false`)
  *
  * @active since v1.0.0
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -18,10 +18,10 @@ data class KtFileContent(val file: KtFile, val content: Sequence<String>)
  * Long lines might be hard to read on smaller screens or printouts. Additionally having a maximum line length
  * in the codebase will help make the code more uniform.
  *
- * @configuration maxLineLength - maximum line length (default: 120)
- * @configuration excludePackageStatements - if package statements should be ignored (default: true)
- * @configuration excludeImportStatements - if import statements should be ignored (default: true)
- * @configuration excludeCommentStatements - if comment statements should be ignored (default: false)
+ * @configuration maxLineLength - maximum line length (default: `120`)
+ * @configuration excludePackageStatements - if package statements should be ignored (default: `true`)
+ * @configuration excludeImportStatements - if import statements should be ignored (default: `true`)
+ * @configuration excludeCommentStatements - if comment statements should be ignored (default: `false`)
  *
  * @active since v1.0.0
  * @author Robbin Voortman

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -43,13 +43,13 @@ import org.jetbrains.kotlin.psi.KtReturnExpression
  * </compliant>
  *
  * @configuration max - define the maximum number of return statements allowed per function
- * (default: 2)
+ * (default: `2`)
  * @configuration excludedFunctions - define functions to be ignored by this check
- * (default: "equals")
+ * (default: `"equals"`)
  * @configuration excludeLabeled - if labeled return statements should be ignored
- * (default: false)
+ * (default: `false`)
  * @configuration excludeReturnFromLambda - if labeled return from a lambda should be ignored
- * (default: true)
+ * (default: `true`)
  * @active since v1.0.0
  *
  * @author Niklas Baudy

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
@@ -34,7 +34,7 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  * }
  * </compliant>
  *
- * @configuration max - maximum amount of throw statements in a method (default: 2)
+ * @configuration max - maximum amount of throw statements in a method (default: `2`)
  *
  * @active since v1.0.0
  * @author schalkms

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -32,7 +32,7 @@ import java.util.Locale
  * </compliant>
  *
  * @configuration acceptableDecimalLength - Length under which decimal base 10 literals are not required to have
- * underscores (default: 5)
+ * underscores (default: `5`)
  *
  * @author Tyler Wong
  */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -39,7 +39,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isAbstract
  * </noncompliant>
  *
  * @configuration excludeAnnotatedClasses - Allows you to provide a list of annotations that disable
- * this check. (default: "dagger.Module")
+ * this check. (default: `"dagger.Module"`)
  *
  * @author schalkms
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
  * can lead to confusion and potential bugs.
  *
  * @configuration allowedNames - unused private member names matching this regex are ignored
- * (default: "(_|ignored|expected|serialVersionUID)")
+ * (default: `"(_|ignored|expected|serialVersionUID)"`)
  *
  * @author Marvin Ramin
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -40,7 +40,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPropertyParameter
  * </compliant>
  *
  * @configuration excludeAnnotatedClasses - allows to provide a list of annotations that disable this check
- * (default: "")
+ * (default: `""`)
  *
  * @author Ivan Balaksha
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -40,7 +40,7 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  * </compliant>
  *
  * @configuration excludeImports - Define a whitelist of package names that should be allowed to be imported
- * with wildcard imports. (default: 'java.util.*,kotlinx.android.synthetic.*')
+ * with wildcard imports. (default: `'java.util.*,kotlinx.android.synthetic.*'`)
  *
  * @active since v1.0.0
  * @author Artur Bosch

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
@@ -108,7 +108,7 @@ class EndOfSentenceFormatSpec : Spek({
         it("does not report KDoc which doesn't contain any real sentence but many tags") {
             val code = """
 			/**
-			 * @configuration this - just an example (default: 150)
+			 * @configuration this - just an example (default: `150`)
 			 *
 			 * @active since v1.0.0
 			 * @author person1


### PR DESCRIPTION
An effort to remove dokka warnings from the build. Only one remaining, which looks to be a bug in dokka itself: https://github.com/Kotlin/dokka/issues/90

Note that there are no changes to any documentation produced by detekt-generator, but default values in the `@configuration` tag in KDoc for rules must now be delimited by backticks, so instead of `default: false` it must be:
```
default: `false`
```

This works better with dokka as dokka will treat anything delimited by backticks as a code span and won't try to create a link for anything inside a code span which is surrounded by `[]` (which was a problem for default values like `[a-z][A-Za-z0-9]*`)