### PR TITLE
Added auto correct information to finding

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -18,7 +18,8 @@ open class CodeSmell(
     override val entity: Entity,
     override val message: String,
     override val metrics: List<Metric> = listOf(),
-    override val references: List<Entity> = listOf()
+    override val references: List<Entity> = listOf(),
+    override val autoCorrect: Boolean = false
 ) : Finding {
 
     override val id: String = issue.id

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -19,7 +19,7 @@ open class CodeSmell(
     override val message: String,
     override val metrics: List<Metric> = listOf(),
     override val references: List<Entity> = listOf(),
-    override val autoCorrect: Boolean = false
+    override val autoCorrectEnabled: Boolean = false
 ) : Finding {
 
     override val id: String = issue.id

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -18,8 +18,7 @@ open class CodeSmell(
     override val entity: Entity,
     override val message: String,
     override val metrics: List<Metric> = listOf(),
-    override val references: List<Entity> = listOf(),
-    override val autoCorrectEnabled: Boolean = false
+    override val references: List<Entity> = listOf()
 ) : Finding {
 
     override val id: String = issue.id
@@ -44,8 +43,41 @@ open class CodeSmell(
 }
 
 /**
+ * Represents a code smell for that can be auto corrected.
+ *
+ * @see CodeSmell
+ */
+open class CorrectableCodeSmell(
+    issue: Issue,
+    entity: Entity,
+    message: String,
+    metrics: List<Metric> = listOf(),
+    references: List<Entity> = listOf(),
+    val autoCorrectEnabled: Boolean
+) : CodeSmell(
+    issue,
+    entity,
+    message,
+    metrics,
+    references
+) {
+    override fun toString(): String {
+        return "CorrectableCodeSmell(" +
+                "autoCorrectEnabled=$autoCorrectEnabled," +
+                "issue=$issue, " +
+                "entity=$entity, " +
+                "message=$message, " +
+                "metrics=$metrics, " +
+                "references=$references, " +
+                "id='$id')"
+    }
+}
+
+/**
  * Represents a code smell for which a specific metric can be determined which is responsible
  * for the existence of this rule violation.
+ *
+ * @see CodeSmell
  */
 open class ThresholdedCodeSmell(
     issue: Issue,

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
@@ -14,7 +14,7 @@ interface Finding : Compactable, HasEntity, HasMetrics {
     val issue: Issue
     val references: List<Entity>
     val message: String
-    val autoCorrect: Boolean
+    val autoCorrectEnabled: Boolean
 
     fun messageOrDescription(): String
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
@@ -14,7 +14,6 @@ interface Finding : Compactable, HasEntity, HasMetrics {
     val issue: Issue
     val references: List<Entity>
     val message: String
-    val autoCorrectEnabled: Boolean
 
     fun messageOrDescription(): String
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
@@ -14,6 +14,7 @@ interface Finding : Compactable, HasEntity, HasMetrics {
     val issue: Issue
     val references: List<Entity>
     val message: String
+    val autoCorrect: Boolean
 
     fun messageOrDescription(): String
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -70,7 +70,7 @@ abstract class FormattingRule(config: Config) : Rule(config) {
                                     "($line, $column)",
                                     root.originalFilePath() ?: root.containingFile.name)),
                     message,
-                    autoCorrect = autoCorrect))
+                    autoCorrectEnabled = autoCorrect))
         }
     }
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -2,8 +2,8 @@ package io.gitlab.arturbosch.detekt.formatting
 
 import com.pinterest.ktlint.core.EditorConfig
 import com.pinterest.ktlint.core.KtLint
-import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.CorrectableCodeSmell
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
@@ -63,7 +63,7 @@ abstract class FormattingRule(config: Config) : Rule(config) {
         }
         wrapping.visit(node, autoCorrect) { _, message, _ ->
             val (line, column) = positionByOffset(node.startOffset)
-            report(CodeSmell(issue,
+            report(CorrectableCodeSmell(issue,
                     Entity(node.toString(), "", "",
                             Location(SourceLocation(line, column),
                                     TextLocation(node.startOffset, node.psi.endOffset),

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -69,7 +69,8 @@ abstract class FormattingRule(config: Config) : Rule(config) {
                                     TextLocation(node.startOffset, node.psi.endOffset),
                                     "($line, $column)",
                                     root.originalFilePath() ?: root.containingFile.name)),
-                    message))
+                    message,
+                    autoCorrect = autoCorrect))
         }
     }
 


### PR DESCRIPTION
This makes it possible for Reports to be aware of where a particular finding had the auto correct function turned on or not.

Part of the same effort as being done in [PR 1593](https://github.com/arturbosch/detekt/pull/1593). This change will help my company integrate Detekt with our tools and provide auto fixes when necessary.