### PR TITLE
Ignore void types in overridden function signatures.

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -424,6 +424,7 @@ style:
     imports: ''
   ForbiddenVoid:
     active: false
+    ignoreOverridden: false
   FunctionOnlyReturningConstant:
     active: false
     ignoreOverridableFunction: true

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Java6Assertions.assertThat
 import org.spekframework.spek2.Spek
@@ -9,13 +10,13 @@ class ForbiddenVoidSpec : Spek({
     describe("ForbiddenVoid rule") {
         it("should report all Void type usage") {
             val code = """
-				lateinit var c: () -> Void
+                lateinit var c: () -> Void
 
-				fun method(param: Void) {
-					val a: Void? = null
-					val b: Void = null!!
-				}
-			"""
+                fun method(param: Void) {
+                    val a: Void? = null
+                    val b: Void = null!!
+                }
+            """
 
             val findings = ForbiddenVoid().lint(code)
             assertThat(findings).hasSize(4)
@@ -23,12 +24,56 @@ class ForbiddenVoidSpec : Spek({
 
         it("should not report Void class literal") {
             val code = """
-				val clazz = java.lang.Void::class
-				val klass = Void::class
-			"""
+                val clazz = java.lang.Void::class
+                val klass = Void::class
+            """
 
             val findings = ForbiddenVoid().lint(code)
             assertThat(findings).isEmpty()
+        }
+
+        it("should not report Void in overriding function declarations if ignoreOverridden is enabled") {
+            val code = """
+                override fun method(param: Void) : Void {
+                    doSomething()
+                }
+                """
+
+            val findings = ForbiddenVoid(TestConfig(mapOf(ForbiddenVoid.IGNORE_OVERRIDDEN to "true"))).lint(code)
+            assertThat(findings).isEmpty()
+        }
+
+        it("should not report Void in overriding function declarations with parametrized types if ignoreOverridden is enabled") {
+            val code = """
+                override fun method(param: Future<Foo<Void>>) : Future<Foo<Void>> {
+                    doSomething()
+                }
+                """
+
+            val findings = ForbiddenVoid(TestConfig(mapOf(ForbiddenVoid.IGNORE_OVERRIDDEN to "true"))).lint(code)
+            assertThat(findings).isEmpty()
+        }
+
+        it("should report Void in body of overriding function even if ignoreOverridden is enabled") {
+            val code = """
+                override fun method(param: String) : Int {
+                    val a: Void? = null
+                }
+            """
+
+            val findings = ForbiddenVoid(TestConfig(mapOf(ForbiddenVoid.IGNORE_OVERRIDDEN to "true"))).lint(code)
+            assertThat(findings).hasSize(1)
+        }
+
+        it("should report Void in not overridden function declarations if ignoreOverridden is enabled") {
+            val code = """
+                fun method(param: Void) : Void {
+                    doSomething()
+                }
+            """
+
+            val findings = ForbiddenVoid(TestConfig(mapOf(ForbiddenVoid.IGNORE_OVERRIDDEN to "true"))).lint(code)
+            assertThat(findings).hasSize(2)
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
@@ -32,48 +32,52 @@ class ForbiddenVoidSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
-        it("should not report Void in overriding function declarations if ignoreOverridden is enabled") {
-            val code = """
+        describe("ignoreOverridden is enabled") {
+            val config = TestConfig(mapOf(ForbiddenVoid.IGNORE_OVERRIDDEN to "true"))
+
+            it("should not report Void in overriding function declarations") {
+                val code = """
                 override fun method(param: Void) : Void {
                     doSomething()
                 }
                 """
 
-            val findings = ForbiddenVoid(TestConfig(mapOf(ForbiddenVoid.IGNORE_OVERRIDDEN to "true"))).lint(code)
-            assertThat(findings).isEmpty()
-        }
+                val findings = ForbiddenVoid(config).lint(code)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should not report Void in overriding function declarations with parametrized types if ignoreOverridden is enabled") {
-            val code = """
+            it("should not report Void in overriding function declarations with parametrized types") {
+                val code = """
                 override fun method(param: Future<Foo<Void>>) : Future<Foo<Void>> {
                     doSomething()
                 }
                 """
 
-            val findings = ForbiddenVoid(TestConfig(mapOf(ForbiddenVoid.IGNORE_OVERRIDDEN to "true"))).lint(code)
-            assertThat(findings).isEmpty()
-        }
+                val findings = ForbiddenVoid(config).lint(code)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should report Void in body of overriding function even if ignoreOverridden is enabled") {
-            val code = """
+            it("should report Void in body of overriding function even") {
+                val code = """
                 override fun method(param: String) : Int {
                     val a: Void? = null
                 }
-            """
+                """
 
-            val findings = ForbiddenVoid(TestConfig(mapOf(ForbiddenVoid.IGNORE_OVERRIDDEN to "true"))).lint(code)
-            assertThat(findings).hasSize(1)
-        }
+                val findings = ForbiddenVoid(config).lint(code)
+                assertThat(findings).hasSize(1)
+            }
 
-        it("should report Void in not overridden function declarations if ignoreOverridden is enabled") {
-            val code = """
+            it("should report Void in not overridden function declarations") {
+                val code = """
                 fun method(param: Void) : Void {
                     doSomething()
                 }
-            """
+                """
 
-            val findings = ForbiddenVoid(TestConfig(mapOf(ForbiddenVoid.IGNORE_OVERRIDDEN to "true"))).lint(code)
-            assertThat(findings).hasSize(2)
+                val findings = ForbiddenVoid(config).lint(code)
+                assertThat(findings).hasSize(2)
+            }
         }
     }
 })

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -246,6 +246,12 @@ and has only one value - the `Unit` object.
 
 **Debt**: 5min
 
+#### Configuration options:
+
+* `ignoreOverridden` (default: `false`)
+
+   ignores void types in signatures of overridden functions
+
 #### Noncompliant Code:
 
 ```kotlin


### PR DESCRIPTION
Closes #1569 