### PR TITLE
Custom reports in gradle plugin

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -1,20 +1,22 @@
 package io.gitlab.arturbosch.detekt
 
+import io.gitlab.arturbosch.detekt.extensions.CustomDetektReport
+import io.gitlab.arturbosch.detekt.extensions.DetektReportType
 import io.gitlab.arturbosch.detekt.extensions.DetektReports
 import io.gitlab.arturbosch.detekt.internal.configurableFileCollection
 import io.gitlab.arturbosch.detekt.internal.fileProperty
 import io.gitlab.arturbosch.detekt.invoke.BaselineArgument
 import io.gitlab.arturbosch.detekt.invoke.BuildUponDefaultConfigArgument
 import io.gitlab.arturbosch.detekt.invoke.ConfigArgument
+import io.gitlab.arturbosch.detekt.invoke.CustomReportArgument
 import io.gitlab.arturbosch.detekt.invoke.DebugArgument
+import io.gitlab.arturbosch.detekt.invoke.DefaultReportArgument
 import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.DisableDefaultRuleSetArgument
 import io.gitlab.arturbosch.detekt.invoke.FailFastArgument
-import io.gitlab.arturbosch.detekt.invoke.HtmlReportArgument
 import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
 import io.gitlab.arturbosch.detekt.invoke.PluginsArgument
-import io.gitlab.arturbosch.detekt.invoke.XmlReportArgument
 import io.gitlab.arturbosch.detekt.output.mergeXmlReports
 import org.gradle.api.Action
 import org.gradle.api.file.ConfigurableFileCollection
