### PR TITLE
Do not use relativePath as it is not set anymore and will crash the detekt run

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.api
 
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
-import io.gitlab.arturbosch.detekt.api.internal.relativePath
+import io.gitlab.arturbosch.detekt.api.internal.absolutePath
 import io.gitlab.arturbosch.detekt.api.internal.validateIdentifier
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -40,5 +40,5 @@ class RuleSet(val id: RuleSetId, val rules: List<BaseRule>) {
         }
 
     private fun isFileIgnored(file: KtFile) =
-        pathFilters?.isIgnored(Paths.get(file.relativePath())) == true
+        pathFilters?.isIgnored(Paths.get(file.absolutePath())) == true
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
@@ -44,8 +44,8 @@ class DetektFacade(
         val findings = HashMap<String, List<Finding>>()
 
         val filesToAnalyze = environment.getSourceFiles()
-            .filterNot { file -> pathFilters?.isIgnored(Paths.get(file.virtualFilePath)) ?: false }
-            .apply { forEach { it.addUserData(it.virtualFilePath) } }
+            .filterNot { file -> pathFilters?.isIgnored(Paths.get(file.virtualFilePath)) == true }
+            .onEach { it.addUserData(it.virtualFilePath) }
         val bindingContext = generateBindingContext(filesToAnalyze)
 
         processors.forEach { it.onStart(filesToAnalyze) }

--- a/reports/failfast.yml
+++ b/reports/failfast.yml
@@ -1,24 +1,6 @@
 build:
   maxIssues: 1
 
-test-pattern: # Configure exclusions for test sources
-  active: true
-  patterns: # Test file regexes
-    - '.*/test/.*'
-    - '.*Test.kt'
-    - '.*Spec.kt'
-  exclude-rule-sets:
-    - 'comments'
-  exclude-rules:
-    - 'NamingRules'
-    - 'WildcardImport'
-    - 'MagicNumber'
-    - 'MaxLineLength'
-    - 'LateinitUsage'
-    - 'StringLiteralDuplication'
-    - 'SpreadOperator'
-    - 'UnsafeCast'
-
 comments:
   CommentOverPrivateProperty:
     active: true
@@ -26,6 +8,7 @@ comments:
 complexity:
   StringLiteralDuplication:
     active: true
+    excludes: "**/test/**,**/*.Test.kt,**/*.Spec.kt"
     threshold: 5
     ignoreAnnotation: true
     excludeStringsWithLessThan5Characters: true
@@ -77,6 +60,7 @@ naming:
 potential-bugs:
   UnsafeCast:
     active: true
+    excludes: "**/test/**,**/*.Test.kt,**/*.Spec.kt"
   UselessPostfixExpression:
     active: true
 
@@ -84,6 +68,7 @@ style:
   CollapsibleIfStatements:
     active: true
   MaxLineLength:
+    excludes: "**/test/**,**/*.Test.kt,**/*.Spec.kt"
     excludeCommentStatements: true
   MagicNumber:
     ignoreHashCodeFunction: true


### PR DESCRIPTION
The kotlin environment handles now the compilation of kt files and we do not add a relative path to the user data anymore.