### PR TITLE
JDK 12 on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ environment:
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
     - JAVA_HOME: C:\Program Files\Java\jdk11
+    - JAVA_HOME: C:\Program Files\Java\jdk12
 
 init:
   - git config --global --unset core.autocrlf


### PR DESCRIPTION
Brings JDK matrix on Windows CI into parity with Linux and macOS