### PR TITLE
Provide meaningful config error message by tracking sub configurations

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.api
 
 import io.gitlab.arturbosch.detekt.api.Config.Companion.PRIMITIVES
+import java.util.LinkedList
 import kotlin.reflect.KClass
 
 /**
@@ -113,12 +114,11 @@ abstract class BaseConfig : HierarchicalConfig {
     }
 
     private fun keySequence(key: String): String {
-        val seq: Sequence<String> = sequence {
-            var current = parent
-            while (current != null) {
-                yield(current.key)
-                current = (current.config as? HierarchicalConfig)?.parent
-            }
+        val seq = LinkedList<String>()
+        var current = parent
+        while (current != null) {
+            seq.addFirst(current.key)
+            current = (current.config as? HierarchicalConfig)?.parent
         }
         val keySeq = seq.joinToString(" > ")
         return if (keySeq.isEmpty()) key else "$keySeq > $key"

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -1,5 +1,8 @@
 package io.gitlab.arturbosch.detekt.api
 
+import io.gitlab.arturbosch.detekt.api.Config.Companion.PRIMITIVES
+import kotlin.reflect.KClass
+
 /**
  * A configuration holds information about how to configure specific rules.
  *
@@ -30,7 +33,7 @@ interface Config {
      */
     class InvalidConfigurationError(
         msg: String = "Provided configuration file is invalid:" +
-                " Structure must be from type Map<String,Any>!"
+            " Structure must be from type Map<String,Any>!"
     ) : RuntimeException(msg)
 
     companion object {
@@ -44,43 +47,81 @@ interface Config {
 
         const val EXCLUDES_KEY = "excludes"
         const val INCLUDES_KEY = "includes"
+
+        val PRIMITIVES: Set<KClass<out Any>> = setOf(
+            Int::class,
+            Boolean::class,
+            Float::class,
+            Double::class,
+            String::class,
+            Short::class,
+            Char::class,
+            Long::class
+        )
     }
+}
+
+interface HierarchicalConfig : Config {
+    /**
+     * Returns the parent config which encloses this config part.
+     */
+    val parent: Parent?
+
+    data class Parent(val config: Config, val key: String)
 }
 
 /**
  * NOP-implementation of a config object.
  */
