### PR TITLE
Adds support for ignoreFailures to gradle plugin

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -44,6 +44,7 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.VerificationTask
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import java.io.File
 
@@ -54,7 +55,7 @@ import java.io.File
  * @author Matthew Haughton
  */
 @CacheableTask
-open class Detekt : SourceTask() {
+open class Detekt : SourceTask(), VerificationTask {
 
     @Deprecated("Replace with getSource/setSource")
     var input: FileCollection
@@ -140,9 +141,12 @@ open class Detekt : SourceTask() {
         get() = failFastProp.get()
         set(value) = failFastProp.set(value)
 
+    private val ignoreFailuresProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     @Input
     @Optional
-    val ignoreFailures: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    override fun getIgnoreFailures(): Boolean = ignoreFailuresProp.get()
+    override fun setIgnoreFailures(value: Boolean) = ignoreFailuresProp.set(value)
+    fun setIgnoreFailures(value: Provider<Boolean>) = ignoreFailuresProp.set(value)
 
     @Optional
     @Input
@@ -226,7 +230,7 @@ open class Detekt : SourceTask() {
             project = project,
             arguments = arguments.toList(),
             debug = debugOrDefault,
-            ignoreFailures = ignoreFailures.getOrElse(false)
+            ignoreFailures = ignoreFailuresProp.getOrElse(false)
         )
 
         DetektInvoker.invokeCli(project, arguments.toList(), detektClasspath.plus(pluginClasspath), debugOrDefault)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -140,6 +140,10 @@ open class Detekt : SourceTask() {
         get() = failFastProp.get()
         set(value) = failFastProp.set(value)
 
+    @Input
+    @Optional
+    val ignoreFailures: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+
     @Optional
     @Input
     val autoCorrectProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
@@ -217,6 +221,13 @@ open class Detekt : SourceTask() {
 
             CustomReportArgument(reportId, destination)
         })
+
+        DetektInvoker.invokeCli(
+            project = project,
+            arguments = arguments.toList(),
+            debug = debugOrDefault,
+            ignoreFailures = ignoreFailures.getOrElse(false)
+        )
 
         DetektInvoker.invokeCli(project, arguments.toList(), detektClasspath.plus(pluginClasspath), debugOrDefault)
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -230,10 +230,9 @@ open class Detekt : SourceTask(), VerificationTask {
             project = project,
             arguments = arguments.toList(),
             debug = debugOrDefault,
-            ignoreFailures = ignoreFailuresProp.getOrElse(false)
+            ignoreFailures = ignoreFailuresProp.getOrElse(false),
+            classpath = detektClasspath.plus(pluginClasspath)
         )
-
-        DetektInvoker.invokeCli(project, arguments.toList(), detektClasspath.plus(pluginClasspath), debugOrDefault)
 
         if (xmlReportTargetFileOrNull != null) {
             val xmlReports = project.subprojects.flatMap { subproject ->

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -131,7 +131,7 @@ open class DetektCreateBaselineTask : SourceTask() {
             arguments = arguments.toList(),
             debug = debug.getOrElse(false),
             ignoreFailures = ignoreFailures.getOrElse(false),
-            classpath = detektClasspath.plus(pluginClasspath),
+            classpath = detektClasspath.plus(pluginClasspath)
         )
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -132,7 +132,6 @@ open class DetektCreateBaselineTask : SourceTask() {
             debug = debug.getOrElse(false),
             ignoreFailures = ignoreFailures.getOrElse(false),
             classpath = detektClasspath.plus(pluginClasspath),
-
-            )
+        )
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -95,6 +95,10 @@ open class DetektCreateBaselineTask : SourceTask() {
     @Optional
     var failFast: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
+    @Input
+    @Optional
+    val ignoreFailures: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+
     @Optional
     @Input
     val autoCorrectProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
@@ -123,10 +127,12 @@ open class DetektCreateBaselineTask : SourceTask() {
         )
 
         DetektInvoker.invokeCli(
-            project,
-            arguments.toList(),
-            detektClasspath.plus(pluginClasspath),
-            debug.getOrElse(false)
-        )
+            project = project,
+            arguments = arguments.toList(),
+            debug = debug.getOrElse(false),
+            ignoreFailures = ignoreFailures.getOrElse(false),
+            classpath = detektClasspath.plus(pluginClasspath),
+
+            )
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -110,7 +110,6 @@ class DetektPlugin : Plugin<Project> {
             it.disableDefaultRuleSets.set(project.provider { extension.disableDefaultRuleSets })
             it.buildUponDefaultConfig.set(project.provider { extension.buildUponDefaultConfig })
             it.failFast.set(project.provider { extension.failFast })
-            it.ignoreFailures.set(project.provider { extension.ignoreFailures })
             it.plugins.set(project.provider { extension.plugins })
             it.setSource(existingInputDirectoriesProvider(project, extension))
             it.setIncludes(defaultIncludes)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -66,7 +66,7 @@ class DetektPlugin : Plugin<Project> {
             it.setExcludes(defaultExcludes)
             it.reportsDir.set(project.provider { extension.customReportsDir })
             it.reports = extension.reports
-            it.ignoreFailures.set(project.provider { extension.ignoreFailures })
+            it.setIgnoreFailures(project.provider { extension.ignoreFailures })
 
             project.subprojects.forEach { subProject ->
                 subProject.tasks.firstOrNull { t -> t is Detekt }?.let { subprojectTask ->

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -66,6 +66,7 @@ class DetektPlugin : Plugin<Project> {
             it.setExcludes(defaultExcludes)
             it.reportsDir.set(project.provider { extension.customReportsDir })
             it.reports = extension.reports
+            it.ignoreFailures.set(project.provider { extension.ignoreFailures })
 
             project.subprojects.forEach { subProject ->
                 subProject.tasks.firstOrNull { t -> t is Detekt }?.let { subprojectTask ->
@@ -109,6 +110,7 @@ class DetektPlugin : Plugin<Project> {
             it.disableDefaultRuleSets.set(project.provider { extension.disableDefaultRuleSets })
             it.buildUponDefaultConfig.set(project.provider { extension.buildUponDefaultConfig })
             it.failFast.set(project.provider { extension.failFast })
+            it.ignoreFailures.set(project.provider { extension.ignoreFailures })
             it.plugins.set(project.provider { extension.plugins })
             it.setSource(existingInputDirectoriesProvider(project, extension))
             it.setIncludes(defaultIncludes)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -16,6 +16,12 @@ import java.io.File
  */
 open class DetektExtension(project: Project) : CodeQualityExtension() {
 
+    var ignoreFailures: Boolean
+        @JvmName("ignoreFailures_")
+        get() = isIgnoreFailures
+        @JvmName("ignoreFailures_")
+        set(value) = setIgnoreFailures(value)
+
     val customReportsDir: File?
         get() = reportsDir
 
@@ -26,7 +32,7 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
     fun idea(configure: Action<IdeaExtension>) = configure.execute(idea)
 
     var input: ConfigurableFileCollection =
-            project.configurableFileCollection().from(DEFAULT_SRC_DIR_JAVA, DEFAULT_SRC_DIR_KOTLIN)
+        project.configurableFileCollection().from(DEFAULT_SRC_DIR_JAVA, DEFAULT_SRC_DIR_KOTLIN)
 
     var baseline: File? = null
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.invoke
 
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
+import org.gradle.process.internal.ExecException
 
 /**
  * @author Marvin Ramin
@@ -12,15 +13,25 @@ object DetektInvoker {
         project: Project,
         arguments: List<CliArgument>,
         classpath: FileCollection,
-        debug: Boolean = false
+        debug: Boolean = false,
+        ignoreFailures: Boolean = false
     ) {
         val cliArguments = arguments.flatMap(CliArgument::toArgument)
 
         if (debug) println(cliArguments)
-        project.javaexec {
+
+        val proc = project.javaexec {
             it.main = DETEKT_MAIN
             it.classpath = classpath
             it.args = cliArguments
+            it.isIgnoreExitValue = true
+        }
+        val exitValue = proc.exitValue
+        if (debug) println("Detekt finished with exit value $exitValue")
+
+        when (exitValue) {
+            1 -> throw ExecException("There was a problem running detekt.")
+            2 -> if (!ignoreFailures) throw ExecException("MaxIssues or failThreshold count was reached.")
         }
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -1,8 +1,10 @@
 package io.gitlab.arturbosch.detekt.invoke
 
+import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT
+import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT_PLUGINS
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
-import org.gradle.process.internal.ExecException
 
 /**
  * @author Marvin Ramin
@@ -30,8 +32,8 @@ object DetektInvoker {
         if (debug) println("Detekt finished with exit value $exitValue")
 
         when (exitValue) {
-            1 -> throw ExecException("There was a problem running detekt.")
-            2 -> if (!ignoreFailures) throw ExecException("MaxIssues or failThreshold count was reached.")
+            1 -> throw GradleException("There was a problem running detekt.")
+            2 -> if (!ignoreFailures) throw GradleException("MaxIssues or failThreshold count was reached.")
         }
     }
 }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -361,6 +361,46 @@ internal class DetektTaskDslTest : Spek({
                         }
                     }
                 }
+
+                describe("using the ignoreFailures toggle") {
+                    val projectLayoutWithTooManyIssues = ProjectLayout(
+                        numberOfSourceFilesInRootPerSourceDir = 15,
+                        numberOfCodeSmellsInRootPerSourceDir = 15
+                    )
+
+                    it("build succeeds with more issues than threshold if enabled") {
+
+                        val config = """
+                        |detekt {
+                        |   ignoreFailures = true
+                        |}
+                        """
+
+                        val gradleRunner = builder
+                            .withProjectLayout(projectLayoutWithTooManyIssues)
+                            .withDetektConfig(config)
+                            .build()
+
+                        gradleRunner.runDetektTaskAndCheckResult { result ->
+                            assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                        }
+                    }
+                    it("build fails with more issues than threshold successfully if disabled") {
+
+                        val config = """
+                        |detekt {
+                        |   ignoreFailures = false
+                        |}
+                        """
+
+                        val gradleRunner = builder
+                            .withProjectLayout(projectLayoutWithTooManyIssues)
+                            .withDetektConfig(config)
+                            .build()
+
+                        gradleRunner.runDetektTaskAndExpectFailure()
+                    }
+                }
             }
         }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -196,6 +196,7 @@ internal class DetektTaskDslTest : Spek({
                         |    debug = true
                         |    parallel = true
                         |    disableDefaultRuleSets = true
+                        |    ignoreFailures = true
                         |}
                         """
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -380,6 +380,7 @@ internal class DetektTaskDslTest : Spek({
                     |    disableDefaultRuleSets = true
                     |    buildUponDefaultConfig = true
                     |    failFast = false
+                    |    ignoreFailures = false
                     |    autoCorrect = false
                     |    reports {
                     |        xml {
@@ -416,6 +417,7 @@ internal class DetektTaskDslTest : Spek({
                     |    disableDefaultRuleSets = true
                     |    buildUponDefaultConfig = true
                     |    failFast = false
+                    |    ignoreFailures = false
                     |    autoCorrect = false
                     |    reports {
                     |        xml {

--- a/docs/pages/gettingstarted/groovydsl.md
+++ b/docs/pages/gettingstarted/groovydsl.md
@@ -105,6 +105,7 @@ detekt {
     baseline = file("path/to/baseline.xml")               // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
     disableDefaultRuleSets = false                        // Disables all default detekt rulesets and will only run detekt with custom rules defined in plugins passed in with `detektPlugins` configuration. `false` by default.
     debug = false                                         // Adds debug output during task execution. `false` by default.
+    ignoreFailures = false                                // If set to `true` the build does not fail when maxIssues or failThreshold count was reached. Defaults to `false`.
     reports {
         xml {
             enabled = true                                // Enable/Disable XML report (default: true)

--- a/docs/pages/gettingstarted/kotlindsl.md
+++ b/docs/pages/gettingstarted/kotlindsl.md
@@ -45,6 +45,7 @@ detekt {
     baseline = file("path/to/baseline.xml")               // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
     disableDefaultRuleSets = false                        // Disables all default detekt rulesets and will only run detekt with custom rules defined in plugins passed in with `detektPlugins` configuration. `false` by default.
     debug = false                                         // Adds debug output during task execution. `false` by default.
+    ignoreFailures = false                                // If set to `true` the build does not fail when maxIssues or failThreshold count was reached. Defaults to `false`.
     reports {
         xml {
             enabled = true                                // Enable/Disable XML report (default: true)


### PR DESCRIPTION
Closes #1435 

The `ignoreFailures` property inherited from  `CodeQualityExtension` now can be used to continue the build even if there are more findings than allowed.