### PR TITLE
Add rule to detekt missing or invalid package declaration.

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -325,6 +325,9 @@ naming:
     parameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
     ignoreOverriddenFunctions: true
+  InvalidPackageDeclaration:
+    active: false
+    rootPackage: ''
   MatchingDeclarationName:
     active: true
   MemberNameEqualsClassName:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclaration.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclaration.kt
@@ -1,0 +1,72 @@
+package io.gitlab.arturbosch.detekt.rules.naming
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.absolutePath
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtPackageDirective
+import java.nio.file.Paths
+
+/**
+ * Reports when the package declaration is missing or the file location does not match the declared package.
+ *
+ * @configuration rootPackage - if specified this part of the package structure is ignored (default: `''`)
+ *
+ * @author Markus Schwarz
+ */
+class InvalidPackageDeclaration(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Maintainability,
+        "Kotlin source files should be stored in the directory corresponding to its package statement.",
+        debt = Debt.FIVE_MINS
+    )
+
+    private val rootPackage: String = valueOrDefault(ROOT_PACKAGE, "")
+
+    private var normalizedPathFromPackageDeclaration: String = ""
+
+    override fun visitPackageDirective(directive: KtPackageDirective) {
+        super.visitPackageDirective(directive)
+        normalizedPathFromPackageDeclaration = directive.packageNames.map(KtElement::getText).toNormalizedForm()
+    }
+
+    override fun postVisit(root: KtFile) {
+        super.postVisit(root)
+        val declaredPath = normalizedPathFromPackageDeclaration
+        if (declaredPath.isBlank()) {
+            root.reportInvalidPackageDeclaration("The file does not contain a package declaration.")
+        } else {
+            val normalizedFilePath = root.absolutePath()?.let { Paths.get(it).parent?.toNormalizedForm() }
+            val normalizedRootPackage = packageNameToNormalizedForm(rootPackage)
+            val expectedPath = if (normalizedRootPackage.isBlank())
+                declaredPath
+            else
+                declaredPath.substringAfter(normalizedRootPackage)
+
+            val isInRootPackage = expectedPath.isBlank()
+            if (!isInRootPackage && normalizedFilePath != null && !normalizedFilePath.endsWith(expectedPath)) {
+                root.reportInvalidPackageDeclaration("The package declaration does not match the actual file location.")
+            }
+        }
+    }
+
+    private fun KtFile.reportInvalidPackageDeclaration(message: String) {
+        report(CodeSmell(issue, Entity.from(this), message))
+    }
+
+    private fun <T> Iterable<T>.toNormalizedForm() = joinToString("|")
+
+    private fun packageNameToNormalizedForm(packageName: String) = packageName.split('.').toNormalizedForm()
+
+    companion object {
+        const val ROOT_PACKAGE = "rootPackage"
+    }
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/NamingProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/NamingProvider.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.providers
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.rules.naming.InvalidPackageDeclaration
 import io.gitlab.arturbosch.detekt.rules.naming.MatchingDeclarationName
 import io.gitlab.arturbosch.detekt.rules.naming.MemberNameEqualsClassName
 import io.gitlab.arturbosch.detekt.rules.naming.NamingRules