-internal object EmptyConfig : Config {
-    override fun <T : Any> valueOrNull(key: String): T? = null
+internal object EmptyConfig : HierarchicalConfig {
+
+    override val parent: HierarchicalConfig.Parent? = null
 
     override fun subConfig(key: String) = this
+
     @Suppress("UNCHECKED_CAST")
     override fun <T : Any> valueOrDefault(key: String, default: T): T = when (key) {
         "active" -> true as T
         else -> default
     }
+
+    override fun <T : Any> valueOrNull(key: String): T? = null
 }
 
 /**
  * Convenient base configuration which parses/casts the configuration value based on the type of the default value.
  */
-abstract class BaseConfig : Config {
+abstract class BaseConfig : HierarchicalConfig {
 
     protected open fun valueOrDefaultInternal(key: String, result: Any?, default: Any): Any {
         return try {
             if (result != null) {
-                when (result) {
-                    is String -> tryParseBasedOnDefault(result, default)
+                when {
+                    result is String -> tryParseBasedOnDefault(result, default)
+                    default::class in PRIMITIVES &&
+                        result::class != default::class -> throw ClassCastException()
                     else -> result
                 }
             } else {
                 default
             }
         } catch (e: ClassCastException) {
-            throw IllegalArgumentException("Value \"$result\" set for config parameter '$key' is not of required type ${default::class.simpleName}.")
-        } catch (e: NumberFormatException) {
-            throw IllegalArgumentException("Value \"$result\" set for config parameter '$key' is not of required type ${default::class.simpleName}.", e)
+            error("Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of required type ${default::class.simpleName}.")
+        } catch (_: NumberFormatException) {
+            error("Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of required type ${default::class.simpleName}.")
         }
+    }
+
+    private fun keySequence(key: String): String {
+        val seq: Sequence<String> = sequence {
+            var current = parent
+            while (current != null) {
+                yield(current.key)
+                current = (current.config as? HierarchicalConfig)?.parent
+            }
+        }
+        val keySeq = seq.joinToString(" > ")
+        return if (keySeq.isEmpty()) key else "$keySeq > $key"
     }
 
     protected open fun tryParseBasedOnDefault(result: String, defaultResult: Any): Any = when (defaultResult) {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -62,12 +62,19 @@ interface Config {
     }
 }
 
+/**
+ * A configuration which keeps track of the config it got sub-config'ed from by the [subConfig] function.
+ * It's main usage is to recreate the property-path which was taken when using the [subConfig] function repeatedly.
+ */
 interface HierarchicalConfig : Config {
     /**
      * Returns the parent config which encloses this config part.
      */
     val parent: Parent?
 
+    /**
+     * Keeps track of which key was taken to [subConfig] this configuration.
+     */
     data class Parent(val config: Config, val key: String)
 }
 
@@ -106,7 +113,7 @@ abstract class BaseConfig : HierarchicalConfig {
             } else {
                 default
             }
-        } catch (e: ClassCastException) {
+        } catch (_: ClassCastException) {
             error("Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of required type ${default::class.simpleName}.")
         } catch (_: NumberFormatException) {
             error("Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of required type ${default::class.simpleName}.")

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/YamlConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/YamlConfig.kt
@@ -13,11 +13,14 @@ import java.nio.file.Path
  * @author Artur Bosch
  */
 @Suppress("UNCHECKED_CAST")
-class YamlConfig internal constructor(val properties: Map<String, Any>) : BaseConfig() {
+class YamlConfig internal constructor(
+    val properties: Map<String, Any>,
+    override val parent: HierarchicalConfig.Parent?
+) : BaseConfig() {
 
     override fun subConfig(key: String): Config {
         val subProperties = properties.getOrElse(key) { mapOf<String, Any>() }
-        return YamlConfig(subProperties as Map<String, Any>)
+        return YamlConfig(subProperties as Map<String, Any>, HierarchicalConfig.Parent(this, key))
     }
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T {
@@ -61,7 +64,7 @@ class YamlConfig internal constructor(val properties: Map<String, Any>) : BaseCo
             } else {
                 val map: Any = Yaml().load(yamlInput)
                 if (map is Map<*, *>) {
-                    YamlConfig(map as Map<String, Any>)
+                    YamlConfig(map as Map<String, Any>, parent = null)
                 } else {
                     throw Config.InvalidConfigurationError()
                 }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigSpec.kt
@@ -67,7 +67,7 @@ class ConfigSpec : Spek({
                 config.subConfig("RuleSet")
                     .subConfig("Rule")
                     .valueOrDefault("threshold", 6)
-            }.withMessage("Value \"v5.7\" set for config parameter \"Rule > RuleSet > threshold\" is not of required type Int.")
+            }.withMessage("Value \"v5.7\" set for config parameter \"RuleSet > Rule > threshold\" is not of required type Int.")
         }
 
         it("prints whole config-key path for ClassCastException") {
@@ -76,7 +76,7 @@ class ConfigSpec : Spek({
                 val bool: Int = config.subConfig("RuleSet")
                     .subConfig("Rule")
                     .valueOrDefault("active", 1)
-            }.withMessage("Value \"[]\" set for config parameter \"Rule > RuleSet > active\" is not of required type Int.")
+            }.withMessage("Value \"[]\" set for config parameter \"RuleSet > Rule > active\" is not of required type Int.")
         }
     }
 })

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.api
 
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.assertj.core.api.Assertions.fail
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -40,7 +40,7 @@ class ConfigSpec : Spek({
         }
 
         it("tests wrong sub config conversion") {
-            assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy {
+            assertThatIllegalStateException().isThrownBy {
                 @Suppress("UNUSED_VARIABLE")
                 val ignored = config.valueOrDefault("style", "")
             }.withMessage("Value \"{WildcardImport={active=true}, NoElseInWhenExpression={active=true}, MagicNumber={active=true, ignoreNumbers=-1,0,1,2}}\" set for config parameter \"style\" is not of required type String.")
@@ -63,7 +63,7 @@ class ConfigSpec : Spek({
         val config by memoized { yamlConfig("wrong-property-type.yml") }
 
         it("prints whole config-key path for NumberFormatException") {
-            assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy {
+            assertThatIllegalStateException().isThrownBy {
                 config.subConfig("RuleSet")
                     .subConfig("Rule")
                     .valueOrDefault("threshold", 6)
@@ -71,7 +71,7 @@ class ConfigSpec : Spek({
         }
 
         it("prints whole config-key path for ClassCastException") {
-            assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy {
+            assertThatIllegalStateException().isThrownBy {
                 @Suppress("UNUSED_VARIABLE")
                 val bool: Int = config.subConfig("RuleSet")
                     .subConfig("Rule")

--- a/detekt-api/src/test/resources/wrong-property-type.yml
+++ b/detekt-api/src/test/resources/wrong-property-type.yml
@@ -1,0 +1,4 @@
+RuleSet:
+  Rule:
+    active: []
+    threshold: v5.7

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
@@ -1,12 +1,16 @@
 package io.gitlab.arturbosch.detekt.test
 
 import io.gitlab.arturbosch.detekt.api.BaseConfig
+import io.gitlab.arturbosch.detekt.api.HierarchicalConfig
 
 /**
  * @author Artur Bosch
  */
 @Suppress("UNCHECKED_CAST")
-open class TestConfig(private val values: Map<String, String> = mutableMapOf()) : BaseConfig() {
+open class TestConfig(
+    private val values: Map<String, String> = mutableMapOf(),
+    override val parent: HierarchicalConfig.Parent? = null
+) : BaseConfig() {
 
     override fun subConfig(key: String) = this
 
@@ -35,9 +39,9 @@ open class TestConfig(private val values: Map<String, String> = mutableMapOf()) 
         if (result.startsWith('[') && result.endsWith(']')) {
             val str = result.substring(1, result.length - 1)
             return str.splitToSequence(',')
-                    .map { it.trim() }
-                    .filter { it.isNotEmpty() }
-                    .toList()
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .toList()
         }
         throw ClassCastException()
     }


### PR DESCRIPTION
References:
- #1497
- #1498 

Now they look like:
`Value "[]" set for config parameter "RuleSet > Rule > active" is not of required type Int.`

Closes #1516 