### PR TITLE
Publish detekt-api docs to the detekt documentation site

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -200,9 +200,8 @@ subprojects {
     }
 
     val javadocJar by tasks.creating(Jar::class) {
-        dependsOn("dokka")
+        from(tasks.javadoc)
         archiveClassifier.set("javadoc")
-        from(buildDir.resolve("javadoc"))
     }
 
     artifacts {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@ import com.jfrog.bintray.gradle.BintrayExtension
 import io.gitlab.arturbosch.detekt.Detekt
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
-import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.Date
 
@@ -13,7 +12,7 @@ plugins {
     id("com.github.johnrengelman.shadow") version "5.0.0" apply false
     id("org.sonarqube") version "2.7"
     id("io.gitlab.arturbosch.detekt")
-    id("org.jetbrains.dokka") version "0.9.18"
+    id("org.jetbrains.dokka") version "0.9.18" apply false
     jacoco
 }
 
@@ -66,7 +65,6 @@ subprojects {
         plugin("com.jfrog.bintray")
         plugin("maven-publish")
         plugin("io.gitlab.arturbosch.detekt")
-        plugin("org.jetbrains.dokka")
     }
 
     if (project.name != "detekt-test") {
@@ -181,16 +179,6 @@ subprojects {
                 })
             })
         })