@@ -18,10 +19,13 @@ class NamingProvider : RuleSetProvider {
     override val ruleSetId: String = "naming"
 
     override fun instance(config: Config): RuleSet {
-        return RuleSet(ruleSetId, listOf(
+        return RuleSet(
+            ruleSetId, listOf(
                 MatchingDeclarationName(config),
                 MemberNameEqualsClassName(config),
-                NamingRules(config)
-        ))
+                NamingRules(config),
+                InvalidPackageDeclaration(config)
+            )
+        )
     }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
@@ -1,0 +1,122 @@
+package io.gitlab.arturbosch.detekt.rules.naming
+
+import io.gitlab.arturbosch.detekt.api.internal.ABSOLUTE_PATH
+import io.gitlab.arturbosch.detekt.rules.naming.InvalidPackageDeclaration.Companion.ROOT_PACKAGE
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileContentForTest
+import io.gitlab.arturbosch.detekt.test.lint
+import org.jetbrains.kotlin.psi.KtFile
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.nio.file.FileSystems
+import java.nio.file.Paths
+
+/**
+ * @configuration rootPackage - maximum name length (default: `64`)
+ * @author Markus Schwarz
+ */
+internal class InvalidPackageDeclarationSpec : Spek({
+
+    describe("InvalidPackageDeclaration rule") {
+
+        it("should pass if package declaration is correct") {
+            val source = """
+                |package foo.bar
+                |
+                |class C
+                |""".trimMargin()
+            val ktFile = compileContentForTest(source)
+            ktFile.setAbsolutePath("project/src/foo/bar/File.kt")
+            val findings = InvalidPackageDeclaration().lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+
+        it("should report if package declaration is missing") {
+            val ktFile = compileContentForTest("class C")
+            val findings = InvalidPackageDeclaration().lint(ktFile)
+            assertThat(findings).hasSize(1)
+        }
+
+        it("should report if package declaration does not match source location") {
+            val source = """
+                |package foo
+                |
+                |class C
+                |""".trimMargin()
+            val ktFile = compileContentForTest(source)
+            ktFile.setAbsolutePath("project/src/bar/File.kt")
+            val findings = InvalidPackageDeclaration().lint(ktFile)
+            assertThat(findings).hasSize(1)
+        }
+
+        describe("with root package specified") {
+            val config = TestConfig(mapOf(ROOT_PACKAGE to "com.example"))
+
+            it("should pass if file is located within the root package") {
+                val source = """
+                |package com.example
+                |
+                |class C
+                |""".trimMargin()
+                val ktFile = compileContentForTest(source).apply { setAbsolutePath("src/File.kt") }
+                val findings = InvalidPackageDeclaration(config).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should pass if file is located relative to root package") {
+                val source = """
+                |package com.example.foo.bar
+                |
+                |class C
+                |""".trimMargin()
+                val ktFile = compileContentForTest(source)
+                ktFile.setAbsolutePath("src/foo/bar/File.kt")
+                val findings = InvalidPackageDeclaration(config).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should pass if file is located in directory corresponding to package declaration") {
+                val source = """
+                |package com.example.foo.bar
+                |
+                |class C
+                |""".trimMargin()
+                val ktFile = compileContentForTest(source)
+                ktFile.setAbsolutePath("src/com/example/foo/bar/File.kt")
+                val findings = InvalidPackageDeclaration(config).lint(ktFile)
+                assertThat(findings).isEmpty()
+            }
+
+            it("should report if package declaration does not match") {
+                val source = """
+                |package com.example.foo.baz
+                |
+                |class C
+                |""".trimMargin()
+                val ktFile = compileContentForTest(source)
+                ktFile.setAbsolutePath("src/foo/bar/File.kt")
+                val findings = InvalidPackageDeclaration(config).lint(ktFile)
+                assertThat(findings).hasSize(1)
+            }
+            it("should report if file path matches root package but package declaration differs") {
+                val source = """
+                |package io.foo.bar
+                |
+                |class C
+                |""".trimMargin()
+                val ktFile = compileContentForTest(source)
+                ktFile.setAbsolutePath("src/com/example/File.kt")
+                val findings = InvalidPackageDeclaration(config).lint(ktFile)
+                assertThat(findings).hasSize(1)
+            }
+        }
+    }
+})
+
+private fun KtFile.setAbsolutePath(universalPath: String) {
+    val pathSegments = universalPath.split('/')
+    val aRootPath = FileSystems.getDefault().rootDirectories.first()
+    val path = Paths.get(aRootPath.toString(), *pathSegments.toTypedArray())
+    putUserData(ABSOLUTE_PATH, path?.toString())
+}

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -148,6 +148,20 @@ Reports function parameter names which do not follow the specified naming conven
 
    ignores overridden functions with parameters not matching the pattern
 
+### InvalidPackageDeclaration
+
+Reports when the package declaration is missing or the file location does not match the declared package.
+
+**Severity**: Maintainability
+
+**Debt**: 5min
+
+#### Configuration options:
+
+* `rootPackage` (default: `''`)
+
+   if specified this part of the package structure is ignored
+
 ### MatchingDeclarationName
 
 "If a Kotlin file contains a single non-private class (potentially with related top-level declarations),


### PR DESCRIPTION
Closes #744 

This rule makes sure there is a package declared and that the package matches the file location.

> In pure Kotlin projects, the recommended directory structure is to follow the package structure with the common root package omitted (e.g. if all the code in the project is in the "org.example.kotlin" package and its subpackages, files with the "org.example.kotlin" package should be placed directly under the source root, and files in "org.example.kotlin.foo.bar" should be in the "foo/bar" subdirectory of the source root).

In order to support this use case, the `rootPackage` must be specified