### PR TITLE
Gradle plugin: create task per source set (JVM)

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ProjectExtension.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ProjectExtension.kt
@@ -22,6 +22,8 @@ import org.jetbrains.kotlin.com.intellij.pom.tree.TreeAspect
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.TreeCopyHandler
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.JVMConfigurationKeys
+import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.psi.KtPsiFactory
 import sun.reflect.ReflectionFactory
 import java.io.File
@@ -54,8 +56,9 @@ private fun createProject(configuration: CompilerConfiguration = CompilerConfigu
 }
 
 fun createCompilerConfiguration(
+    pathsToAnalyze: List<Path>,
     classpath: List<String>,
-    pathsToAnalyze: List<Path>
+    jvmTarget: JvmTarget
 ): CompilerConfiguration {
 
     val javaFiles = pathsToAnalyze.flatMap { path ->
@@ -72,6 +75,7 @@ fun createCompilerConfiguration(
     }
 
     return CompilerConfiguration().apply {
+        put(JVMConfigurationKeys.JVM_TARGET, jvmTarget)
         addJavaSourceRoots(javaFiles)
         addKotlinSourceRoots(kotlinFiles)
         addJvmClasspathRoots(classpath.map { File(it) })

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ProjectExtension.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ProjectExtension.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.com.intellij.pom.PomTransaction
 import org.jetbrains.kotlin.com.intellij.pom.impl.PomTransactionBase
 import org.jetbrains.kotlin.com.intellij.pom.tree.TreeAspect
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.TreeCopyHandler
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.psi.KtPsiFactory
 import sun.reflect.ReflectionFactory
@@ -40,6 +41,7 @@ fun createKotlinCoreEnvironment(configuration: CompilerConfiguration = CompilerC
     System.setProperty("idea.io.use.fallback", "true")
     configuration.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY,
             PrintingMessageCollector(System.err, MessageRenderer.PLAIN_FULL_PATHS, false))
+    configuration.put(CommonConfigurationKeys.MODULE_NAME, "detekt")
     return KotlinCoreEnvironment.createForProduction(Disposer.newDisposable(),
         configuration, EnvironmentConfigFiles.JVM_CONFIG_FILES)
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.cli
 
 import com.beust.jcommander.Parameter
+import org.jetbrains.kotlin.config.JvmTarget
 import java.nio.file.Path
 
 /**
@@ -26,13 +27,6 @@ class CliArgs : Args {
     @Parameter(names = ["--excludes", "-ex"],
         description = "Globing patterns describing paths to exclude from the analysis.")
     var excludes: String? = null
-
-    @Parameter(
-        names = ["--classpath", "-cp"],
-        required = false,
-        description = "EXPERIMENTAL: Compile Classpath of the project."
-    )
-    var classpath: String? = null
 
     @Parameter(names = ["--config", "-c"],
         description = "Path to the config file (path/to/config.yml). " +
@@ -106,6 +100,25 @@ class CliArgs : Args {
         description = "Prints the AST for given [input] file. Must be no directory.",
         hidden = true)
     var printAst: Boolean = false
+
+    /*
+        The following @Parameters are used for type and symbol resolving. When additional parameters are required the
+        names should mirror the names found in this file (e.g. "classpath", "jvm-target"):
+        https://github.com/JetBrains/kotlin/blob/master/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments.kt
+    */
+    @Parameter(
+        names = ["--classpath", "-cp"],
+        description = "EXPERIMENTAL: Paths where to find user class files"
+    )
+    var classpath: String? = null
+
+    @Parameter(
+        names = ["--jvm-target"],
+        converter = JvmTargetConverter::class,
+        description = "EXPERIMENTAL: Target version of the generated JVM bytecode that was generated during " +
+                "compilation and is now being used for type resolution (1.6, 1.8, 9, 10, 11 or 12)"
+    )
+    var jvmTarget: JvmTarget = JvmTarget.DEFAULT
 
     val inputPaths: List<Path> by lazy {
         MultipleExistingPathConverter().convert(input ?: System.getProperty("user.dir"))

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -28,9 +28,11 @@ fun main(args: Array<String>) {
         executable.execute()
     } catch (e: BuildFailure) {
         // Exit with status code 2 when maxIssues or failThreshold count was reached in BuildFailureReport.
+        e.printStackTrace()
         exitProcess(2)
     } catch (e: Exception) {
         // Exit with status code 1 when an unexpected error occurred.
+        e.printStackTrace()
         exitProcess(1)
     }
     // Exit with status code 0 when detekt ran normally and maxIssues or failThreshold count was not reached in

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/PathConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/PathConverters.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.cli
 
 import com.beust.jcommander.IStringConverter
 import com.beust.jcommander.ParameterException
+import org.jetbrains.kotlin.config.JvmTarget
 import java.io.File
 import java.net.URL
 import java.nio.file.Files
@@ -44,6 +45,11 @@ class MultipleClasspathResourceConverter : DetektInputPathConverter<URL> {
 
 class MultipleExistingPathConverter : DetektInputPathConverter<Path> {
     override val converter = ExistingPathConverter()
+}
+
+class JvmTargetConverter : IStringConverter<JvmTarget> {
+    override fun convert(value: String): JvmTarget =
+        checkNotNull(JvmTarget.fromString(value)) { "Invalid value passed to --jvm-target" }
 }
 
 /**

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -35,7 +35,8 @@ class Runner(private val arguments: CliArgs) : Executable {
             parallelCompilation = parallel,
             excludeDefaultRuleSets = disableDefaultRuleSets,
             pluginPaths = createPlugins(),
-            classpath = createClasspath()
+            classpath = createClasspath(),
+            jvmTarget = jvmTarget
         )
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
@@ -32,7 +32,8 @@ class DetektFacade(
     private val inputPaths = settings.inputPaths
     private val classpath = settings.classpath
     private val pathFilters = settings.pathFilters
-    private val compilerConfiguration = createCompilerConfiguration(classpath, inputPaths)
+    private val jvmTarget = settings.jvmTarget
+    private val compilerConfiguration = createCompilerConfiguration(inputPaths, classpath, jvmTarget)
     private val environment = createKotlinCoreEnvironment(compilerConfiguration)
     private val compiler = KtTreeCompiler.instance(settings)
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
@@ -7,8 +7,17 @@ import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.createCompilerConfiguration
 import io.gitlab.arturbosch.detekt.api.createKotlinCoreEnvironment
+import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
+import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
+import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
+import org.jetbrains.kotlin.cli.jvm.compiler.NoScopeRecordCliBindingTrace
+import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
+import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProviderFactory
 import java.nio.file.Path
+import java.nio.file.Paths
 
 /**
  * @author Artur Bosch
@@ -20,34 +29,58 @@ class DetektFacade(
 ) {
 
     private val saveSupported = settings.config.valueOrDefault("autoCorrect", false)
-    private val pathsToAnalyze = settings.inputPaths
+    private val inputPaths = settings.inputPaths
     private val classpath = settings.classpath
-    private val compilerConfiguration = createCompilerConfiguration(classpath, pathsToAnalyze)
+    private val pathFilters = settings.pathFilters
+    private val compilerConfiguration = createCompilerConfiguration(classpath, inputPaths)
     private val environment = createKotlinCoreEnvironment(compilerConfiguration)
     private val compiler = KtTreeCompiler.instance(settings)
 
     fun run(): Detektion {
         val notifications = mutableListOf<Notification>()
-        val ktFiles = mutableListOf<KtFile>()
         val findings = HashMap<String, List<Finding>>()
 
-        for (current in pathsToAnalyze) {
-            val files = compiler.compile(current)
+        val filesToAnalyze = environment.getSourceFiles()
+            .filter { file -> !pathFilters.any { it.matches(Paths.get(file.virtualFilePath)) } }
+            .apply { forEach { it.addUserData(it.virtualFilePath) } }
+        val bindingContext = generateBindingContext(filesToAnalyze)
 
-            processors.forEach { it.onStart(files) }
-            findings.mergeSmells(detektor.run(files, environment, classpath.isNotEmpty()))
-            if (saveSupported) {
+        processors.forEach { it.onStart(filesToAnalyze) }
+
+        if (saveSupported) {
+            for (current in inputPaths) {
+                val files = compiler.compile(current)
+
                 KtFileModifier(current).saveModifiedFiles(files) {
                     notifications.add(it)
                 }
             }
-
-            ktFiles.addAll(files)
         }
 
+        findings.mergeSmells(detektor.run(filesToAnalyze, bindingContext))
+
         val result = DetektResult(findings.toSortedMap())
-        processors.forEach { it.onFinish(ktFiles, result) }
+        processors.forEach { it.onFinish(filesToAnalyze, result) }
         return result
+    }
+
+    private fun generateBindingContext(filesForEnvironment: List<KtFile>): BindingContext {
+        return if (classpath.isNotEmpty()) {
+            val analyzer = AnalyzerWithCompilerReport(
+                PrintingMessageCollector(System.err, MessageRenderer.PLAIN_FULL_PATHS, true),
+                environment.configuration.languageVersionSettings
+            )
+            analyzer.analyzeAndReport(filesForEnvironment) {
+                TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(
+                    environment.project, filesForEnvironment, NoScopeRecordCliBindingTrace(),
+                    environment.configuration, environment::createPackagePartProvider,
+                    ::FileBasedDeclarationProviderFactory
+                )
+            }
+            analyzer.analysisResult.bindingContext
+        } else {
+            BindingContext.EMPTY
+        }
     }
 
     fun run(project: Path, files: List<KtFile>): Detektion = runOnFiles(project, files)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
@@ -44,7 +44,7 @@ class DetektFacade(
         val findings = HashMap<String, List<Finding>>()
 
         val filesToAnalyze = environment.getSourceFiles()
-            .filter { file -> !pathFilters.any { it.matches(Paths.get(file.virtualFilePath)) } }
+            .filterNot { file -> pathFilters?.isIgnored(Paths.get(file.virtualFilePath)) ?: false }
             .apply { forEach { it.addUserData(it.virtualFilePath) } }
         val bindingContext = generateBindingContext(filesToAnalyze)
 
@@ -104,6 +104,7 @@ class DetektFacade(
     }
 
     private object DetektMessageRenderer : PlainTextMessageRenderer() {
+        override fun getName() = "detekt message renderer"
         override fun getPath(location: CompilerMessageLocation) = location.path
         override fun render(
             severity: CompilerMessageSeverity,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.com.intellij.testFramework.LightVirtualFile
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
+import java.nio.file.Paths
 
 /**
  * @author Artur Bosch
@@ -47,11 +48,23 @@ open class KtCompiler {
         return psiFile as? KtFile ?: throw IllegalStateException("kotlin file expected")
     }
 
-    private fun String.determineLineSeparator(): String {
-        val i = this.lastIndexOf('\n')
-        if (i == -1) {
-            return if (this.lastIndexOf('\r') == -1) System.getProperty("line.separator") else "\r"
-        }
-        return if (i != 0 && this[i] == '\r') "\r\n" else "\n"
+}
+
+fun KtFile.addUserData(rootPath: String) {
+    val root = Paths.get(rootPath)
+    val content = root.toFile().readText()
+    val lineSeparator = content.determineLineSeparator()
+
+    this.apply {
+        putUserData(LINE_SEPARATOR, lineSeparator)
+        putUserData(ABSOLUTE_PATH, rootPath)
     }
+}
+
+internal fun String.determineLineSeparator(): String {
+    val i = this.lastIndexOf('\n')
+    if (i == -1) {
+        return if (this.lastIndexOf('\r') == -1) System.getProperty("line.separator") else "\r"
+    }
+    return if (i != 0 && this[i] == '\r') "\r\n" else "\n"
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
+import org.jetbrains.kotlin.config.JvmTarget
 import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
@@ -24,6 +25,7 @@ data class ProcessingSettings @JvmOverloads constructor(
     val excludeDefaultRuleSets: Boolean = false,
     val pluginPaths: List<Path> = emptyList(),
     val classpath: List<String> = emptyList(),
+    val jvmTarget: JvmTarget = JvmTarget.DEFAULT,
     val executorService: ExecutorService = ForkJoinPool.commonPool(),
     val outPrinter: PrintStream = System.out,
     val errorPrinter: PrintStream = System.err,
@@ -40,6 +42,7 @@ data class ProcessingSettings @JvmOverloads constructor(
         excludeDefaultRuleSets: Boolean = false,
         pluginPaths: List<Path> = emptyList(),
         classpath: List<String> = emptyList(),
+        jvmTarget: JvmTarget = JvmTarget.DEFAULT,
         executorService: ExecutorService = ForkJoinPool.commonPool(),
         outPrinter: PrintStream = System.out,
         errorPrinter: PrintStream = System.err,
@@ -52,6 +55,7 @@ data class ProcessingSettings @JvmOverloads constructor(
         excludeDefaultRuleSets,
         pluginPaths,
         classpath,
+        jvmTarget,
         executorService,
         outPrinter,
         errorPrinter,

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -37,6 +37,8 @@ val assertjVersion = "3.12.2"
 
 dependencies {
     implementation(kotlin("stdlib"))
+    implementation(kotlin("gradle-plugin"))
+    implementation(kotlin("gradle-plugin-api"))
 
     testImplementation(kotlin("reflect"))
     testImplementation("org.assertj:assertj-core:$assertjVersion")

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.internal.configurableFileCollection
 import io.gitlab.arturbosch.detekt.internal.fileProperty
 import io.gitlab.arturbosch.detekt.invoke.BaselineArgument
 import io.gitlab.arturbosch.detekt.invoke.BuildUponDefaultConfigArgument
+import io.gitlab.arturbosch.detekt.invoke.ClasspathArgument
 import io.gitlab.arturbosch.detekt.invoke.ConfigArgument
 import io.gitlab.arturbosch.detekt.invoke.CustomReportArgument
 import io.gitlab.arturbosch.detekt.invoke.DebugArgument
@@ -28,6 +29,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
@@ -69,6 +71,10 @@ open class Detekt : SourceTask() {
     @Optional
     @PathSensitive(PathSensitivity.RELATIVE)
     var config: ConfigurableFileCollection = project.configurableFileCollection()
+
+    @Classpath
+    @Optional
+    val classpath = project.configurableFileCollection()
 
     @Input
     @Optional
@@ -154,6 +160,7 @@ open class Detekt : SourceTask() {
         val debugOrDefault = debugProp.getOrElse(false)
         val arguments = mutableListOf(
             InputArgument(source),
+            ClasspathArgument(classpath),
             ConfigArgument(config),
             PluginsArgument(plugins.orNull),
             BaselineArgument(baseline.orNull),

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -16,6 +16,7 @@ import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.DisableDefaultRuleSetArgument
 import io.gitlab.arturbosch.detekt.invoke.FailFastArgument
 import io.gitlab.arturbosch.detekt.invoke.InputArgument
+import io.gitlab.arturbosch.detekt.invoke.JvmTargetArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
 import io.gitlab.arturbosch.detekt.invoke.PluginsArgument
 import io.gitlab.arturbosch.detekt.output.mergeXmlReports
@@ -75,6 +76,14 @@ open class Detekt : SourceTask() {
     @Classpath
     @Optional
     val classpath = project.configurableFileCollection()
+
+    @Input
+    @Optional
+    internal val jvmTargetProp: Property<String> = project.objects.property(String::class.javaObjectType)
+    var jvmTarget: String
+        @Internal
+        get() = jvmTargetProp.get()
+        set(value) = jvmTargetProp.set(value)
 
     @Input
     @Optional
@@ -161,6 +170,7 @@ open class Detekt : SourceTask() {
         val arguments = mutableListOf(
             InputArgument(source),
             ClasspathArgument(classpath),
+            JvmTargetArgument(jvmTargetProp.orNull),
             ConfigArgument(config),
             PluginsArgument(plugins.orNull),
             BaselineArgument(baseline.orNull),

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.UnknownTaskException
@@ -13,7 +14,6 @@ import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.SourceSet
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.File
 
 /**
@@ -89,8 +89,8 @@ class DetektPlugin : Plugin<Project> {
     }
 
     private fun registerDetektTask(project: Project, extension: DetektExtension, sourceSet: SourceSet) {
-        @Suppress("UnsafeCast")
-        val kotlinSourceSet = sourceSet.getConvention("kotlin") as KotlinSourceSet
+        val kotlinSourceSet = sourceSet.getConvention("kotlin") as? KotlinSourceSet
+            ?: throw GradleException("Kotlin source set not found. Please report on detekt's issue tracker")
         project.tasks.register(DETEKT + sourceSet.name.capitalize(), Detekt::class.java) {
             it.debugProp.set(project.provider { extension.debug })
             it.parallelProp.set(project.provider { extension.parallel })

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -16,6 +16,7 @@ private const val PLUGINS_PARAMETER = "--plugins"
 private const val REPORT_PARAMETER = "--report"
 private const val GENERATE_CONFIG_PARAMETER = "--generate-config"
 private const val CREATE_BASELINE_PARAMETER = "--create-baseline"
+private const val CLASSPATH_PARAMETER = "--classpath"
 
 internal sealed class CliArgument {
     abstract fun toArgument(): List<String>
@@ -31,6 +32,12 @@ internal object GenerateConfigArgument : CliArgument() {
 
 internal data class InputArgument(val fileCollection: FileCollection) : CliArgument() {
     override fun toArgument() = listOf(INPUT_PARAMETER, fileCollection.joinToString(",") { it.absolutePath })
+}
+
+internal data class ClasspathArgument(val fileCollection: FileCollection) : CliArgument() {
+    override fun toArgument() = if (!fileCollection.isEmpty) listOf(
+        CLASSPATH_PARAMETER,
+        fileCollection.joinToString(";") { it.absolutePath }) else emptyList()
 }
 
 internal data class PluginsArgument(val plugins: String?) : CliArgument() {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -17,6 +17,7 @@ private const val REPORT_PARAMETER = "--report"
 private const val GENERATE_CONFIG_PARAMETER = "--generate-config"
 private const val CREATE_BASELINE_PARAMETER = "--create-baseline"
 private const val CLASSPATH_PARAMETER = "--classpath"
+private const val JVM_TARGET_PARAMETER = "--jvm-target"
 
 internal sealed class CliArgument {
     abstract fun toArgument(): List<String>
@@ -38,6 +39,10 @@ internal data class ClasspathArgument(val fileCollection: FileCollection) : CliA
     override fun toArgument() = if (!fileCollection.isEmpty) listOf(
         CLASSPATH_PARAMETER,
         fileCollection.joinToString(";") { it.absolutePath }) else emptyList()
+}
+
+internal data class JvmTargetArgument(val jvmTarget: String?) : CliArgument() {
+    override fun toArgument() = jvmTarget?.let { listOf(JVM_TARGET_PARAMETER, it) } ?: emptyList()
 }
 
 internal data class PluginsArgument(val plugins: String?) : CliArgument() {


### PR DESCRIPTION
Closes #1198. Don't merge until tests & docs are added. Does nothing by default - users have to explicitly run the auto-generated tasks.

Try out various scenarios and help spot regressions or cases where the type resolution won't work - I've tried on the kotlinconf app and it does what it's supposed to, but I've also modified some core code that I'm not that familiar with so hopefully haven't broken anything. Tests pass.

To test:
* Check out this branch
* Add this to style block in `reports/failfast.yml`:
```yaml
  UselessCallOnNotNull:
    active: true
```
* Insert `val testList = listOf<String>().orEmpty()` somewhere in the main source set of one of the projects
* Run `./gradlew detektMain` - the above offending code should be detected by UselessCallOnNotNull rule which shows type resolution working as expected.

Limitations:
* Doesn't support JS or native projects. Type resolution capability in detekt only works on JVM currently so this isn't really an issue.
* No Android support. Will investigate, but may not include support for now.
* No multiplatform project support. I don't see this as a blocker as it's experimental in Kotlin currently.

Also closes #1580