### PR TITLE
Lazily add `detekt` task as a dependency of the `check` task

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.UnknownTaskException
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
 import org.gradle.language.base.plugins.LifecycleBasePlugin
@@ -51,13 +50,9 @@ class DetektPlugin : Plugin<Project> {
             }
         }
 
-        val checkTaskProvider = try {
-            project.tasks.named(LifecycleBasePlugin.CHECK_TASK_NAME)
-        } catch (ignored: UnknownTaskException) {
-            null
+        project.tasks.matching { it.name == LifecycleBasePlugin.CHECK_TASK_NAME }.configureEach {
+            it.dependsOn(detektTaskProvider)
         }
-
-        checkTaskProvider?.configure { it.dependsOn(detektTaskProvider) }
     }
 
     private fun registerCreateBaselineTask(project: Project, extension: DetektExtension) =

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPluginTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPluginTest.kt
@@ -1,0 +1,26 @@
+package io.gitlab.arturbosch.detekt
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Task
+import org.gradle.language.base.plugins.LifecycleBasePlugin
+import org.gradle.testfixtures.ProjectBuilder
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object DetektPluginTest : Spek({
+    describe("detekt plugin") {
+
+        fun Task.dependencies() = taskDependencies.getDependencies(this)
+
+        it("lazily adds detekt as a dependency of the `check` task") {
+            val project = ProjectBuilder.builder().build()
+
+            /** Ordering here is important - to prove lazily adding the dependency works the LifecycleBasePlugin must be
+             * added to the project after the detekt plugin. */
+            project.pluginManager.apply(DetektPlugin::class.java)
+            project.pluginManager.apply(LifecycleBasePlugin::class.java)
+
+            assertThat(project.tasks.getAt("check").dependencies().map {it.name }).contains("detekt")
+        }
+    }
+})

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPluginTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPluginTest.kt
@@ -15,7 +15,7 @@ object DetektPluginTest : Spek({
         it("lazily adds detekt as a dependency of the `check` task") {
             val project = ProjectBuilder.builder().build()
 
-            /** Ordering here is important - to prove lazily adding the dependency works the LifecycleBasePlugin must be
+            /* Ordering here is important - to prove lazily adding the dependency works the LifecycleBasePlugin must be
              * added to the project after the detekt plugin. */
             project.pluginManager.apply(DetektPlugin::class.java)
             project.pluginManager.apply(LifecycleBasePlugin::class.java)

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPluginTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPluginTest.kt
@@ -20,7 +20,7 @@ object DetektPluginTest : Spek({
             project.pluginManager.apply(DetektPlugin::class.java)
             project.pluginManager.apply(LifecycleBasePlugin::class.java)
 
-            assertThat(project.tasks.getAt("check").dependencies().map {it.name }).contains("detekt")
+            assertThat(project.tasks.getAt("check").dependencies().map { it.name }).contains("detekt")
         }
     }
 })


### PR DESCRIPTION
Fixes #1640 

This uses ProjectBuilder instead of GradleRunner for its tests. It's much lighter weight and runs more quickly and is useful for testing task and plugin configuration. In this case, I created a new test, which failed, then updated the plugin setup code and saw the test pass.