### PR TITLE
Move autocorrect to cli

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -83,6 +83,13 @@ class CliArgs : Args {
             "Additional configuration files can override properties but not the 'active' one.")
     var failFast: Boolean = false
 
+    @Parameter(names = ["--auto-correct", "-ac"],
+        description = "Allow rules to auto correct code if they support it. " +
+            "The default rule sets do NOT support auto correcting and won't change any line in the users code base. " +
+            "However custom rules can be written to support auto correcting. " +
+            "The additional 'formatting' rule set, added with '--plugins', does support it and needs this flag.")
+    var autoCorrect: Boolean = false
+
     @Parameter(names = ["--debug"],
         description = "Prints extra information about configurations and extensions.")
     var debug: Boolean = false
@@ -116,7 +123,7 @@ class CliArgs : Args {
         names = ["--jvm-target"],
         converter = JvmTargetConverter::class,
         description = "EXPERIMENTAL: Target version of the generated JVM bytecode that was generated during " +
-                "compilation and is now being used for type resolution (1.6, 1.8, 9, 10, 11 or 12)"
+            "compilation and is now being used for type resolution (1.6, 1.8, 9, 10, 11 or 12)"
     )
     var jvmTarget: JvmTarget = JvmTarget.DEFAULT
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -33,6 +33,7 @@ class Runner(private val arguments: CliArgs) : Executable {
             config = loadConfiguration(),
             pathFilters = createFilters(),
             parallelCompilation = parallel,
+            autoCorrect = autoCorrect,
             excludeDefaultRuleSets = disableDefaultRuleSets,
             pluginPaths = createPlugins(),
             classpath = createClasspath(),

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
@@ -30,6 +30,7 @@ class SingleRuleRunner(private val arguments: CliArgs) : Executable {
                 config = loadConfiguration(),
                 pathFilters = createFilters(),
                 parallelCompilation = parallel,
+                autoCorrect = autoCorrect,
                 excludeDefaultRuleSets = disableDefaultRuleSets,
                 pluginPaths = createPlugins())
         }

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -1,5 +1,3 @@
-autoCorrect: true
-
 build:
   maxIssues: 10
   weights:

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
@@ -30,7 +30,7 @@ class DetektFacade(
     private val processors: List<FileProcessListener>
 ) {
 
-    private val saveSupported = settings.config.valueOrDefault("autoCorrect", false)
+    private val saveSupported = settings.autoCorrect
     private val inputPaths = settings.inputPaths
     private val classpath = settings.classpath
     private val pathFilters = settings.pathFilters

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -29,6 +29,7 @@ data class ProcessingSettings @JvmOverloads constructor(
     val executorService: ExecutorService = ForkJoinPool.commonPool(),
     val outPrinter: PrintStream = System.out,
     val errorPrinter: PrintStream = System.err,
+    val autoCorrect: Boolean = false,
     val debug: Boolean = false
 ) {
     /**
@@ -46,6 +47,7 @@ data class ProcessingSettings @JvmOverloads constructor(
         executorService: ExecutorService = ForkJoinPool.commonPool(),
         outPrinter: PrintStream = System.out,
         errorPrinter: PrintStream = System.err,
+        autoCorrect: Boolean = false,
         debug: Boolean = false
     ) : this(
         listOf(inputPath),
@@ -59,6 +61,7 @@ data class ProcessingSettings @JvmOverloads constructor(
         executorService,
         outPrinter,
         errorPrinter,
+        autoCorrect,
         debug
     )
 

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -18,8 +18,6 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
 
     override fun print(item: List<RuleSetPage>): String {
         return yaml {
-            yaml { defaultGenericConfiguration() }
-            emptyLine()
             yaml { defaultBuildConfiguration() }
             emptyLine()
             yaml { defaultProcessorsConfiguration() }
@@ -66,12 +64,6 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
             }
             emptyLine()
         }
-    }
-
-    private fun defaultGenericConfiguration(): String {
-        return """
-			autoCorrect: true
-			""".trimIndent()
     }
 
     private fun defaultBuildConfiguration(): String {


### PR DESCRIPTION
The last orphant config property which is suited best to be part of the cli args and gradle properties.
A new gradle plugin property must be merged when all other modules get a RC15 release. 