### PR TITLE
Document build-upon-default-config

### DIFF
--- a/docs/pages/configurations.md
+++ b/docs/pages/configurations.md
@@ -18,7 +18,7 @@ _detekt_ uses a yaml style configuration file for various things:
 
 See the [default-detekt-config.yml](https://github.com/arturbosch/detekt/blob/master/detekt-cli/src/main/resources/default-detekt-config.yml) file for all defined configuration options and their default values. 
 
-_Note:_ When using a custom config file, the default values are ignored unless you also set the `build-upon-default-config` flag.
+_Note:_ When using a custom config file, the default values are ignored unless you also set the `--build-upon-default-config` flag.
 
 #### Rule sets and rules
 

--- a/docs/pages/configurations.md
+++ b/docs/pages/configurations.md
@@ -16,7 +16,9 @@ _detekt_ uses a yaml style configuration file for various things:
 - console and output formats
 - autoCorrect support
 
-See the [default-detekt-config.yml](https://github.com/arturbosch/detekt/blob/master/detekt-cli/src/main/resources/default-detekt-config.yml) file for all defined configuration options and their default values.
+See the [default-detekt-config.yml](https://github.com/arturbosch/detekt/blob/master/detekt-cli/src/main/resources/default-detekt-config.yml) file for all defined configuration options and their default values. 
+
+_Note:_ When using a custom config file, the default values are ignored unless you also set the `build-upon-default-config` flag.
 
 #### Rule sets and rules
 

--- a/docs/pages/gettingstarted/cli.md
+++ b/docs/pages/gettingstarted/cli.md
@@ -43,6 +43,10 @@ Usage: detekt [options]
     --disable-default-rulesets, -dd
       Disables default rule sets.
       Default: false
+    --build-upon-default-config
+      Apply values from config files as changes to the default configuration
+      (instead of starting from an empty configuration).
+      Default: false
     --fail-fast
       Shortcut for 'build-upon-default-config' together with all available rules active 
       and exit code 0 only when no code smells are found.

--- a/docs/pages/gettingstarted/groovydsl.md
+++ b/docs/pages/gettingstarted/groovydsl.md
@@ -101,6 +101,7 @@ detekt {
     )
     parallel = false                                      // Builds the AST in parallel. Rules are always executed in parallel. Can lead to speedups in larger projects. `false` by default.
     config = files("path/to/config.yml")                  // Define the detekt configuration(s) you want to use. Defaults to the default detekt configuration.
+    buildUponDefaultConfig = false                        // Interpret config files as updates to the default config. `false` by default.
     baseline = file("path/to/baseline.xml")               // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
     disableDefaultRuleSets = false                        // Disables all default detekt rulesets and will only run detekt with custom rules defined in `plugins`. `false` by default.
     plugins = "other/optional/ruleset.jar"                // Additional jar file containing custom detekt rules.

--- a/docs/pages/gettingstarted/kotlindsl.md
+++ b/docs/pages/gettingstarted/kotlindsl.md
@@ -41,6 +41,7 @@ detekt {
     )
     parallel = false                                      // Builds the AST in parallel. Rules are always executed in parallel. Can lead to speedups in larger projects. `false` by default.
     config = files("path/to/config.yml")                  // Define the detekt configuration(s) you want to use. Defaults to the default detekt configuration.
+    buildUponDefaultConfig = false                        // Interpret config files as updates to the default config. `false` by default.
     baseline = file("path/to/baseline.xml")               // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
     disableDefaultRuleSets = false                        // Disables all default detekt rulesets and will only run detekt with custom rules defined in `plugins`. `false` by default.
     plugins = "other/optional/ruleset.jar"                // Additional jar file containing custom detekt rules.


### PR DESCRIPTION
Flag `build-upon-default-config` has not yet been documented (in the "getting started" guides). Since the default behaviour is rather unexpected (most other tools I know have this behaviour by default), I propose adding a mention right where new users would find it.

See #1248 that introduced the flag, and also #500.