### PR TITLE
Revert "Check cross-module coverage with Jacoco"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - ./gradlew verifyGeneratorOutput
 after_success:
   - .buildscript/deploy_snapshot.sh
-  - ./gradlew rootJacocoTestReport
+  - ./gradlew jacocoTestReport
   - bash <(curl -s https://codecov.io/bash)
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,19 +67,16 @@ subprojects {
         plugin("maven-publish")
         plugin("io.gitlab.arturbosch.detekt")
         plugin("org.jetbrains.dokka")
+        plugin("jacoco")
     }
 
-    if (project.name != "detekt-test") {
-        apply { plugin("jacoco") }
+    val jacocoVersion: String by project
+    jacoco.toolVersion = jacocoVersion
 
-        val jacocoVersion: String by project
-        jacoco.toolVersion = jacocoVersion
-
-        tasks.jacocoTestReport.configure {
-            reports.xml.isEnabled = false
-            reports.html.isEnabled = false
-            dependsOn(tasks.named("test"))
-        }
+    tasks.named<JacocoReport>("jacocoTestReport").configure {
+        reports.xml.isEnabled = true
+        reports.html.isEnabled = true
+        dependsOn(tasks.named("test"))
     }
 
     tasks.withType<Detekt> {
@@ -302,26 +299,5 @@ val detektAll by tasks.registering(Detekt::class) {
     reports {
         xml.enabled = false
         html.enabled = false
-    }
-}
-
-tasks.create<JacocoReport>("rootJacocoTestReport") {
-    val jacocoReportTasks =
-        subprojects
-            .filterNot { it.project.name == "detekt-test" }
-            .map { it.tasks["jacocoTestReport"] as? JacocoReport }
-    dependsOn(jacocoReportTasks)
-
-    val executionData = jacocoReportTasks.mapNotNull { it?.executionData }.toTypedArray()
-    executionData(executionData)
-    reports.xml.isEnabled = true
-    reports.xml.destination = file("$buildDir/reports/jacoco/jacocoRootReport.xml")
-
-    subprojects.forEach { testedProject ->
-        val sourceSets = testedProject.sourceSets
-        this@create.additionalSourceDirs.from(files(sourceSets.main.get().allSource.srcDirs))
-        this@create.sourceDirectories.from(files(sourceSets.main.get().allSource.srcDirs))
-        this@create.classDirectories.from(files(sourceSets.main.get().output))
-        this@create.dependsOn(testedProject.tasks.named("test"))
     }
 }


### PR DESCRIPTION
Reverts arturbosch/detekt#1566

While the PR did successfully achieve the goal of improving the coverage by consolidating reports, I've just noticed that after merging to master Codecov reports were not being generated anymore.

Reverting for now so coverage reports hopefully come back online.