@@ -30,6 +32,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
@@ -136,40 +139,57 @@ open class Detekt : SourceTask() {
 
     private val effectiveReportsDir = project.provider { reportsDir.getOrElse(defaultReportsDir.asFile) }
 
+    val customReports: Provider<Collection<CustomDetektReport>>
+        @Nested
+        get() = project.provider { reports.custom }
+
     init {
         group = LifecycleBasePlugin.VERIFICATION_GROUP
     }
 
     @TaskAction
     fun check() {
-        val xmlReportTargetFile = xmlReportFile.orNull
+        val xmlReportTargetFileOrNull = xmlReportFile.orNull
+        val htmlReportTargetFileOrNull = htmlReportFile.orNull
         val debugOrDefault = debugProp.getOrElse(false)
         val arguments = mutableListOf(
             InputArgument(source),
             ConfigArgument(config),
             PluginsArgument(plugins.orNull),
             BaselineArgument(baseline.orNull),
-            XmlReportArgument(xmlReportTargetFile),
-            HtmlReportArgument(htmlReportFile.orNull),
+            DefaultReportArgument(DetektReportType.XML, xmlReportTargetFileOrNull),
+            DefaultReportArgument(DetektReportType.HTML, htmlReportTargetFileOrNull),
             DebugArgument(debugOrDefault),
             ParallelArgument(parallelProp.getOrElse(false)),
             BuildUponDefaultConfigArgument(buildUponDefaultConfigProp.getOrElse(false)),
             FailFastArgument(failFastProp.getOrElse(false)),
             DisableDefaultRuleSetArgument(disableDefaultRuleSetsProp.getOrElse(false))
         )
+        arguments.addAll(customReports.get().map {
+            val type = it.typeProperty.orNull
+            val destination = it.destinationProperty.orNull
+
+            checkNotNull(type) { "If a custom report is specified, the type must be present" }
+            check(!DetektReportType.isWellKnownReportTypeId(type)) {
+                "The custom report type may not be same as one of the default types"
+            }
+            checkNotNull(destination) { "If a custom report is specified, the destination must be present" }
+
+            CustomReportArgument(type, destination)
+        })
 
         DetektInvoker.invokeCli(project, arguments.toList(), debugOrDefault)
 
-        if (xmlReportTargetFile != null) {
+        if (xmlReportTargetFileOrNull != null) {
             val xmlReports = project.subprojects.flatMap { subproject ->
                 subproject.tasks.mapNotNull { task ->
                     if (task is Detekt) task.xmlReportFile.orNull?.asFile else null
                 }
             }
             if (!xmlReports.isEmpty() && debugOrDefault) {
-                logger.info("Merging report files of subprojects $xmlReports into $xmlReportTargetFile")
+                logger.info("Merging report files of subprojects $xmlReports into $xmlReportTargetFileOrNull")
             }
-            mergeXmlReports(xmlReportTargetFile.asFile, xmlReports)
+            mergeXmlReports(xmlReportTargetFileOrNull.asFile, xmlReports)
         }
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -166,16 +166,16 @@ open class Detekt : SourceTask() {
             DisableDefaultRuleSetArgument(disableDefaultRuleSetsProp.getOrElse(false))
         )
         arguments.addAll(customReports.get().map {
-            val type = it.typeProperty.orNull
+            val reportId = it.reportIdProp.orNull
             val destination = it.destinationProperty.orNull
 
-            checkNotNull(type) { "If a custom report is specified, the type must be present" }
-            check(!DetektReportType.isWellKnownReportTypeId(type)) {
-                "The custom report type may not be same as one of the default types"
+            checkNotNull(reportId) { "If a custom report is specified, the reportId must be present" }
+            check(!DetektReportType.isWellKnownReportId(reportId)) {
+                "The custom report reportId may not be same as one of the default reports"
             }
             checkNotNull(destination) { "If a custom report is specified, the destination must be present" }
 
-            CustomReportArgument(type, destination)
+            CustomReportArgument(reportId, destination)
         })
 
         DetektInvoker.invokeCli(project, arguments.toList(), debugOrDefault)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/CustomDetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/CustomDetektReport.kt
@@ -11,10 +11,10 @@ import java.io.File
 class CustomDetektReport(private val project: Project) {
 
     @Internal
-    val typeProperty: Property<String> = project.objects.property(String::class.java)
-    var type: String
-        get() = typeProperty.get()
-        set(value) = typeProperty.set(value)
+    val reportIdProp: Property<String> = project.objects.property(String::class.java)
+    var reportId: String
+        get() = reportIdProp.get()
+        set(value) = reportIdProp.set(value)
 
     @OutputFile
     val destinationProperty: RegularFileProperty = project.fileProperty()
@@ -23,6 +23,6 @@ class CustomDetektReport(private val project: Project) {
         set(value) = destinationProperty.set(value)
 
     override fun toString(): String {
-        return "CustomDetektReport(type=$type, destination=$destination)"
+        return "CustomDetektReport(reportId=$reportId, destination=$destination)"
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/CustomDetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/CustomDetektReport.kt
@@ -1,0 +1,28 @@
+package io.gitlab.arturbosch.detekt.extensions
+
+import io.gitlab.arturbosch.detekt.internal.fileProperty
+import org.gradle.api.Project
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import java.io.File
+
+class CustomDetektReport(private val project: Project) {
+
+    @Internal
+    val typeProperty: Property<String> = project.objects.property(String::class.java)
+    var type: String
+        get() = typeProperty.get()
+        set(value) = typeProperty.set(value)
+
+    @OutputFile
+    val destinationProperty: RegularFileProperty = project.fileProperty()
+    var destination: File
+        get() = destinationProperty.get().asFile
+        set(value) = destinationProperty.set(value)
+
+    override fun toString(): String {
+        return "CustomDetektReport(type=$type, destination=$destination)"
+    }
+}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReportType.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReportType.kt
@@ -1,11 +1,11 @@
 package io.gitlab.arturbosch.detekt.extensions
 
-enum class DetektReportType(val typeId: String, val extension: String) {
+enum class DetektReportType(val reportId: String, val extension: String) {
 
     XML("xml", "xml"),
     HTML("html", "html");
 
     companion object {
-        fun isWellKnownReportTypeId(typeId: String) = typeId in values().map(DetektReportType::typeId)
+        fun isWellKnownReportId(reportId: String) = reportId in values().map(DetektReportType::reportId)
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReportType.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReportType.kt
@@ -1,7 +1,11 @@
 package io.gitlab.arturbosch.detekt.extensions
 
-enum class DetektReportType(val extension: String) {
+enum class DetektReportType(val typeId: String, val extension: String) {
 
-    XML("xml"),
-    HTML("html")
+    XML("xml", "xml"),
+    HTML("html", "html");
+
+    companion object {
+        fun isWellKnownReportTypeId(typeId: String) = typeId in values().map(DetektReportType::typeId)
+    }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
@@ -6,15 +6,22 @@ import io.gitlab.arturbosch.detekt.extensions.DetektReportType.XML
 import org.gradle.api.Project
 import org.gradle.util.ConfigureUtil
 
-class DetektReports(project: Project) {
+class DetektReports(private val project: Project) {
 
     val xml = DetektReport(XML, project)
 
     val html = DetektReport(HTML, project)
+
+    val custom = mutableListOf<CustomDetektReport>()
 
     fun xml(configure: DetektReport.() -> Unit) = xml.configure()
     fun xml(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, xml)
 
     fun html(configure: DetektReport.() -> Unit) = html.configure()
     fun html(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, html)
+
+    fun custom(configure: CustomDetektReport.() -> Unit) = createAndAddCustomReport().configure()
+    fun custom(closure: Closure<*>): CustomDetektReport = ConfigureUtil.configure(closure, createAndAddCustomReport())
+
+    private fun createAndAddCustomReport() = CustomDetektReport(project).apply { custom.add(this) }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -43,11 +43,11 @@ internal data class BaselineArgument(val baseline: RegularFile?) : CliArgument()
 
 internal data class DefaultReportArgument(val type: DetektReportType, val file: RegularFile?) : CliArgument() {
     override fun toArgument() =
-        file?.let { listOf(REPORT_PARAMETER, "${type.typeId}:${it.asFile.absoluteFile}") } ?: emptyList()
+        file?.let { listOf(REPORT_PARAMETER, "${type.reportId}:${it.asFile.absoluteFile}") } ?: emptyList()
 }
 
-internal data class CustomReportArgument(val type: String, val file: RegularFile) : CliArgument() {
-    override fun toArgument() = listOf(REPORT_PARAMETER, "$type:${file.asFile.absolutePath}")
+internal data class CustomReportArgument(val reportId: String, val file: RegularFile) : CliArgument() {
+    override fun toArgument() = listOf(REPORT_PARAMETER, "$reportId:${file.asFile.absolutePath}")
 }
 
 internal data class ConfigArgument(val config: FileCollection) : CliArgument() {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.invoke
 
+import io.gitlab.arturbosch.detekt.extensions.DetektReportType
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
 
@@ -40,12 +41,13 @@ internal data class BaselineArgument(val baseline: RegularFile?) : CliArgument()
     override fun toArgument() = baseline?.let { listOf(BASELINE_PARAMETER, it.asFile.absolutePath) } ?: emptyList()
 }
 
-internal data class XmlReportArgument(val file: RegularFile?) : CliArgument() {
-    override fun toArgument() = file?.let { listOf(REPORT_PARAMETER, "xml:${it.asFile.absoluteFile}") } ?: emptyList()
+internal data class DefaultReportArgument(val type: DetektReportType, val file: RegularFile?) : CliArgument() {
+    override fun toArgument() =
+        file?.let { listOf(REPORT_PARAMETER, "${type.typeId}:${it.asFile.absoluteFile}") } ?: emptyList()
 }
 
-internal data class HtmlReportArgument(val file: RegularFile?) : CliArgument() {
-    override fun toArgument() = file?.let { listOf(REPORT_PARAMETER, "html:${it.asFile.absolutePath}") } ?: emptyList()
+internal data class CustomReportArgument(val type: String, val file: RegularFile) : CliArgument() {
+    override fun toArgument() = listOf(REPORT_PARAMETER, "$type:${file.asFile.absolutePath}")
 }
 
 internal data class ConfigArgument(val config: FileCollection) : CliArgument() {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslTest.kt
@@ -14,10 +14,10 @@ internal class CreateBaselineTaskDslTest : Spek({
             describe("using ${builder.gradleBuildName}") {
                 it("can be executed when baseline file is specified") {
                     val detektConfig = """
-						|detekt {
-						| 	baseline = file("build/baseline.xml")
-						|}
-						"""
+                        |detekt {
+                        |   baseline = file("build/baseline.xml")
+                        |}
+                        """
                     val gradleRunner = builder
                         .withDetektConfig(detektConfig)
                         .build()

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -248,18 +248,18 @@ internal class DetektTaskDslTest : Spek({
                     }
                 }
 
-                describe("with custom report types") {
+                describe("with custom reports") {
                     it("passes multiple custom report params to cli") {
 
                         val config = """
                         |detekt {
                         |    reports {
                         |        custom {
-                        |           type = "customXml"
+                        |           reportId = "customXml"
                         |           destination = file("build/reports/custom.xml")
                         |       }
                         |        custom {
-                        |           type = "customJson"
+                        |           reportId = "customJson"
                         |           destination = file("build/reports/custom.json")
                         |       }
                         |    }
@@ -280,7 +280,7 @@ internal class DetektTaskDslTest : Spek({
                             assertThat(result.output).contains("--report customJson:$customJsonReportFilePath")
                         }
                     }
-                    it("fails if type of custom report is missing") {
+                    it("fails if reportId of custom report is missing") {
 
                         val config = """
                         |detekt {
@@ -304,7 +304,7 @@ internal class DetektTaskDslTest : Spek({
                         |detekt {
                         |    reports {
                         |        custom {
-                        |           type = "foo"
+                        |           reportId = "foo"
                         |       }
                         |    }
                         |}
@@ -324,7 +324,7 @@ internal class DetektTaskDslTest : Spek({
                         |detekt {
                         |    reports {
                         |        custom {
-                        |           type = "foo"
+                        |           reportId = "foo"
                         |           destination = file("$aDirectory")
                         |       }
                         |    }
@@ -339,13 +339,13 @@ internal class DetektTaskDslTest : Spek({
                     }
 
                     DetektReportType.values().forEach { wellKnownType ->
-                        it("fails if type of custom report is $wellKnownType") {
+                        it("fails if reportId of custom report is $wellKnownType") {
 
                             val config = """
                                 |detekt {
                                 |    reports {
                                 |        custom {
-                                |           type = "${wellKnownType.typeId}"
+                                |           reportId = "${wellKnownType.reportId}"
                                 |           destination = file("build/reports/custom.xml")
                                 |       }
                                 |    }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.DslTestBuilder.Companion.groovy
 import io.gitlab.arturbosch.detekt.DslTestBuilder.Companion.kotlin
+import io.gitlab.arturbosch.detekt.extensions.DetektReportType
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
 import org.spekframework.spek2.Spek
@@ -41,10 +42,10 @@ internal class DetektTaskDslTest : Spek({
 
                     val customVersion = "1.0.0.RC8"
                     val config = """
-						|detekt {
-						|	toolVersion = "$customVersion"
-						|}
-						"""
+                        |detekt {
+                        |    toolVersion = "$customVersion"
+                        |}
+                        """
 
                     val gradleRunner = builder.withDetektConfig(config).build()
                     gradleRunner.runTasksAndCheckResult("dependencies", "--configuration", "detekt") { result ->
@@ -56,10 +57,10 @@ internal class DetektTaskDslTest : Spek({
                 it("can be applied with multiple config files") {
 
                     val config = """
-						|detekt {
-						|	config = files("firstConfig.yml", "secondConfig.yml")
-						|}
-						"""
+                        |detekt {
+                        |    config = files("firstConfig.yml", "secondConfig.yml")
+                        |}
+                        """
 
                     val gradleRunner = builder.withDetektConfig(config).build()
 
@@ -77,10 +78,10 @@ internal class DetektTaskDslTest : Spek({
 
                     val customSrc = "gensrc/kotlin"
                     val config = """
-						|detekt {
-						|	input = files("$customSrc", "folder_that_does_not_exist")
-						|}
-						"""
+                        |detekt {
+                        |    input = files("$customSrc", "folder_that_does_not_exist")
+                        |}
+                        """
 
                     val gradleRunner = builder
                         .withProjectLayout(ProjectLayout(1, srcDirs = listOf(customSrc)))
@@ -95,15 +96,16 @@ internal class DetektTaskDslTest : Spek({
                         assertThat(result.output).doesNotContain("folder_that_does_not_exist")
                     }
                 }
+
                 it("can be applied with classes in multiple custom input directories") {
 
                     val customSrc1 = "gensrc/kotlin"
                     val customSrc2 = "src/main/kotlin"
                     val config = """
-						|detekt {
-						|	input = files("$customSrc1", "$customSrc2")
-						|}
-						"""
+                        |detekt {
+                        |    input = files("$customSrc1", "$customSrc2")
+                        |}
+                        """
 
                     val projectLayout = ProjectLayout(1, srcDirs = listOf(customSrc1, customSrc2))
                     val gradleRunner = builder
@@ -121,13 +123,14 @@ internal class DetektTaskDslTest : Spek({
                         assertThat(result.output).contains("number of classes: 2")
                     }
                 }
+
                 it("can change the general reports dir") {
 
                     val config = """
-						|detekt {
-						|	reportsDir = file("build/detekt-reports")
-						|}
-						"""
+                        |detekt {
+                        |    reportsDir = file("build/detekt-reports")
+                        |}
+                        """
 
                     val gradleRunner = builder
                         .withDetektConfig(config)
@@ -139,16 +142,17 @@ internal class DetektTaskDslTest : Spek({
                         assertThat(projectFile("build/detekt-reports/detekt.html")).exists()
                     }
                 }
+
                 it("can change the general reports dir but overwrite single report") {
 
                     val config = """
-						|detekt {
-						|	reportsDir = file("build/detekt-reports")
-						|	reports {
-						|		xml.destination = file("build/xml-reports/custom-detekt.xml")
-						|	}
-						|}
-						"""
+                        |detekt {
+                        |    reportsDir = file("build/detekt-reports")
+                        |    reports {
+                        |        xml.destination = file("build/xml-reports/custom-detekt.xml")
+                        |    }
+                        |}
+                        """
 
                     val gradleRunner = builder
                         .withDetektConfig(config)
@@ -160,18 +164,19 @@ internal class DetektTaskDslTest : Spek({
                         assertThat(projectFile("build/detekt-reports/detekt.html")).exists()
                     }
                 }
+
                 it("can disable reports") {
 
                     val config = """
-						|detekt {
-						|	reports {
-						|		xml.enabled = false
-						|		html {
-						|			enabled = false
-						|		}
-						|	}
-						|}
-						"""
+                        |detekt {
+                        |    reports {
+                        |        xml.enabled = false
+                        |        html {
+                        |            enabled = false
+                        |        }
+                        |    }
+                        |}
+                        """
 
                     val gradleRunner = builder
                         .withDetektConfig(config)
@@ -183,15 +188,16 @@ internal class DetektTaskDslTest : Spek({
                         assertThat(projectFile("build/reports/detekt/detekt.html")).doesNotExist()
                     }
                 }
+
                 it("can change all flags") {
 
                     val config = """
-						|detekt {
-						|	debug = true
-						|	parallel = true
-						|	disableDefaultRuleSets = true
-						|}
-						"""
+                        |detekt {
+                        |    debug = true
+                        |    parallel = true
+                        |    disableDefaultRuleSets = true
+                        |}
+                        """
 
                     val gradleRunner = builder
                         .withDetektConfig(config)
@@ -202,15 +208,16 @@ internal class DetektTaskDslTest : Spek({
                         assertThat(result.output).contains("--debug", "--parallel", "--disable-default-rulesets")
                     }
                 }
+
                 it("allows setting a baseline file") {
 
                     val baselineFilename = "detekt-baseline.xml"
 
                     val config = """
-						|detekt {
-						|	baseline = file("$baselineFilename")
-						|}
-						"""
+                        |detekt {
+                        |    baseline = file("$baselineFilename")
+                        |}
+                        """
 
                     val gradleRunner = builder
                         .withDetektConfig(config)
@@ -226,10 +233,10 @@ internal class DetektTaskDslTest : Spek({
                 it("can be used with formatting plugin") {
 
                     val config = """
-					|dependencies {
-					| detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$VERSION_UNDER_TEST")
-					|}
-						"""
+                    |dependencies {
+                    | detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$VERSION_UNDER_TEST")
+                    |}
+                        """
 
                     val gradleRunner = builder
                         .withDetektConfig(config)
@@ -240,6 +247,119 @@ internal class DetektTaskDslTest : Spek({
                         assertThat(result.output).contains("io.gitlab.arturbosch.detekt:detekt-formatting:$VERSION_UNDER_TEST")
                     }
                 }
+
+                describe("with custom report types") {
+                    it("passes multiple custom report params to cli") {
+
+                        val config = """
+                        |detekt {
+                        |    reports {
+                        |        custom {
+                        |           type = "customXml"
+                        |           destination = file("build/reports/custom.xml")
+                        |       }
+                        |        custom {
+                        |           type = "customJson"
+                        |           destination = file("build/reports/custom.json")
+                        |       }
+                        |    }
+                        |}
+                        """
+
+                        val gradleRunner = builder
+                            .withDetektConfig(config)
+                            .build()
+
+                        val customXmlReportFilePath = gradleRunner.projectFile("build/reports/custom.xml").absolutePath
+                        val customJsonReportFilePath =
+                            gradleRunner.projectFile("build/reports/custom.json").absolutePath
+
+                        gradleRunner.runDetektTaskAndCheckResult { result ->
+                            assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                            assertThat(result.output).contains("--report customXml:$customXmlReportFilePath")
+                            assertThat(result.output).contains("--report customJson:$customJsonReportFilePath")
+                        }
+                    }
+                    it("fails if type of custom report is missing") {
+
+                        val config = """
+                        |detekt {
+                        |    reports {
+                        |        custom {
+                        |           destination = file("build/reports/custom.xml")
+                        |       }
+                        |    }
+                        |}
+                        """
+
+                        val gradleRunner = builder
+                            .withDetektConfig(config)
+                            .build()
+
+                        gradleRunner.runDetektTaskAndExpectFailure()
+                    }
+                    it("fails if destination of custom report is missing") {
+
+                        val config = """
+                        |detekt {
+                        |    reports {
+                        |        custom {
+                        |           type = "foo"
+                        |       }
+                        |    }
+                        |}
+                        """
+
+                        val gradleRunner = builder
+                            .withDetektConfig(config)
+                            .build()
+
+                        gradleRunner.runDetektTaskAndExpectFailure()
+                    }
+
+                    it("fails if the destination is a directory") {
+                        val aDirectory = "\${rootDir}/src"
+
+                        val config = """
+                        |detekt {
+                        |    reports {
+                        |        custom {
+                        |           type = "foo"
+                        |           destination = file("$aDirectory")
+                        |       }
+                        |    }
+                        |}
+                        """
+
+                        val gradleRunner = builder
+                            .withDetektConfig(config)
+                            .build()
+
+                        gradleRunner.runDetektTaskAndExpectFailure()
+                    }
+
+                    DetektReportType.values().forEach { wellKnownType ->
+                        it("fails if type of custom report is $wellKnownType") {
+
+                            val config = """
+                                |detekt {
+                                |    reports {
+                                |        custom {
+                                |           type = "${wellKnownType.typeId}"
+                                |           destination = file("build/reports/custom.xml")
+                                |       }
+                                |    }
+                                |}
+                                """
+
+                            val gradleRunner = builder
+                                .withDetektConfig(config)
+                                .build()
+
+                            gradleRunner.runDetektTaskAndExpectFailure()
+                        }
+                    }
+                }
             }
         }
 
@@ -247,27 +367,27 @@ internal class DetektTaskDslTest : Spek({
             it("can be done using the groovy dsl") {
 
                 val config = """
-					|task detektFailFast(type: io.gitlab.arturbosch.detekt.Detekt) {
-					|	description = "Runs a failfast detekt build."
-					|
-					|	input = files("${"$"}projectDir")
-					|	config = files("config.yml")
-					|	includes = ["**/*.kt", "**/*.kts"]
-					|	excludes = ["build/"]
-					|	debug = true
-					|	parallel = true
-					|	disableDefaultRuleSets = true
-					|	buildUponDefaultConfig = true
-					|	failFast = false
-					|	reports {
-					|		xml {
-					|			enabled = true
-					|			destination = file("build/reports/failfast.xml")
-					|		}
-					|		html.destination = file("build/reports/failfast.html")
-					|	}
-					|}
-				"""
+                    |task detektFailFast(type: io.gitlab.arturbosch.detekt.Detekt) {
+                    |    description = "Runs a failfast detekt build."
+                    |
+                    |    input = files("${"$"}projectDir")
+                    |    config = files("config.yml")
+                    |    includes = ["**/*.kt", "**/*.kts"]
+                    |    excludes = ["build/"]
+                    |    debug = true
+                    |    parallel = true
+                    |    disableDefaultRuleSets = true
+                    |    buildUponDefaultConfig = true
+                    |    failFast = false
+                    |    reports {
+                    |        xml {
+                    |            enabled = true
+                    |            destination = file("build/reports/failfast.xml")
+                    |        }
+                    |        html.destination = file("build/reports/failfast.html")
+                    |    }
+                    |}
+                """
 
                 val gradleRunner = groovy().withDetektConfig(config).build()
                 gradleRunner.writeProjectFile("config.yml", "")
@@ -282,27 +402,27 @@ internal class DetektTaskDslTest : Spek({
             it("can be done using the kotlin dsl") {
 
                 val config = """
-					|task<io.gitlab.arturbosch.detekt.Detekt>("detektFailFast") {
-					|	description = "Runs a failfast detekt build."
-					|
-					|	input = files("${"$"}projectDir")
-					|	setIncludes(listOf("**/*.kt", "**/*.kts"))
-					|	setExcludes(listOf("build/"))
-					|	config = files("config.yml")
-					|	debug = true
-					|	parallel = true
-					|	disableDefaultRuleSets = true
-					|	buildUponDefaultConfig = true
-					|	failFast = false
-					|	reports {
-					|		xml {
-					|			enabled = true
-					|			destination = file("build/reports/failfast.xml")
-					|		}
-					|		html.destination = file("build/reports/failfast.html")
-					|	}
-					|}
-				"""
+                    |task<io.gitlab.arturbosch.detekt.Detekt>("detektFailFast") {
+                    |    description = "Runs a failfast detekt build."
+                    |
+                    |    input = files("${"$"}projectDir")
+                    |    setIncludes(listOf("**/*.kt", "**/*.kts"))
+                    |    setExcludes(listOf("build/"))
+                    |    config = files("config.yml")
+                    |    debug = true
+                    |    parallel = true
+                    |    disableDefaultRuleSets = true
+                    |    buildUponDefaultConfig = true
+                    |    failFast = false
+                    |    reports {
+                    |        xml {
+                    |            enabled = true
+                    |            destination = file("build/reports/failfast.xml")
+                    |        }
+                    |        html.destination = file("build/reports/failfast.html")
+                    |    }
+                    |}
+                """
 
                 val gradleRunner = kotlin().withDetektConfig(config).build()
                 gradleRunner.writeProjectFile("config.yml", "")

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleConsolidationTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleConsolidationTest.kt
@@ -43,48 +43,48 @@ internal class DetektTaskMultiModuleConsolidationTest : Spek({
         it("using the groovy dsl") {
 
             val mainBuildFileContent: String = """
-				|import io.gitlab.arturbosch.detekt.DetektPlugin
-				|
-				|plugins {
-				|   id "java-library"
-				|   id "io.gitlab.arturbosch.detekt"
-				|}
-				|
-				|allprojects {
-				|	repositories {
-				|		mavenLocal()
-				|		jcenter()
-				|	}
-				|}
-				|subprojects {
-				|	apply plugin: "java-library"
-				|	apply plugin: "io.gitlab.arturbosch.detekt"
-				|}
-				""".trimMargin()
+                |import io.gitlab.arturbosch.detekt.DetektPlugin
+                |
+                |plugins {
+                |   id "java-library"
+                |   id "io.gitlab.arturbosch.detekt"
+                |}
+                |
+                |allprojects {
+                |    repositories {
+                |        mavenLocal()
+                |        jcenter()
+                |    }
+                |}
+                |subprojects {
+                |    apply plugin: "java-library"
+                |    apply plugin: "io.gitlab.arturbosch.detekt"
+                |}
+                """.trimMargin()
 
             gradleRunner = DslGradleRunner(projectLayout, "build.gradle", mainBuildFileContent)
         }
         it("using the kotlin dsl") {
 
             val mainBuildFileContent: String = """
-				|import io.gitlab.arturbosch.detekt.detekt
-				|
-				|plugins {
-				|   `java-library`
-				|	id("io.gitlab.arturbosch.detekt")
-				|}
-				|
-				|allprojects {
-				|	repositories {
-				|		mavenLocal()
-				|		jcenter()
-				|	}
-				|}
-				|subprojects {
-				|	plugins.apply("java-library")
-				|	plugins.apply("io.gitlab.arturbosch.detekt")
-				|}
-				""".trimMargin()
+                |import io.gitlab.arturbosch.detekt.detekt
+                |
+                |plugins {
+                |   `java-library`
+                |    id("io.gitlab.arturbosch.detekt")
+                |}
+                |
+                |allprojects {
+                |    repositories {
+                |        mavenLocal()
+                |        jcenter()
+                |    }
+                |}
+                |subprojects {
+                |    plugins.apply("java-library")
+                |    plugins.apply("io.gitlab.arturbosch.detekt")
+                |}
+                """.trimMargin()
 
             gradleRunner = DslGradleRunner(projectLayout, "build.gradle.kts", mainBuildFileContent)
         }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
@@ -41,9 +41,9 @@ abstract class DslTestBuilder {
 
     fun build(): DslGradleRunner {
         val mainBuildFileContent = """
-			| $gradleBuildConfig
-			| $detektConfig
-		""".trimMargin()
+            | $gradleBuildConfig
+            | $detektConfig
+        """.trimMargin()
         val runner = DslGradleRunner(
             projectLayout,
             gradleBuildName,
@@ -59,35 +59,35 @@ abstract class DslTestBuilder {
     private class GroovyBuilder : DslTestBuilder() {
         override val gradleBuildName: String = "build.gradle"
         override val gradleBuildConfig: String = """
-				|import io.gitlab.arturbosch.detekt.DetektPlugin
-				|
-				|plugins {
-				|   id "java-library"
-				|   id "io.gitlab.arturbosch.detekt"
-				|}
-				|
-				|repositories {
-				|	jcenter()
-				|	mavenLocal()
-				|}
-				""".trimMargin()
+                |import io.gitlab.arturbosch.detekt.DetektPlugin
+                |
+                |plugins {
+                |   id "java-library"
+                |   id "io.gitlab.arturbosch.detekt"
+                |}
+                |
+                |repositories {
+                |    jcenter()
+                |    mavenLocal()
+                |}
+                """.trimMargin()
     }
 
     private class KotlinBuilder : DslTestBuilder() {
         override val gradleBuildName: String = "build.gradle.kts"
         override val gradleBuildConfig: String = """
-				|import io.gitlab.arturbosch.detekt.detekt
-				|
-				|plugins {
-				|   `java-library`
-				|	id("io.gitlab.arturbosch.detekt")
-				|}
-				|
-				|repositories {
-				|	jcenter()
-				|	mavenLocal()
-				|}
-				""".trimMargin()
+                |import io.gitlab.arturbosch.detekt.detekt
+                |
+                |plugins {
+                |   `java-library`
+                |    id("io.gitlab.arturbosch.detekt")
+                |}
+                |
+                |repositories {
+                |    jcenter()
+                |    mavenLocal()
+                |}
+                """.trimMargin()
     }
 
     companion object {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorTest.kt
@@ -19,11 +19,11 @@ internal class PluginTaskBehaviorTest : Spek({
     val baselineFileName = "baseline.xml"
 
     val detektConfig = """
-					|detekt {
-					|	config = files("$configFileName")
-					|	baseline = file("$baselineFileName")
-					|}
-				"""
+                    |detekt {
+                    |    config = files("$configFileName")
+                    |    baseline = file("$baselineFileName")
+                    |}
+                """
 
     describe("The Detekt Gradle Plugin :detekt Task") {
         lateinit var gradleRunner: DslGradleRunner
@@ -67,11 +67,11 @@ internal class PluginTaskBehaviorTest : Spek({
         }
         it("should run again after changing config") {
             val configFileWithCommentsDisabled = """
-							|autoCorrect: true
-							|failFast: false
-							|comments:
-							|  active: false
-						""".trimMargin()
+                            |autoCorrect: true
+                            |failFast: false
+                            |comments:
+                            |  active: false
+                        """.trimMargin()
 
             gradleRunner.runDetektTaskAndCheckResult { result ->
                 assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
@@ -86,11 +86,11 @@ internal class PluginTaskBehaviorTest : Spek({
         }
         it("should run again after changing baseline") {
             val changedBaselineContent = """
-							|<some>
-							|	<more/>
-							|	<xml/>
-							|</some>
-						""".trimMargin()
+                            |<some>
+                            |    <more/>
+                            |    <xml/>
+                            |</some>
+                        """.trimMargin()
 
             gradleRunner.runDetektTaskAndCheckResult { result ->
                 assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/output/XmlReportConsolidationTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/output/XmlReportConsolidationTest.kt
@@ -8,8 +8,8 @@ import java.io.File
 import java.nio.file.Files
 
 private fun fileContent(data: String = "") = """<?xml version="1.0" encoding="utf-8"?>
-		|<checkstyle version="4.3">
-		|$data</checkstyle>""".trimMargin()
+        |<checkstyle version="4.3">
+        |$data</checkstyle>""".trimMargin()
 
 private val emptyContent = fileContent()
 
@@ -48,16 +48,16 @@ internal class XmlReportConsolidationTest : Spek({
         }
         it("data is merged from multiple sources into an empty target file") {
             val content1 = """
-				|<file name="Dummy1.kt">
-				|	<error line="1" column="2" severity="warning" message="a" source="A" />
-				|</file>
-				|""".trimMargin()
+                |<file name="Dummy1.kt">
+                |    <error line="1" column="2" severity="warning" message="a" source="A" />
+                |</file>
+                |""".trimMargin()
             val content2 = """
-				|<file name="Dummy2.kt">
-				|	<error line="2" column="2" severity="warning" message="b" source="B" />
-				|	<error line="22" column="22" severity="warning" message="b" source="B" />
-				|</file>
-				|""".trimMargin()
+                |<file name="Dummy2.kt">
+                |    <error line="2" column="2" severity="warning" message="b" source="B" />
+                |    <error line="22" column="22" severity="warning" message="b" source="B" />
+                |</file>
+                |""".trimMargin()
 
             val target = Files.createTempFile("target", ".xml").toFile()
             target.writeText(emptyContent)
@@ -72,21 +72,21 @@ internal class XmlReportConsolidationTest : Spek({
         }
         it("data is merged from multiple sources into a non empty target file") {
             val targetContent = """
-				|<file name="Target.kt">
-				|	<error line="1" column="2" severity="warning" message="a" source="A" />
-				|</file>
-				|""".trimMargin()
+                |<file name="Target.kt">
+                |    <error line="1" column="2" severity="warning" message="a" source="A" />
+                |</file>
+                |""".trimMargin()
             val content1 = """
-				|<file name="Dummy1.kt">
-				|	<error line="1" column="2" severity="warning" message="a" source="A" />
-				|</file>
-				|""".trimMargin()
+                |<file name="Dummy1.kt">
+                |    <error line="1" column="2" severity="warning" message="a" source="A" />
+                |</file>
+                |""".trimMargin()
             val content2 = """
-				|<file name="Dummy2.kt">
-				|	<error line="2" column="2" severity="warning" message="b" source="B" />
-				|	<error line="22" column="22" severity="warning" message="b" source="B" />
-				|</file>
-				|""".trimMargin()
+                |<file name="Dummy2.kt">
+                |    <error line="2" column="2" severity="warning" message="b" source="B" />
+                |    <error line="22" column="22" severity="warning" message="b" source="B" />
+                |</file>
+                |""".trimMargin()
 
             val target = Files.createTempFile("target", ".xml").toFile()
             target.writeText(fileContent(targetContent))

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/InclusionExclusionPatternsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/InclusionExclusionPatternsSpec.kt
@@ -71,7 +71,6 @@ class InclusionExclusionPatternsSpec : Spek({
 
     describe("rule should only run on included files") {
 
-
         it("should only run on dummies") {
             val config = TestConfig(mapOf(
                 "includes" to "**Dummy*.kt",

--- a/docs/pages/gettingstarted/groovydsl.md
+++ b/docs/pages/gettingstarted/groovydsl.md
@@ -108,11 +108,15 @@ detekt {
     reports {
         xml {
             enabled = true                                // Enable/Disable XML report (default: true)
-            destination = file("build/reports/detekt.xml")  // Path where XML report will be stored (default: `build/reports/detekt/detekt.xml`)
+            destination = file("build/reports/detekt.xml") // Path where XML report will be stored (default: `build/reports/detekt/detekt.xml`)
         }
         html {
             enabled = true                                // Enable/Disable HTML report (default: true)
             destination = file("build/reports/detekt.html") // Path where HTML report will be stored (default: `build/reports/detekt/detekt.html`)
+        }
+        custom {
+            reportId = "CustomJsonReport"                   // The simple class name of your custom report.
+            destination = file("build/reports/detekt.json") // Path where report will be stored
         }
     }
 }

--- a/docs/pages/gettingstarted/kotlindsl.md
+++ b/docs/pages/gettingstarted/kotlindsl.md
@@ -54,6 +54,10 @@ detekt {
             enabled = true                                // Enable/Disable HTML report (default: true)
             destination = file("build/reports/detekt.html") // Path where HTML report will be stored (default: `build/reports/detekt/detekt.html`)
         }
+        custom {
+            reportId = "CustomJsonReport"                   // The simple class name of your custom report.
+            destination = file("build/reports/detekt.json") // Path where report will be stored
+        }
     }
 }
 ```


### PR DESCRIPTION
Replacement of #1596. Closes #1583 

This allows users to use their custom reports with the gradle plugin.

```
detekt {
    reports {
        custom {
            reportId = "CustomJsonReport"
            destination = file("build/reports/detekt.json")
        }
    }
}
```