### PR TITLE
Create a KotlinScriptEngine pool to speed up tests

### DIFF
--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEngine.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEngine.kt
@@ -1,45 +1,27 @@
 package io.gitlab.arturbosch.detekt.test
 
-import org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback
-import org.jetbrains.kotlin.script.jsr223.KotlinJsr223JvmLocalScriptEngine
-import javax.script.ScriptEngineManager
 import javax.script.ScriptException
 
 /**
- * The object to create the Kotlin script engine for code compilation.
+ * The object to use the Kotlin script engine for code compilation.
  *
  * @author schalkms
  */
 object KotlinScriptEngine {
 
-    private lateinit var engine: KotlinJsr223JvmLocalScriptEngine
-
-    init {
-        createEngine()
-    }
-
     /**
      * Compiles a given code string with the Jsr223 script engine.
      * If a compilation error occurs the script engine is recovered.
      *
-     * @param code The String to compile
+     * @param code the String to compile
      * @throws ScriptException
      */
     fun compile(code: String) {
         try {
-            engine.compile(code)
+            KotlinScriptEnginePool.getEngine().compile(code)
         } catch (e: ScriptException) {
-            createEngine() // recover
+            KotlinScriptEnginePool.recoverEngine()
             throw KotlinScriptException(e)
         }
-    }
-
-    private fun createEngine() {
-        setIdeaIoUseFallback() // To avoid error on Windows
-
-        val scriptEngineManager = ScriptEngineManager()
-        val localEngine = scriptEngineManager.getEngineByExtension("kts") as? KotlinJsr223JvmLocalScriptEngine
-        requireNotNull(localEngine) { "Kotlin script engine not supported" }
-        engine = localEngine
     }
 }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEnginePool.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEnginePool.kt
@@ -1,0 +1,44 @@
+package io.gitlab.arturbosch.detekt.test
+
+import org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback
+import org.jetbrains.kotlin.script.jsr223.KotlinJsr223JvmLocalScriptEngine
+import javax.script.ScriptEngineManager
+
+/**
+ * The object to manage a pool of Kotlin script engines to distribute the load for compiling code.
+ * The load for compiling code is distributed over a number of engines.
+ *
+ * @author schalkms
+ */
+object KotlinScriptEnginePool {
+
+    private const val NUMBER_OF_ENGINES = 8
+
+    private val engines: Array<KotlinJsr223JvmLocalScriptEngine>
+    private var id = 0
+
+    init {
+        engines = Array(NUMBER_OF_ENGINES) { createEngine() }
+    }
+
+    fun getEngine(): KotlinJsr223JvmLocalScriptEngine {
+        id++
+        if (id == NUMBER_OF_ENGINES) {
+            id = 0
+        }
+        return engines[id]
+    }
+
+    fun recoverEngine() {
+        engines[id] = createEngine()
+    }
+
+    private fun createEngine(): KotlinJsr223JvmLocalScriptEngine {
+        setIdeaIoUseFallback() // To avoid error on Windows
+
+        val scriptEngineManager = ScriptEngineManager()
+        val engine = scriptEngineManager.getEngineByExtension("kts") as? KotlinJsr223JvmLocalScriptEngine
+        requireNotNull(engine) { "Kotlin script engine not supported" }
+        return engine
+    }
+}


### PR DESCRIPTION
This speeds up the execution of detekt-rules:tests.
The load for compiling code is distributed over a number of engines.

This runs all the tests for detekt's rules in ~20 seconds on my machine.