### PR TITLE
Make KtFile.unnormalizeContent a public method

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Paul Merlin](https://github.com/eskatos) - Gradle build improvements
 - [Konstantin Aksenov](https://github.com/vacxe) - Coding improvement
 - [Matthew Haughton](https://github.com/3flex) - Added type resolution, Dependency updates, Coding + Documentation improvements
-- [Janusz Bagiński](https://github.com/jbaginski) - Fixed line number reporting for MaxLineLengthRule 
+- [Janusz Bagiński](https://github.com/jbaginski) - Fixed line number reporting for MaxLineLengthRule
 - [Mike Kobit](https://github.com/mkobit) - Gradle build improvements
 - [Philipp Hofmann](https://github.com/philipphofmann) - Readme improvements
 - [Olivier PEREZ](https://github.com/olivierperez) - Fixed Typo in Readme
@@ -165,7 +165,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 
 ### Mentions
 
-[![androidweekly](https://img.shields.io/badge/androidweekly.net-259-orange.svg?style=flat-square)](http://androidweekly.net/issues/issue-259) 
+[![androidweekly](https://img.shields.io/badge/androidweekly.net-259-orange.svg?style=flat-square)](http://androidweekly.net/issues/issue-259)
 [![androidweekly](https://img.shields.io/badge/androidweekly.cn-154-orange.svg?style=flat-square)](http://androidweekly.cn/android-dev-wekly-issue-154/)
 
 As mentioned in...

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
@@ -15,20 +15,20 @@ class KtFileModifier(private val project: Path) {
 
     fun saveModifiedFiles(ktFiles: List<KtFile>, notification: (Notification) -> Unit) {
         ktFiles.filter { it.modificationStamp > 0 }
-                .map { it.absolutePath() to it.unnormalizeContent() }
-                .filter { it.first != null }
+                .map { it.absolutePath().orEmpty() to it.unnormalizeContent() }
+                .filter { it.first.isNotBlank() }
                 .map { project.resolve(it.first) to it.second }
                 .forEach {
                     notification.invoke(ModificationNotification(it.first))
                     Files.write(it.first, it.second.toByteArray())
                 }
     }
+}
 
-    private fun KtFile.unnormalizeContent(): String {
-        val lineSeparator = getUserData(LINE_SEPARATOR)
-        require(lineSeparator != null) {
-            "No line separator entry for ktFile ${javaFileFacadeFqName.asString()}"
-        }
-        return StringUtilRt.convertLineSeparators(text, lineSeparator)
+fun KtFile.unnormalizeContent(): String {
+    val lineSeparator = getUserData(LINE_SEPARATOR)
+    require(lineSeparator != null) {
+        "No line separator entry for ktFile ${javaFileFacadeFqName.asString()}"
     }
+    return StringUtilRt.convertLineSeparators(text, lineSeparator)
 }


### PR DESCRIPTION
An alternative to #1593.

Making `KtFile.unnormalizeContent` available will make it possible to add implement the same functionality, but without needing to add a dependency to `org.jetbrains.kotlin:kotlin-compiler-embeddable`.