### PR TITLE
Don't trigger SpreadOperator rule when array copy not required

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
@@ -7,39 +7,87 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.descriptors.ConstructorDescriptor
+import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.KtValueArgumentList
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.CompileTimeConstantUtils
+import org.jetbrains.kotlin.resolve.DescriptorUtils
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 
 /**
- * Using a spread operator causes a full copy of the array to be created before calling a method.
- * This has a very high performance penalty.
- * Benchmarks showing this performance penalty can be seen here:
+ * In most cases using a spread operator causes a full copy of the array to be created before calling a method.
+ * This has a very high performance penalty. Benchmarks showing this performance penalty can be seen here:
  * https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
  *
+ * The Kotlin compiler since v1.1.60 has an optimization that skips the array copy when an array constructor
+ * function is used to create the arguments that are passed to the vararg parameter. When type resolution is enabled in
+ * detekt this case will not be flagged by the rule since it doesn't suffer the performance penalty of an array copy.
+ *
  * <noncompliant>
- * fun foo(strs: Array<String>) {
- *     bar(*strs)
- * }
+ * val strs = arrayOf("value one", "value two")
+ * val foo = bar(*strs)
  *
  * fun bar(vararg strs: String) {
  *     strs.forEach { println(it) }
  * }
  * </noncompliant>
  *
+ * <compliant>
+ * // array copy skipped in this case since Kotlin 1.1.60
+ * val foo = bar(*arrayOf("value one", "value two"))
+ *
+ * // array not passed so no array copy is required
+ * val foo2 = bar("value one", "value two")
+ *
+ * fun bar(vararg strs: String) {
+ *     strs.forEach { println(it) }
+ * }
+ * </compliant>
+ *
  * @active since v1.0.0
  * @author Ivan Balaksha
+ * @author Matthew Haughton
  */
 class SpreadOperator(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue("SpreadOperator", Severity.Performance,
-            "Using a spread operator causes a full copy of the array to be created before calling a method " +
-                    "has a very high performance penalty.",
+            "In most cases using a spread operator causes a full copy of the array to be created before calling a " +
+                    "method which has a very high performance penalty.",
             Debt.TWENTY_MINS)
 
     override fun visitValueArgumentList(list: KtValueArgumentList) {
         super.visitValueArgumentList(list)
-        list.arguments.filter { it.getSpreadElement() != null }
-                .onEach {
+        list.arguments
+            .filter { it.isSpread }
+            .filterNotNull()
+            .forEach {
+                if (bindingContext == BindingContext.EMPTY) {
                     report(CodeSmell(issue, Entity.from(list), issue.description))
+                    return
                 }
+                if (!it.canSkipArrayCopyForSpreadArgument()) {
+                    report(
+                        CodeSmell(
+                            issue,
+                            Entity.from(list),
+                            "Used in this way a spread operator causes a full copy of the array to be created before " +
+                                    "calling a method which has a very high performance penalty."
+                        )
+                    )
+                }
+            }
+    }
+
+    /**
+     * Checks if an array copy can be skipped for this usage of the spread operator. If not, an array copy is required
+     * for this usage of the spread operator, which will have a performance impact.
+     */
+    private fun KtValueArgument.canSkipArrayCopyForSpreadArgument(): Boolean {
+        val resolvedCall = getArgumentExpression().getResolvedCall(bindingContext) ?: return false
+        val calleeDescriptor = resolvedCall.resultingDescriptor
+        return calleeDescriptor is ConstructorDescriptor ||
+                CompileTimeConstantUtils.isArrayFunctionCall(resolvedCall) ||
+                DescriptorUtils.getFqName(calleeDescriptor).asString() == "kotlin.arrayOfNulls"
     }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
@@ -1,7 +1,10 @@
 package io.gitlab.arturbosch.detekt.rules.performance
 
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -12,41 +15,171 @@ import org.spekframework.spek2.style.specification.describe
 class SpreadOperatorSpec : Spek({
     val subject by memoized { SpreadOperator() }
 
-    describe("test vararg cases") {
-        it("as vararg") {
-            val code = """
-				fun test0(strs: Array<String>) {
-					test(*strs)
-				}
+    lateinit var environment: KotlinCoreEnvironment
 
-				fun test(vararg strs: String) {
-					strs.forEach { println(it) }
-				}"""
-            assertThat(subject.compileAndLint(code)).hasSize(1)
-        }
+    beforeEachTest {
+        environment = KtTestCompiler.createEnvironment()
+    }
 
-        it("without vararg") {
-            val code = """
+    describe("SpreadOperator rule") {
+        /** This rule has different behaviour depending on whether type resolution is enabled in detekt or not. The two
+         * `context` blocks are there to test behaviour when type resolution is enabled and type resolution is disabled
+         * as different warning messages are shown in each case.
+         */
+        context("with type resolution") {
+
+            val typeResolutionEnabledMessage = "Used in this way a spread operator causes a full copy of the array to" +
+                    " be created before calling a method which has a very high performance penalty."
+
+            it("reports when array copy required using named parameters") {
+                val code = """
+                    val xsArray = intArrayOf(1)
+                    fun foo(vararg xs: Int) {}
+                    val testVal = foo(xs = *xsArray)
+                """
+                val actual = subject.lintWithContext(environment, code)
+                assertThat(actual).hasSize(1)
+                assertThat(actual.first().message).isEqualTo(typeResolutionEnabledMessage)
+            }
+            it("reports when array copy required without using named parameters") {
+                val code = """
+                    val xsArray = intArrayOf(1)
+                    fun foo(vararg xs: Int) {}
+                    val testVal = foo(*xsArray)
+                """
+                val actual = subject.lintWithContext(environment, code)
+                assertThat(actual).hasSize(1)
+                assertThat(actual.first().message).isEqualTo(typeResolutionEnabledMessage)
+            }
+            it("doesn't report when using array constructor with spread operator") {
+                val code = """
+                    fun foo(vararg xs: Int) {}
+                    val testVal = foo(xs = *intArrayOf(1))
+                """
+                assertThat(subject.lintWithContext(environment, code)).isEmpty()
+            }
+
+            it("doesn't report when using array constructor with spread operator when varargs parameter comes first") {
+                val code = """
+                    fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
+                    val list = asList(-1, 0, *arrayOf(1, 2, 3), 4, stringValue = "5")
+                """
+                assertThat(subject.lintWithContext(environment, code)).isEmpty()
+            }
+
+            it("doesn't report when passing values directly") {
+                val code = """
+                    fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
+                    val list = asList(-1, 0, 1, 2, 3, 4, stringValue = "5")
+                """
+                assertThat(subject.lintWithContext(environment, code)).isEmpty()
+            }
+
+            it("doesn't report when function doesn't take a vararg parameter") {
+                val code = """
 				fun test0(strs: Array<String>) {
 					test(strs)
 				}
 
 				fun test(strs: Array<String>) {
 					strs.forEach { println(it) }
-				}"""
-            assertThat(subject.compileAndLint(code)).isEmpty()
-        }
+				}
+                """
+                assertThat(subject.lintWithContext(environment, code)).isEmpty()
+            }
 
-        it("expression inside params") {
-            val code = """
+            it("doesn't report with expression inside params") {
+                val code = """
 				fun test0(strs: Array<String>) {
 					test(2*2)
 				}
 
 				fun test(test : Int) {
 					println(test)
-				}"""
-            assertThat(subject.compileAndLint(code)).isEmpty()
+				}
+                """
+                assertThat(subject.lintWithContext(environment, code)).isEmpty()
+            }
+        }
+
+        context("without type resolution") {
+
+            val typeResolutionDisabledMessage = "In most cases using a spread operator causes a full copy of the " +
+                    "array to be created before calling a method which has a very high performance penalty."
+
+            it("reports when array copy required using named parameters") {
+                val code = """
+                    val xsArray = intArrayOf(1)
+                    fun foo(vararg xs: Int) {}
+                    val testVal = foo(xs = *xsArray)
+                """
+                val actual = subject.compileAndLint(code)
+                assertThat(actual).hasSize(1)
+                assertThat(actual.first().message).isEqualTo(typeResolutionDisabledMessage)
+            }
+            it("reports when array copy required without using named parameters") {
+                val code = """
+                    val xsArray = intArrayOf(1)
+                    fun foo(vararg xs: Int) {}
+                    val testVal = foo(*xsArray)
+                """
+                val actual = subject.compileAndLint(code)
+                assertThat(actual).hasSize(1)
+                assertThat(actual.first().message).isEqualTo(typeResolutionDisabledMessage)
+            }
+            it("doesn't report when using array constructor with spread operator") {
+                val code = """
+                    fun foo(vararg xs: Int) {}
+                    val testVal = foo(xs = *intArrayOf(1))
+                """
+                val actual = subject.compileAndLint(code)
+                assertThat(actual).hasSize(1)
+                assertThat(actual.first().message).isEqualTo(typeResolutionDisabledMessage)
+            }
+
+            it("doesn't report when using array constructor with spread operator when varargs parameter comes first") {
+                val code = """
+                    fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
+                    val list = asList(-1, 0, *arrayOf(1, 2, 3), 4, stringValue = "5")
+                """
+                val actual = subject.compileAndLint(code)
+                assertThat(actual).hasSize(1)
+                assertThat(actual.first().message).isEqualTo(typeResolutionDisabledMessage)
+            }
+
+            it("doesn't report when passing values directly") {
+                val code = """
+                    fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
+                    val list = asList(-1, 0, 1, 2, 3, 4, stringValue = "5")
+                """
+                assertThat(subject.compileAndLint(code)).isEmpty()
+            }
+
+            it("doesn't report when function doesn't take a vararg parameter") {
+                val code = """
+				fun test0(strs: Array<String>) {
+					test(strs)
+				}
+
+				fun test(strs: Array<String>) {
+					strs.forEach { println(it) }
+				}
+                """
+                assertThat(subject.compileAndLint(code)).isEmpty()
+            }
+
+            it("doesn't report with expression inside params") {
+                val code = """
+				fun test0(strs: Array<String>) {
+					test(2*2)
+				}
+
+				fun test(test : Int) {
+					println(test)
+				}
+                """
+                assertThat(subject.compileAndLint(code)).isEmpty()
+            }
         }
     }
 })

--- a/docs/pages/documentation/performance.md
+++ b/docs/pages/documentation/performance.md
@@ -73,10 +73,13 @@ for (i in 1..10) {
 
 ### SpreadOperator
 
-Using a spread operator causes a full copy of the array to be created before calling a method.
-This has a very high performance penalty.
-Benchmarks showing this performance penalty can be seen here:
+In most cases using a spread operator causes a full copy of the array to be created before calling a method.
+This has a very high performance penalty. Benchmarks showing this performance penalty can be seen here:
 https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+
+The Kotlin compiler since v1.1.60 has an optimization that skips the array copy when an array constructor
+function is used to create the arguments that are passed to the vararg parameter. When type resolution is enabled in
+detekt this case will not be flagged by the rule since it doesn't suffer the performance penalty of an array copy.
 
 **Severity**: Performance
 
@@ -85,9 +88,22 @@ https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts
 #### Noncompliant Code:
 
 ```kotlin
-fun foo(strs: Array<String>) {
-    bar(*strs)
+val strs = arrayOf("value one", "value two")
+val foo = bar(*strs)
+
+fun bar(vararg strs: String) {
+    strs.forEach { println(it) }
 }
+```
+
+#### Compliant Code:
+
+```kotlin
+// array copy skipped in this case since Kotlin 1.1.60
+val foo = bar(*arrayOf("value one", "value two"))
+
+// array not passed so no array copy is required
+val foo2 = bar("value one", "value two")
 
 fun bar(vararg strs: String) {
     strs.forEach { println(it) }


### PR DESCRIPTION
Closes #554 