### PR TITLE
Issue #1611: Fix path issue with DetektTaskDslTest

### DIFF
--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -270,9 +270,9 @@ internal class DetektTaskDslTest : Spek({
                             .withDetektConfig(config)
                             .build()
 
-                        val customXmlReportFilePath = gradleRunner.projectFile("build/reports/custom.xml").absolutePath
+                        val customXmlReportFilePath = gradleRunner.projectFile("build/reports/custom.xml").canonicalPath
                         val customJsonReportFilePath =
-                            gradleRunner.projectFile("build/reports/custom.json").absolutePath
+                            gradleRunner.projectFile("build/reports/custom.json").canonicalPath
 
                         gradleRunner.runDetektTaskAndCheckResult { result ->
                             assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)


### PR DESCRIPTION
... again! My previous commit was a rebase from a branch that
was just a couple days old; I didn't test after rebasing. In
the few days since I had pulled, an additional change came in
that asserted an `absolutePath` instead of a `canonicalPath`.