### PR TITLE
Mark `plugins` config option in gradle plugin dsl as deprecated.

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -69,6 +69,7 @@ open class Detekt : SourceTask() {
 
     @Input
     @Optional
+    @Deprecated("Use detektPlugins within dependencies instead")
     var plugins: Property<String> = project.objects.property(String::class.java)
 
     @Internal

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -61,6 +61,7 @@ open class DetektCreateBaselineTask : SourceTask() {
 
     @Input
     @Optional
+    @Deprecated("Use detektPlugins within dependencies instead")
     var plugins: Property<String> = project.objects.property(String::class.java)
 
     @Internal

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -44,6 +44,7 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
     @Deprecated("Replace with task setIncludes/setExcludes")
     var filters: String? = null
 
+    @Deprecated("Use detektPlugins within dependencies instead")
     var plugins: String? = null
 
     companion object {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -32,6 +32,7 @@ internal data class InputArgument(val fileCollection: FileCollection) : CliArgum
     override fun toArgument() = listOf(INPUT_PARAMETER, fileCollection.joinToString(",") { it.absolutePath })
 }
 
+@Deprecated("Will be removed in favor of 'detektPlugins'")
 internal data class PluginsArgument(val plugins: String?) : CliArgument() {
     override fun toArgument() = plugins?.let { listOf(PLUGINS_PARAMETER, it) } ?: emptyList()
 }

--- a/docs/pages/gettingstarted/groovydsl.md
+++ b/docs/pages/gettingstarted/groovydsl.md
@@ -103,7 +103,7 @@ detekt {
     config = files("path/to/config.yml")                  // Define the detekt configuration(s) you want to use. Defaults to the default detekt configuration.
     baseline = file("path/to/baseline.xml")               // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
     disableDefaultRuleSets = false                        // Disables all default detekt rulesets and will only run detekt with custom rules defined in `plugins`. `false` by default.
-    plugins = "other/optional/ruleset.jar"                // Additional jar file containing custom detekt rules.
+    plugins = "other/optional/ruleset.jar"                // Additional jar file containing custom detekt rules. (Deprecated: Use detektPlugins instead.)
     debug = false                                         // Adds debug output during task execution. `false` by default.
     reports {
         xml {

--- a/docs/pages/gettingstarted/kotlindsl.md
+++ b/docs/pages/gettingstarted/kotlindsl.md
@@ -43,7 +43,7 @@ detekt {
     config = files("path/to/config.yml")                  // Define the detekt configuration(s) you want to use. Defaults to the default detekt configuration.
     baseline = file("path/to/baseline.xml")               // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
     disableDefaultRuleSets = false                        // Disables all default detekt rulesets and will only run detekt with custom rules defined in `plugins`. `false` by default.
-    plugins = "other/optional/ruleset.jar"                // Additional jar file containing custom detekt rules.
+    plugins = "other/optional/ruleset.jar"                // Additional jar file containing custom detekt rules. (Deprecated: Use detektPlugins instead.)
     debug = false                                         // Adds debug output during task execution. `false` by default.
     reports {
         xml {


### PR DESCRIPTION
As suggested by @3flex in https://github.com/arturbosch/detekt/pull/1596#discussion_r276919771 the `plugins` option in the gradle plugin dsl should not be removed in favor of `detektPlugins`.