### PR TITLE
Issue #1611: Fix path issue with DetektTaskDslTest

### DIFF
--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -68,7 +68,7 @@ internal class DetektTaskDslTest : Spek({
 
                     gradleRunner.runDetektTaskAndCheckResult { result ->
                         assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        val expectedConfigParam = "--config ${firstConfig.absolutePath},${secondConfig.absolutePath}"
+                        val expectedConfigParam = "--config ${firstConfig.canonicalPath},${secondConfig.canonicalPath}"
                         assertThat(result.output).contains(expectedConfigParam)
                     }
                 }
@@ -90,7 +90,7 @@ internal class DetektTaskDslTest : Spek({
                     gradleRunner.runDetektTaskAndCheckResult { result ->
 
                         assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        val expectedInputParam = "--input ${projectFile(customSrc).absolutePath}"
+                        val expectedInputParam = "--input ${projectFile(customSrc).canonicalPath}"
                         assertThat(result.output).contains(expectedInputParam)
                         assertThat(result.output).doesNotContain("folder_that_does_not_exist")
                     }
@@ -114,8 +114,8 @@ internal class DetektTaskDslTest : Spek({
                     gradleRunner.runDetektTaskAndCheckResult { result ->
 
                         assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        val file1 = projectFile("$customSrc1/MyRoot0Class.kt").absolutePath
-                        val file2 = projectFile("$customSrc2/MyRoot0Class.kt").absolutePath
+                        val file1 = projectFile("$customSrc1/MyRoot0Class.kt").canonicalPath
+                        val file2 = projectFile("$customSrc2/MyRoot0Class.kt").canonicalPath
                         val expectedInputParam = "--input $file1,$file2"
                         assertThat(result.output).contains(expectedInputParam)
                         assertThat(result.output).contains("number of classes: 2")
@@ -219,7 +219,7 @@ internal class DetektTaskDslTest : Spek({
 
                     gradleRunner.runDetektTaskAndCheckResult { result ->
                         assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        val expectedBaselineArgument = "--baseline ${projectFile(baselineFilename).absolutePath}"
+                        val expectedBaselineArgument = "--baseline ${projectFile(baselineFilename).canonicalPath}"
                         assertThat(result.output).contains(expectedBaselineArgument)
                     }
                 }


### PR DESCRIPTION
macOS puts various temporary directories into a separate mount
point, and then creates symlinks from the more-traditional
POSIX layout locations to the separate mount point. This change
uses `canonicalPath` instead of `absolutePath` to align the
expected locations with what happens during shell expansion.

This might also address #1616.