### PR TITLE
Improve handling of classpaths in Gradle plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       osx_image: xcode10.2
 install: true
 script:
-  - ./gradlew build --build-cache -PwarningsAsErrors=true --scan
+  - ./gradlew build --build-cache --parallel -PwarningsAsErrors=true --scan
   - ./gradlew shadowJar
   - java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar --help
   - java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar -i . --baseline ./reports/baseline.xml -ex "**/resources/**,**/detekt*/build/**" -c ./detekt-cli/src/main/resources/default-detekt-config.yml,./reports/failfast.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - gradlew.bat --version
 
 build_script:
-  - gradlew build --build-cache -PwarningsAsErrors=true
+  - gradlew build --build-cache --parallel -PwarningsAsErrors=true
   - gradlew installShadowDist
   - detekt-cli\build\install\detekt-cli-shadow\bin\detekt-cli --help
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,8 +42,6 @@ tasks.withType<Test> {
 }
 
 tasks.withType<Detekt> {
-    dependsOn("detekt-cli:assemble")
-    dependsOn("detekt-formatting:assemble")
     dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":detekt"))
 }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -49,6 +49,7 @@ import java.io.File
  * @author Artur Bosch
  * @author Marvin Ramin
  * @author Markus Schwarz
+ * @author Matthew Haughton
  */
 @CacheableTask
 open class Detekt : SourceTask() {
@@ -62,6 +63,12 @@ open class Detekt : SourceTask() {
     @Optional
     @Deprecated("Replace with setIncludes/setExcludes")
     var filters: Property<String> = project.objects.property(String::class.java)
+
+    @Classpath
+    val detektClasspath = project.configurableFileCollection()
+
+    @Classpath
+    val pluginClasspath = project.configurableFileCollection()
 
     @InputFile
     @Optional
@@ -195,7 +202,7 @@ open class Detekt : SourceTask() {
             CustomReportArgument(reportId, destination)
         })
 
-        DetektInvoker.invokeCli(project, arguments.toList(), debugOrDefault)
+        DetektInvoker.invokeCli(project, arguments.toList(), detektClasspath.plus(pluginClasspath), debugOrDefault)
 
         if (xmlReportTargetFileOrNull != null) {
             val xmlReports = project.subprojects.flatMap { subproject ->

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -21,6 +21,7 @@ import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
 import io.gitlab.arturbosch.detekt.invoke.PluginsArgument
 import io.gitlab.arturbosch.detekt.output.mergeXmlReports
 import org.gradle.api.Action
+import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.FileCollection
@@ -94,6 +95,8 @@ open class Detekt : SourceTask() {
 
     @Input
     @Optional
+    @Deprecated("Set plugins using the detektPlugins configuration " +
+            "(see https://arturbosch.github.io/detekt/extensions.html#let-detekt-know-about-your-extensions)")
     var plugins: Property<String> = project.objects.property(String::class.java)
 
     @Internal
@@ -171,6 +174,9 @@ open class Detekt : SourceTask() {
 
     @TaskAction
     fun check() {
+        if (plugins.isPresent && !pluginClasspath.isEmpty)
+            throw GradleException("Cannot set value for plugins on detekt task and apply detektPlugins configuration " +
+                    "at the same time.")
         val xmlReportTargetFileOrNull = xmlReportFile.orNull
         val htmlReportTargetFileOrNull = htmlReportFile.orNull
         val debugOrDefault = debugProp.getOrElse(false)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -17,6 +17,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
@@ -32,6 +33,7 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
  * @author Artur Bosch
  * @author Marvin Ramin
  * @author Markus Schwarz
+ * @author Matthew Haughton
  */
 open class DetektCreateBaselineTask : SourceTask() {
 
@@ -62,6 +64,12 @@ open class DetektCreateBaselineTask : SourceTask() {
     @Input
     @Optional
     var plugins: Property<String> = project.objects.property(String::class.java)
+
+    @Classpath
+    val detektClasspath = project.configurableFileCollection()
+
+    @Classpath
+    val pluginClasspath = project.configurableFileCollection()
 
     @Internal
     @Optional
@@ -98,6 +106,11 @@ open class DetektCreateBaselineTask : SourceTask() {
             DisableDefaultRuleSetArgument(disableDefaultRuleSets.getOrElse(false))
         )
 
-        DetektInvoker.invokeCli(project, arguments.toList(), debug.getOrElse(false))
+        DetektInvoker.invokeCli(
+            project,
+            arguments.toList(),
+            detektClasspath.plus(pluginClasspath),
+            debug.getOrElse(false)
+        )
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -13,6 +13,7 @@ import io.gitlab.arturbosch.detekt.invoke.FailFastArgument
 import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
 import io.gitlab.arturbosch.detekt.invoke.PluginsArgument
+import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
@@ -63,6 +64,8 @@ open class DetektCreateBaselineTask : SourceTask() {
 
     @Input
     @Optional
+    @Deprecated("Set plugins using the detektPlugins configuration " +
+            "(see https://arturbosch.github.io/detekt/extensions.html#let-detekt-know-about-your-extensions)")
     var plugins: Property<String> = project.objects.property(String::class.java)
 
     @Classpath
@@ -93,6 +96,9 @@ open class DetektCreateBaselineTask : SourceTask() {
 
     @TaskAction
     fun baseline() {
+        if (plugins.isPresent && !pluginClasspath.isEmpty)
+            throw GradleException("Cannot set value for plugins on detekt task and apply detektPlugins configuration " +
+                    "at the same time.")
         val arguments = mutableListOf(
             CreateBaselineArgument,
             BaselineArgument(baseline.get()),

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -1,9 +1,11 @@
 package io.gitlab.arturbosch.detekt
 
+import io.gitlab.arturbosch.detekt.internal.configurableFileCollection
 import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.GenerateConfigArgument
 import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.language.base.plugins.LifecycleBasePlugin
@@ -11,6 +13,7 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
 /**
  * @author Artur Bosch
  * @author Marvin Ramin
+ * @author Matthew Haughton
  */
 open class DetektGenerateConfigTask : SourceTask() {
 
@@ -24,6 +27,9 @@ open class DetektGenerateConfigTask : SourceTask() {
         get() = source
         set(value) = setSource(value)
 
+    @Classpath
+    val detektClasspath = project.configurableFileCollection()
+
     @TaskAction
     fun generateConfig() {
         val arguments = mutableListOf(
@@ -31,6 +37,6 @@ open class DetektGenerateConfigTask : SourceTask() {
             InputArgument(source)
         )
 
-        DetektInvoker.invokeCli(project, arguments.toList())
+        DetektInvoker.invokeCli(project, arguments.toList(), detektClasspath)
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -12,6 +12,7 @@ import java.io.File
  * @author Said Tahsin Dane
  * @author Marvin Ramin
  * @author Markus Schwarz
+ * @author Matthew Haughton
  */
 open class DetektExtension(project: Project) : CodeQualityExtension() {
 
@@ -44,6 +45,8 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
     @Deprecated("Replace with task setIncludes/setExcludes")
     var filters: String? = null
 
+    @Deprecated("Set plugins using the detektPlugins configuration " +
+            "(see https://arturbosch.github.io/detekt/extensions.html#let-detekt-know-about-your-extensions)")
     var plugins: String? = null
 
     companion object {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -1,32 +1,27 @@
 package io.gitlab.arturbosch.detekt.invoke
 
-import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT
-import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT_PLUGINS
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 
 /**
  * @author Marvin Ramin
+ * @author Matthew Haughton
  */
 object DetektInvoker {
-    internal fun invokeCli(project: Project, arguments: List<CliArgument>, debug: Boolean = false) {
+    internal fun invokeCli(
+        project: Project,
+        arguments: List<CliArgument>,
+        classpath: FileCollection,
+        debug: Boolean = false
+    ) {
         val cliArguments = arguments.flatMap(CliArgument::toArgument)
 
         if (debug) println(cliArguments)
         project.javaexec {
             it.main = DETEKT_MAIN
-            it.classpath = getConfigurations(project, debug)
+            it.classpath = classpath
             it.args = cliArguments
         }
-    }
-
-    private fun getConfigurations(project: Project, debug: Boolean = false): FileCollection {
-        val detektConfigurations = setOf(CONFIGURATION_DETEKT_PLUGINS, CONFIGURATION_DETEKT)
-        val configurations = project.configurations.filter { detektConfigurations.contains(it.name) }
-
-        val files = project.files(configurations)
-        if (debug) files.forEach { println(it) }
-        return files
     }
 }
 

--- a/docs/pages/gettingstarted/groovydsl.md
+++ b/docs/pages/gettingstarted/groovydsl.md
@@ -103,8 +103,7 @@ detekt {
     config = files("path/to/config.yml")                  // Define the detekt configuration(s) you want to use. Defaults to the default detekt configuration.
     buildUponDefaultConfig = false                        // Interpret config files as updates to the default config. `false` by default.
     baseline = file("path/to/baseline.xml")               // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
-    disableDefaultRuleSets = false                        // Disables all default detekt rulesets and will only run detekt with custom rules defined in `plugins`. `false` by default.
-    plugins = "other/optional/ruleset.jar"                // Additional jar file containing custom detekt rules.
+    disableDefaultRuleSets = false                        // Disables all default detekt rulesets and will only run detekt with custom rules defined in plugins passed in with `detektPlugins` configuration. `false` by default.
     debug = false                                         // Adds debug output during task execution. `false` by default.
     reports {
         xml {

--- a/docs/pages/gettingstarted/kotlindsl.md
+++ b/docs/pages/gettingstarted/kotlindsl.md
@@ -43,8 +43,7 @@ detekt {
     config = files("path/to/config.yml")                  // Define the detekt configuration(s) you want to use. Defaults to the default detekt configuration.
     buildUponDefaultConfig = false                        // Interpret config files as updates to the default config. `false` by default.
     baseline = file("path/to/baseline.xml")               // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
-    disableDefaultRuleSets = false                        // Disables all default detekt rulesets and will only run detekt with custom rules defined in `plugins`. `false` by default.
-    plugins = "other/optional/ruleset.jar"                // Additional jar file containing custom detekt rules.
+    disableDefaultRuleSets = false                        // Disables all default detekt rulesets and will only run detekt with custom rules defined in plugins passed in with `detektPlugins` configuration. `false` by default.
     debug = false                                         // Adds debug output during task execution. `false` by default.
     reports {
         xml {


### PR DESCRIPTION
This change achieves a few things:
* Allows adding multiple dependencies to the `detektPlugins` configuration which isn't currently possible (refer #1596 for details)
* Improves up-to-date checks by giving Gradle more information about the classpaths used by the tasks
* As a result, fixes #1208

This change should not impact anyone's existing build configuration.

cc: @marschwar 