### PR TITLE
Possibility to customize logging level output

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Andrew Arnott](https://github.com/andrew-arnott) - UnusedPrivateMember improvement
 - [Tyler Wong](https://github.com/tylerbwong) - UnderscoresInNumericLiterals rule
 - [Daniele Conti](https://github.com/fourlastor) - ObjectPropertyNaming improvement
+- [Nivaldo Bondanca](https://github.com/hick209) - Logging improvements
 
 ### Mentions
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -47,14 +47,14 @@ fun CliArgs.loadConfiguration(): Config {
         declaredConfig = FailFastConfig(declaredConfig ?: initializedDefaultConfig, initializedDefaultConfig)
     }
 
-    if (debug) println("\n$declaredConfig\n")
+    LOG.debug("\n$declaredConfig\n")
     return declaredConfig ?: loadDefaultConfig()
 }
 
 private fun Config.deprecatedFailFastUsage(): Boolean {
     val value: Boolean? = valueOrNull("failFast")
     value?.let {
-        LOG.printer.println(
+        LOG.warn(
             "Using deprecated property 'failFast' in the yaml config. " +
                     "Please migrate to the new '--fail-fast' cli-flag or 'failFast' detekt extension property."
         )

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/DetektProgressListener.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/DetektProgressListener.kt
@@ -10,11 +10,11 @@ import org.jetbrains.kotlin.psi.KtFile
 class DetektProgressListener : FileProcessListener {
 
     override fun onProcess(file: KtFile) {
-        kotlin.io.print(".")
+        LOG.debug(".", newLine = false)
     }
 
     override fun onFinish(files: List<KtFile>, result: Detektion) {
         val middlePart = if (files.size == 1) "file was" else "files were"
-        kotlin.io.println("\n\n${files.size} kotlin $middlePart analyzed.")
+        LOG.info("\n\n${files.size} kotlin $middlePart analyzed.")
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
@@ -35,9 +35,9 @@ fun JCommander.failWithErrorMessages(vararg messages: String?) {
 
 fun JCommander.failWithErrorMessages(messages: Iterable<String?>) {
     messages.forEach {
-        println(it)
+        LOG.error(it)
     }
-    println()
+    LOG.error("")
     this.usage()
     exitProcess(1)
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/LOG.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/LOG.kt
@@ -1,24 +1,61 @@
 package io.gitlab.arturbosch.detekt.cli
 
+import io.gitlab.arturbosch.detekt.cli.LogLevel.DEBUG
+import io.gitlab.arturbosch.detekt.cli.LogLevel.ERROR
+import io.gitlab.arturbosch.detekt.cli.LogLevel.INFO
+import io.gitlab.arturbosch.detekt.cli.LogLevel.VERBOSE
+import io.gitlab.arturbosch.detekt.cli.LogLevel.WARN
+import io.gitlab.arturbosch.detekt.cli.LogLevel.NONE
 import java.io.PrintStream
 
 /**
  * @author Artur Bosch
  */
+@Suppress("TooManyFunctions")
 object LOG {
-
+    @Deprecated("Use LOG.level instead", ReplaceWith("LOG.level", "io.gitlab.arturbosch.detekt.cli.LOG"))
+    var active: Boolean
+        get() = level != NONE
+        set(value) {
+            level = when {
+                value -> {
+                    // Only reset the level if log is not set
+                    if (level == NONE) INFO else level
+                }
+                else -> NONE
+            }
+        }
+    var level: LogLevel = INFO
     var printer: PrintStream = System.out
-    var active: Boolean = false
 
-    fun debug(message: String) {
-        if (active) {
-            printer.println(message)
-        }
-    }
+    fun verbose(message: Any?) = log(VERBOSE, message)
+    fun verbose(message: () -> Any?) = log(VERBOSE, message)
 
-    fun debug(message: () -> String) {
-        if (active) {
-            printer.println(message.invoke())
-        }
+    fun debug(message: Any?) = log(DEBUG, message)
+    fun debug(message: () -> Any?) = log(DEBUG, message)
+
+    fun info(message: Any?) = log(INFO, message)
+    fun info(message: () -> Any?) = log(INFO, message)
+
+    fun warn(message: Any?) = log(WARN, message)
+    fun warn(message: () -> Any?) = log(WARN, message)
+
+    fun error(message: Any?) = log(ERROR, message)
+    fun error(message: () -> Any?) = log(ERROR, message)
+
+    private fun log(level: LogLevel, message: Any?) {
+        if (level >= this.level) printer.println(message)
     }
+    private inline fun log(level: LogLevel, message: () -> Any?) {
+        if (level >= this.level) printer.println(message.invoke())
+    }
+}
+
+enum class LogLevel {
+    VERBOSE,
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR,
+    NONE
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/LOG.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/LOG.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.cli.LogLevel.ERROR
 import io.gitlab.arturbosch.detekt.cli.LogLevel.INFO
 import io.gitlab.arturbosch.detekt.cli.LogLevel.VERBOSE
 import io.gitlab.arturbosch.detekt.cli.LogLevel.WARN
-import io.gitlab.arturbosch.detekt.cli.LogLevel.NONE
 import java.io.PrintStream
 
 /**
@@ -13,18 +12,6 @@ import java.io.PrintStream
  */
 @Suppress("TooManyFunctions")
 object LOG {
-    @Deprecated("Use LOG.level instead", ReplaceWith("LOG.level", "io.gitlab.arturbosch.detekt.cli.LOG"))
-    var active: Boolean
-        get() = level != NONE
-        set(value) {
-            level = when {
-                value -> {
-                    // Only reset the level if log is not set
-                    if (level == NONE) INFO else level
-                }
-                else -> NONE
-            }
-        }
     var level: LogLevel = INFO
     var printer: PrintStream = System.out
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/LOG.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/LOG.kt
@@ -15,26 +15,38 @@ object LOG {
     var level: LogLevel = INFO
     var printer: PrintStream = System.out
 
-    fun verbose(message: Any?) = log(VERBOSE, message)
-    fun verbose(message: () -> Any?) = log(VERBOSE, message)
+    fun verbose(message: Any?, newLine: Boolean = true) = log(VERBOSE, message, newLine)
+    fun verbose(newLine: Boolean = true, message: () -> Any?) = log(VERBOSE, message, newLine)
 
-    fun debug(message: Any?) = log(DEBUG, message)
-    fun debug(message: () -> Any?) = log(DEBUG, message)
+    fun debug(message: Any?, newLine: Boolean = true) = log(DEBUG, message, newLine)
+    fun debug(newLine: Boolean = true, message: () -> Any?) = log(DEBUG, message, newLine)
 
-    fun info(message: Any?) = log(INFO, message)
-    fun info(message: () -> Any?) = log(INFO, message)
+    fun info(message: Any?, newLine: Boolean = true) = log(INFO, message, newLine)
+    fun info(newLine: Boolean = true, message: () -> Any?) = log(INFO, message, newLine)
 
-    fun warn(message: Any?) = log(WARN, message)
-    fun warn(message: () -> Any?) = log(WARN, message)
+    fun warn(message: Any?, newLine: Boolean = true) = log(WARN, message, newLine)
+    fun warn(newLine: Boolean = true, message: () -> Any?) = log(WARN, message, newLine)
 
-    fun error(message: Any?) = log(ERROR, message)
-    fun error(message: () -> Any?) = log(ERROR, message)
+    fun error(message: Any?, newLine: Boolean = true) = log(ERROR, message, newLine)
+    fun error(newLine: Boolean = true, message: () -> Any?) = log(ERROR, message, newLine)
 
-    private fun log(level: LogLevel, message: Any?) {
-        if (level >= this.level) printer.println(message)
+    private fun log(level: LogLevel, message: Any?, newLine: Boolean) {
+        if (level >= this.level) {
+            if (newLine) {
+                printer.println(message)
+            } else {
+                printer.print(message)
+            }
+        }
     }
-    private inline fun log(level: LogLevel, message: () -> Any?) {
-        if (level >= this.level) printer.println(message.invoke())
+    private inline fun log(level: LogLevel, message: () -> Any?, newLine: Boolean) {
+        if (level >= this.level) {
+            if (newLine) {
+                printer.println(message())
+            } else {
+                printer.print(message())
+            }
+        }
     }
 }
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -17,7 +17,9 @@ import kotlin.system.exitProcess
 @Suppress("TooGenericExceptionCaught")
 fun main(args: Array<String>) {
     val arguments = parseArguments(args)
-    LOG.active = arguments.debug
+    if (arguments.debug) {
+        LOG.level = LogLevel.DEBUG
+    }
     val executable = when {
         arguments.generateConfig -> ConfigExporter()
         arguments.runRule != null -> SingleRuleRunner(arguments)

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -17,9 +17,7 @@ import kotlin.system.exitProcess
 @Suppress("TooGenericExceptionCaught")
 fun main(args: Array<String>) {
     val arguments = parseArguments(args)
-    if (arguments.debug) {
-        LOG.level = LogLevel.DEBUG
-    }
+    LOG.level = parseLogLevel(arguments)
     val executable = when {
         arguments.generateConfig -> ConfigExporter()
         arguments.runRule != null -> SingleRuleRunner(arguments)
@@ -39,6 +37,9 @@ fun main(args: Array<String>) {
     // BuildFailureReport.
     exitProcess(0)
 }
+
+private fun parseLogLevel(arguments: CliArgs) =
+    arguments.logLevel ?: if (arguments.debug) LogLevel.DEBUG else LOG.level
 
 private fun parseArguments(args: Array<String>): CliArgs {
     val (arguments, jcommander) = parseArguments<CliArgs>(args)

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFacade.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFacade.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.cli.baseline
 
 import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.cli.LOG
 import io.gitlab.arturbosch.detekt.cli.baselineId
 import io.gitlab.arturbosch.detekt.core.exists
 import io.gitlab.arturbosch.detekt.core.isFile
@@ -35,7 +36,7 @@ class BaselineFacade(val baselineFile: Path) {
         val smellBaseline = Baseline(blacklist, Whitelist(ids))
         baselineFile.parent?.let { Files.createDirectories(it) }
         BaselineFormat().write(smellBaseline, baselineFile)
-        println("Successfully wrote smell baseline to $baselineFile")
+        LOG.info("Successfully wrote smell baseline to $baselineFile")
     }
 
     private fun baselineExists() = baselineFile.exists() && baselineFile.isFile()

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/BuildFailureReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/BuildFailureReport.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.SingleAssign
+import io.gitlab.arturbosch.detekt.cli.LOG
 import java.util.HashMap
 
 /**
@@ -57,7 +58,7 @@ class BuildFailureReport : ConsoleReport() {
     private fun checkDeprecation() {
         if (buildConfig.valueOrDefault(WARNING_THRESHOLD, Int.MIN_VALUE) != Int.MIN_VALUE ||
                 buildConfig.valueOrDefault(FAIL_THRESHOLD, Int.MIN_VALUE) != Int.MIN_VALUE) {
-            println("[Deprecation] - 'warningThreshold' and 'failThreshold' properties are deprecated." +
+            LOG.warn("[Deprecation] - 'warningThreshold' and 'failThreshold' properties are deprecated." +
                     " Please use the new 'maxIssues' config property.")
         }
     }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinter.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.cli.runners
 
 import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import io.gitlab.arturbosch.detekt.cli.CliArgs
+import io.gitlab.arturbosch.detekt.cli.LOG
 import io.gitlab.arturbosch.detekt.core.KtCompiler
 import io.gitlab.arturbosch.detekt.core.isFile
 import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
@@ -26,7 +27,7 @@ class AstPrinter(private val arguments: CliArgs) : Executable {
 
         val input = arguments.inputPaths.first()
         val ktFile = KtCompiler().compile(input, input)
-        println(ElementPrinter.dump(ktFile))
+        LOG.error(ElementPrinter.dump(ktFile))
     }
 }
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporter.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.cli.runners
 
 import io.gitlab.arturbosch.detekt.cli.ClasspathResourceConverter
 import io.gitlab.arturbosch.detekt.cli.DEFAULT_CONFIG
+import io.gitlab.arturbosch.detekt.cli.LOG
 import java.io.File
 
 /**
@@ -12,6 +13,6 @@ class ConfigExporter : Executable {
     override fun execute() {
         val defaultConfig = ClasspathResourceConverter().convert(DEFAULT_CONFIG).openStream()
         defaultConfig.copyTo(File(DEFAULT_CONFIG).outputStream())
-        println("\nSuccessfully copied $DEFAULT_CONFIG to project location.")
+        LOG.error("\nSuccessfully copied $DEFAULT_CONFIG to project location.")
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.cli.runners
 
 import io.gitlab.arturbosch.detekt.cli.CliArgs
+import io.gitlab.arturbosch.detekt.cli.LOG
 import io.gitlab.arturbosch.detekt.cli.OutputFacade
 import io.gitlab.arturbosch.detekt.cli.createClasspath
 import io.gitlab.arturbosch.detekt.cli.createPathFilters
@@ -24,7 +25,7 @@ class Runner(private val arguments: CliArgs) : Executable {
             OutputFacade(arguments, detektion, settings).run()
         }
 
-        println("\ndetekt finished in $time ms.")
+        LOG.debug("\ndetekt finished in $time ms.")
     }
 
     private fun createSettings(): ProcessingSettings {

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/LOGSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/LOGSpec.kt
@@ -1,0 +1,94 @@
+package io.gitlab.arturbosch.detekt.cli
+
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import org.assertj.core.api.Assertions.assertThat
+import java.io.PrintStream
+
+internal class LOGSpec : Spek({
+
+    describe("Logging messages") {
+
+        val defaultLogs: () -> Unit = {
+            LOG.verbose("verbose")
+            LOG.debug("debug")
+            LOG.info("info")
+            LOG.warn("warn")
+            LOG.error("error")
+        }
+
+        fun captureLog(action: () -> Unit): List<String> {
+            val tempFile = createTempFile()
+            PrintStream(tempFile).use {
+                LOG.printer = it
+                action()
+            }
+            return tempFile.readLines()
+        }
+
+        it ("all logs are suppressed when level = NONE") {
+            LOG.level = LogLevel.NONE
+
+            val logLines = captureLog(defaultLogs)
+
+            assertThat(logLines.size).isEqualTo(0)
+        }
+
+        it ("everything is logged when level = VERBOSE") {
+            LOG.level = LogLevel.VERBOSE
+
+            val logLines = captureLog(defaultLogs)
+
+            assertThat(logLines.size).isEqualTo(5)
+        }
+
+        it ("only the necessary log levels are output") {
+            LOG.level = LogLevel.WARN
+
+            val logLines = captureLog(defaultLogs)
+
+            assertThat(logLines.size).isEqualTo(2)
+            assertThat(logLines[0]).isEqualTo("warn")
+            assertThat(logLines[1]).isEqualTo("error")
+        }
+
+        it ("lambdas are not executed if not necessary") {
+            LOG.level = LogLevel.INFO
+
+            var verbose = false
+            var debug = false
+            var info = false
+            var warn = false
+            var error = false
+            val logLines = captureLog {
+                LOG.verbose {
+                    verbose = true
+                    "verbose"
+                }
+                LOG.debug {
+                    debug = true
+                    "debug"
+                }
+                LOG.info {
+                    info = true
+                    "info"
+                }
+                LOG.warn {
+                    warn = true
+                    "warn"
+                }
+                LOG.error {
+                    error = true
+                    "error"
+                }
+            }
+
+            assertThat(logLines.size).isEqualTo(3)
+            assertThat(verbose).isFalse()
+            assertThat(debug).isFalse()
+            assertThat(info).isTrue()
+            assertThat(warn).isTrue()
+            assertThat(error).isTrue()
+        }
+    }
+})

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/LOGSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/LOGSpec.kt
@@ -90,5 +90,18 @@ internal class LOGSpec : Spek({
             assertThat(warn).isTrue()
             assertThat(error).isTrue()
         }
+
+        it ("no new lines are printed") {
+            LOG.level = LogLevel.VERBOSE
+
+            val logLines = captureLog {
+                LOG.verbose(newLine = false) { "a" }
+                LOG.debug(newLine = false) { "b" }
+                LOG.info("c", newLine = false)
+            }
+
+            assertThat(logLines.size).isEqualTo(1)
+            assertThat(logLines[0]).isEqualTo("abc")
+        }
     }
 })

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Runner.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Runner.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.generator
 
+import io.gitlab.arturbosch.detekt.cli.LOG
 import io.gitlab.arturbosch.detekt.core.KtTreeCompiler
 import io.gitlab.arturbosch.detekt.generator.collection.DetektCollector
 import io.gitlab.arturbosch.detekt.generator.printer.DetektPrinter
@@ -29,6 +30,6 @@ class Runner(private val arguments: GeneratorArgs) {
             printer.print(collector.items)
         }
 
-        println("\nGenerated all detekt documentation in $time ms.")
+        LOG.error("\nGenerated all detekt documentation in $time ms.")
     }
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/AbstractWriter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/AbstractWriter.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.generator.out
 
+import io.gitlab.arturbosch.detekt.cli.LOG
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -14,7 +15,7 @@ internal abstract class AbstractWriter {
         val filePath = path.resolve("$fileName.$ending")
         filePath.parent?.let { Files.createDirectories(it) }
         Files.write(filePath, content().toByteArray())
-        println("Wrote: $fileName.$ending")
+        LOG.info("Wrote: $fileName.$ending")
     }
 }
 


### PR DESCRIPTION
I'm working on adding Detekt to the Linter of my company.
Right now we already have a linter in place for all the languages we work with, except for Kotlin.
Our linter calls other tools and expects a very clear output format.
I've created an extension for ConsoleOutput and was almost able to get the output I needed. The problem was that the output does not come out clean.
I've tried to suppress the extra content, but was not able to do so without hacking the codebase.

Therefore I decided to add logging levels so that it will be possible to integrate Detekt with our Linter.

To run it, I did:
`java -jar detekt-cli-nivaldo.jar --plugins custom-reporter.jar --config detekt-config.yml --log-level none`