-    }
-
-    tasks.withType<DokkaTask> {
-        // suppresses undocumented classes but not dokka warnings https://github.com/Kotlin/dokka/issues/90
-        reportUndocumented = false
-        outputFormat = "javadoc"
-        outputDirectory = "$buildDir/javadoc"
-        // Java 8 is only version supported both by Oracle/OpenJDK and Dokka itself
-        // https://github.com/Kotlin/dokka/issues/294
-        enabled = JavaVersion.current().isJava8
     }
 
     val sourcesJar by tasks.creating(Jar::class) {

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -24,9 +24,6 @@ dependencies {
 tasks.withType<DokkaTask> {
     // suppresses undocumented classes but not dokka warnings https://github.com/Kotlin/dokka/issues/90
     reportUndocumented = false
-    outputFormat = "javadoc"
-    outputDirectory = "$buildDir/javadoc"
-    // Java 8 is only version supported both by Oracle/OpenJDK and Dokka itself
-    // https://github.com/Kotlin/dokka/issues/294
-    enabled = JavaVersion.current().isJava8
+    @Suppress("MagicNumber")
+    jdkVersion = 8
 }

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -1,3 +1,9 @@
+import org.jetbrains.dokka.gradle.DokkaTask
+
+plugins {
+    id("org.jetbrains.dokka")
+}
+
 configurations.testImplementation.extendsFrom(configurations["kotlinTest"])
 
 val yamlVersion: String by project
@@ -13,4 +19,14 @@ dependencies {
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
     testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
+}
+
+tasks.withType<DokkaTask> {
+    // suppresses undocumented classes but not dokka warnings https://github.com/Kotlin/dokka/issues/90
+    reportUndocumented = false
+    outputFormat = "javadoc"
+    outputDirectory = "$buildDir/javadoc"
+    // Java 8 is only version supported both by Oracle/OpenJDK and Dokka itself
+    // https://github.com/Kotlin/dokka/issues/294
+    enabled = JavaVersion.current().isJava8
 }

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
 tasks.withType<DokkaTask> {
     // suppresses undocumented classes but not dokka warnings https://github.com/Kotlin/dokka/issues/90
     reportUndocumented = false
+    outputFormat = "jekyll"
+    outputDirectory = "$rootDir/docs/pages/kdoc"
     @Suppress("MagicNumber")
     jdkVersion = 8
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/BaseRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/BaseRule.kt
@@ -30,10 +30,10 @@ abstract class BaseRule(
     /**
      * Before starting visiting kotlin elements, a check is performed if this rule should be triggered.
      * Pre- and post-visit-hooks are executed before/after the visiting process.
-     * [BindingContext] holds the result of the semantic analysis of the source code by the Kotlin compiler. Rules that
+     * BindingContext holds the result of the semantic analysis of the source code by the Kotlin compiler. Rules that
      * rely on symbols and types being resolved can use the BindingContext for this analysis. Note that detekt must
      * receive the correct compile classpath for the code being analyzed otherwise the default value
-     * [BindingContext.EMPTY] will be used and it will not be possible for detekt to resolve types or symbols.
+     * BindingContext.EMPTY will be used and it will not be possible for detekt to resolve types or symbols.
      */
     fun visitFile(root: KtFile, bindingContext: BindingContext = BindingContext.EMPTY) {
         this.bindingContext = bindingContext

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -69,7 +69,9 @@ fun assertDefaultConfigUpToDate() {
 fun assertDocumentationUpToDate() {
     val configDiff = ByteArrayOutputStream()
     exec {
-        commandLine = listOf("git", "diff", "${rootProject.rootDir}/docs/pages/documentation")
+        commandLine = listOf(
+            "git", "diff", "${rootProject.rootDir}/docs/pages/documentation", "${rootProject.rootDir}/docs/pages/kdoc"
+        )
         standardOutput = configDiff
     }
 

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -18,6 +18,7 @@ val detektVersion: String by project
 val generateDocumentation: Task by tasks.creating {
     dependsOn(":detekt-generator:shadowJar")
     description = "Generates detekt documentation and the default config.yml based on Rule KDoc"
+    group = "documentation"
 
     inputs.files(
         fileTree("${rootProject.rootDir}/detekt-rules/src/main/kotlin"),

--- a/docs/_data/sidebars/home_sidebar.yml
+++ b/docs/_data/sidebars/home_sidebar.yml
@@ -80,3 +80,9 @@ entries:
     - title: style
       url: /style.html
       output: web
+  - title: KDoc
+    output: web
+    folderitems:
+    - title: detekt-api
+      url: /pages/kdoc/detekt-api/index.html
+      output: web

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -4,32 +4,32 @@
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
 <title>{{ page.title }} | {{ site.site_title }}</title>
-<link rel="stylesheet" href="{{ "css/syntax.css" }}">
+<link rel="stylesheet" href="{{ "css/syntax.css" | relative_url }}">
 
 <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
 <!--<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">-->
-<link rel="stylesheet" href="css/modern-business.css">
+<link rel="stylesheet" href="{{ "css/modern-business.css" | relative_url }}">
 <!-- Latest compiled and minified CSS -->
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-<link rel="stylesheet" href="css/customstyles.css">
-<link rel="stylesheet" href="css/boxshadowproperties.css">
+<link rel="stylesheet" href="{{ "css/customstyles.css" | relative_url }}">
+<link rel="stylesheet" href="{{ "css/boxshadowproperties.css" | relative_url }}">
 <!-- most color styles are extracted out to here -->
-<link rel="stylesheet" href="css/theme-blue.css">
+<link rel="stylesheet" href="{{ "css/theme-blue.css" | relative_url }}">
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js"></script>
-<script src="{{ "js/jquery.navgoco.min.js" }}"></script>
+<script src="{{ "js/jquery.navgoco.min.js" | relative_url }}"></script>
 
 
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 <!-- Anchor.js -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/2.0.0/anchor.min.js"></script>
-<script src="{{ "js/toc.js" }}"></script>
-<script src="{{ "js/customscripts.js" }}"></script>
+<script src="{{ "js/toc.js" | relative_url }}"></script>
+<script src="{{ "js/customscripts.js" | relative_url }}"></script>
 
-<link rel="shortcut icon" href="{{ "images/favicon.ico"  }}">
+<link rel="shortcut icon" href="{{ "images/favicon.ico" | relative_url }}">
 
 <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
 <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -13,12 +13,12 @@
           {% if folderitem.external_url %}
           <li><a href="{{folderitem.external_url}}" target="_blank">{{folderitem.title}}</a></li>
           {% elsif page.url == folderitem.url %}
-          <li class="active"><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+          <li class="active"><a href="{{folderitem.url | relative_url }}">{{folderitem.title}}</a></li>
           {% elsif folderitem.type == "empty" %}
-          <li><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+          <li><a href="{{folderitem.url | relative_url }}">{{folderitem.title}}</a></li>
 
           {% else %}
-          <li><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+          <li><a href="{{folderitem.url | relative_url }}">{{folderitem.title}}</a></li>
           {% endif %}
           {% for subfolders in folderitem.subfolders %}
           {% if subfolders.output contains "web" %}
@@ -30,9 +30,9 @@
                   {% if subfolderitem.external_url %}
                   <li><a href="{{subfolderitem.external_url}}" target="_blank">{{subfolderitem.title}}</a></li>
                   {% elsif page.url == subfolderitem.url %}
-                  <li class="active"><a href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
+                  <li class="active"><a href="{{subfolderitem.url | relative_url }}">{{subfolderitem.title}}</a></li>
                   {% else %}
-                  <li><a href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
+                  <li><a href="{{subfolderitem.url | relative_url }}">{{subfolderitem.title}}</a></li>
                   {% endif %}
                   {% endif %}
                   {% endfor %}

--- a/docs/_includes/topnav.html
+++ b/docs/_includes/topnav.html
@@ -60,12 +60,12 @@
                         <input type="text" id="search-input" placeholder="{{site.data.strings.search_placeholder_text}}">
                         <ul id="results-container"></ul>
                     </div>
-                    <script src="{{ "js/jekyll-search.js"}}" type="text/javascript"></script>
+                    <script src="{{ "js/jekyll-search.js" | relative_url }}" type="text/javascript"></script>
                     <script type="text/javascript">
                             SimpleJekyllSearch.init({
                                 searchInput: document.getElementById('search-input'),
                                 resultsContainer: document.getElementById('results-container'),
-                                dataSource: '{{ "search.json" }}',
+                                dataSource: '{{ "search.json" | relative_url }}',
                                 searchResultTemplate: '<li><a href="{url}" title="{{page.title | escape }}">{title}</a></li>',
                     noResultsText: '{{site.data.strings.search_no_results_text}}',
                             limit: 10,

--- a/docs/pages/kdoc/detekt-api/alltypes/index.md
+++ b/docs/pages/kdoc/detekt-api/alltypes/index.md
@@ -1,0 +1,53 @@
+---
+title: alltypes - detekt-api
+---
+
+### All Types
+
+| [io.gitlab.arturbosch.detekt.api.AnnotationExcluder](../io.gitlab.arturbosch.detekt.api/-annotation-excluder/index.html) | Primary use case for an AnnotationExcluder is to decide if a KtElement should be excluded from further analysis. This is done by checking if a special annotation is present over the element. |
+| [io.gitlab.arturbosch.detekt.api.BaseConfig](../io.gitlab.arturbosch.detekt.api/-base-config/index.html) | Convenient base configuration which parses/casts the configuration value based on the type of the default value. |
+| [io.gitlab.arturbosch.detekt.api.BaseRule](../io.gitlab.arturbosch.detekt.api/-base-rule/index.html) | Defines the visiting mechanism for KtFile's. |
+| [io.gitlab.arturbosch.detekt.api.CodeSmell](../io.gitlab.arturbosch.detekt.api/-code-smell/index.html) | A code smell indicates any possible design problem inside a program's source code. The type of a code smell is described by an [Issue](../io.gitlab.arturbosch.detekt.api/-issue/index.html). |
+| [io.gitlab.arturbosch.detekt.api.Compactable](../io.gitlab.arturbosch.detekt.api/-compactable/index.html) | Provides a compact string representation. |
+| [io.gitlab.arturbosch.detekt.api.CompositeConfig](../io.gitlab.arturbosch.detekt.api/-composite-config/index.html) | Wraps two different configuration which should be considered when retrieving properties. |
+| [io.gitlab.arturbosch.detekt.api.Config](../io.gitlab.arturbosch.detekt.api/-config/index.html) | A configuration holds information about how to configure specific rules. |
+| [io.gitlab.arturbosch.detekt.api.ConfigAware](../io.gitlab.arturbosch.detekt.api/-config-aware/index.html) | Interface which is implemented by each Rule class to provide utility functions to retrieve specific or generic properties from the underlying detekt configuration file. |
+| [io.gitlab.arturbosch.detekt.api.ConsoleReport](../io.gitlab.arturbosch.detekt.api/-console-report/index.html) | Extension point which describes how findings should be printed on the console. |
+| [io.gitlab.arturbosch.detekt.api.Context](../io.gitlab.arturbosch.detekt.api/-context/index.html) | A context describes the storing and reporting mechanism of [Finding](../io.gitlab.arturbosch.detekt.api/-finding/index.html)'s inside a [Rule](../io.gitlab.arturbosch.detekt.api/-rule/index.html). Additionally it handles suppression and aliases management. |
+| [io.gitlab.arturbosch.detekt.api.Debt](../io.gitlab.arturbosch.detekt.api/-debt/index.html) | Debt describes the estimated amount of work needed to fix a given issue. |
+| [io.gitlab.arturbosch.detekt.api.DefaultContext](../io.gitlab.arturbosch.detekt.api/-default-context/index.html) | Default [Context](../io.gitlab.arturbosch.detekt.api/-context/index.html) implementation. |
+| [io.gitlab.arturbosch.detekt.api.Detektion](../io.gitlab.arturbosch.detekt.api/-detektion/index.html) | Storage for all kinds of findings and additional information which needs to be transferred from the detekt engine to the user. |
+| [io.gitlab.arturbosch.detekt.api.DetektVisitor](../io.gitlab.arturbosch.detekt.api/-detekt-visitor/index.html) | Basic visitor which is used inside detekt. Guarantees a better looking name as the extended base class :). |
+| [io.gitlab.arturbosch.detekt.api.Entity](../io.gitlab.arturbosch.detekt.api/-entity/index.html) | Stores information about a specific code fragment. |
+| [io.gitlab.arturbosch.detekt.api.Extension](../io.gitlab.arturbosch.detekt.api/-extension/index.html) | Defines extension points in detekt. Currently supported extensions are: |
+| [io.gitlab.arturbosch.detekt.api.FileProcessListener](../io.gitlab.arturbosch.detekt.api/-file-process-listener/index.html) | Gather additional metrics about the analyzed kotlin file. Pay attention to the thread policy of each function! |
+| [io.gitlab.arturbosch.detekt.api.Finding](../io.gitlab.arturbosch.detekt.api/-finding/index.html) | Base interface of detection findings. Inherits a bunch of useful behaviour from sub interfaces. |
+| [io.gitlab.arturbosch.detekt.api.HasEntity](../io.gitlab.arturbosch.detekt.api/-has-entity/index.html) | Describes a source code position. |
+| [io.gitlab.arturbosch.detekt.api.HasMetrics](../io.gitlab.arturbosch.detekt.api/-has-metrics/index.html) | Adds metric container behaviour. |
+| [io.gitlab.arturbosch.detekt.api.Issue](../io.gitlab.arturbosch.detekt.api/-issue/index.html) | An issue represents a problem in the codebase. |
+| [org.jetbrains.kotlin.psi.KtAnnotated](../io.gitlab.arturbosch.detekt.api/org.jetbrains.kotlin.psi.-kt-annotated/index.html) (extensions in package io.gitlab.arturbosch.detekt.api) |  |
+| [org.jetbrains.kotlin.psi.KtCallExpression](../io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-call-expression/index.html) (extensions in package io.gitlab.arturbosch.detekt.api.internal) |  |
+| [org.jetbrains.kotlin.psi.KtElement](../io.gitlab.arturbosch.detekt.api/org.jetbrains.kotlin.psi.-kt-element/index.html) (extensions in package io.gitlab.arturbosch.detekt.api) |  |
+| [org.jetbrains.kotlin.psi.KtFile](../io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-file/index.html) (extensions in package io.gitlab.arturbosch.detekt.api.internal) |  |
+| [io.gitlab.arturbosch.detekt.api.LazyRegex](../io.gitlab.arturbosch.detekt.api/-lazy-regex/index.html) | LazyRegex class provides a lazy evaluation of a Regex pattern for usages inside Rules. It computes the value once when reaching the point of its usage and returns the same value when requested again. |
+| [io.gitlab.arturbosch.detekt.api.Location](../io.gitlab.arturbosch.detekt.api/-location/index.html) | Specifies a position within a source code fragment. |
+| [io.gitlab.arturbosch.detekt.api.internal.McCabeVisitor](../io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/index.html) | Counts the cyclomatic complexity of functions. |
+| [io.gitlab.arturbosch.detekt.api.Metric](../io.gitlab.arturbosch.detekt.api/-metric/index.html) | Metric type, can be an integer or double value. Internally it is stored as an integer, but the conversion factor and is double attributes can be used to retrieve it as a double value. |
+| [io.gitlab.arturbosch.detekt.api.MultiRule](../io.gitlab.arturbosch.detekt.api/-multi-rule/index.html) |  |
+| [io.gitlab.arturbosch.detekt.api.Notification](../io.gitlab.arturbosch.detekt.api/-notification/index.html) | Any kind of notification which should be printed to the console. For example when using the formatting rule set, any change to your kotlin file is a notification. |
+| [io.gitlab.arturbosch.detekt.api.OutputReport](../io.gitlab.arturbosch.detekt.api/-output-report/index.html) | Translates detekt's result container - [Detektion](../io.gitlab.arturbosch.detekt.api/-detektion/index.html) - into an output report which is written inside a file. |
+| [io.gitlab.arturbosch.detekt.api.ProjectMetric](../io.gitlab.arturbosch.detekt.api/-project-metric/index.html) | Anything that can be expressed as a number value for projects. |
+| [io.gitlab.arturbosch.detekt.api.Rule](../io.gitlab.arturbosch.detekt.api/-rule/index.html) | A rule defines how one specific code structure should look like. If code is found which does not meet this structure, it is considered as harmful regarding maintainability or readability. |
+| [io.gitlab.arturbosch.detekt.api.RuleId](../io.gitlab.arturbosch.detekt.api/-rule-id.html) | The type to use when referring to rule ids giving it more context then a String would. |
+| [io.gitlab.arturbosch.detekt.api.RuleSet](../io.gitlab.arturbosch.detekt.api/-rule-set/index.html) | A rule set is a collection of rules and must be defined within a rule set provider implementation. |
+| [io.gitlab.arturbosch.detekt.api.RuleSetId](../io.gitlab.arturbosch.detekt.api/-rule-set-id.html) |  |
+| [io.gitlab.arturbosch.detekt.api.RuleSetProvider](../io.gitlab.arturbosch.detekt.api/-rule-set-provider/index.html) | A rule set provider, as the name states, is responsible for creating rule sets. |
+| [io.gitlab.arturbosch.detekt.api.Severity](../io.gitlab.arturbosch.detekt.api/-severity/index.html) | Rules can classified into different severity grades. Maintainer can choose a grade which is most harmful to their projects. |
+| [io.gitlab.arturbosch.detekt.api.SingleAssign](../io.gitlab.arturbosch.detekt.api/-single-assign/index.html) | Allows to assign a property just once. Further assignments result in [IllegalStateException](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-illegal-state-exception/index.html)'s. |
+| [io.gitlab.arturbosch.detekt.api.SourceLocation](../io.gitlab.arturbosch.detekt.api/-source-location/index.html) | Stores line and column information of a location. |
+| [io.gitlab.arturbosch.detekt.api.SplitPattern](../io.gitlab.arturbosch.detekt.api/-split-pattern/index.html) | Splits given text into parts and provides testing utilities for its elements. Basic use cases are to specify different function or class names in the detekt yaml config and test for their appearance in specific rules. |
+| [io.gitlab.arturbosch.detekt.api.TextLocation](../io.gitlab.arturbosch.detekt.api/-text-location/index.html) | Stores character start and end positions of an text file. |
+| [io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell](../io.gitlab.arturbosch.detekt.api/-thresholded-code-smell/index.html) | Represents a code smell for which a specific metric can be determined which is responsible for the existence of this rule violation. |
+| [io.gitlab.arturbosch.detekt.api.ThresholdRule](../io.gitlab.arturbosch.detekt.api/-threshold-rule/index.html) | Provides a threshold attribute for this rule, which is specified manually for default values but can be also obtained from within a configuration object. |
+| [io.gitlab.arturbosch.detekt.api.YamlConfig](../io.gitlab.arturbosch.detekt.api/-yaml-config/index.html) | Config implementation using the yaml format. SubConfigurations can return sub maps according to the yaml specification. |
+

--- a/docs/pages/kdoc/detekt-api/index.md
+++ b/docs/pages/kdoc/detekt-api/index.md
@@ -1,0 +1,14 @@
+---
+title: detekt-api
+---
+
+[detekt-api](./index.html)
+
+### Packages
+
+| [io.gitlab.arturbosch.detekt.api](io.gitlab.arturbosch.detekt.api/index.html) |  |
+| [io.gitlab.arturbosch.detekt.api.internal](io.gitlab.arturbosch.detekt.api.internal/index.html) |  |
+
+### Index
+
+[All Types](alltypes/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-a-b-s-o-l-u-t-e_-p-a-t-h.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-a-b-s-o-l-u-t-e_-p-a-t-h.md
@@ -1,0 +1,9 @@
+---
+title: ABSOLUTE_PATH - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api.internal](index.html) / [ABSOLUTE_PATH](./-a-b-s-o-l-u-t-e_-p-a-t-h.html)
+
+# ABSOLUTE_PATH
+
+`val ABSOLUTE_PATH: Key<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/-init-.md
@@ -1,0 +1,21 @@
+---
+title: McCabeVisitor.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [McCabeVisitor](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`McCabeVisitor(ignoreSimpleWhenEntries: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)`)`
+
+Counts the cyclomatic complexity of functions.
+
+**Author**
+Artur Bosch
+
+**Author**
+schalkms
+
+**Author**
+Sebastiano Poggi
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/index.md
@@ -1,0 +1,39 @@
+---
+title: McCabeVisitor - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [McCabeVisitor](./index.html)
+
+# McCabeVisitor
+
+`class McCabeVisitor : `[`DetektVisitor`](../../io.gitlab.arturbosch.detekt.api/-detekt-visitor/index.html)
+
+Counts the cyclomatic complexity of functions.
+
+**Author**
+Artur Bosch
+
+**Author**
+schalkms
+
+**Author**
+Sebastiano Poggi
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `McCabeVisitor(ignoreSimpleWhenEntries: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)`)`<br>Counts the cyclomatic complexity of functions. |
+
+### Properties
+
+| [mcc](mcc.html) | `var mcc: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+
+### Functions
+
+| [isInsideObjectLiteral](is-inside-object-literal.html) | `fun isInsideObjectLiteral(function: KtNamedFunction): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html) |
+| [visitCallExpression](visit-call-expression.html) | `fun visitCallExpression(expression: KtCallExpression): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [visitIfExpression](visit-if-expression.html) | `fun visitIfExpression(expression: KtIfExpression): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [visitLoopExpression](visit-loop-expression.html) | `fun visitLoopExpression(loopExpression: KtLoopExpression): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [visitNamedFunction](visit-named-function.html) | `fun visitNamedFunction(function: KtNamedFunction): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [visitTryExpression](visit-try-expression.html) | `fun visitTryExpression(expression: KtTryExpression): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [visitWhenExpression](visit-when-expression.html) | `fun visitWhenExpression(expression: KtWhenExpression): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/is-inside-object-literal.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/is-inside-object-literal.md
@@ -1,0 +1,9 @@
+---
+title: McCabeVisitor.isInsideObjectLiteral - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [McCabeVisitor](index.html) / [isInsideObjectLiteral](./is-inside-object-literal.html)
+
+# isInsideObjectLiteral
+
+`fun isInsideObjectLiteral(function: KtNamedFunction): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/mcc.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/mcc.md
@@ -1,0 +1,9 @@
+---
+title: McCabeVisitor.mcc - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [McCabeVisitor](index.html) / [mcc](./mcc.html)
+
+# mcc
+
+`var mcc: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/visit-call-expression.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/visit-call-expression.md
@@ -1,0 +1,9 @@
+---
+title: McCabeVisitor.visitCallExpression - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [McCabeVisitor](index.html) / [visitCallExpression](./visit-call-expression.html)
+
+# visitCallExpression
+
+`fun visitCallExpression(expression: KtCallExpression): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/visit-if-expression.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/visit-if-expression.md
@@ -1,0 +1,9 @@
+---
+title: McCabeVisitor.visitIfExpression - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [McCabeVisitor](index.html) / [visitIfExpression](./visit-if-expression.html)
+
+# visitIfExpression
+
+`fun visitIfExpression(expression: KtIfExpression): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/visit-loop-expression.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/visit-loop-expression.md
@@ -1,0 +1,9 @@
+---
+title: McCabeVisitor.visitLoopExpression - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [McCabeVisitor](index.html) / [visitLoopExpression](./visit-loop-expression.html)
+
+# visitLoopExpression
+
+`fun visitLoopExpression(loopExpression: KtLoopExpression): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/visit-named-function.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/visit-named-function.md
@@ -1,0 +1,9 @@
+---
+title: McCabeVisitor.visitNamedFunction - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [McCabeVisitor](index.html) / [visitNamedFunction](./visit-named-function.html)
+
+# visitNamedFunction
+
+`fun visitNamedFunction(function: KtNamedFunction): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/visit-try-expression.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/visit-try-expression.md
@@ -1,0 +1,9 @@
+---
+title: McCabeVisitor.visitTryExpression - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [McCabeVisitor](index.html) / [visitTryExpression](./visit-try-expression.html)
+
+# visitTryExpression
+
+`fun visitTryExpression(expression: KtTryExpression): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/visit-when-expression.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/visit-when-expression.md
@@ -1,0 +1,9 @@
+---
+title: McCabeVisitor.visitWhenExpression - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [McCabeVisitor](index.html) / [visitWhenExpression](./visit-when-expression.html)
+
+# visitWhenExpression
+
+`fun visitWhenExpression(expression: KtWhenExpression): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-r-e-l-a-t-i-v-e_-p-a-t-h.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-r-e-l-a-t-i-v-e_-p-a-t-h.md
@@ -1,0 +1,9 @@
+---
+title: RELATIVE_PATH - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api.internal](index.html) / [RELATIVE_PATH](./-r-e-l-a-t-i-v-e_-p-a-t-h.html)
+
+# RELATIVE_PATH
+
+`val RELATIVE_PATH: Key<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/index.md
@@ -1,0 +1,26 @@
+---
+title: io.gitlab.arturbosch.detekt.api.internal - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api.internal](./index.html)
+
+## Package io.gitlab.arturbosch.detekt.api.internal
+
+### Types
+
+| [McCabeVisitor](-mc-cabe-visitor/index.html) | `class McCabeVisitor : `[`DetektVisitor`](../io.gitlab.arturbosch.detekt.api/-detekt-visitor/index.html)<br>Counts the cyclomatic complexity of functions. |
+
+### Extensions for External Classes
+
+| [org.jetbrains.kotlin.psi.KtCallExpression](org.jetbrains.kotlin.psi.-kt-call-expression/index.html) |  |
+| [org.jetbrains.kotlin.psi.KtFile](org.jetbrains.kotlin.psi.-kt-file/index.html) |  |
+
+### Properties
+
+| [ABSOLUTE_PATH](-a-b-s-o-l-u-t-e_-p-a-t-h.html) | `val ABSOLUTE_PATH: Key<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>` |
+| [RELATIVE_PATH](-r-e-l-a-t-i-v-e_-p-a-t-h.html) | `val RELATIVE_PATH: Key<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>` |
+
+### Functions
+
+| [pathMatcher](path-matcher.html) | `fun pathMatcher(pattern: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`PathMatcher`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/PathMatcher.html)<br>Converts given [pattern](path-matcher.html#io.gitlab.arturbosch.detekt.api.internal$pathMatcher(kotlin.String)/pattern) into a [PathMatcher](https://docs.oracle.com/javase/8/docs/api/java/nio/file/PathMatcher.html) specified by [FileSystem.getPathMatcher](https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)). We only support the "glob:" syntax to stay os independently. Internally a globbing pattern is transformed to a regex respecting the Windows file system. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-call-expression/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-call-expression/index.md
@@ -1,0 +1,10 @@
+---
+title: io.gitlab.arturbosch.detekt.api.internal.org.jetbrains.kotlin.psi.KtCallExpression - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [org.jetbrains.kotlin.psi.KtCallExpression](./index.html)
+
+### Extensions for org.jetbrains.kotlin.psi.KtCallExpression
+
+| [isUsedForNesting](is-used-for-nesting.html) | `fun KtCallExpression.isUsedForNesting(): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-call-expression/is-used-for-nesting.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-call-expression/is-used-for-nesting.md
@@ -1,0 +1,9 @@
+---
+title: isUsedForNesting - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [org.jetbrains.kotlin.psi.KtCallExpression](index.html) / [isUsedForNesting](./is-used-for-nesting.html)
+
+# isUsedForNesting
+
+`fun KtCallExpression.isUsedForNesting(): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-file/absolute-path.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-file/absolute-path.md
@@ -1,0 +1,9 @@
+---
+title: absolutePath - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [org.jetbrains.kotlin.psi.KtFile](index.html) / [absolutePath](./absolute-path.html)
+
+# absolutePath
+
+`fun KtFile.absolutePath(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`?`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-file/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-file/index.md
@@ -1,0 +1,11 @@
+---
+title: io.gitlab.arturbosch.detekt.api.internal.org.jetbrains.kotlin.psi.KtFile - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [org.jetbrains.kotlin.psi.KtFile](./index.html)
+
+### Extensions for org.jetbrains.kotlin.psi.KtFile
+
+| [absolutePath](absolute-path.html) | `fun KtFile.absolutePath(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`?` |
+| [relativePath](relative-path.html) | `fun KtFile.relativePath(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`?` |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-file/relative-path.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-file/relative-path.md
@@ -1,0 +1,9 @@
+---
+title: relativePath - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [org.jetbrains.kotlin.psi.KtFile](index.html) / [relativePath](./relative-path.html)
+
+# relativePath
+
+`fun KtFile.relativePath(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`?`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/path-matcher.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/path-matcher.md
@@ -1,0 +1,14 @@
+---
+title: pathMatcher - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api.internal](index.html) / [pathMatcher](./path-matcher.html)
+
+# pathMatcher
+
+`fun pathMatcher(pattern: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`PathMatcher`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/PathMatcher.html)
+
+Converts given [pattern](path-matcher.html#io.gitlab.arturbosch.detekt.api.internal$pathMatcher(kotlin.String)/pattern) into a [PathMatcher](https://docs.oracle.com/javase/8/docs/api/java/nio/file/PathMatcher.html) specified by [FileSystem.getPathMatcher](https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)).
+We only support the "glob:" syntax to stay os independently.
+Internally a globbing pattern is transformed to a regex respecting the Windows file system.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-annotation-excluder/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-annotation-excluder/-init-.md
@@ -1,0 +1,23 @@
+---
+title: AnnotationExcluder.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [AnnotationExcluder](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`AnnotationExcluder(root: KtFile, excludes: `[`SplitPattern`](../-split-pattern/index.html)`)`
+
+Primary use case for an AnnotationExcluder is to decide if a KtElement should be
+excluded from further analysis. This is done by checking if a special annotation
+is present over the element.
+
+**Author**
+Niklas Baudy
+
+**Author**
+Artur Bosch
+
+**Author**
+schalkms
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-annotation-excluder/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-annotation-excluder/index.md
@@ -1,0 +1,31 @@
+---
+title: AnnotationExcluder - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [AnnotationExcluder](./index.html)
+
+# AnnotationExcluder
+
+`class AnnotationExcluder`
+
+Primary use case for an AnnotationExcluder is to decide if a KtElement should be
+excluded from further analysis. This is done by checking if a special annotation
+is present over the element.
+
+**Author**
+Niklas Baudy
+
+**Author**
+Artur Bosch
+
+**Author**
+schalkms
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `AnnotationExcluder(root: KtFile, excludes: `[`SplitPattern`](../-split-pattern/index.html)`)`<br>Primary use case for an AnnotationExcluder is to decide if a KtElement should be excluded from further analysis. This is done by checking if a special annotation is present over the element. |
+
+### Functions
+
+| [shouldExclude](should-exclude.html) | `fun shouldExclude(annotations: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<KtAnnotationEntry>): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)<br>Is true if any given annotation name is declared in the SplitPattern which basically describes entries to exclude. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-annotation-excluder/should-exclude.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-annotation-excluder/should-exclude.md
@@ -1,0 +1,13 @@
+---
+title: AnnotationExcluder.shouldExclude - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [AnnotationExcluder](index.html) / [shouldExclude](./should-exclude.html)
+
+# shouldExclude
+
+`fun shouldExclude(annotations: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<KtAnnotationEntry>): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)
+
+Is true if any given annotation name is declared in the SplitPattern
+which basically describes entries to exclude.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-config/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-config/-init-.md
@@ -1,0 +1,12 @@
+---
+title: BaseConfig.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [BaseConfig](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`BaseConfig()`
+
+Convenient base configuration which parses/casts the configuration value based on the type of the default value.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-config/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-config/index.md
@@ -1,0 +1,31 @@
+---
+title: BaseConfig - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [BaseConfig](./index.html)
+
+# BaseConfig
+
+`abstract class BaseConfig : `[`Config`](../-config/index.html)
+
+Convenient base configuration which parses/casts the configuration value based on the type of the default value.
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `BaseConfig()`<br>Convenient base configuration which parses/casts the configuration value based on the type of the default value. |
+
+### Functions
+
+| [tryParseBasedOnDefault](try-parse-based-on-default.html) | `open fun tryParseBasedOnDefault(result: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, defaultResult: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`): `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html) |
+| [valueOrDefaultInternal](value-or-default-internal.html) | `open fun valueOrDefaultInternal(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, result: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`?, default: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`): `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html) |
+
+### Inherited Functions
+
+| [subConfig](../-config/sub-config.html) | `abstract fun subConfig(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Config`](../-config/index.html)<br>Tries to retrieve part of the configuration based on given key. |
+| [valueOrDefault](../-config/value-or-default.html) | `abstract fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrDefault(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, default: `[`T`](../-config/value-or-default.html#T)`): `[`T`](../-config/value-or-default.html#T)<br>Retrieves a sub configuration or value based on given key. If configuration property cannot be found the specified default value is returned. |
+| [valueOrNull](../-config/value-or-null.html) | `abstract fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`T`](../-config/value-or-null.html#T)`?`<br>Retrieves a sub configuration or value based on given key. If the configuration property cannot be found, null is returned. |
+
+### Inheritors
+
+| [YamlConfig](../-yaml-config/index.html) | `class YamlConfig : `[`BaseConfig`](./index.html)<br>Config implementation using the yaml format. SubConfigurations can return sub maps according to the yaml specification. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-config/try-parse-based-on-default.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-config/try-parse-based-on-default.md
@@ -1,0 +1,9 @@
+---
+title: BaseConfig.tryParseBasedOnDefault - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [BaseConfig](index.html) / [tryParseBasedOnDefault](./try-parse-based-on-default.html)
+
+# tryParseBasedOnDefault
+
+`protected open fun tryParseBasedOnDefault(result: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, defaultResult: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`): `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-config/value-or-default-internal.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-config/value-or-default-internal.md
@@ -1,0 +1,9 @@
+---
+title: BaseConfig.valueOrDefaultInternal - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [BaseConfig](index.html) / [valueOrDefaultInternal](./value-or-default-internal.html)
+
+# valueOrDefaultInternal
+
+`protected open fun valueOrDefaultInternal(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, result: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`?, default: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`): `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/-init-.md
@@ -1,0 +1,21 @@
+---
+title: BaseRule.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [BaseRule](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`BaseRule(context: `[`Context`](../-context/index.html)` = DefaultContext())`
+
+Defines the visiting mechanism for KtFile's.
+
+Custom rule implementations should actually use [Rule](../-rule/index.html) as base class.
+
+The extraction of this class from [Rule](../-rule/index.html) actually resulted from the need
+of running many different checks on the same KtFile but within a single
+potential costly visiting process, see [MultiRule](../-multi-rule/index.html).
+
+This base rule class abstracts over single and multi rules and allows the
+detekt core engine to only care about a single type.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/binding-context.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/binding-context.md
@@ -1,0 +1,9 @@
+---
+title: BaseRule.bindingContext - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [BaseRule](index.html) / [bindingContext](./binding-context.html)
+
+# bindingContext
+
+`var bindingContext: BindingContext`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/context.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/context.md
@@ -1,0 +1,9 @@
+---
+title: BaseRule.context - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [BaseRule](index.html) / [context](./context.html)
+
+# context
+
+`protected val context: `[`Context`](../-context/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/index.md
@@ -1,0 +1,44 @@
+---
+title: BaseRule - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [BaseRule](./index.html)
+
+# BaseRule
+
+`abstract class BaseRule : `[`DetektVisitor`](../-detekt-visitor/index.html)`, `[`Context`](../-context/index.html)
+
+Defines the visiting mechanism for KtFile's.
+
+Custom rule implementations should actually use [Rule](../-rule/index.html) as base class.
+
+The extraction of this class from [Rule](../-rule/index.html) actually resulted from the need
+of running many different checks on the same KtFile but within a single
+potential costly visiting process, see [MultiRule](../-multi-rule/index.html).
+
+This base rule class abstracts over single and multi rules and allows the
+detekt core engine to only care about a single type.
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `BaseRule(context: `[`Context`](../-context/index.html)` = DefaultContext())`<br>Defines the visiting mechanism for KtFile's. |
+
+### Properties
+
+| [bindingContext](binding-context.html) | `var bindingContext: BindingContext` |
+| [context](context.html) | `val context: `[`Context`](../-context/index.html) |
+| [ruleId](rule-id.html) | `open val ruleId: `[`RuleId`](../-rule-id.html) |
+
+### Functions
+
+| [postVisit](post-visit.html) | `open fun postVisit(root: KtFile): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Could be overridden by subclasses to specify a behaviour which should be done after visiting kotlin elements. |
+| [preVisit](pre-visit.html) | `open fun preVisit(root: KtFile): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Could be overridden by subclasses to specify a behaviour which should be done before visiting kotlin elements. |
+| [visit](visit.html) | `open fun visit(root: KtFile): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [visitCondition](visit-condition.html) | `abstract fun visitCondition(root: KtFile): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)<br>Basic mechanism to decide if a rule should run or not. |
+| [visitFile](visit-file.html) | `fun visitFile(root: KtFile, bindingContext: BindingContext = BindingContext.EMPTY): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Before starting visiting kotlin elements, a check is performed if this rule should be triggered. Pre- and post-visit-hooks are executed before/after the visiting process. BindingContext holds the result of the semantic analysis of the source code by the Kotlin compiler. Rules that rely on symbols and types being resolved can use the BindingContext for this analysis. Note that detekt must receive the correct compile classpath for the code being analyzed otherwise the default value BindingContext.EMPTY will be used and it will not be possible for detekt to resolve types or symbols. |
+
+### Inheritors
+
+| [MultiRule](../-multi-rule/index.html) | `abstract class MultiRule : `[`BaseRule`](./index.html) |
+| [Rule](../-rule/index.html) | `abstract class Rule : `[`BaseRule`](./index.html)`, `[`ConfigAware`](../-config-aware/index.html)<br>A rule defines how one specific code structure should look like. If code is found which does not meet this structure, it is considered as harmful regarding maintainability or readability. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/post-visit.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/post-visit.md
@@ -1,0 +1,13 @@
+---
+title: BaseRule.postVisit - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [BaseRule](index.html) / [postVisit](./post-visit.html)
+
+# postVisit
+
+`protected open fun postVisit(root: KtFile): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Could be overridden by subclasses to specify a behaviour which should be done after
+visiting kotlin elements.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/pre-visit.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/pre-visit.md
@@ -1,0 +1,13 @@
+---
+title: BaseRule.preVisit - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [BaseRule](index.html) / [preVisit](./pre-visit.html)
+
+# preVisit
+
+`protected open fun preVisit(root: KtFile): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Could be overridden by subclasses to specify a behaviour which should be done before
+visiting kotlin elements.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/rule-id.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/rule-id.md
@@ -1,0 +1,9 @@
+---
+title: BaseRule.ruleId - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [BaseRule](index.html) / [ruleId](./rule-id.html)
+
+# ruleId
+
+`open val ruleId: `[`RuleId`](../-rule-id.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/visit-condition.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/visit-condition.md
@@ -1,0 +1,15 @@
+---
+title: BaseRule.visitCondition - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [BaseRule](index.html) / [visitCondition](./visit-condition.html)
+
+# visitCondition
+
+`abstract fun visitCondition(root: KtFile): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)
+
+Basic mechanism to decide if a rule should run or not.
+
+By default any rule which is declared 'active' in the [Config](../-config/index.html)
+or not suppressed by a [Suppress](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-suppress/index.html) annotation on file level should run.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/visit-file.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/visit-file.md
@@ -1,0 +1,17 @@
+---
+title: BaseRule.visitFile - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [BaseRule](index.html) / [visitFile](./visit-file.html)
+
+# visitFile
+
+`fun visitFile(root: KtFile, bindingContext: BindingContext = BindingContext.EMPTY): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Before starting visiting kotlin elements, a check is performed if this rule should be triggered.
+Pre- and post-visit-hooks are executed before/after the visiting process.
+BindingContext holds the result of the semantic analysis of the source code by the Kotlin compiler. Rules that
+rely on symbols and types being resolved can use the BindingContext for this analysis. Note that detekt must
+receive the correct compile classpath for the code being analyzed otherwise the default value
+BindingContext.EMPTY will be used and it will not be possible for detekt to resolve types or symbols.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/visit.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-rule/visit.md
@@ -1,0 +1,9 @@
+---
+title: BaseRule.visit - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [BaseRule](index.html) / [visit](./visit.html)
+
+# visit
+
+`open fun visit(root: KtFile): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/-init-.md
@@ -1,0 +1,25 @@
+---
+title: CodeSmell.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CodeSmell](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`CodeSmell(issue: `[`Issue`](../-issue/index.html)`, entity: `[`Entity`](../-entity/index.html)`, message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, metrics: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Metric`](../-metric/index.html)`> = listOf(), references: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Entity`](../-entity/index.html)`> = listOf())`
+
+A code smell indicates any possible design problem inside a program's source code.
+The type of a code smell is described by an [Issue](../-issue/index.html).
+
+If the design problem results from metric violations, a list of [Metric](../-metric/index.html)'s
+can describe further the kind of metrics.
+
+If the design problem manifests by different source locations, references to these
+locations can be stored in additional [Entity](../-entity/index.html)'s.
+
+**Author**
+Artur Bosch
+
+**Author**
+Marvin Ramin
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/compact-with-signature.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/compact-with-signature.md
@@ -1,0 +1,12 @@
+---
+title: CodeSmell.compactWithSignature - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CodeSmell](index.html) / [compactWithSignature](./compact-with-signature.html)
+
+# compactWithSignature
+
+`open fun compactWithSignature(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+
+Overrides [Compactable.compactWithSignature](../-compactable/compact-with-signature.html)
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/compact.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/compact.md
@@ -1,0 +1,12 @@
+---
+title: CodeSmell.compact - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CodeSmell](index.html) / [compact](./compact.html)
+
+# compact
+
+`open fun compact(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+
+Overrides [Compactable.compact](../-compactable/compact.html)
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/entity.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/entity.md
@@ -1,0 +1,12 @@
+---
+title: CodeSmell.entity - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CodeSmell](index.html) / [entity](./entity.html)
+
+# entity
+
+`open val entity: `[`Entity`](../-entity/index.html)
+
+Overrides [HasEntity.entity](../-has-entity/entity.html)
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/id.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/id.md
@@ -1,0 +1,12 @@
+---
+title: CodeSmell.id - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CodeSmell](index.html) / [id](./id.html)
+
+# id
+
+`open val id: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+
+Overrides [Finding.id](../-finding/id.html)
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/index.md
@@ -1,0 +1,49 @@
+---
+title: CodeSmell - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CodeSmell](./index.html)
+
+# CodeSmell
+
+`open class CodeSmell : `[`Finding`](../-finding/index.html)
+
+A code smell indicates any possible design problem inside a program's source code.
+The type of a code smell is described by an [Issue](../-issue/index.html).
+
+If the design problem results from metric violations, a list of [Metric](../-metric/index.html)'s
+can describe further the kind of metrics.
+
+If the design problem manifests by different source locations, references to these
+locations can be stored in additional [Entity](../-entity/index.html)'s.
+
+**Author**
+Artur Bosch
+
+**Author**
+Marvin Ramin
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `CodeSmell(issue: `[`Issue`](../-issue/index.html)`, entity: `[`Entity`](../-entity/index.html)`, message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, metrics: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Metric`](../-metric/index.html)`> = listOf(), references: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Entity`](../-entity/index.html)`> = listOf())`<br>A code smell indicates any possible design problem inside a program's source code. The type of a code smell is described by an [Issue](../-issue/index.html). |
+
+### Properties
+
+| [entity](entity.html) | `open val entity: `[`Entity`](../-entity/index.html) |
+| [id](id.html) | `open val id: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [issue](issue.html) | `val issue: `[`Issue`](../-issue/index.html) |
+| [message](message.html) | `open val message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [metrics](metrics.html) | `open val metrics: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Metric`](../-metric/index.html)`>` |
+| [references](references.html) | `open val references: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Entity`](../-entity/index.html)`>` |
+
+### Functions
+
+| [compact](compact.html) | `open fun compact(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [compactWithSignature](compact-with-signature.html) | `open fun compactWithSignature(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [messageOrDescription](message-or-description.html) | `open fun messageOrDescription(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [toString](to-string.html) | `open fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+
+### Inheritors
+
+| [ThresholdedCodeSmell](../-thresholded-code-smell/index.html) | `open class ThresholdedCodeSmell : `[`CodeSmell`](./index.html)<br>Represents a code smell for which a specific metric can be determined which is responsible for the existence of this rule violation. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/issue.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/issue.md
@@ -1,0 +1,12 @@
+---
+title: CodeSmell.issue - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CodeSmell](index.html) / [issue](./issue.html)
+
+# issue
+
+`val issue: `[`Issue`](../-issue/index.html)
+
+Overrides [Finding.issue](../-finding/issue.html)
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/message-or-description.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/message-or-description.md
@@ -1,0 +1,12 @@
+---
+title: CodeSmell.messageOrDescription - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CodeSmell](index.html) / [messageOrDescription](./message-or-description.html)
+
+# messageOrDescription
+
+`open fun messageOrDescription(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+
+Overrides [Finding.messageOrDescription](../-finding/message-or-description.html)
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/message.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/message.md
@@ -1,0 +1,12 @@
+---
+title: CodeSmell.message - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CodeSmell](index.html) / [message](./message.html)
+
+# message
+
+`open val message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+
+Overrides [Finding.message](../-finding/message.html)
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/metrics.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/metrics.md
@@ -1,0 +1,12 @@
+---
+title: CodeSmell.metrics - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CodeSmell](index.html) / [metrics](./metrics.html)
+
+# metrics
+
+`open val metrics: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Metric`](../-metric/index.html)`>`
+
+Overrides [HasMetrics.metrics](../-has-metrics/metrics.html)
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/references.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/references.md
@@ -1,0 +1,12 @@
+---
+title: CodeSmell.references - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CodeSmell](index.html) / [references](./references.html)
+
+# references
+
+`open val references: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Entity`](../-entity/index.html)`>`
+
+Overrides [Finding.references](../-finding/references.html)
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/to-string.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-code-smell/to-string.md
@@ -1,0 +1,9 @@
+---
+title: CodeSmell.toString - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CodeSmell](index.html) / [toString](./to-string.html)
+
+# toString
+
+`open fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-compactable/compact-with-signature.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-compactable/compact-with-signature.md
@@ -1,0 +1,9 @@
+---
+title: Compactable.compactWithSignature - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Compactable](index.html) / [compactWithSignature](./compact-with-signature.html)
+
+# compactWithSignature
+
+`open fun compactWithSignature(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-compactable/compact.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-compactable/compact.md
@@ -1,0 +1,9 @@
+---
+title: Compactable.compact - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Compactable](index.html) / [compact](./compact.html)
+
+# compact
+
+`abstract fun compact(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-compactable/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-compactable/index.md
@@ -1,0 +1,23 @@
+---
+title: Compactable - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Compactable](./index.html)
+
+# Compactable
+
+`interface Compactable`
+
+Provides a compact string representation.
+
+### Functions
+
+| [compact](compact.html) | `abstract fun compact(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [compactWithSignature](compact-with-signature.html) | `open fun compactWithSignature(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+
+### Inheritors
+
+| [Entity](../-entity/index.html) | `data class Entity : `[`Compactable`](./index.html)<br>Stores information about a specific code fragment. |
+| [Finding](../-finding/index.html) | `interface Finding : `[`Compactable`](./index.html)`, `[`HasEntity`](../-has-entity/index.html)`, `[`HasMetrics`](../-has-metrics/index.html)<br>Base interface of detection findings. Inherits a bunch of useful behaviour from sub interfaces. |
+| [Location](../-location/index.html) | `data class Location : `[`Compactable`](./index.html)<br>Specifies a position within a source code fragment. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-composite-config/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-composite-config/-init-.md
@@ -1,0 +1,15 @@
+---
+title: CompositeConfig.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CompositeConfig](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`CompositeConfig(lookFirst: `[`Config`](../-config/index.html)`, lookSecond: `[`Config`](../-config/index.html)`)`
+
+Wraps two different configuration which should be considered when retrieving properties.
+
+**Author**
+Artur Bosch
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-composite-config/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-composite-config/index.md
@@ -1,0 +1,26 @@
+---
+title: CompositeConfig - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CompositeConfig](./index.html)
+
+# CompositeConfig
+
+`class CompositeConfig : `[`Config`](../-config/index.html)
+
+Wraps two different configuration which should be considered when retrieving properties.
+
+**Author**
+Artur Bosch
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `CompositeConfig(lookFirst: `[`Config`](../-config/index.html)`, lookSecond: `[`Config`](../-config/index.html)`)`<br>Wraps two different configuration which should be considered when retrieving properties. |
+
+### Functions
+
+| [subConfig](sub-config.html) | `fun subConfig(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Config`](../-config/index.html)<br>Tries to retrieve part of the configuration based on given key. |
+| [toString](to-string.html) | `fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [valueOrDefault](value-or-default.html) | `fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrDefault(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, default: `[`T`](value-or-default.html#T)`): `[`T`](value-or-default.html#T)<br>Retrieves a sub configuration or value based on given key. If configuration property cannot be found the specified default value is returned. |
+| [valueOrNull](value-or-null.html) | `fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`T`](value-or-null.html#T)`?`<br>Retrieves a sub configuration or value based on given key. If the configuration property cannot be found, null is returned. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-composite-config/sub-config.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-composite-config/sub-config.md
@@ -1,0 +1,14 @@
+---
+title: CompositeConfig.subConfig - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CompositeConfig](index.html) / [subConfig](./sub-config.html)
+
+# subConfig
+
+`fun subConfig(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Config`](../-config/index.html)
+
+Overrides [Config.subConfig](../-config/sub-config.html)
+
+Tries to retrieve part of the configuration based on given key.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-composite-config/to-string.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-composite-config/to-string.md
@@ -1,0 +1,9 @@
+---
+title: CompositeConfig.toString - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CompositeConfig](index.html) / [toString](./to-string.html)
+
+# toString
+
+`fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-composite-config/value-or-default.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-composite-config/value-or-default.md
@@ -1,0 +1,15 @@
+---
+title: CompositeConfig.valueOrDefault - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CompositeConfig](index.html) / [valueOrDefault](./value-or-default.html)
+
+# valueOrDefault
+
+`fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrDefault(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, default: `[`T`](value-or-default.html#T)`): `[`T`](value-or-default.html#T)
+
+Overrides [Config.valueOrDefault](../-config/value-or-default.html)
+
+Retrieves a sub configuration or value based on given key. If configuration property cannot be found
+the specified default value is returned.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-composite-config/value-or-null.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-composite-config/value-or-null.md
@@ -1,0 +1,15 @@
+---
+title: CompositeConfig.valueOrNull - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [CompositeConfig](index.html) / [valueOrNull](./value-or-null.html)
+
+# valueOrNull
+
+`fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`T`](value-or-null.html#T)`?`
+
+Overrides [Config.valueOrNull](../-config/value-or-null.html)
+
+Retrieves a sub configuration or value based on given key.
+If the configuration property cannot be found, null is returned.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/active.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/active.md
@@ -1,0 +1,13 @@
+---
+title: ConfigAware.active - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ConfigAware](index.html) / [active](./active.html)
+
+# active
+
+`open val active: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)
+
+Is this rule specified as active in configuration?
+If an rule is not specified in the underlying configuration, we assume it should not be run.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/auto-correct.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/auto-correct.md
@@ -1,0 +1,13 @@
+---
+title: ConfigAware.autoCorrect - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ConfigAware](index.html) / [autoCorrect](./auto-correct.html)
+
+# autoCorrect
+
+`open val autoCorrect: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)
+
+Does this rule have auto correct specified in configuration?
+For auto correction to work the rule set itself enable it.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/index.md
@@ -1,0 +1,46 @@
+---
+title: ConfigAware - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ConfigAware](./index.html)
+
+# ConfigAware
+
+`interface ConfigAware : `[`Config`](../-config/index.html)
+
+Interface which is implemented by each Rule class to provide
+utility functions to retrieve specific or generic properties
+from the underlying detekt configuration file.
+
+Be aware that there are three config levels by default:
+
+* the top level config layer specifies rule sets and detekt engine properties
+* the rule set level specifies properties concerning the whole rule set and rules
+* the rule level provides additional properties which are used to configure rules
+
+This interface operates on the rule set level as the rule set config is passed to each
+rule in the #RuleSetProvider interface. This is due the fact that users create the
+rule set and all rules upfront and letting them 'sub config' the rule set config would
+be error-prone.
+
+**Author**
+Artur Bosch
+
+### Properties
+
+| [active](active.html) | `open val active: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)<br>Is this rule specified as active in configuration? If an rule is not specified in the underlying configuration, we assume it should not be run. |
+| [autoCorrect](auto-correct.html) | `open val autoCorrect: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)<br>Does this rule have auto correct specified in configuration? For auto correction to work the rule set itself enable it. |
+| [ruleId](rule-id.html) | `abstract val ruleId: `[`RuleId`](../-rule-id.html)<br>Id which is used to retrieve the sub config for the rule implementing this interface. |
+| [ruleSetConfig](rule-set-config.html) | `abstract val ruleSetConfig: `[`Config`](../-config/index.html)<br>Wrapped configuration of the ruleSet this rule is in. Use #valueOrDefault function to retrieve properties specified for the rule implementing this interface instead. Only use this property directly if you need a specific rule set property. |
+
+### Functions
+
+| [subConfig](sub-config.html) | `open fun subConfig(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Config`](../-config/index.html)<br>Tries to retrieve part of the configuration based on given key. |
+| [valueOrDefault](value-or-default.html) | `open fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrDefault(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, default: `[`T`](value-or-default.html#T)`): `[`T`](value-or-default.html#T)<br>Retrieves a sub configuration or value based on given key. If configuration property cannot be found the specified default value is returned. |
+| [valueOrNull](value-or-null.html) | `open fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`T`](value-or-null.html#T)`?`<br>Retrieves a sub configuration or value based on given key. If the configuration property cannot be found, null is returned. |
+| [withAutoCorrect](with-auto-correct.html) | `open fun withAutoCorrect(block: () -> `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>If your rule supports to automatically correct the misbehaviour of underlying smell, specify your code inside this method call, to allow the user of your rule to trigger auto correction only when needed. |
+
+### Inheritors
+
+| [Rule](../-rule/index.html) | `abstract class Rule : `[`BaseRule`](../-base-rule/index.html)`, `[`ConfigAware`](./index.html)<br>A rule defines how one specific code structure should look like. If code is found which does not meet this structure, it is considered as harmful regarding maintainability or readability. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/rule-id.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/rule-id.md
@@ -1,0 +1,12 @@
+---
+title: ConfigAware.ruleId - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ConfigAware](index.html) / [ruleId](./rule-id.html)
+
+# ruleId
+
+`abstract val ruleId: `[`RuleId`](../-rule-id.html)
+
+Id which is used to retrieve the sub config for the rule implementing this interface.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/rule-set-config.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/rule-set-config.md
@@ -1,0 +1,15 @@
+---
+title: ConfigAware.ruleSetConfig - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ConfigAware](index.html) / [ruleSetConfig](./rule-set-config.html)
+
+# ruleSetConfig
+
+`abstract val ruleSetConfig: `[`Config`](../-config/index.html)
+
+Wrapped configuration of the ruleSet this rule is in.
+Use #valueOrDefault function to retrieve properties specified for the rule
+implementing this interface instead.
+Only use this property directly if you need a specific rule set property.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/sub-config.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/sub-config.md
@@ -1,0 +1,14 @@
+---
+title: ConfigAware.subConfig - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ConfigAware](index.html) / [subConfig](./sub-config.html)
+
+# subConfig
+
+`open fun subConfig(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Config`](../-config/index.html)
+
+Overrides [Config.subConfig](../-config/sub-config.html)
+
+Tries to retrieve part of the configuration based on given key.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/value-or-default.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/value-or-default.md
@@ -1,0 +1,15 @@
+---
+title: ConfigAware.valueOrDefault - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ConfigAware](index.html) / [valueOrDefault](./value-or-default.html)
+
+# valueOrDefault
+
+`open fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrDefault(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, default: `[`T`](value-or-default.html#T)`): `[`T`](value-or-default.html#T)
+
+Overrides [Config.valueOrDefault](../-config/value-or-default.html)
+
+Retrieves a sub configuration or value based on given key. If configuration property cannot be found
+the specified default value is returned.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/value-or-null.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/value-or-null.md
@@ -1,0 +1,15 @@
+---
+title: ConfigAware.valueOrNull - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ConfigAware](index.html) / [valueOrNull](./value-or-null.html)
+
+# valueOrNull
+
+`open fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`T`](value-or-null.html#T)`?`
+
+Overrides [Config.valueOrNull](../-config/value-or-null.html)
+
+Retrieves a sub configuration or value based on given key.
+If the configuration property cannot be found, null is returned.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/with-auto-correct.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config-aware/with-auto-correct.md
@@ -1,0 +1,14 @@
+---
+title: ConfigAware.withAutoCorrect - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ConfigAware](index.html) / [withAutoCorrect](./with-auto-correct.html)
+
+# withAutoCorrect
+
+`open fun withAutoCorrect(block: () -> `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+If your rule supports to automatically correct the misbehaviour of underlying smell,
+specify your code inside this method call, to allow the user of your rule to trigger auto correction
+only when needed.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/-e-x-c-l-u-d-e-s_-k-e-y.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/-e-x-c-l-u-d-e-s_-k-e-y.md
@@ -1,0 +1,9 @@
+---
+title: Config.EXCLUDES_KEY - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Config](index.html) / [EXCLUDES_KEY](./-e-x-c-l-u-d-e-s_-k-e-y.html)
+
+# EXCLUDES_KEY
+
+`const val EXCLUDES_KEY: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/-i-n-c-l-u-d-e-s_-k-e-y.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/-i-n-c-l-u-d-e-s_-k-e-y.md
@@ -1,0 +1,9 @@
+---
+title: Config.INCLUDES_KEY - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Config](index.html) / [INCLUDES_KEY](./-i-n-c-l-u-d-e-s_-k-e-y.html)
+
+# INCLUDES_KEY
+
+`const val INCLUDES_KEY: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/-invalid-configuration-error/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/-invalid-configuration-error/-init-.md
@@ -1,0 +1,13 @@
+---
+title: Config.InvalidConfigurationError.<init> - detekt-api
+---
+
+[detekt-api](../../../index.html) / [io.gitlab.arturbosch.detekt.api](../../index.html) / [Config](../index.html) / [InvalidConfigurationError](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`InvalidConfigurationError(msg: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)` = "Provided configuration file is invalid:" +
+                " Structure must be from type Map<String,Any>!")`
+
+Is thrown when loading a configuration results in errors.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/-invalid-configuration-error/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/-invalid-configuration-error/index.md
@@ -1,0 +1,17 @@
+---
+title: Config.InvalidConfigurationError - detekt-api
+---
+
+[detekt-api](../../../index.html) / [io.gitlab.arturbosch.detekt.api](../../index.html) / [Config](../index.html) / [InvalidConfigurationError](./index.html)
+
+# InvalidConfigurationError
+
+`class InvalidConfigurationError : `[`RuntimeException`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-runtime-exception/index.html)
+
+Is thrown when loading a configuration results in errors.
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `InvalidConfigurationError(msg: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)` = "Provided configuration file is invalid:" +
+                " Structure must be from type Map<String,Any>!")`<br>Is thrown when loading a configuration results in errors. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/empty.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/empty.md
@@ -1,0 +1,14 @@
+---
+title: Config.empty - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Config](index.html) / [empty](./empty.html)
+
+# empty
+
+`val empty: `[`Config`](index.html)
+
+An empty configuration with no properties.
+This config should only be used in test cases.
+Always returns the default value except when 'active' is queried, it returns true .
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/index.md
@@ -1,0 +1,40 @@
+---
+title: Config - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Config](./index.html)
+
+# Config
+
+`interface Config`
+
+A configuration holds information about how to configure specific rules.
+
+**Author**
+Artur Bosch
+
+**Author**
+schalkms
+
+### Exceptions
+
+| [InvalidConfigurationError](-invalid-configuration-error/index.html) | `class InvalidConfigurationError : `[`RuntimeException`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-runtime-exception/index.html)<br>Is thrown when loading a configuration results in errors. |
+
+### Functions
+
+| [subConfig](sub-config.html) | `abstract fun subConfig(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Config`](./index.html)<br>Tries to retrieve part of the configuration based on given key. |
+| [valueOrDefault](value-or-default.html) | `abstract fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrDefault(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, default: `[`T`](value-or-default.html#T)`): `[`T`](value-or-default.html#T)<br>Retrieves a sub configuration or value based on given key. If configuration property cannot be found the specified default value is returned. |
+| [valueOrNull](value-or-null.html) | `abstract fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`T`](value-or-null.html#T)`?`<br>Retrieves a sub configuration or value based on given key. If the configuration property cannot be found, null is returned. |
+
+### Companion Object Properties
+
+| [empty](empty.html) | `val empty: `[`Config`](./index.html)<br>An empty configuration with no properties. This config should only be used in test cases. Always returns the default value except when 'active' is queried, it returns true . |
+| [EXCLUDES_KEY](-e-x-c-l-u-d-e-s_-k-e-y.html) | `const val EXCLUDES_KEY: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [INCLUDES_KEY](-i-n-c-l-u-d-e-s_-k-e-y.html) | `const val INCLUDES_KEY: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+
+### Inheritors
+
+| [BaseConfig](../-base-config/index.html) | `abstract class BaseConfig : `[`Config`](./index.html)<br>Convenient base configuration which parses/casts the configuration value based on the type of the default value. |
+| [CompositeConfig](../-composite-config/index.html) | `class CompositeConfig : `[`Config`](./index.html)<br>Wraps two different configuration which should be considered when retrieving properties. |
+| [ConfigAware](../-config-aware/index.html) | `interface ConfigAware : `[`Config`](./index.html)<br>Interface which is implemented by each Rule class to provide utility functions to retrieve specific or generic properties from the underlying detekt configuration file. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/sub-config.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/sub-config.md
@@ -1,0 +1,12 @@
+---
+title: Config.subConfig - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Config](index.html) / [subConfig](./sub-config.html)
+
+# subConfig
+
+`abstract fun subConfig(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Config`](index.html)
+
+Tries to retrieve part of the configuration based on given key.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/value-or-default.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/value-or-default.md
@@ -1,0 +1,13 @@
+---
+title: Config.valueOrDefault - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Config](index.html) / [valueOrDefault](./value-or-default.html)
+
+# valueOrDefault
+
+`abstract fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrDefault(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, default: `[`T`](value-or-default.html#T)`): `[`T`](value-or-default.html#T)
+
+Retrieves a sub configuration or value based on given key. If configuration property cannot be found
+the specified default value is returned.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/value-or-null.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/value-or-null.md
@@ -1,0 +1,13 @@
+---
+title: Config.valueOrNull - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Config](index.html) / [valueOrNull](./value-or-null.html)
+
+# valueOrNull
+
+`abstract fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`T`](value-or-null.html#T)`?`
+
+Retrieves a sub configuration or value based on given key.
+If the configuration property cannot be found, null is returned.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/-init-.md
@@ -1,0 +1,19 @@
+---
+title: ConsoleReport.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ConsoleReport](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`ConsoleReport()`
+
+Extension point which describes how findings should be printed on the console.
+
+Additional [ConsoleReport](index.html)'s can be made available through the [java.util.ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) pattern.
+If the default reporting mechanism should be turned off, exclude the entry 'FindingsReport'
+in the 'console-reports' property of a detekt yaml config.
+
+**Author**
+Artur Bosch
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/index.md
@@ -1,0 +1,37 @@
+---
+title: ConsoleReport - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ConsoleReport](./index.html)
+
+# ConsoleReport
+
+`abstract class ConsoleReport : `[`Extension`](../-extension/index.html)
+
+Extension point which describes how findings should be printed on the console.
+
+Additional [ConsoleReport](./index.html)'s can be made available through the [java.util.ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) pattern.
+If the default reporting mechanism should be turned off, exclude the entry 'FindingsReport'
+in the 'console-reports' property of a detekt yaml config.
+
+**Author**
+Artur Bosch
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `ConsoleReport()`<br>Extension point which describes how findings should be printed on the console. |
+
+### Inherited Properties
+
+| [id](../-extension/id.html) | `open val id: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)<br>Name of the extension. |
+| [priority](../-extension/priority.html) | `open val priority: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)<br>Is used to run extensions in a specific order. The higher the priority the sooner the extension will run in detekt's lifecycle. |
+
+### Functions
+
+| [print](print.html) | `fun print(printer: `[`PrintStream`](https://docs.oracle.com/javase/8/docs/api/java/io/PrintStream.html)`, detektion: `[`Detektion`](../-detektion/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [render](render.html) | `abstract fun render(detektion: `[`Detektion`](../-detektion/index.html)`): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`?` |
+
+### Inherited Functions
+
+| [init](../-extension/init.html) | `open fun init(config: `[`Config`](../-config/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Allows to read any or even user defined properties from the detekt yaml config to setup this extension. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/print.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/print.md
@@ -1,0 +1,9 @@
+---
+title: ConsoleReport.print - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ConsoleReport](index.html) / [print](./print.html)
+
+# print
+
+`fun print(printer: `[`PrintStream`](https://docs.oracle.com/javase/8/docs/api/java/io/PrintStream.html)`, detektion: `[`Detektion`](../-detektion/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/render.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/render.md
@@ -1,0 +1,9 @@
+---
+title: ConsoleReport.render - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ConsoleReport](index.html) / [render](./render.html)
+
+# render
+
+`abstract fun render(detektion: `[`Detektion`](../-detektion/index.html)`): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`?`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-context/clear-findings.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-context/clear-findings.md
@@ -1,0 +1,9 @@
+---
+title: Context.clearFindings - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Context](index.html) / [clearFindings](./clear-findings.html)
+
+# clearFindings
+
+`abstract fun clearFindings(): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-context/findings.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-context/findings.md
@@ -1,0 +1,9 @@
+---
+title: Context.findings - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Context](index.html) / [findings](./findings.html)
+
+# findings
+
+`abstract val findings: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-context/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-context/index.md
@@ -1,0 +1,36 @@
+---
+title: Context - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Context](./index.html)
+
+# Context
+
+`interface Context`
+
+A context describes the storing and reporting mechanism of [Finding](../-finding/index.html)'s inside a [Rule](../-rule/index.html).
+Additionally it handles suppression and aliases management.
+
+The detekt engine retrieves the findings after each KtFile visit and resets the context
+before the next KtFile.
+
+**Author**
+Artur Bosch
+
+**Author**
+Marvin Ramin
+
+### Properties
+
+| [findings](findings.html) | `abstract val findings: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>` |
+
+### Functions
+
+| [clearFindings](clear-findings.html) | `abstract fun clearFindings(): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [report](report.html) | `abstract fun report(finding: `[`Finding`](../-finding/index.html)`, aliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`> = emptySet()): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>`abstract fun report(findings: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>, aliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`> = emptySet()): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+
+### Inheritors
+
+| [BaseRule](../-base-rule/index.html) | `abstract class BaseRule : `[`DetektVisitor`](../-detekt-visitor/index.html)`, `[`Context`](./index.html)<br>Defines the visiting mechanism for KtFile's. |
+| [DefaultContext](../-default-context/index.html) | `open class DefaultContext : `[`Context`](./index.html)<br>Default [Context](./index.html) implementation. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-context/report.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-context/report.md
@@ -1,0 +1,10 @@
+---
+title: Context.report - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Context](index.html) / [report](./report.html)
+
+# report
+
+`abstract fun report(finding: `[`Finding`](../-finding/index.html)`, aliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`> = emptySet()): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+`abstract fun report(findings: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>, aliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`> = emptySet()): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-d-e-f-a-u-l-t_-f-l-o-a-t_-c-o-n-v-e-r-s-i-o-n_-f-a-c-t-o-r.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-d-e-f-a-u-l-t_-f-l-o-a-t_-c-o-n-v-e-r-s-i-o-n_-f-a-c-t-o-r.md
@@ -1,0 +1,12 @@
+---
+title: DEFAULT_FLOAT_CONVERSION_FACTOR - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api](index.html) / [DEFAULT_FLOAT_CONVERSION_FACTOR](./-d-e-f-a-u-l-t_-f-l-o-a-t_-c-o-n-v-e-r-s-i-o-n_-f-a-c-t-o-r.html)
+
+# DEFAULT_FLOAT_CONVERSION_FACTOR
+
+`const val DEFAULT_FLOAT_CONVERSION_FACTOR: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)
+
+To represent a value of 0.5, use the metric value 50 and the conversion factor of 100. (50 / 100 = 0.5)
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/-f-i-v-e_-m-i-n-s.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/-f-i-v-e_-m-i-n-s.md
@@ -1,0 +1,9 @@
+---
+title: Debt.FIVE_MINS - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Debt](index.html) / [FIVE_MINS](./-f-i-v-e_-m-i-n-s.html)
+
+# FIVE_MINS
+
+`val FIVE_MINS: `[`Debt`](index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/-init-.md
@@ -1,0 +1,12 @@
+---
+title: Debt.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Debt](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`Debt(days: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = 0, hours: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = 0, mins: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = 0)`
+
+Debt describes the estimated amount of work needed to fix a given issue.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/-t-e-n_-m-i-n-s.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/-t-e-n_-m-i-n-s.md
@@ -1,0 +1,9 @@
+---
+title: Debt.TEN_MINS - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Debt](index.html) / [TEN_MINS](./-t-e-n_-m-i-n-s.html)
+
+# TEN_MINS
+
+`val TEN_MINS: `[`Debt`](index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/-t-w-e-n-t-y_-m-i-n-s.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/-t-w-e-n-t-y_-m-i-n-s.md
@@ -1,0 +1,9 @@
+---
+title: Debt.TWENTY_MINS - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Debt](index.html) / [TWENTY_MINS](./-t-w-e-n-t-y_-m-i-n-s.html)
+
+# TWENTY_MINS
+
+`val TWENTY_MINS: `[`Debt`](index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/days.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/days.md
@@ -1,0 +1,9 @@
+---
+title: Debt.days - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Debt](index.html) / [days](./days.html)
+
+# days
+
+`val days: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/hours.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/hours.md
@@ -1,0 +1,9 @@
+---
+title: Debt.hours - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Debt](index.html) / [hours](./hours.html)
+
+# hours
+
+`val hours: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/index.md
@@ -1,0 +1,32 @@
+---
+title: Debt - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Debt](./index.html)
+
+# Debt
+
+`data class Debt`
+
+Debt describes the estimated amount of work needed to fix a given issue.
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `Debt(days: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = 0, hours: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = 0, mins: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = 0)`<br>Debt describes the estimated amount of work needed to fix a given issue. |
+
+### Properties
+
+| [days](days.html) | `val days: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+| [hours](hours.html) | `val hours: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+| [mins](mins.html) | `val mins: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+
+### Functions
+
+| [toString](to-string.html) | `fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+
+### Companion Object Properties
+
+| [FIVE_MINS](-f-i-v-e_-m-i-n-s.html) | `val FIVE_MINS: `[`Debt`](./index.html) |
+| [TEN_MINS](-t-e-n_-m-i-n-s.html) | `val TEN_MINS: `[`Debt`](./index.html) |
+| [TWENTY_MINS](-t-w-e-n-t-y_-m-i-n-s.html) | `val TWENTY_MINS: `[`Debt`](./index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/mins.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/mins.md
@@ -1,0 +1,9 @@
+---
+title: Debt.mins - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Debt](index.html) / [mins](./mins.html)
+
+# mins
+
+`val mins: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/to-string.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-debt/to-string.md
@@ -1,0 +1,9 @@
+---
+title: Debt.toString - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Debt](index.html) / [toString](./to-string.html)
+
+# toString
+
+`fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-default-context/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-default-context/-init-.md
@@ -1,0 +1,12 @@
+---
+title: DefaultContext.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [DefaultContext](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`DefaultContext()`
+
+Default [Context](../-context/index.html) implementation.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-default-context/clear-findings.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-default-context/clear-findings.md
@@ -1,0 +1,12 @@
+---
+title: DefaultContext.clearFindings - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [DefaultContext](index.html) / [clearFindings](./clear-findings.html)
+
+# clearFindings
+
+`fun clearFindings(): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Overrides [Context.clearFindings](../-context/clear-findings.html)
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-default-context/findings.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-default-context/findings.md
@@ -1,0 +1,14 @@
+---
+title: DefaultContext.findings - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [DefaultContext](index.html) / [findings](./findings.html)
+
+# findings
+
+`open val findings: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>`
+
+Overrides [Context.findings](../-context/findings.html)
+
+Returns a copy of violations for this rule.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-default-context/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-default-context/index.md
@@ -1,0 +1,25 @@
+---
+title: DefaultContext - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [DefaultContext](./index.html)
+
+# DefaultContext
+
+`open class DefaultContext : `[`Context`](../-context/index.html)
+
+Default [Context](../-context/index.html) implementation.
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `DefaultContext()`<br>Default [Context](../-context/index.html) implementation. |
+
+### Properties
+
+| [findings](findings.html) | `open val findings: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>`<br>Returns a copy of violations for this rule. |
+
+### Functions
+
+| [clearFindings](clear-findings.html) | `fun clearFindings(): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [report](report.html) | `open fun report(finding: `[`Finding`](../-finding/index.html)`, aliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Reports a single code smell finding.`open fun report(findings: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>, aliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Reports a list of code smell findings. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-default-context/report.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-default-context/report.md
@@ -1,0 +1,26 @@
+---
+title: DefaultContext.report - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [DefaultContext](index.html) / [report](./report.html)
+
+# report
+
+`open fun report(finding: `[`Finding`](../-finding/index.html)`, aliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Overrides [Context.report](../-context/report.html)
+
+Reports a single code smell finding.
+
+Before adding a finding, it is checked if it is not suppressed
+by @Suppress or @SuppressWarnings annotations.
+
+`open fun report(findings: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>, aliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Overrides [Context.report](../-context/report.html)
+
+Reports a list of code smell findings.
+
+Before adding a finding, it is checked if it is not suppressed
+by @Suppress or @SuppressWarnings annotations.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detekt-visitor/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detekt-visitor/-init-.md
@@ -1,0 +1,16 @@
+---
+title: DetektVisitor.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [DetektVisitor](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`DetektVisitor()`
+
+Basic visitor which is used inside detekt.
+Guarantees a better looking name as the extended base class :).
+
+**Author**
+Artur Bosch
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detekt-visitor/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detekt-visitor/index.md
@@ -1,0 +1,25 @@
+---
+title: DetektVisitor - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [DetektVisitor](./index.html)
+
+# DetektVisitor
+
+`open class DetektVisitor : KtTreeVisitorVoid`
+
+Basic visitor which is used inside detekt.
+Guarantees a better looking name as the extended base class :).
+
+**Author**
+Artur Bosch
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `DetektVisitor()`<br>Basic visitor which is used inside detekt. Guarantees a better looking name as the extended base class :). |
+
+### Inheritors
+
+| [BaseRule](../-base-rule/index.html) | `abstract class BaseRule : `[`DetektVisitor`](./index.html)`, `[`Context`](../-context/index.html)<br>Defines the visiting mechanism for KtFile's. |
+| [McCabeVisitor](../../io.gitlab.arturbosch.detekt.api.internal/-mc-cabe-visitor/index.html) | `class McCabeVisitor : `[`DetektVisitor`](./index.html)<br>Counts the cyclomatic complexity of functions. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detektion/add-data.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detektion/add-data.md
@@ -1,0 +1,9 @@
+---
+title: Detektion.addData - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Detektion](index.html) / [addData](./add-data.html)
+
+# addData
+
+`abstract fun <V> addData(key: Key<`[`V`](add-data.html#V)`>, value: `[`V`](add-data.html#V)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detektion/add.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detektion/add.md
@@ -1,0 +1,10 @@
+---
+title: Detektion.add - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Detektion](index.html) / [add](./add.html)
+
+# add
+
+`abstract fun add(notification: `[`Notification`](../-notification/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+`abstract fun add(projectMetric: `[`ProjectMetric`](../-project-metric/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detektion/findings.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detektion/findings.md
@@ -1,0 +1,9 @@
+---
+title: Detektion.findings - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Detektion](index.html) / [findings](./findings.html)
+
+# findings
+
+`abstract val findings: `[`Map`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/index.html)`<`[`RuleSetId`](../-rule-set-id.html)`, `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detektion/get-data.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detektion/get-data.md
@@ -1,0 +1,9 @@
+---
+title: Detektion.getData - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Detektion](index.html) / [getData](./get-data.html)
+
+# getData
+
+`abstract fun <V> getData(key: Key<`[`V`](get-data.html#V)`>): `[`V`](get-data.html#V)`?`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detektion/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detektion/index.md
@@ -1,0 +1,28 @@
+---
+title: Detektion - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Detektion](./index.html)
+
+# Detektion
+
+`interface Detektion`
+
+Storage for all kinds of findings and additional information
+which needs to be transferred from the detekt engine to the user.
+
+**Author**
+Artur Bosch
+
+### Properties
+
+| [findings](findings.html) | `abstract val findings: `[`Map`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/index.html)`<`[`RuleSetId`](../-rule-set-id.html)`, `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>>` |
+| [metrics](metrics.html) | `abstract val metrics: `[`Collection`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-collection/index.html)`<`[`ProjectMetric`](../-project-metric/index.html)`>` |
+| [notifications](notifications.html) | `abstract val notifications: `[`Collection`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-collection/index.html)`<`[`Notification`](../-notification/index.html)`>` |
+
+### Functions
+
+| [add](add.html) | `abstract fun add(notification: `[`Notification`](../-notification/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>`abstract fun add(projectMetric: `[`ProjectMetric`](../-project-metric/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [addData](add-data.html) | `abstract fun <V> addData(key: Key<`[`V`](add-data.html#V)`>, value: `[`V`](add-data.html#V)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [getData](get-data.html) | `abstract fun <V> getData(key: Key<`[`V`](get-data.html#V)`>): `[`V`](get-data.html#V)`?` |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detektion/metrics.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detektion/metrics.md
@@ -1,0 +1,9 @@
+---
+title: Detektion.metrics - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Detektion](index.html) / [metrics](./metrics.html)
+
+# metrics
+
+`abstract val metrics: `[`Collection`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-collection/index.html)`<`[`ProjectMetric`](../-project-metric/index.html)`>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detektion/notifications.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-detektion/notifications.md
@@ -1,0 +1,9 @@
+---
+title: Detektion.notifications - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Detektion](index.html) / [notifications](./notifications.html)
+
+# notifications
+
+`abstract val notifications: `[`Collection`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-collection/index.html)`<`[`Notification`](../-notification/index.html)`>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/-init-.md
@@ -1,0 +1,15 @@
+---
+title: Entity.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Entity](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`Entity(name: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, className: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, signature: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, location: `[`Location`](../-location/index.html)`, ktElement: KtElement? = null)`
+
+Stores information about a specific code fragment.
+
+**Author**
+Artur Bosch
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/class-name.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/class-name.md
@@ -1,0 +1,9 @@
+---
+title: Entity.className - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Entity](index.html) / [className](./class-name.html)
+
+# className
+
+`val className: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/compact.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/compact.md
@@ -1,0 +1,12 @@
+---
+title: Entity.compact - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Entity](index.html) / [compact](./compact.html)
+
+# compact
+
+`fun compact(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+
+Overrides [Compactable.compact](../-compactable/compact.html)
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/from.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/from.md
@@ -1,0 +1,12 @@
+---
+title: Entity.from - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Entity](index.html) / [from](./from.html)
+
+# from
+
+`fun from(element: PsiElement, offset: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = 0): `[`Entity`](index.html)
+
+Factory function which retrieves all needed information from the PsiElement itself.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/index.md
@@ -1,0 +1,39 @@
+---
+title: Entity - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Entity](./index.html)
+
+# Entity
+
+`data class Entity : `[`Compactable`](../-compactable/index.html)
+
+Stores information about a specific code fragment.
+
+**Author**
+Artur Bosch
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `Entity(name: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, className: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, signature: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, location: `[`Location`](../-location/index.html)`, ktElement: KtElement? = null)`<br>Stores information about a specific code fragment. |
+
+### Properties
+
+| [className](class-name.html) | `val className: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [ktElement](kt-element.html) | `val ktElement: KtElement?` |
+| [location](location.html) | `val location: `[`Location`](../-location/index.html) |
+| [name](name.html) | `val name: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [signature](signature.html) | `val signature: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+
+### Functions
+
+| [compact](compact.html) | `fun compact(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+
+### Inherited Functions
+
+| [compactWithSignature](../-compactable/compact-with-signature.html) | `open fun compactWithSignature(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+
+### Companion Object Functions
+
+| [from](from.html) | `fun from(element: PsiElement, offset: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = 0): `[`Entity`](./index.html)<br>Factory function which retrieves all needed information from the PsiElement itself. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/kt-element.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/kt-element.md
@@ -1,0 +1,9 @@
+---
+title: Entity.ktElement - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Entity](index.html) / [ktElement](./kt-element.html)
+
+# ktElement
+
+`val ktElement: KtElement?`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/location.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/location.md
@@ -1,0 +1,9 @@
+---
+title: Entity.location - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Entity](index.html) / [location](./location.html)
+
+# location
+
+`val location: `[`Location`](../-location/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/name.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/name.md
@@ -1,0 +1,9 @@
+---
+title: Entity.name - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Entity](index.html) / [name](./name.html)
+
+# name
+
+`val name: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/signature.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-entity/signature.md
@@ -1,0 +1,9 @@
+---
+title: Entity.signature - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Entity](index.html) / [signature](./signature.html)
+
+# signature
+
+`val signature: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-extension/id.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-extension/id.md
@@ -1,0 +1,12 @@
+---
+title: Extension.id - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Extension](index.html) / [id](./id.html)
+
+# id
+
+`open val id: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+
+Name of the extension.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-extension/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-extension/index.md
@@ -1,0 +1,35 @@
+---
+title: Extension - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Extension](./index.html)
+
+# Extension
+
+`interface Extension`
+
+Defines extension points in detekt.
+Currently supported extensions are:
+
+* [FileProcessListener](../-file-process-listener/index.html)
+* [ConsoleReport](../-console-report/index.html)
+* [OutputReport](../-output-report/index.html)
+
+**Author**
+Artur Bosch
+
+### Properties
+
+| [id](id.html) | `open val id: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)<br>Name of the extension. |
+| [priority](priority.html) | `open val priority: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)<br>Is used to run extensions in a specific order. The higher the priority the sooner the extension will run in detekt's lifecycle. |
+
+### Functions
+
+| [init](init.html) | `open fun init(config: `[`Config`](../-config/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Allows to read any or even user defined properties from the detekt yaml config to setup this extension. |
+
+### Inheritors
+
+| [ConsoleReport](../-console-report/index.html) | `abstract class ConsoleReport : `[`Extension`](./index.html)<br>Extension point which describes how findings should be printed on the console. |
+| [FileProcessListener](../-file-process-listener/index.html) | `interface FileProcessListener : `[`Extension`](./index.html)<br>Gather additional metrics about the analyzed kotlin file. Pay attention to the thread policy of each function! |
+| [OutputReport](../-output-report/index.html) | `abstract class OutputReport : `[`Extension`](./index.html)<br>Translates detekt's result container - [Detektion](../-detektion/index.html) - into an output report which is written inside a file. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-extension/init.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-extension/init.md
@@ -1,0 +1,13 @@
+---
+title: Extension.init - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Extension](index.html) / [init](./init.html)
+
+# init
+
+`open fun init(config: `[`Config`](../-config/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Allows to read any or even user defined properties from the detekt yaml config
+to setup this extension.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-extension/priority.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-extension/priority.md
@@ -1,0 +1,13 @@
+---
+title: Extension.priority - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Extension](index.html) / [priority](./priority.html)
+
+# priority
+
+`open val priority: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)
+
+Is used to run extensions in a specific order.
+The higher the priority the sooner the extension will run in detekt's lifecycle.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-file-process-listener/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-file-process-listener/index.md
@@ -1,0 +1,32 @@
+---
+title: FileProcessListener - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [FileProcessListener](./index.html)
+
+# FileProcessListener
+
+`interface FileProcessListener : `[`Extension`](../-extension/index.html)
+
+Gather additional metrics about the analyzed kotlin file.
+Pay attention to the thread policy of each function!
+
+**Author**
+Artur Bosch
+
+### Inherited Properties
+
+| [id](../-extension/id.html) | `open val id: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)<br>Name of the extension. |
+| [priority](../-extension/priority.html) | `open val priority: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)<br>Is used to run extensions in a specific order. The higher the priority the sooner the extension will run in detekt's lifecycle. |
+
+### Functions
+
+| [onFinish](on-finish.html) | `open fun onFinish(files: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<KtFile>, result: `[`Detektion`](../-detektion/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Mainly use this method to save computed metrics from KtFile's to the {@link Detektion} container. Do not do heavy computations here as this method is called from the main thread. |
+| [onProcess](on-process.html) | `open fun onProcess(file: KtFile): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Called when processing of a file begins. This method is called from a thread pool thread. Heavy computations allowed. |
+| [onProcessComplete](on-process-complete.html) | `open fun onProcessComplete(file: KtFile, findings: `[`Map`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>>): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Called when processing of a file completes. This method is called from a thread pool thread. Heavy computations allowed. |
+| [onStart](on-start.html) | `open fun onStart(files: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<KtFile>): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Use this to gather some additional information for the real onProcess function. This calculation should be lightweight as this method is called from the main thread. |
+
+### Inherited Functions
+
+| [init](../-extension/init.html) | `open fun init(config: `[`Config`](../-config/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Allows to read any or even user defined properties from the detekt yaml config to setup this extension. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-file-process-listener/on-finish.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-file-process-listener/on-finish.md
@@ -1,0 +1,13 @@
+---
+title: FileProcessListener.onFinish - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [FileProcessListener](index.html) / [onFinish](./on-finish.html)
+
+# onFinish
+
+`open fun onFinish(files: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<KtFile>, result: `[`Detektion`](../-detektion/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Mainly use this method to save computed metrics from KtFile's to the {@link Detektion} container.
+Do not do heavy computations here as this method is called from the main thread.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-file-process-listener/on-process-complete.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-file-process-listener/on-process-complete.md
@@ -1,0 +1,13 @@
+---
+title: FileProcessListener.onProcessComplete - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [FileProcessListener](index.html) / [onProcessComplete](./on-process-complete.html)
+
+# onProcessComplete
+
+`open fun onProcessComplete(file: KtFile, findings: `[`Map`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>>): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Called when processing of a file completes.
+This method is called from a thread pool thread. Heavy computations allowed.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-file-process-listener/on-process.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-file-process-listener/on-process.md
@@ -1,0 +1,13 @@
+---
+title: FileProcessListener.onProcess - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [FileProcessListener](index.html) / [onProcess](./on-process.html)
+
+# onProcess
+
+`open fun onProcess(file: KtFile): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Called when processing of a file begins.
+This method is called from a thread pool thread. Heavy computations allowed.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-file-process-listener/on-start.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-file-process-listener/on-start.md
@@ -1,0 +1,13 @@
+---
+title: FileProcessListener.onStart - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [FileProcessListener](index.html) / [onStart](./on-start.html)
+
+# onStart
+
+`open fun onStart(files: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<KtFile>): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Use this to gather some additional information for the real onProcess function.
+This calculation should be lightweight as this method is called from the main thread.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-finding/id.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-finding/id.md
@@ -1,0 +1,9 @@
+---
+title: Finding.id - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Finding](index.html) / [id](./id.html)
+
+# id
+
+`abstract val id: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-finding/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-finding/index.md
@@ -1,0 +1,53 @@
+---
+title: Finding - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Finding](./index.html)
+
+# Finding
+
+`interface Finding : `[`Compactable`](../-compactable/index.html)`, `[`HasEntity`](../-has-entity/index.html)`, `[`HasMetrics`](../-has-metrics/index.html)
+
+Base interface of detection findings. Inherits a bunch of useful behaviour
+from sub interfaces.
+
+Basic behaviour of a finding is that is can be assigned to an id and a source code position described as
+an entity. Metrics and entity references can also considered for deeper characterization.
+
+**Author**
+Artur Bosch
+
+### Properties
+
+| [id](id.html) | `abstract val id: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [issue](issue.html) | `abstract val issue: `[`Issue`](../-issue/index.html) |
+| [message](message.html) | `abstract val message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [references](references.html) | `abstract val references: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Entity`](../-entity/index.html)`>` |
+
+### Inherited Properties
+
+| [charPosition](../-has-entity/char-position.html) | `open val charPosition: `[`TextLocation`](../-text-location/index.html) |
+| [entity](../-has-entity/entity.html) | `abstract val entity: `[`Entity`](../-entity/index.html) |
+| [file](../-has-entity/file.html) | `open val file: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [inClass](../-has-entity/in-class.html) | `open val inClass: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [location](../-has-entity/location.html) | `open val location: `[`Location`](../-location/index.html) |
+| [locationAsString](../-has-entity/location-as-string.html) | `open val locationAsString: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [metrics](../-has-metrics/metrics.html) | `abstract val metrics: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Metric`](../-metric/index.html)`>` |
+| [name](../-has-entity/name.html) | `open val name: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [signature](../-has-entity/signature.html) | `open val signature: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [startPosition](../-has-entity/start-position.html) | `open val startPosition: `[`SourceLocation`](../-source-location/index.html) |
+
+### Functions
+
+| [messageOrDescription](message-or-description.html) | `abstract fun messageOrDescription(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+
+### Inherited Functions
+
+| [compact](../-compactable/compact.html) | `abstract fun compact(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [compactWithSignature](../-compactable/compact-with-signature.html) | `open fun compactWithSignature(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [metricByType](../-has-metrics/metric-by-type.html) | `open fun metricByType(type: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Metric`](../-metric/index.html)`?` |
+
+### Inheritors
+
+| [CodeSmell](../-code-smell/index.html) | `open class CodeSmell : `[`Finding`](./index.html)<br>A code smell indicates any possible design problem inside a program's source code. The type of a code smell is described by an [Issue](../-issue/index.html). |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-finding/issue.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-finding/issue.md
@@ -1,0 +1,9 @@
+---
+title: Finding.issue - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Finding](index.html) / [issue](./issue.html)
+
+# issue
+
+`abstract val issue: `[`Issue`](../-issue/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-finding/message-or-description.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-finding/message-or-description.md
@@ -1,0 +1,9 @@
+---
+title: Finding.messageOrDescription - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Finding](index.html) / [messageOrDescription](./message-or-description.html)
+
+# messageOrDescription
+
+`abstract fun messageOrDescription(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-finding/message.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-finding/message.md
@@ -1,0 +1,9 @@
+---
+title: Finding.message - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Finding](index.html) / [message](./message.html)
+
+# message
+
+`abstract val message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-finding/references.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-finding/references.md
@@ -1,0 +1,9 @@
+---
+title: Finding.references - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Finding](index.html) / [references](./references.html)
+
+# references
+
+`abstract val references: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Entity`](../-entity/index.html)`>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/char-position.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/char-position.md
@@ -1,0 +1,9 @@
+---
+title: HasEntity.charPosition - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [HasEntity](index.html) / [charPosition](./char-position.html)
+
+# charPosition
+
+`open val charPosition: `[`TextLocation`](../-text-location/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/entity.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/entity.md
@@ -1,0 +1,9 @@
+---
+title: HasEntity.entity - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [HasEntity](index.html) / [entity](./entity.html)
+
+# entity
+
+`abstract val entity: `[`Entity`](../-entity/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/file.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/file.md
@@ -1,0 +1,9 @@
+---
+title: HasEntity.file - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [HasEntity](index.html) / [file](./file.html)
+
+# file
+
+`open val file: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/in-class.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/in-class.md
@@ -1,0 +1,9 @@
+---
+title: HasEntity.inClass - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [HasEntity](index.html) / [inClass](./in-class.html)
+
+# inClass
+
+`open val inClass: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/index.md
@@ -1,0 +1,28 @@
+---
+title: HasEntity - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [HasEntity](./index.html)
+
+# HasEntity
+
+`interface HasEntity`
+
+Describes a source code position.
+
+### Properties
+
+| [charPosition](char-position.html) | `open val charPosition: `[`TextLocation`](../-text-location/index.html) |
+| [entity](entity.html) | `abstract val entity: `[`Entity`](../-entity/index.html) |
+| [file](file.html) | `open val file: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [inClass](in-class.html) | `open val inClass: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [location](location.html) | `open val location: `[`Location`](../-location/index.html) |
+| [locationAsString](location-as-string.html) | `open val locationAsString: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [name](name.html) | `open val name: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [signature](signature.html) | `open val signature: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [startPosition](start-position.html) | `open val startPosition: `[`SourceLocation`](../-source-location/index.html) |
+
+### Inheritors
+
+| [Finding](../-finding/index.html) | `interface Finding : `[`Compactable`](../-compactable/index.html)`, `[`HasEntity`](./index.html)`, `[`HasMetrics`](../-has-metrics/index.html)<br>Base interface of detection findings. Inherits a bunch of useful behaviour from sub interfaces. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/location-as-string.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/location-as-string.md
@@ -1,0 +1,9 @@
+---
+title: HasEntity.locationAsString - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [HasEntity](index.html) / [locationAsString](./location-as-string.html)
+
+# locationAsString
+
+`open val locationAsString: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/location.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/location.md
@@ -1,0 +1,9 @@
+---
+title: HasEntity.location - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [HasEntity](index.html) / [location](./location.html)
+
+# location
+
+`open val location: `[`Location`](../-location/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/name.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/name.md
@@ -1,0 +1,9 @@
+---
+title: HasEntity.name - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [HasEntity](index.html) / [name](./name.html)
+
+# name
+
+`open val name: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/signature.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/signature.md
@@ -1,0 +1,9 @@
+---
+title: HasEntity.signature - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [HasEntity](index.html) / [signature](./signature.html)
+
+# signature
+
+`open val signature: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/start-position.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/start-position.md
@@ -1,0 +1,9 @@
+---
+title: HasEntity.startPosition - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [HasEntity](index.html) / [startPosition](./start-position.html)
+
+# startPosition
+
+`open val startPosition: `[`SourceLocation`](../-source-location/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-metrics/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-metrics/index.md
@@ -1,0 +1,24 @@
+---
+title: HasMetrics - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [HasMetrics](./index.html)
+
+# HasMetrics
+
+`interface HasMetrics`
+
+Adds metric container behaviour.
+
+### Properties
+
+| [metrics](metrics.html) | `abstract val metrics: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Metric`](../-metric/index.html)`>` |
+
+### Functions
+
+| [metricByType](metric-by-type.html) | `open fun metricByType(type: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Metric`](../-metric/index.html)`?` |
+
+### Inheritors
+
+| [Finding](../-finding/index.html) | `interface Finding : `[`Compactable`](../-compactable/index.html)`, `[`HasEntity`](../-has-entity/index.html)`, `[`HasMetrics`](./index.html)<br>Base interface of detection findings. Inherits a bunch of useful behaviour from sub interfaces. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-metrics/metric-by-type.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-metrics/metric-by-type.md
@@ -1,0 +1,9 @@
+---
+title: HasMetrics.metricByType - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [HasMetrics](index.html) / [metricByType](./metric-by-type.html)
+
+# metricByType
+
+`open fun metricByType(type: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Metric`](../-metric/index.html)`?`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-metrics/metrics.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-metrics/metrics.md
@@ -1,0 +1,9 @@
+---
+title: HasMetrics.metrics - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [HasMetrics](index.html) / [metrics](./metrics.html)
+
+# metrics
+
+`abstract val metrics: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Metric`](../-metric/index.html)`>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-issue/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-issue/-init-.md
@@ -1,0 +1,21 @@
+---
+title: Issue.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Issue](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`Issue(id: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, severity: `[`Severity`](../-severity/index.html)`, description: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, debt: `[`Debt`](../-debt/index.html)`)`
+
+An issue represents a problem in the codebase.
+
+**Author**
+Artur Bosch
+
+**Author**
+Marvin Ramin
+
+**Author**
+schalkms
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-issue/debt.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-issue/debt.md
@@ -1,0 +1,9 @@
+---
+title: Issue.debt - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Issue](index.html) / [debt](./debt.html)
+
+# debt
+
+`val debt: `[`Debt`](../-debt/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-issue/description.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-issue/description.md
@@ -1,0 +1,9 @@
+---
+title: Issue.description - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Issue](index.html) / [description](./description.html)
+
+# description
+
+`val description: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-issue/id.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-issue/id.md
@@ -1,0 +1,9 @@
+---
+title: Issue.id - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Issue](index.html) / [id](./id.html)
+
+# id
+
+`val id: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-issue/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-issue/index.md
@@ -1,0 +1,36 @@
+---
+title: Issue - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Issue](./index.html)
+
+# Issue
+
+`data class Issue`
+
+An issue represents a problem in the codebase.
+
+**Author**
+Artur Bosch
+
+**Author**
+Marvin Ramin
+
+**Author**
+schalkms
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `Issue(id: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, severity: `[`Severity`](../-severity/index.html)`, description: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, debt: `[`Debt`](../-debt/index.html)`)`<br>An issue represents a problem in the codebase. |
+
+### Properties
+
+| [debt](debt.html) | `val debt: `[`Debt`](../-debt/index.html) |
+| [description](description.html) | `val description: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [id](id.html) | `val id: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [severity](severity.html) | `val severity: `[`Severity`](../-severity/index.html) |
+
+### Functions
+
+| [toString](to-string.html) | `fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-issue/severity.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-issue/severity.md
@@ -1,0 +1,9 @@
+---
+title: Issue.severity - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Issue](index.html) / [severity](./severity.html)
+
+# severity
+
+`val severity: `[`Severity`](../-severity/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-issue/to-string.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-issue/to-string.md
@@ -1,0 +1,9 @@
+---
+title: Issue.toString - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Issue](index.html) / [toString](./to-string.html)
+
+# toString
+
+`fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-lazy-regex/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-lazy-regex/-init-.md
@@ -1,0 +1,19 @@
+---
+title: LazyRegex.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [LazyRegex](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`LazyRegex(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, default: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`)`
+
+LazyRegex class provides a lazy evaluation of a Regex pattern for usages inside Rules.
+It computes the value once when reaching the point of its usage and returns the same
+value when requested again.
+
+`key` &amp; `default` are used to retrieve a value from config.
+
+**Author**
+Pavlos-Petros Tournaris
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-lazy-regex/get-value.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-lazy-regex/get-value.md
@@ -1,0 +1,9 @@
+---
+title: LazyRegex.getValue - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [LazyRegex](index.html) / [getValue](./get-value.html)
+
+# getValue
+
+`fun getValue(thisRef: `[`Rule`](../-rule/index.html)`, property: `[`KProperty`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-property/index.html)`<*>): `[`Regex`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/-regex/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-lazy-regex/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-lazy-regex/index.md
@@ -1,0 +1,27 @@
+---
+title: LazyRegex - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [LazyRegex](./index.html)
+
+# LazyRegex
+
+`class LazyRegex : `[`ReadOnlyProperty`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.properties/-read-only-property/index.html)`<`[`Rule`](../-rule/index.html)`, `[`Regex`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/-regex/index.html)`>`
+
+LazyRegex class provides a lazy evaluation of a Regex pattern for usages inside Rules.
+It computes the value once when reaching the point of its usage and returns the same
+value when requested again.
+
+`key` &amp; `default` are used to retrieve a value from config.
+
+**Author**
+Pavlos-Petros Tournaris
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `LazyRegex(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, default: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`)`<br>LazyRegex class provides a lazy evaluation of a Regex pattern for usages inside Rules. It computes the value once when reaching the point of its usage and returns the same value when requested again. |
+
+### Functions
+
+| [getValue](get-value.html) | `fun getValue(thisRef: `[`Rule`](../-rule/index.html)`, property: `[`KProperty`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-property/index.html)`<*>): `[`Regex`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/-regex/index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/-init-.md
@@ -1,0 +1,15 @@
+---
+title: Location.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Location](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`Location(source: `[`SourceLocation`](../-source-location/index.html)`, text: `[`TextLocation`](../-text-location/index.html)`, locationString: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, file: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`)`
+
+Specifies a position within a source code fragment.
+
+**Author**
+Artur Bosch
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/compact.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/compact.md
@@ -1,0 +1,12 @@
+---
+title: Location.compact - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Location](index.html) / [compact](./compact.html)
+
+# compact
+
+`fun compact(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+
+Overrides [Compactable.compact](../-compactable/compact.html)
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/file.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/file.md
@@ -1,0 +1,9 @@
+---
+title: Location.file - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Location](index.html) / [file](./file.html)
+
+# file
+
+`val file: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/from.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/from.md
@@ -1,0 +1,9 @@
+---
+title: Location.from - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Location](index.html) / [from](./from.html)
+
+# from
+
+`fun from(element: PsiElement, offset: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = 0): `[`Location`](index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/index.md
@@ -1,0 +1,39 @@
+---
+title: Location - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Location](./index.html)
+
+# Location
+
+`data class Location : `[`Compactable`](../-compactable/index.html)
+
+Specifies a position within a source code fragment.
+
+**Author**
+Artur Bosch
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `Location(source: `[`SourceLocation`](../-source-location/index.html)`, text: `[`TextLocation`](../-text-location/index.html)`, locationString: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, file: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`)`<br>Specifies a position within a source code fragment. |
+
+### Properties
+
+| [file](file.html) | `val file: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [locationString](location-string.html) | `val locationString: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [source](source.html) | `val source: `[`SourceLocation`](../-source-location/index.html) |
+| [text](text.html) | `val text: `[`TextLocation`](../-text-location/index.html) |
+
+### Functions
+
+| [compact](compact.html) | `fun compact(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+
+### Inherited Functions
+
+| [compactWithSignature](../-compactable/compact-with-signature.html) | `open fun compactWithSignature(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+
+### Companion Object Functions
+
+| [from](from.html) | `fun from(element: PsiElement, offset: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = 0): `[`Location`](./index.html) |
+| [startLineAndColumn](start-line-and-column.html) | `fun startLineAndColumn(element: PsiElement, offset: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = 0): LineAndColumn` |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/location-string.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/location-string.md
@@ -1,0 +1,9 @@
+---
+title: Location.locationString - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Location](index.html) / [locationString](./location-string.html)
+
+# locationString
+
+`val locationString: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/source.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/source.md
@@ -1,0 +1,9 @@
+---
+title: Location.source - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Location](index.html) / [source](./source.html)
+
+# source
+
+`val source: `[`SourceLocation`](../-source-location/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/start-line-and-column.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/start-line-and-column.md
@@ -1,0 +1,9 @@
+---
+title: Location.startLineAndColumn - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Location](index.html) / [startLineAndColumn](./start-line-and-column.html)
+
+# startLineAndColumn
+
+`fun startLineAndColumn(element: PsiElement, offset: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = 0): LineAndColumn`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/text.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/text.md
@@ -1,0 +1,9 @@
+---
+title: Location.text - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Location](index.html) / [text](./text.html)
+
+# text
+
+`val text: `[`TextLocation`](../-text-location/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/-init-.md
@@ -1,0 +1,16 @@
+---
+title: Metric.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Metric](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`Metric(type: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, value: `[`Double`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-double/index.html)`, threshold: `[`Double`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-double/index.html)`, conversionFactor: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = DEFAULT_FLOAT_CONVERSION_FACTOR)``Metric(type: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, value: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`, threshold: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`, isDouble: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)` = false, conversionFactor: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = DEFAULT_FLOAT_CONVERSION_FACTOR)`
+
+Metric type, can be an integer or double value. Internally it is stored as an integer,
+but the conversion factor and is double attributes can be used to retrieve it as a double value.
+
+**Author**
+Artur Bosch
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/conversion-factor.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/conversion-factor.md
@@ -1,0 +1,9 @@
+---
+title: Metric.conversionFactor - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Metric](index.html) / [conversionFactor](./conversion-factor.html)
+
+# conversionFactor
+
+`val conversionFactor: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/double-threshold.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/double-threshold.md
@@ -1,0 +1,9 @@
+---
+title: Metric.doubleThreshold - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Metric](index.html) / [doubleThreshold](./double-threshold.html)
+
+# doubleThreshold
+
+`fun doubleThreshold(): `[`Double`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-double/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/double-value.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/double-value.md
@@ -1,0 +1,9 @@
+---
+title: Metric.doubleValue - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Metric](index.html) / [doubleValue](./double-value.html)
+
+# doubleValue
+
+`fun doubleValue(): `[`Double`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-double/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/index.md
@@ -1,0 +1,34 @@
+---
+title: Metric - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Metric](./index.html)
+
+# Metric
+
+`data class Metric`
+
+Metric type, can be an integer or double value. Internally it is stored as an integer,
+but the conversion factor and is double attributes can be used to retrieve it as a double value.
+
+**Author**
+Artur Bosch
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `Metric(type: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, value: `[`Double`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-double/index.html)`, threshold: `[`Double`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-double/index.html)`, conversionFactor: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = DEFAULT_FLOAT_CONVERSION_FACTOR)``Metric(type: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, value: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`, threshold: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`, isDouble: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)` = false, conversionFactor: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = DEFAULT_FLOAT_CONVERSION_FACTOR)`<br>Metric type, can be an integer or double value. Internally it is stored as an integer, but the conversion factor and is double attributes can be used to retrieve it as a double value. |
+
+### Properties
+
+| [conversionFactor](conversion-factor.html) | `val conversionFactor: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+| [isDouble](is-double.html) | `val isDouble: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html) |
+| [threshold](threshold.html) | `val threshold: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+| [type](type.html) | `val type: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [value](value.html) | `val value: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+
+### Functions
+
+| [doubleThreshold](double-threshold.html) | `fun doubleThreshold(): `[`Double`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-double/index.html) |
+| [doubleValue](double-value.html) | `fun doubleValue(): `[`Double`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-double/index.html) |
+| [toString](to-string.html) | `fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/is-double.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/is-double.md
@@ -1,0 +1,9 @@
+---
+title: Metric.isDouble - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Metric](index.html) / [isDouble](./is-double.html)
+
+# isDouble
+
+`val isDouble: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/threshold.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/threshold.md
@@ -1,0 +1,9 @@
+---
+title: Metric.threshold - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Metric](index.html) / [threshold](./threshold.html)
+
+# threshold
+
+`val threshold: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/to-string.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/to-string.md
@@ -1,0 +1,9 @@
+---
+title: Metric.toString - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Metric](index.html) / [toString](./to-string.html)
+
+# toString
+
+`fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/type.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/type.md
@@ -1,0 +1,9 @@
+---
+title: Metric.type - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Metric](index.html) / [type](./type.html)
+
+# type
+
+`val type: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/value.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-metric/value.md
@@ -1,0 +1,9 @@
+---
+title: Metric.value - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Metric](index.html) / [value](./value.html)
+
+# value
+
+`val value: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/-init-.md
@@ -1,0 +1,9 @@
+---
+title: MultiRule.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [MultiRule](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`MultiRule()`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/active-rules.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/active-rules.md
@@ -1,0 +1,9 @@
+---
+title: MultiRule.activeRules - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [MultiRule](index.html) / [activeRules](./active-rules.html)
+
+# activeRules
+
+`var activeRules: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`Rule`](../-rule/index.html)`>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/index.md
@@ -1,0 +1,38 @@
+---
+title: MultiRule - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [MultiRule](./index.html)
+
+# MultiRule
+
+`abstract class MultiRule : `[`BaseRule`](../-base-rule/index.html)
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `MultiRule()` |
+
+### Properties
+
+| [activeRules](active-rules.html) | `var activeRules: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`Rule`](../-rule/index.html)`>` |
+| [ruleFilters](rule-filters.html) | `var ruleFilters: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`RuleId`](../-rule-id.html)`>` |
+| [rules](rules.html) | `abstract val rules: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Rule`](../-rule/index.html)`>` |
+
+### Inherited Properties
+
+| [bindingContext](../-base-rule/binding-context.html) | `var bindingContext: BindingContext` |
+| [context](../-base-rule/context.html) | `val context: `[`Context`](../-context/index.html) |
+| [ruleId](../-base-rule/rule-id.html) | `open val ruleId: `[`RuleId`](../-rule-id.html) |
+
+### Functions
+
+| [postVisit](post-visit.html) | `open fun postVisit(root: KtFile): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Could be overridden by subclasses to specify a behaviour which should be done after visiting kotlin elements. |
+| [preVisit](pre-visit.html) | `open fun preVisit(root: KtFile): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Could be overridden by subclasses to specify a behaviour which should be done before visiting kotlin elements. |
+| [runIfActive](run-if-active.html) | `fun <T : `[`Rule`](../-rule/index.html)`> `[`T`](run-if-active.html#T)`.runIfActive(block: `[`T`](run-if-active.html#T)`.() -> `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [visitCondition](visit-condition.html) | `open fun visitCondition(root: KtFile): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)<br>Basic mechanism to decide if a rule should run or not. |
+
+### Inherited Functions
+
+| [visit](../-base-rule/visit.html) | `open fun visit(root: KtFile): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [visitFile](../-base-rule/visit-file.html) | `fun visitFile(root: KtFile, bindingContext: BindingContext = BindingContext.EMPTY): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Before starting visiting kotlin elements, a check is performed if this rule should be triggered. Pre- and post-visit-hooks are executed before/after the visiting process. BindingContext holds the result of the semantic analysis of the source code by the Kotlin compiler. Rules that rely on symbols and types being resolved can use the BindingContext for this analysis. Note that detekt must receive the correct compile classpath for the code being analyzed otherwise the default value BindingContext.EMPTY will be used and it will not be possible for detekt to resolve types or symbols. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/post-visit.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/post-visit.md
@@ -1,0 +1,15 @@
+---
+title: MultiRule.postVisit - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [MultiRule](index.html) / [postVisit](./post-visit.html)
+
+# postVisit
+
+`protected open fun postVisit(root: KtFile): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Overrides [BaseRule.postVisit](../-base-rule/post-visit.html)
+
+Could be overridden by subclasses to specify a behaviour which should be done after
+visiting kotlin elements.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/pre-visit.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/pre-visit.md
@@ -1,0 +1,15 @@
+---
+title: MultiRule.preVisit - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [MultiRule](index.html) / [preVisit](./pre-visit.html)
+
+# preVisit
+
+`protected open fun preVisit(root: KtFile): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Overrides [BaseRule.preVisit](../-base-rule/pre-visit.html)
+
+Could be overridden by subclasses to specify a behaviour which should be done before
+visiting kotlin elements.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/rule-filters.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/rule-filters.md
@@ -1,0 +1,9 @@
+---
+title: MultiRule.ruleFilters - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [MultiRule](index.html) / [ruleFilters](./rule-filters.html)
+
+# ruleFilters
+
+`var ruleFilters: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`RuleId`](../-rule-id.html)`>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/rules.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/rules.md
@@ -1,0 +1,9 @@
+---
+title: MultiRule.rules - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [MultiRule](index.html) / [rules](./rules.html)
+
+# rules
+
+`abstract val rules: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Rule`](../-rule/index.html)`>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/run-if-active.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/run-if-active.md
@@ -1,0 +1,9 @@
+---
+title: MultiRule.runIfActive - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [MultiRule](index.html) / [runIfActive](./run-if-active.html)
+
+# runIfActive
+
+`fun <T : `[`Rule`](../-rule/index.html)`> `[`T`](run-if-active.html#T)`.runIfActive(block: `[`T`](run-if-active.html#T)`.() -> `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/visit-condition.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-multi-rule/visit-condition.md
@@ -1,0 +1,17 @@
+---
+title: MultiRule.visitCondition - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [MultiRule](index.html) / [visitCondition](./visit-condition.html)
+
+# visitCondition
+
+`open fun visitCondition(root: KtFile): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)
+
+Overrides [BaseRule.visitCondition](../-base-rule/visit-condition.html)
+
+Basic mechanism to decide if a rule should run or not.
+
+By default any rule which is declared 'active' in the [Config](../-config/index.html)
+or not suppressed by a [Suppress](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-suppress/index.html) annotation on file level should run.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/index.md
@@ -1,0 +1,21 @@
+---
+title: Notification - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Notification](./index.html)
+
+# Notification
+
+`interface Notification`
+
+Any kind of notification which should be printed to the console.
+For example when using the formatting rule set, any change to
+your kotlin file is a notification.
+
+**Author**
+Artur Bosch
+
+### Properties
+
+| [message](message.html) | `abstract val message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/message.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/message.md
@@ -1,0 +1,9 @@
+---
+title: Notification.message - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Notification](index.html) / [message](./message.html)
+
+# message
+
+`abstract val message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-output-report/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-output-report/-init-.md
@@ -1,0 +1,19 @@
+---
+title: OutputReport.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [OutputReport](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`OutputReport()`
+
+Translates detekt's result container - [Detektion](../-detektion/index.html) - into an output report
+which is written inside a file.
+
+**Author**
+Artur Bosch
+
+**Author**
+Marvin Ramin
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-output-report/ending.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-output-report/ending.md
@@ -1,0 +1,12 @@
+---
+title: OutputReport.ending - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [OutputReport](index.html) / [ending](./ending.html)
+
+# ending
+
+`abstract val ending: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+
+Supported ending of this report type.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-output-report/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-output-report/index.md
@@ -1,0 +1,42 @@
+---
+title: OutputReport - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [OutputReport](./index.html)
+
+# OutputReport
+
+`abstract class OutputReport : `[`Extension`](../-extension/index.html)
+
+Translates detekt's result container - [Detektion](../-detektion/index.html) - into an output report
+which is written inside a file.
+
+**Author**
+Artur Bosch
+
+**Author**
+Marvin Ramin
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `OutputReport()`<br>Translates detekt's result container - [Detektion](../-detektion/index.html) - into an output report which is written inside a file. |
+
+### Properties
+
+| [ending](ending.html) | `abstract val ending: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)<br>Supported ending of this report type. |
+| [name](name.html) | `open val name: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`?`<br>Name of the report. Is used to exclude this report in the yaml config. |
+
+### Inherited Properties
+
+| [id](../-extension/id.html) | `open val id: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)<br>Name of the extension. |
+| [priority](../-extension/priority.html) | `open val priority: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)<br>Is used to run extensions in a specific order. The higher the priority the sooner the extension will run in detekt's lifecycle. |
+
+### Functions
+
+| [render](render.html) | `abstract fun render(detektion: `[`Detektion`](../-detektion/index.html)`): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`?`<br>Defines the translation process of detekt's result into a string. |
+| [write](write.html) | `fun write(filePath: `[`Path`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html)`, detektion: `[`Detektion`](../-detektion/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Renders result and writes it to the given [filePath](write.html#io.gitlab.arturbosch.detekt.api.OutputReport$write(java.nio.file.Path, io.gitlab.arturbosch.detekt.api.Detektion)/filePath). |
+
+### Inherited Functions
+
+| [init](../-extension/init.html) | `open fun init(config: `[`Config`](../-config/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Allows to read any or even user defined properties from the detekt yaml config to setup this extension. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-output-report/name.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-output-report/name.md
@@ -1,0 +1,12 @@
+---
+title: OutputReport.name - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [OutputReport](index.html) / [name](./name.html)
+
+# name
+
+`open val name: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`?`
+
+Name of the report. Is used to exclude this report in the yaml config.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-output-report/render.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-output-report/render.md
@@ -1,0 +1,12 @@
+---
+title: OutputReport.render - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [OutputReport](index.html) / [render](./render.html)
+
+# render
+
+`abstract fun render(detektion: `[`Detektion`](../-detektion/index.html)`): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`?`
+
+Defines the translation process of detekt's result into a string.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-output-report/write.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-output-report/write.md
@@ -1,0 +1,12 @@
+---
+title: OutputReport.write - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [OutputReport](index.html) / [write](./write.html)
+
+# write
+
+`fun write(filePath: `[`Path`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html)`, detektion: `[`Detektion`](../-detektion/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Renders result and writes it to the given [filePath](write.html#io.gitlab.arturbosch.detekt.api.OutputReport$write(java.nio.file.Path, io.gitlab.arturbosch.detekt.api.Detektion)/filePath).
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-project-metric/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-project-metric/-init-.md
@@ -1,0 +1,15 @@
+---
+title: ProjectMetric.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ProjectMetric](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`ProjectMetric(type: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, value: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`, priority: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = -1, isDouble: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)` = false, conversionFactor: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = DEFAULT_FLOAT_CONVERSION_FACTOR)`
+
+Anything that can be expressed as a number value for projects.
+
+**Author**
+Artur Bosch
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-project-metric/conversion-factor.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-project-metric/conversion-factor.md
@@ -1,0 +1,9 @@
+---
+title: ProjectMetric.conversionFactor - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ProjectMetric](index.html) / [conversionFactor](./conversion-factor.html)
+
+# conversionFactor
+
+`val conversionFactor: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-project-metric/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-project-metric/index.md
@@ -1,0 +1,31 @@
+---
+title: ProjectMetric - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ProjectMetric](./index.html)
+
+# ProjectMetric
+
+`open class ProjectMetric`
+
+Anything that can be expressed as a number value for projects.
+
+**Author**
+Artur Bosch
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `ProjectMetric(type: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, value: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`, priority: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = -1, isDouble: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)` = false, conversionFactor: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)` = DEFAULT_FLOAT_CONVERSION_FACTOR)`<br>Anything that can be expressed as a number value for projects. |
+
+### Properties
+
+| [conversionFactor](conversion-factor.html) | `val conversionFactor: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+| [isDouble](is-double.html) | `val isDouble: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html) |
+| [priority](priority.html) | `val priority: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+| [type](type.html) | `val type: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [value](value.html) | `val value: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+
+### Functions
+
+| [toString](to-string.html) | `open fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-project-metric/is-double.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-project-metric/is-double.md
@@ -1,0 +1,9 @@
+---
+title: ProjectMetric.isDouble - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ProjectMetric](index.html) / [isDouble](./is-double.html)
+
+# isDouble
+
+`val isDouble: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-project-metric/priority.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-project-metric/priority.md
@@ -1,0 +1,9 @@
+---
+title: ProjectMetric.priority - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ProjectMetric](index.html) / [priority](./priority.html)
+
+# priority
+
+`val priority: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-project-metric/to-string.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-project-metric/to-string.md
@@ -1,0 +1,9 @@
+---
+title: ProjectMetric.toString - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ProjectMetric](index.html) / [toString](./to-string.html)
+
+# toString
+
+`open fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-project-metric/type.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-project-metric/type.md
@@ -1,0 +1,9 @@
+---
+title: ProjectMetric.type - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ProjectMetric](index.html) / [type](./type.html)
+
+# type
+
+`val type: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-project-metric/value.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-project-metric/value.md
@@ -1,0 +1,9 @@
+---
+title: ProjectMetric.value - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ProjectMetric](index.html) / [value](./value.html)
+
+# value
+
+`val value: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-id.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-id.md
@@ -1,0 +1,12 @@
+---
+title: RuleId - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api](index.html) / [RuleId](./-rule-id.html)
+
+# RuleId
+
+`typealias RuleId = `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+
+The type to use when referring to rule ids giving it more context then a String would.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set-id.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set-id.md
@@ -1,0 +1,9 @@
+---
+title: RuleSetId - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api](index.html) / [RuleSetId](./-rule-set-id.html)
+
+# RuleSetId
+
+`typealias RuleSetId = `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set-provider/build-ruleset.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set-provider/build-ruleset.md
@@ -1,0 +1,15 @@
+---
+title: RuleSetProvider.buildRuleset - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [RuleSetProvider](index.html) / [buildRuleset](./build-ruleset.html)
+
+# buildRuleset
+
+`open fun buildRuleset(config: `[`Config`](../-config/index.html)`): `[`RuleSet`](../-rule-set/index.html)`?`
+
+Can return a rule set if this specific rule set is not considered as ignore.
+
+Api notice: As the rule set id is not known before creating the rule set instance,
+we must first create the rule set and then check if it is active.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set-provider/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set-provider/index.md
@@ -1,0 +1,27 @@
+---
+title: RuleSetProvider - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [RuleSetProvider](./index.html)
+
+# RuleSetProvider
+
+`interface RuleSetProvider`
+
+A rule set provider, as the name states, is responsible for creating rule sets.
+
+When writing own rule set providers make sure to register them according the ServiceLoader documentation.
+http://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html
+
+**Author**
+Artur Bosch
+
+### Properties
+
+| [ruleSetId](rule-set-id.html) | `abstract val ruleSetId: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)<br>Every rule set must be pre-configured with an ID to validate if this rule set must be created for current analysis. |
+
+### Functions
+
+| [buildRuleset](build-ruleset.html) | `open fun buildRuleset(config: `[`Config`](../-config/index.html)`): `[`RuleSet`](../-rule-set/index.html)`?`<br>Can return a rule set if this specific rule set is not considered as ignore. |
+| [instance](instance.html) | `abstract fun instance(config: `[`Config`](../-config/index.html)`): `[`RuleSet`](../-rule-set/index.html)<br>This function must be implemented to provide custom rule sets. Make sure to pass the configuration to each rule to allow rules to be self configurable. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set-provider/instance.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set-provider/instance.md
@@ -1,0 +1,14 @@
+---
+title: RuleSetProvider.instance - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [RuleSetProvider](index.html) / [instance](./instance.html)
+
+# instance
+
+`abstract fun instance(config: `[`Config`](../-config/index.html)`): `[`RuleSet`](../-rule-set/index.html)
+
+This function must be implemented to provide custom rule sets.
+Make sure to pass the configuration to each rule to allow rules
+to be self configurable.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set-provider/rule-set-id.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set-provider/rule-set-id.md
@@ -1,0 +1,13 @@
+---
+title: RuleSetProvider.ruleSetId - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [RuleSetProvider](index.html) / [ruleSetId](./rule-set-id.html)
+
+# ruleSetId
+
+`abstract val ruleSetId: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+
+Every rule set must be pre-configured with an ID to validate if this rule set
+must be created for current analysis.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set/-init-.md
@@ -1,0 +1,15 @@
+---
+title: RuleSet.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [RuleSet](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`RuleSet(id: `[`RuleSetId`](../-rule-set-id.html)`, rules: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`BaseRule`](../-base-rule/index.html)`>)`
+
+A rule set is a collection of rules and must be defined within a rule set provider implementation.
+
+**Author**
+Artur Bosch
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set/accept.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set/accept.md
@@ -1,0 +1,21 @@
+---
+title: RuleSet.accept - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [RuleSet](index.html) / [accept](./accept.html)
+
+# accept
+
+`fun accept(file: KtFile, bindingContext: BindingContext = BindingContext.EMPTY): `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>`
+
+Visits given file with all rules of this rule set, returning a list
+of all code smell findings.
+
+`fun accept(file: KtFile, ruleFilters: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`RuleId`](../-rule-id.html)`>, bindingContext: BindingContext = BindingContext.EMPTY): `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>`
+
+Visits given file with all non-filtered rules of this rule set.
+If a rule is a [MultiRule](../-multi-rule/index.html) the filters are passed to it via a setter
+and later used to filter sub rules of the [MultiRule](../-multi-rule/index.html).
+
+A list of findings is returned for given KtFile
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set/id.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set/id.md
@@ -1,0 +1,9 @@
+---
+title: RuleSet.id - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [RuleSet](index.html) / [id](./id.html)
+
+# id
+
+`val id: `[`RuleSetId`](../-rule-set-id.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set/index.md
@@ -1,0 +1,28 @@
+---
+title: RuleSet - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [RuleSet](./index.html)
+
+# RuleSet
+
+`class RuleSet`
+
+A rule set is a collection of rules and must be defined within a rule set provider implementation.
+
+**Author**
+Artur Bosch
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `RuleSet(id: `[`RuleSetId`](../-rule-set-id.html)`, rules: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`BaseRule`](../-base-rule/index.html)`>)`<br>A rule set is a collection of rules and must be defined within a rule set provider implementation. |
+
+### Properties
+
+| [id](id.html) | `val id: `[`RuleSetId`](../-rule-set-id.html) |
+| [rules](rules.html) | `val rules: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`BaseRule`](../-base-rule/index.html)`>` |
+
+### Functions
+
+| [accept](accept.html) | `fun accept(file: KtFile, bindingContext: BindingContext = BindingContext.EMPTY): `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>`<br>Visits given file with all rules of this rule set, returning a list of all code smell findings.`fun accept(file: KtFile, ruleFilters: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`RuleId`](../-rule-id.html)`>, bindingContext: BindingContext = BindingContext.EMPTY): `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>`<br>Visits given file with all non-filtered rules of this rule set. If a rule is a [MultiRule](../-multi-rule/index.html) the filters are passed to it via a setter and later used to filter sub rules of the [MultiRule](../-multi-rule/index.html). |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set/rules.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set/rules.md
@@ -1,0 +1,9 @@
+---
+title: RuleSet.rules - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [RuleSet](index.html) / [rules](./rules.html)
+
+# rules
+
+`val rules: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`BaseRule`](../-base-rule/index.html)`>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/-init-.md
@@ -1,0 +1,24 @@
+---
+title: Rule.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Rule](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`Rule(ruleSetConfig: `[`Config`](../-config/index.html)` = Config.empty, ruleContext: `[`Context`](../-context/index.html)` = DefaultContext())`
+
+A rule defines how one specific code structure should look like. If code is found
+which does not meet this structure, it is considered as harmful regarding maintainability
+or readability.
+
+A rule is implemented using the visitor pattern and should be started using the visit(KtFile)
+function. If calculations must be done before or after the visiting process, here are
+two predefined (preVisit/postVisit) functions which can be overridden to setup/teardown additional data.
+
+**Author**
+Artur Bosch
+
+**Author**
+Marvin Ramin
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/aliases.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/aliases.md
@@ -1,0 +1,12 @@
+---
+title: Rule.aliases - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Rule](index.html) / [aliases](./aliases.html)
+
+# aliases
+
+`val aliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>`
+
+List of rule ids which can optionally be used in suppress annotations to refer to this rule.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/default-rule-id-aliases.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/default-rule-id-aliases.md
@@ -1,0 +1,17 @@
+---
+title: Rule.defaultRuleIdAliases - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Rule](index.html) / [defaultRuleIdAliases](./default-rule-id-aliases.html)
+
+# defaultRuleIdAliases
+
+`open val defaultRuleIdAliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>`
+
+The default names which can be used instead of this #ruleId to refer to this rule in suppression's.
+
+When overriding this property make sure to meet following structure for detekt-generator to pick
+it up and generate documentation for aliases:
+
+override val defaultRuleIdAliases = setOf("Name1", "Name2")
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/excludes.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/excludes.md
@@ -1,0 +1,15 @@
+---
+title: Rule.excludes - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Rule](index.html) / [excludes](./excludes.html)
+
+# excludes
+
+`open val excludes: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`PathMatcher`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/PathMatcher.html)`>?`
+
+When specified this rule will not run on KtFile's having a path matching any exclusion pattern.
+
+**Return**
+path matchers or null which means no KtFile's get excluded except inclusion patterns are defined
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/includes.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/includes.md
@@ -1,0 +1,15 @@
+---
+title: Rule.includes - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Rule](index.html) / [includes](./includes.html)
+
+# includes
+
+`open val includes: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`PathMatcher`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/PathMatcher.html)`>?`
+
+When specified this rule only runs on KtFile's with paths matching any inclusion pattern.
+
+**Return**
+path matchers or null which means for every KtFile this rule must run
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/index.md
@@ -1,0 +1,65 @@
+---
+title: Rule - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Rule](./index.html)
+
+# Rule
+
+`abstract class Rule : `[`BaseRule`](../-base-rule/index.html)`, `[`ConfigAware`](../-config-aware/index.html)
+
+A rule defines how one specific code structure should look like. If code is found
+which does not meet this structure, it is considered as harmful regarding maintainability
+or readability.
+
+A rule is implemented using the visitor pattern and should be started using the visit(KtFile)
+function. If calculations must be done before or after the visiting process, here are
+two predefined (preVisit/postVisit) functions which can be overridden to setup/teardown additional data.
+
+**Author**
+Artur Bosch
+
+**Author**
+Marvin Ramin
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `Rule(ruleSetConfig: `[`Config`](../-config/index.html)` = Config.empty, ruleContext: `[`Context`](../-context/index.html)` = DefaultContext())`<br>A rule defines how one specific code structure should look like. If code is found which does not meet this structure, it is considered as harmful regarding maintainability or readability. |
+
+### Properties
+
+| [aliases](aliases.html) | `val aliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>`<br>List of rule ids which can optionally be used in suppress annotations to refer to this rule. |
+| [defaultRuleIdAliases](default-rule-id-aliases.html) | `open val defaultRuleIdAliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>`<br>The default names which can be used instead of this #ruleId to refer to this rule in suppression's. |
+| [excludes](excludes.html) | `open val excludes: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`PathMatcher`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/PathMatcher.html)`>?`<br>When specified this rule will not run on KtFile's having a path matching any exclusion pattern. |
+| [includes](includes.html) | `open val includes: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`PathMatcher`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/PathMatcher.html)`>?`<br>When specified this rule only runs on KtFile's with paths matching any inclusion pattern. |
+| [issue](issue.html) | `abstract val issue: `[`Issue`](../-issue/index.html)<br>A rule is motivated to point out a specific issue in the code base. |
+| [ruleId](rule-id.html) | `val ruleId: `[`RuleId`](../-rule-id.html)<br>An id this rule is identified with. Conventionally the rule id is derived from the issue id as these two classes have a coexistence. |
+| [ruleSetConfig](rule-set-config.html) | `open val ruleSetConfig: `[`Config`](../-config/index.html)<br>Wrapped configuration of the ruleSet this rule is in. Use #valueOrDefault function to retrieve properties specified for the rule implementing this interface instead. Only use this property directly if you need a specific rule set property. |
+
+### Inherited Properties
+
+| [active](../-config-aware/active.html) | `open val active: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)<br>Is this rule specified as active in configuration? If an rule is not specified in the underlying configuration, we assume it should not be run. |
+| [autoCorrect](../-config-aware/auto-correct.html) | `open val autoCorrect: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)<br>Does this rule have auto correct specified in configuration? For auto correction to work the rule set itself enable it. |
+| [bindingContext](../-base-rule/binding-context.html) | `var bindingContext: BindingContext` |
+| [context](../-base-rule/context.html) | `val context: `[`Context`](../-context/index.html) |
+
+### Functions
+
+| [report](report.html) | `fun report(finding: `[`Finding`](../-finding/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>`fun report(findings: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Simplified version of [Context.report](../-context/report.html) with aliases retrieval from the config. |
+| [visitCondition](visit-condition.html) | `open fun visitCondition(root: KtFile): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)<br>Basic mechanism to decide if a rule should run or not. |
+
+### Inherited Functions
+
+| [postVisit](../-base-rule/post-visit.html) | `open fun postVisit(root: KtFile): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Could be overridden by subclasses to specify a behaviour which should be done after visiting kotlin elements. |
+| [preVisit](../-base-rule/pre-visit.html) | `open fun preVisit(root: KtFile): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Could be overridden by subclasses to specify a behaviour which should be done before visiting kotlin elements. |
+| [subConfig](../-config-aware/sub-config.html) | `open fun subConfig(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Config`](../-config/index.html)<br>Tries to retrieve part of the configuration based on given key. |
+| [valueOrDefault](../-config-aware/value-or-default.html) | `open fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrDefault(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, default: `[`T`](../-config-aware/value-or-default.html#T)`): `[`T`](../-config-aware/value-or-default.html#T)<br>Retrieves a sub configuration or value based on given key. If configuration property cannot be found the specified default value is returned. |
+| [valueOrNull](../-config-aware/value-or-null.html) | `open fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`T`](../-config-aware/value-or-null.html#T)`?`<br>Retrieves a sub configuration or value based on given key. If the configuration property cannot be found, null is returned. |
+| [visit](../-base-rule/visit.html) | `open fun visit(root: KtFile): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [visitFile](../-base-rule/visit-file.html) | `fun visitFile(root: KtFile, bindingContext: BindingContext = BindingContext.EMPTY): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Before starting visiting kotlin elements, a check is performed if this rule should be triggered. Pre- and post-visit-hooks are executed before/after the visiting process. BindingContext holds the result of the semantic analysis of the source code by the Kotlin compiler. Rules that rely on symbols and types being resolved can use the BindingContext for this analysis. Note that detekt must receive the correct compile classpath for the code being analyzed otherwise the default value BindingContext.EMPTY will be used and it will not be possible for detekt to resolve types or symbols. |
+| [withAutoCorrect](../-config-aware/with-auto-correct.html) | `open fun withAutoCorrect(block: () -> `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>If your rule supports to automatically correct the misbehaviour of underlying smell, specify your code inside this method call, to allow the user of your rule to trigger auto correction only when needed. |
+
+### Inheritors
+
+| [ThresholdRule](../-threshold-rule/index.html) | `abstract class ThresholdRule : `[`Rule`](./index.html)<br>Provides a threshold attribute for this rule, which is specified manually for default values but can be also obtained from within a configuration object. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/issue.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/issue.md
@@ -1,0 +1,12 @@
+---
+title: Rule.issue - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Rule](index.html) / [issue](./issue.html)
+
+# issue
+
+`abstract val issue: `[`Issue`](../-issue/index.html)
+
+A rule is motivated to point out a specific issue in the code base.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/report.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/report.md
@@ -1,0 +1,13 @@
+---
+title: Rule.report - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Rule](index.html) / [report](./report.html)
+
+# report
+
+`fun report(finding: `[`Finding`](../-finding/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+`fun report(findings: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Simplified version of [Context.report](../-context/report.html) with aliases retrieval from the config.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/rule-id.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/rule-id.md
@@ -1,0 +1,17 @@
+---
+title: Rule.ruleId - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Rule](index.html) / [ruleId](./rule-id.html)
+
+# ruleId
+
+`val ruleId: `[`RuleId`](../-rule-id.html)
+
+Overrides [BaseRule.ruleId](../-base-rule/rule-id.html)
+
+Overrides [ConfigAware.ruleId](../-config-aware/rule-id.html)
+
+An id this rule is identified with.
+Conventionally the rule id is derived from the issue id as these two classes have a coexistence.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/rule-set-config.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/rule-set-config.md
@@ -1,0 +1,17 @@
+---
+title: Rule.ruleSetConfig - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Rule](index.html) / [ruleSetConfig](./rule-set-config.html)
+
+# ruleSetConfig
+
+`open val ruleSetConfig: `[`Config`](../-config/index.html)
+
+Overrides [ConfigAware.ruleSetConfig](../-config-aware/rule-set-config.html)
+
+Wrapped configuration of the ruleSet this rule is in.
+Use #valueOrDefault function to retrieve properties specified for the rule
+implementing this interface instead.
+Only use this property directly if you need a specific rule set property.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/visit-condition.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule/visit-condition.md
@@ -1,0 +1,17 @@
+---
+title: Rule.visitCondition - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Rule](index.html) / [visitCondition](./visit-condition.html)
+
+# visitCondition
+
+`open fun visitCondition(root: KtFile): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)
+
+Overrides [BaseRule.visitCondition](../-base-rule/visit-condition.html)
+
+Basic mechanism to decide if a rule should run or not.
+
+By default any rule which is declared 'active' in the [Config](../-config/index.html)
+or not suppressed by a [Suppress](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-suppress/index.html) annotation on file level should run.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/-code-smell.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/-code-smell.md
@@ -1,0 +1,9 @@
+---
+title: Severity.CodeSmell - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Severity](index.html) / [CodeSmell](./-code-smell.html)
+
+# CodeSmell
+
+`CodeSmell`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/-defect.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/-defect.md
@@ -1,0 +1,9 @@
+---
+title: Severity.Defect - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Severity](index.html) / [Defect](./-defect.html)
+
+# Defect
+
+`Defect`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/-maintainability.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/-maintainability.md
@@ -1,0 +1,9 @@
+---
+title: Severity.Maintainability - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Severity](index.html) / [Maintainability](./-maintainability.html)
+
+# Maintainability
+
+`Maintainability`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/-minor.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/-minor.md
@@ -1,0 +1,9 @@
+---
+title: Severity.Minor - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Severity](index.html) / [Minor](./-minor.html)
+
+# Minor
+
+`Minor`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/-performance.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/-performance.md
@@ -1,0 +1,9 @@
+---
+title: Severity.Performance - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Severity](index.html) / [Performance](./-performance.html)
+
+# Performance
+
+`Performance`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/-security.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/-security.md
@@ -1,0 +1,9 @@
+---
+title: Severity.Security - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Severity](index.html) / [Security](./-security.html)
+
+# Security
+
+`Security`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/-style.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/-style.md
@@ -1,0 +1,9 @@
+---
+title: Severity.Style - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Severity](index.html) / [Style](./-style.html)
+
+# Style
+
+`Style`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/-warning.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/-warning.md
@@ -1,0 +1,9 @@
+---
+title: Severity.Warning - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Severity](index.html) / [Warning](./-warning.html)
+
+# Warning
+
+`Warning`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-severity/index.md
@@ -1,0 +1,24 @@
+---
+title: Severity - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Severity](./index.html)
+
+# Severity
+
+`enum class Severity`
+
+Rules can classified into different severity grades. Maintainer can choose
+a grade which is most harmful to their projects.
+
+### Enum Values
+
+| [CodeSmell](-code-smell.html) |  |
+| [Style](-style.html) |  |
+| [Warning](-warning.html) |  |
+| [Defect](-defect.html) |  |
+| [Minor](-minor.html) |  |
+| [Maintainability](-maintainability.html) |  |
+| [Security](-security.html) |  |
+| [Performance](-performance.html) |  |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-single-assign/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-single-assign/-init-.md
@@ -1,0 +1,16 @@
+---
+title: SingleAssign.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SingleAssign](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`SingleAssign()`
+
+Allows to assign a property just once.
+Further assignments result in [IllegalStateException](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-illegal-state-exception/index.html)'s.
+
+**Author**
+Artur Bosch
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-single-assign/get-value.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-single-assign/get-value.md
@@ -1,0 +1,9 @@
+---
+title: SingleAssign.getValue - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SingleAssign](index.html) / [getValue](./get-value.html)
+
+# getValue
+
+`operator fun getValue(thisRef: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`?, property: `[`KProperty`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-property/index.html)`<*>): `[`T`](index.html#T)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-single-assign/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-single-assign/index.md
@@ -1,0 +1,25 @@
+---
+title: SingleAssign - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SingleAssign](./index.html)
+
+# SingleAssign
+
+`class SingleAssign<T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`>`
+
+Allows to assign a property just once.
+Further assignments result in [IllegalStateException](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-illegal-state-exception/index.html)'s.
+
+**Author**
+Artur Bosch
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `SingleAssign()`<br>Allows to assign a property just once. Further assignments result in [IllegalStateException](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-illegal-state-exception/index.html)'s. |
+
+### Functions
+
+| [getValue](get-value.html) | `operator fun getValue(thisRef: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`?, property: `[`KProperty`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-property/index.html)`<*>): `[`T`](index.html#T) |
+| [setValue](set-value.html) | `operator fun setValue(thisRef: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`?, property: `[`KProperty`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-property/index.html)`<*>, value: `[`T`](index.html#T)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-single-assign/set-value.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-single-assign/set-value.md
@@ -1,0 +1,9 @@
+---
+title: SingleAssign.setValue - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SingleAssign](index.html) / [setValue](./set-value.html)
+
+# setValue
+
+`operator fun setValue(thisRef: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`?, property: `[`KProperty`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-property/index.html)`<*>, value: `[`T`](index.html#T)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-source-location/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-source-location/-init-.md
@@ -1,0 +1,12 @@
+---
+title: SourceLocation.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SourceLocation](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`SourceLocation(line: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`, column: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`)`
+
+Stores line and column information of a location.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-source-location/column.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-source-location/column.md
@@ -1,0 +1,9 @@
+---
+title: SourceLocation.column - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SourceLocation](index.html) / [column](./column.html)
+
+# column
+
+`val column: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-source-location/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-source-location/index.md
@@ -1,0 +1,25 @@
+---
+title: SourceLocation - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SourceLocation](./index.html)
+
+# SourceLocation
+
+`data class SourceLocation`
+
+Stores line and column information of a location.
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `SourceLocation(line: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`, column: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`)`<br>Stores line and column information of a location. |
+
+### Properties
+
+| [column](column.html) | `val column: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+| [line](line.html) | `val line: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+
+### Functions
+
+| [toString](to-string.html) | `fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-source-location/line.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-source-location/line.md
@@ -1,0 +1,9 @@
+---
+title: SourceLocation.line - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SourceLocation](index.html) / [line](./line.html)
+
+# line
+
+`val line: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-source-location/to-string.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-source-location/to-string.md
@@ -1,0 +1,9 @@
+---
+title: SourceLocation.toString - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SourceLocation](index.html) / [toString](./to-string.html)
+
+# toString
+
+`fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-split-pattern/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-split-pattern/-init-.md
@@ -1,0 +1,14 @@
+---
+title: SplitPattern.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SplitPattern](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`SplitPattern(text: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, delimiters: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)` = ",", removeTrailingAsterisks: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)` = true)`
+
+Splits given text into parts and provides testing utilities for its elements.
+Basic use cases are to specify different function or class names in the detekt
+yaml config and test for their appearance in specific rules.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-split-pattern/contains.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-split-pattern/contains.md
@@ -1,0 +1,9 @@
+---
+title: SplitPattern.contains - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SplitPattern](index.html) / [contains](./contains.html)
+
+# contains
+
+`fun contains(value: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`?): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-split-pattern/equals.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-split-pattern/equals.md
@@ -1,0 +1,9 @@
+---
+title: SplitPattern.equals - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SplitPattern](index.html) / [equals](./equals.html)
+
+# equals
+
+`fun equals(value: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`?): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-split-pattern/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-split-pattern/index.md
@@ -1,0 +1,27 @@
+---
+title: SplitPattern - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SplitPattern](./index.html)
+
+# SplitPattern
+
+`class SplitPattern`
+
+Splits given text into parts and provides testing utilities for its elements.
+Basic use cases are to specify different function or class names in the detekt
+yaml config and test for their appearance in specific rules.
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `SplitPattern(text: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, delimiters: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)` = ",", removeTrailingAsterisks: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)` = true)`<br>Splits given text into parts and provides testing utilities for its elements. Basic use cases are to specify different function or class names in the detekt yaml config and test for their appearance in specific rules. |
+
+### Functions
+
+| [contains](contains.html) | `fun contains(value: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`?): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html) |
+| [equals](equals.html) | `fun equals(value: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`?): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html) |
+| [mapAll](map-all.html) | `fun <T> mapAll(transform: (`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`) -> `[`T`](map-all.html#T)`): `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`T`](map-all.html#T)`>` |
+| [matches](matches.html) | `fun matches(value: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>` |
+| [none](none.html) | `fun none(value: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html) |
+| [startWith](start-with.html) | `fun startWith(name: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`?): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-split-pattern/map-all.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-split-pattern/map-all.md
@@ -1,0 +1,9 @@
+---
+title: SplitPattern.mapAll - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SplitPattern](index.html) / [mapAll](./map-all.html)
+
+# mapAll
+
+`fun <T> mapAll(transform: (`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`) -> `[`T`](map-all.html#T)`): `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`T`](map-all.html#T)`>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-split-pattern/matches.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-split-pattern/matches.md
@@ -1,0 +1,9 @@
+---
+title: SplitPattern.matches - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SplitPattern](index.html) / [matches](./matches.html)
+
+# matches
+
+`fun matches(value: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-split-pattern/none.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-split-pattern/none.md
@@ -1,0 +1,9 @@
+---
+title: SplitPattern.none - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SplitPattern](index.html) / [none](./none.html)
+
+# none
+
+`fun none(value: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-split-pattern/start-with.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-split-pattern/start-with.md
@@ -1,0 +1,9 @@
+---
+title: SplitPattern.startWith - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [SplitPattern](index.html) / [startWith](./start-with.html)
+
+# startWith
+
+`fun startWith(name: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`?): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-text-location/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-text-location/-init-.md
@@ -1,0 +1,12 @@
+---
+title: TextLocation.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [TextLocation](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`TextLocation(start: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`, end: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`)`
+
+Stores character start and end positions of an text file.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-text-location/end.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-text-location/end.md
@@ -1,0 +1,9 @@
+---
+title: TextLocation.end - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [TextLocation](index.html) / [end](./end.html)
+
+# end
+
+`val end: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-text-location/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-text-location/index.md
@@ -1,0 +1,25 @@
+---
+title: TextLocation - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [TextLocation](./index.html)
+
+# TextLocation
+
+`data class TextLocation`
+
+Stores character start and end positions of an text file.
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `TextLocation(start: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`, end: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`)`<br>Stores character start and end positions of an text file. |
+
+### Properties
+
+| [end](end.html) | `val end: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+| [start](start.html) | `val start: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+
+### Functions
+
+| [toString](to-string.html) | `fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-text-location/start.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-text-location/start.md
@@ -1,0 +1,9 @@
+---
+title: TextLocation.start - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [TextLocation](index.html) / [start](./start.html)
+
+# start
+
+`val start: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-text-location/to-string.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-text-location/to-string.md
@@ -1,0 +1,9 @@
+---
+title: TextLocation.toString - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [TextLocation](index.html) / [toString](./to-string.html)
+
+# toString
+
+`fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-threshold-rule/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-threshold-rule/-init-.md
@@ -1,0 +1,13 @@
+---
+title: ThresholdRule.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ThresholdRule](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`ThresholdRule(config: `[`Config`](../-config/index.html)`, defaultThreshold: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`)`
+
+Provides a threshold attribute for this rule, which is specified manually for default values
+but can be also obtained from within a configuration object.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-threshold-rule/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-threshold-rule/index.md
@@ -1,0 +1,36 @@
+---
+title: ThresholdRule - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ThresholdRule](./index.html)
+
+# ThresholdRule
+
+`abstract class ThresholdRule : `[`Rule`](../-rule/index.html)
+
+Provides a threshold attribute for this rule, which is specified manually for default values
+but can be also obtained from within a configuration object.
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `ThresholdRule(config: `[`Config`](../-config/index.html)`, defaultThreshold: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`)`<br>Provides a threshold attribute for this rule, which is specified manually for default values but can be also obtained from within a configuration object. |
+
+### Properties
+
+| [threshold](threshold.html) | `val threshold: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)<br>The used threshold for this rule is loaded from the configuration or used from the constructor value. |
+
+### Inherited Properties
+
+| [aliases](../-rule/aliases.html) | `val aliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>`<br>List of rule ids which can optionally be used in suppress annotations to refer to this rule. |
+| [defaultRuleIdAliases](../-rule/default-rule-id-aliases.html) | `open val defaultRuleIdAliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>`<br>The default names which can be used instead of this #ruleId to refer to this rule in suppression's. |
+| [excludes](../-rule/excludes.html) | `open val excludes: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`PathMatcher`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/PathMatcher.html)`>?`<br>When specified this rule will not run on KtFile's having a path matching any exclusion pattern. |
+| [includes](../-rule/includes.html) | `open val includes: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`PathMatcher`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/PathMatcher.html)`>?`<br>When specified this rule only runs on KtFile's with paths matching any inclusion pattern. |
+| [issue](../-rule/issue.html) | `abstract val issue: `[`Issue`](../-issue/index.html)<br>A rule is motivated to point out a specific issue in the code base. |
+| [ruleId](../-rule/rule-id.html) | `val ruleId: `[`RuleId`](../-rule-id.html)<br>An id this rule is identified with. Conventionally the rule id is derived from the issue id as these two classes have a coexistence. |
+| [ruleSetConfig](../-rule/rule-set-config.html) | `open val ruleSetConfig: `[`Config`](../-config/index.html)<br>Wrapped configuration of the ruleSet this rule is in. Use #valueOrDefault function to retrieve properties specified for the rule implementing this interface instead. Only use this property directly if you need a specific rule set property. |
+
+### Inherited Functions
+
+| [report](../-rule/report.html) | `fun report(finding: `[`Finding`](../-finding/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>`fun report(findings: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)<br>Simplified version of [Context.report](../-context/report.html) with aliases retrieval from the config. |
+| [visitCondition](../-rule/visit-condition.html) | `open fun visitCondition(root: KtFile): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)<br>Basic mechanism to decide if a rule should run or not. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-threshold-rule/threshold.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-threshold-rule/threshold.md
@@ -1,0 +1,12 @@
+---
+title: ThresholdRule.threshold - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ThresholdRule](index.html) / [threshold](./threshold.html)
+
+# threshold
+
+`protected val threshold: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)
+
+The used threshold for this rule is loaded from the configuration or used from the constructor value.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-thresholded-code-smell/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-thresholded-code-smell/-init-.md
@@ -1,0 +1,13 @@
+---
+title: ThresholdedCodeSmell.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ThresholdedCodeSmell](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`ThresholdedCodeSmell(issue: `[`Issue`](../-issue/index.html)`, entity: `[`Entity`](../-entity/index.html)`, metric: `[`Metric`](../-metric/index.html)`, message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, references: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Entity`](../-entity/index.html)`> = emptyList())`
+
+Represents a code smell for which a specific metric can be determined which is responsible
+for the existence of this rule violation.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-thresholded-code-smell/compact.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-thresholded-code-smell/compact.md
@@ -1,0 +1,12 @@
+---
+title: ThresholdedCodeSmell.compact - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ThresholdedCodeSmell](index.html) / [compact](./compact.html)
+
+# compact
+
+`open fun compact(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+
+Overrides [CodeSmell.compact](../-code-smell/compact.html)
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-thresholded-code-smell/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-thresholded-code-smell/index.md
@@ -1,0 +1,42 @@
+---
+title: ThresholdedCodeSmell - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ThresholdedCodeSmell](./index.html)
+
+# ThresholdedCodeSmell
+
+`open class ThresholdedCodeSmell : `[`CodeSmell`](../-code-smell/index.html)
+
+Represents a code smell for which a specific metric can be determined which is responsible
+for the existence of this rule violation.
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | `ThresholdedCodeSmell(issue: `[`Issue`](../-issue/index.html)`, entity: `[`Entity`](../-entity/index.html)`, metric: `[`Metric`](../-metric/index.html)`, message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, references: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Entity`](../-entity/index.html)`> = emptyList())`<br>Represents a code smell for which a specific metric can be determined which is responsible for the existence of this rule violation. |
+
+### Properties
+
+| [metric](metric.html) | `val metric: `[`Metric`](../-metric/index.html) |
+| [threshold](threshold.html) | `val threshold: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+| [value](value.html) | `val value: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+
+### Inherited Properties
+
+| [entity](../-code-smell/entity.html) | `open val entity: `[`Entity`](../-entity/index.html) |
+| [id](../-code-smell/id.html) | `open val id: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [issue](../-code-smell/issue.html) | `val issue: `[`Issue`](../-issue/index.html) |
+| [message](../-code-smell/message.html) | `open val message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [metrics](../-code-smell/metrics.html) | `open val metrics: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Metric`](../-metric/index.html)`>` |
+| [references](../-code-smell/references.html) | `open val references: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Entity`](../-entity/index.html)`>` |
+
+### Functions
+
+| [compact](compact.html) | `open fun compact(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [messageOrDescription](message-or-description.html) | `open fun messageOrDescription(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+
+### Inherited Functions
+
+| [compactWithSignature](../-code-smell/compact-with-signature.html) | `open fun compactWithSignature(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [toString](../-code-smell/to-string.html) | `open fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-thresholded-code-smell/message-or-description.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-thresholded-code-smell/message-or-description.md
@@ -1,0 +1,12 @@
+---
+title: ThresholdedCodeSmell.messageOrDescription - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ThresholdedCodeSmell](index.html) / [messageOrDescription](./message-or-description.html)
+
+# messageOrDescription
+
+`open fun messageOrDescription(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+
+Overrides [CodeSmell.messageOrDescription](../-code-smell/message-or-description.html)
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-thresholded-code-smell/metric.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-thresholded-code-smell/metric.md
@@ -1,0 +1,9 @@
+---
+title: ThresholdedCodeSmell.metric - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ThresholdedCodeSmell](index.html) / [metric](./metric.html)
+
+# metric
+
+`val metric: `[`Metric`](../-metric/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-thresholded-code-smell/threshold.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-thresholded-code-smell/threshold.md
@@ -1,0 +1,9 @@
+---
+title: ThresholdedCodeSmell.threshold - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ThresholdedCodeSmell](index.html) / [threshold](./threshold.html)
+
+# threshold
+
+`val threshold: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-thresholded-code-smell/value.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-thresholded-code-smell/value.md
@@ -1,0 +1,9 @@
+---
+title: ThresholdedCodeSmell.value - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ThresholdedCodeSmell](index.html) / [value](./value.html)
+
+# value
+
+`val value: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/index.md
@@ -1,0 +1,37 @@
+---
+title: YamlConfig - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [YamlConfig](./index.html)
+
+# YamlConfig
+
+`class YamlConfig : `[`BaseConfig`](../-base-config/index.html)
+
+Config implementation using the yaml format. SubConfigurations can return sub maps according to the
+yaml specification.
+
+**Author**
+Artur Bosch
+
+### Properties
+
+| [properties](properties.html) | `val properties: `[`Map`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`>` |
+
+### Functions
+
+| [subConfig](sub-config.html) | `fun subConfig(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Config`](../-config/index.html)<br>Tries to retrieve part of the configuration based on given key. |
+| [toString](to-string.html) | `fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [valueOrDefault](value-or-default.html) | `fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrDefault(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, default: `[`T`](value-or-default.html#T)`): `[`T`](value-or-default.html#T)<br>Retrieves a sub configuration or value based on given key. If configuration property cannot be found the specified default value is returned. |
+| [valueOrNull](value-or-null.html) | `fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`T`](value-or-null.html#T)`?`<br>Retrieves a sub configuration or value based on given key. If the configuration property cannot be found, null is returned. |
+
+### Inherited Functions
+
+| [tryParseBasedOnDefault](../-base-config/try-parse-based-on-default.html) | `open fun tryParseBasedOnDefault(result: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, defaultResult: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`): `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html) |
+| [valueOrDefaultInternal](../-base-config/value-or-default-internal.html) | `open fun valueOrDefaultInternal(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, result: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`?, default: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`): `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html) |
+
+### Companion Object Functions
+
+| [load](load.html) | `fun load(path: `[`Path`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html)`): `[`Config`](../-config/index.html)<br>Factory method to load a yaml configuration. Given path must exist and end with "yml". |
+| [loadResource](load-resource.html) | `fun loadResource(url: `[`URL`](https://docs.oracle.com/javase/8/docs/api/java/net/URL.html)`): `[`Config`](../-config/index.html)<br>Factory method to load a yaml configuration from a URL. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/load-resource.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/load-resource.md
@@ -1,0 +1,12 @@
+---
+title: YamlConfig.loadResource - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [YamlConfig](index.html) / [loadResource](./load-resource.html)
+
+# loadResource
+
+`fun loadResource(url: `[`URL`](https://docs.oracle.com/javase/8/docs/api/java/net/URL.html)`): `[`Config`](../-config/index.html)
+
+Factory method to load a yaml configuration from a URL.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/load.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/load.md
@@ -1,0 +1,12 @@
+---
+title: YamlConfig.load - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [YamlConfig](index.html) / [load](./load.html)
+
+# load
+
+`fun load(path: `[`Path`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html)`): `[`Config`](../-config/index.html)
+
+Factory method to load a yaml configuration. Given path must exist and end with "yml".
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/properties.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/properties.md
@@ -1,0 +1,9 @@
+---
+title: YamlConfig.properties - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [YamlConfig](index.html) / [properties](./properties.html)
+
+# properties
+
+`val properties: `[`Map`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/sub-config.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/sub-config.md
@@ -1,0 +1,14 @@
+---
+title: YamlConfig.subConfig - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [YamlConfig](index.html) / [subConfig](./sub-config.html)
+
+# subConfig
+
+`fun subConfig(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Config`](../-config/index.html)
+
+Overrides [Config.subConfig](../-config/sub-config.html)
+
+Tries to retrieve part of the configuration based on given key.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/to-string.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/to-string.md
@@ -1,0 +1,9 @@
+---
+title: YamlConfig.toString - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [YamlConfig](index.html) / [toString](./to-string.html)
+
+# toString
+
+`fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/value-or-default.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/value-or-default.md
@@ -1,0 +1,15 @@
+---
+title: YamlConfig.valueOrDefault - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [YamlConfig](index.html) / [valueOrDefault](./value-or-default.html)
+
+# valueOrDefault
+
+`fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrDefault(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, default: `[`T`](value-or-default.html#T)`): `[`T`](value-or-default.html#T)
+
+Overrides [Config.valueOrDefault](../-config/value-or-default.html)
+
+Retrieves a sub configuration or value based on given key. If configuration property cannot be found
+the specified default value is returned.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/value-or-null.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/value-or-null.md
@@ -1,0 +1,15 @@
+---
+title: YamlConfig.valueOrNull - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [YamlConfig](index.html) / [valueOrNull](./value-or-null.html)
+
+# valueOrNull
+
+`fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`T`](value-or-null.html#T)`?`
+
+Overrides [Config.valueOrNull](../-config/value-or-null.html)
+
+Retrieves a sub configuration or value based on given key.
+If the configuration property cannot be found, null is returned.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/create-compiler-configuration.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/create-compiler-configuration.md
@@ -1,0 +1,9 @@
+---
+title: createCompilerConfiguration - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api](index.html) / [createCompilerConfiguration](./create-compiler-configuration.html)
+
+# createCompilerConfiguration
+
+`fun createCompilerConfiguration(classpath: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>, pathsToAnalyze: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Path`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html)`>): CompilerConfiguration`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/create-kotlin-core-environment.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/create-kotlin-core-environment.md
@@ -1,0 +1,9 @@
+---
+title: createKotlinCoreEnvironment - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api](index.html) / [createKotlinCoreEnvironment](./create-kotlin-core-environment.html)
+
+# createKotlinCoreEnvironment
+
+`fun createKotlinCoreEnvironment(configuration: CompilerConfiguration = CompilerConfiguration()): KotlinCoreEnvironment`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/index.md
@@ -1,0 +1,71 @@
+---
+title: io.gitlab.arturbosch.detekt.api - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api](./index.html)
+
+## Package io.gitlab.arturbosch.detekt.api
+
+### Types
+
+| [AnnotationExcluder](-annotation-excluder/index.html) | `class AnnotationExcluder`<br>Primary use case for an AnnotationExcluder is to decide if a KtElement should be excluded from further analysis. This is done by checking if a special annotation is present over the element. |
+| [BaseConfig](-base-config/index.html) | `abstract class BaseConfig : `[`Config`](-config/index.html)<br>Convenient base configuration which parses/casts the configuration value based on the type of the default value. |
+| [BaseRule](-base-rule/index.html) | `abstract class BaseRule : `[`DetektVisitor`](-detekt-visitor/index.html)`, `[`Context`](-context/index.html)<br>Defines the visiting mechanism for KtFile's. |
+| [CodeSmell](-code-smell/index.html) | `open class CodeSmell : `[`Finding`](-finding/index.html)<br>A code smell indicates any possible design problem inside a program's source code. The type of a code smell is described by an [Issue](-issue/index.html). |
+| [Compactable](-compactable/index.html) | `interface Compactable`<br>Provides a compact string representation. |
+| [CompositeConfig](-composite-config/index.html) | `class CompositeConfig : `[`Config`](-config/index.html)<br>Wraps two different configuration which should be considered when retrieving properties. |
+| [Config](-config/index.html) | `interface Config`<br>A configuration holds information about how to configure specific rules. |
+| [ConfigAware](-config-aware/index.html) | `interface ConfigAware : `[`Config`](-config/index.html)<br>Interface which is implemented by each Rule class to provide utility functions to retrieve specific or generic properties from the underlying detekt configuration file. |
+| [ConsoleReport](-console-report/index.html) | `abstract class ConsoleReport : `[`Extension`](-extension/index.html)<br>Extension point which describes how findings should be printed on the console. |
+| [Context](-context/index.html) | `interface Context`<br>A context describes the storing and reporting mechanism of [Finding](-finding/index.html)'s inside a [Rule](-rule/index.html). Additionally it handles suppression and aliases management. |
+| [Debt](-debt/index.html) | `data class Debt`<br>Debt describes the estimated amount of work needed to fix a given issue. |
+| [DefaultContext](-default-context/index.html) | `open class DefaultContext : `[`Context`](-context/index.html)<br>Default [Context](-context/index.html) implementation. |
+| [Detektion](-detektion/index.html) | `interface Detektion`<br>Storage for all kinds of findings and additional information which needs to be transferred from the detekt engine to the user. |
+| [DetektVisitor](-detekt-visitor/index.html) | `open class DetektVisitor : KtTreeVisitorVoid`<br>Basic visitor which is used inside detekt. Guarantees a better looking name as the extended base class :). |
+| [Entity](-entity/index.html) | `data class Entity : `[`Compactable`](-compactable/index.html)<br>Stores information about a specific code fragment. |
+| [Extension](-extension/index.html) | `interface Extension`<br>Defines extension points in detekt. Currently supported extensions are: |
+| [FileProcessListener](-file-process-listener/index.html) | `interface FileProcessListener : `[`Extension`](-extension/index.html)<br>Gather additional metrics about the analyzed kotlin file. Pay attention to the thread policy of each function! |
+| [Finding](-finding/index.html) | `interface Finding : `[`Compactable`](-compactable/index.html)`, `[`HasEntity`](-has-entity/index.html)`, `[`HasMetrics`](-has-metrics/index.html)<br>Base interface of detection findings. Inherits a bunch of useful behaviour from sub interfaces. |
+| [HasEntity](-has-entity/index.html) | `interface HasEntity`<br>Describes a source code position. |
+| [HasMetrics](-has-metrics/index.html) | `interface HasMetrics`<br>Adds metric container behaviour. |
+| [Issue](-issue/index.html) | `data class Issue`<br>An issue represents a problem in the codebase. |
+| [LazyRegex](-lazy-regex/index.html) | `class LazyRegex : `[`ReadOnlyProperty`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.properties/-read-only-property/index.html)`<`[`Rule`](-rule/index.html)`, `[`Regex`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/-regex/index.html)`>`<br>LazyRegex class provides a lazy evaluation of a Regex pattern for usages inside Rules. It computes the value once when reaching the point of its usage and returns the same value when requested again. |
+| [Location](-location/index.html) | `data class Location : `[`Compactable`](-compactable/index.html)<br>Specifies a position within a source code fragment. |
+| [Metric](-metric/index.html) | `data class Metric`<br>Metric type, can be an integer or double value. Internally it is stored as an integer, but the conversion factor and is double attributes can be used to retrieve it as a double value. |
+| [MultiRule](-multi-rule/index.html) | `abstract class MultiRule : `[`BaseRule`](-base-rule/index.html) |
+| [Notification](-notification/index.html) | `interface Notification`<br>Any kind of notification which should be printed to the console. For example when using the formatting rule set, any change to your kotlin file is a notification. |
+| [OutputReport](-output-report/index.html) | `abstract class OutputReport : `[`Extension`](-extension/index.html)<br>Translates detekt's result container - [Detektion](-detektion/index.html) - into an output report which is written inside a file. |
+| [ProjectMetric](-project-metric/index.html) | `open class ProjectMetric`<br>Anything that can be expressed as a number value for projects. |
+| [Rule](-rule/index.html) | `abstract class Rule : `[`BaseRule`](-base-rule/index.html)`, `[`ConfigAware`](-config-aware/index.html)<br>A rule defines how one specific code structure should look like. If code is found which does not meet this structure, it is considered as harmful regarding maintainability or readability. |
+| [RuleSet](-rule-set/index.html) | `class RuleSet`<br>A rule set is a collection of rules and must be defined within a rule set provider implementation. |
+| [RuleSetProvider](-rule-set-provider/index.html) | `interface RuleSetProvider`<br>A rule set provider, as the name states, is responsible for creating rule sets. |
+| [Severity](-severity/index.html) | `enum class Severity`<br>Rules can classified into different severity grades. Maintainer can choose a grade which is most harmful to their projects. |
+| [SingleAssign](-single-assign/index.html) | `class SingleAssign<T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`>`<br>Allows to assign a property just once. Further assignments result in [IllegalStateException](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-illegal-state-exception/index.html)'s. |
+| [SourceLocation](-source-location/index.html) | `data class SourceLocation`<br>Stores line and column information of a location. |
+| [SplitPattern](-split-pattern/index.html) | `class SplitPattern`<br>Splits given text into parts and provides testing utilities for its elements. Basic use cases are to specify different function or class names in the detekt yaml config and test for their appearance in specific rules. |
+| [TextLocation](-text-location/index.html) | `data class TextLocation`<br>Stores character start and end positions of an text file. |
+| [ThresholdedCodeSmell](-thresholded-code-smell/index.html) | `open class ThresholdedCodeSmell : `[`CodeSmell`](-code-smell/index.html)<br>Represents a code smell for which a specific metric can be determined which is responsible for the existence of this rule violation. |
+| [ThresholdRule](-threshold-rule/index.html) | `abstract class ThresholdRule : `[`Rule`](-rule/index.html)<br>Provides a threshold attribute for this rule, which is specified manually for default values but can be also obtained from within a configuration object. |
+| [YamlConfig](-yaml-config/index.html) | `class YamlConfig : `[`BaseConfig`](-base-config/index.html)<br>Config implementation using the yaml format. SubConfigurations can return sub maps according to the yaml specification. |
+
+### Type Aliases
+
+| [RuleId](-rule-id.html) | `typealias RuleId = `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)<br>The type to use when referring to rule ids giving it more context then a String would. |
+| [RuleSetId](-rule-set-id.html) | `typealias RuleSetId = `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+
+### Extensions for External Classes
+
+| [org.jetbrains.kotlin.psi.KtAnnotated](org.jetbrains.kotlin.psi.-kt-annotated/index.html) |  |
+| [org.jetbrains.kotlin.psi.KtElement](org.jetbrains.kotlin.psi.-kt-element/index.html) |  |
+
+### Properties
+
+| [DEFAULT_FLOAT_CONVERSION_FACTOR](-d-e-f-a-u-l-t_-f-l-o-a-t_-c-o-n-v-e-r-s-i-o-n_-f-a-c-t-o-r.html) | `const val DEFAULT_FLOAT_CONVERSION_FACTOR: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)<br>To represent a value of 0.5, use the metric value 50 and the conversion factor of 100. (50 / 100 = 0.5) |
+| [psiFactory](psi-factory.html) | `val psiFactory: KtPsiFactory`<br>Allows to generate different kinds of KtElement's. |
+| [psiProject](psi-project.html) | `val psiProject: Project`<br>The initialized kotlin environment which is used to translate kotlin code to a Kotlin-AST. |
+
+### Functions
+
+| [createCompilerConfiguration](create-compiler-configuration.html) | `fun createCompilerConfiguration(classpath: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>, pathsToAnalyze: `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Path`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html)`>): CompilerConfiguration` |
+| [createKotlinCoreEnvironment](create-kotlin-core-environment.html) | `fun createKotlinCoreEnvironment(configuration: CompilerConfiguration = CompilerConfiguration()): KotlinCoreEnvironment` |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/org.jetbrains.kotlin.psi.-kt-annotated/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/org.jetbrains.kotlin.psi.-kt-annotated/index.md
@@ -1,0 +1,10 @@
+---
+title: io.gitlab.arturbosch.detekt.api.org.jetbrains.kotlin.psi.KtAnnotated - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [org.jetbrains.kotlin.psi.KtAnnotated](./index.html)
+
+### Extensions for org.jetbrains.kotlin.psi.KtAnnotated
+
+| [isSuppressedBy](is-suppressed-by.html) | `fun KtAnnotated.isSuppressedBy(id: `[`RuleId`](../-rule-id.html)`, aliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)<br>Checks if this kt element is suppressed by @Suppress or @SuppressWarnings annotations. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/org.jetbrains.kotlin.psi.-kt-annotated/is-suppressed-by.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/org.jetbrains.kotlin.psi.-kt-annotated/is-suppressed-by.md
@@ -1,0 +1,12 @@
+---
+title: isSuppressedBy - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [org.jetbrains.kotlin.psi.KtAnnotated](index.html) / [isSuppressedBy](./is-suppressed-by.html)
+
+# isSuppressedBy
+
+`fun KtAnnotated.isSuppressedBy(id: `[`RuleId`](../-rule-id.html)`, aliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)
+
+Checks if this kt element is suppressed by @Suppress or @SuppressWarnings annotations.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/org.jetbrains.kotlin.psi.-kt-element/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/org.jetbrains.kotlin.psi.-kt-element/index.md
@@ -1,0 +1,10 @@
+---
+title: io.gitlab.arturbosch.detekt.api.org.jetbrains.kotlin.psi.KtElement - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [org.jetbrains.kotlin.psi.KtElement](./index.html)
+
+### Extensions for org.jetbrains.kotlin.psi.KtElement
+
+| [isSuppressedBy](is-suppressed-by.html) | `fun KtElement.isSuppressedBy(id: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, aliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)<br>Checks if this psi element is suppressed by @Suppress or @SuppressWarnings annotations. If this element cannot have annotations, the first annotative parent is searched. |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/org.jetbrains.kotlin.psi.-kt-element/is-suppressed-by.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/org.jetbrains.kotlin.psi.-kt-element/is-suppressed-by.md
@@ -1,0 +1,13 @@
+---
+title: isSuppressedBy - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [org.jetbrains.kotlin.psi.KtElement](index.html) / [isSuppressedBy](./is-suppressed-by.html)
+
+# isSuppressedBy
+
+`fun KtElement.isSuppressedBy(id: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, aliases: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>): `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)
+
+Checks if this psi element is suppressed by @Suppress or @SuppressWarnings annotations.
+If this element cannot have annotations, the first annotative parent is searched.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/psi-factory.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/psi-factory.md
@@ -1,0 +1,12 @@
+---
+title: psiFactory - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api](index.html) / [psiFactory](./psi-factory.html)
+
+# psiFactory
+
+`val psiFactory: KtPsiFactory`
+
+Allows to generate different kinds of KtElement's.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/psi-project.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/psi-project.md
@@ -1,0 +1,12 @@
+---
+title: psiProject - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api](index.html) / [psiProject](./psi-project.html)
+
+# psiProject
+
+`val psiProject: Project`
+
+The initialized kotlin environment which is used to translate kotlin code to a Kotlin-AST.
+

--- a/docs/pages/kdoc/detekt-api/package-list
+++ b/docs/pages/kdoc/detekt-api/package-list
@@ -1,0 +1,9 @@
+$dokka.format:jekyll
+$dokka.linkExtension:html
+$dokka.location:io.gitlab.arturbosch.detekt.api$isSuppressedBy(org.jetbrains.kotlin.psi.KtAnnotated, kotlin.String, kotlin.collections.Set((kotlin.String)))io.gitlab.arturbosch.detekt.api/org.jetbrains.kotlin.psi.-kt-annotated/is-suppressed-by.html
+$dokka.location:io.gitlab.arturbosch.detekt.api$isSuppressedBy(org.jetbrains.kotlin.psi.KtElement, kotlin.String, kotlin.collections.Set((kotlin.String)))io.gitlab.arturbosch.detekt.api/org.jetbrains.kotlin.psi.-kt-element/is-suppressed-by.html
+$dokka.location:io.gitlab.arturbosch.detekt.api.internal$absolutePath(org.jetbrains.kotlin.psi.KtFile)io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-file/absolute-path.html
+$dokka.location:io.gitlab.arturbosch.detekt.api.internal$isUsedForNesting(org.jetbrains.kotlin.psi.KtCallExpression)io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-call-expression/is-used-for-nesting.html
+$dokka.location:io.gitlab.arturbosch.detekt.api.internal$relativePath(org.jetbrains.kotlin.psi.KtFile)io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-file/relative-path.html
+io.gitlab.arturbosch.detekt.api
+io.gitlab.arturbosch.detekt.api.internal

--- a/docs/search.json
+++ b/docs/search.json
@@ -11,7 +11,7 @@ search: exclude
 "title": "{{ page.title | escape }}",
 "tags": "{{ page.tags }}",
 "keywords": "{{page.keywords}}",
-"url": "{{ page.url | remove: "/"}}",
+"url": "{{ page.url }}",
 "summary": "{{page.summary | strip }}"
 }
 {% unless forloop.last and site.posts.size < 1 %},{% endunless %}


### PR DESCRIPTION
Two big changes;
1. Publishes detekt-api KDoc to the documentation website
2. Stops producing Javadoc JARs - instead, generates an empty Javadoc JAR to satisfy publishing requirements, but users will have to go to the docs site to view it (or read the source). See [what Square publishes for okio](https://search.maven.org/artifact/com.squareup.okio/okio/2.2.2/jar) as an example of this practice used in the wild.

dokka will no longer run on any module other than detekt-api. This reduces build time, and doesn't provide any value since @arturbosch [has previously said](https://github.com/arturbosch/detekt/issues/1206#issuecomment-445131559):

> I consider detekt-api, public parts of detekt-cli like CliArgs, the Baseline and YamlConfig and the gradle dsl / detekt extension as public api

Therefore only detekt-api (and the rules documentation, which is already being generated) needs to be published IMHO.

Closes #1574 