### PR TITLE
Unify use of kotlin environment and make AST modification work again

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ProjectExtension.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ProjectExtension.kt
@@ -45,7 +45,10 @@ fun createKotlinCoreEnvironment(configuration: CompilerConfiguration = CompilerC
             PrintingMessageCollector(System.err, MessageRenderer.PLAIN_FULL_PATHS, false))
     configuration.put(CommonConfigurationKeys.MODULE_NAME, "detekt")
     return KotlinCoreEnvironment.createForProduction(Disposer.newDisposable(),
-        configuration, EnvironmentConfigFiles.JVM_CONFIG_FILES)
+        configuration, EnvironmentConfigFiles.JVM_CONFIG_FILES).apply {
+        makeMutable(project as? MockProject ?: throw IllegalStateException(
+            "Unexpected Type for psi project. MockProject expected. Please report this!"))
+    }
 }
 
 private fun createProject(configuration: CompilerConfiguration = CompilerConfiguration()): Project {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ProjectExtension.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ProjectExtension.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.api
 
+import io.gitlab.arturbosch.detekt.api.internal.DetektPomModel
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoots
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
@@ -9,21 +10,12 @@ import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.config.addJavaSourceRoots
 import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
-import org.jetbrains.kotlin.com.intellij.openapi.extensions.ExtensionPoint
-import org.jetbrains.kotlin.com.intellij.openapi.extensions.Extensions
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
-import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
 import org.jetbrains.kotlin.com.intellij.pom.PomModel
-import org.jetbrains.kotlin.com.intellij.pom.PomModelAspect
-import org.jetbrains.kotlin.com.intellij.pom.PomTransaction
-import org.jetbrains.kotlin.com.intellij.pom.impl.PomTransactionBase
-import org.jetbrains.kotlin.com.intellij.pom.tree.TreeAspect
-import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.TreeCopyHandler
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
 import org.jetbrains.kotlin.config.JvmTarget
-import sun.reflect.ReflectionFactory
 import java.io.File
 import java.nio.file.Path
 
@@ -39,9 +31,8 @@ fun createKotlinCoreEnvironment(configuration: CompilerConfiguration = CompilerC
         EnvironmentConfigFiles.JVM_CONFIG_FILES
     )
 
-    val mockProject = environment.project as? MockProject ?: error("MockProject class type expected")
-    makeMutable(mockProject)
-//    mockProject?.registerService(PomModel::class.java, DetektPomModel())
+    val project = environment.project as? MockProject ?: error("MockProject type expected")
+    project.registerService(PomModel::class.java, DetektPomModel(project))
 
     return environment
 }
@@ -71,33 +62,4 @@ fun createCompilerConfiguration(
         addKotlinSourceRoots(kotlinFiles)
         addJvmClasspathRoots(classpath.map { File(it) })
     }
-}
-
-fun makeMutable(project: MockProject) {
-    // Based on KtLint by Shyiko
-    val pomModel: PomModel = object : UserDataHolderBase(), PomModel {
-
-        override fun runTransaction(transaction: PomTransaction) {
-            (transaction as? PomTransactionBase)?.run()
-        }
-
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : PomModelAspect> getModelAspect(aspect: Class<T>): T? {
-            if (aspect == TreeAspect::class.java) {
-                // using approach described in https://git.io/vKQTo due to the magical bytecode of TreeAspect
-                // (check constructor signature and compare it to the source)
-                // (org.jetbrains.kotlin:kotlin-compiler-embeddable:1.0.3)
-                val constructor = ReflectionFactory.getReflectionFactory().newConstructorForSerialization(
-                    aspect, Any::class.java.getDeclaredConstructor())
-                return constructor.newInstance() as T
-            }
-            return null
-        }
-    }
-    val extensionPoint = "org.jetbrains.kotlin.com.intellij.treeCopyHandler"
-    val extensionClassName = TreeCopyHandler::class.java.name!!
-    arrayOf(Extensions.getArea(project), Extensions.getArea(null))
-        .filter { !it.hasExtensionPoint(extensionPoint) }
-        .forEach { it.registerExtensionPoint(extensionPoint, extensionClassName, ExtensionPoint.Kind.INTERFACE) }
-    project.registerService(PomModel::class.java, pomModel)
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/DetektPomModel.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/DetektPomModel.kt
@@ -1,0 +1,42 @@
+package io.gitlab.arturbosch.detekt.api.internal
+
+import org.jetbrains.kotlin.com.intellij.openapi.extensions.ExtensionPoint
+import org.jetbrains.kotlin.com.intellij.openapi.extensions.Extensions
+import org.jetbrains.kotlin.com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
+import org.jetbrains.kotlin.com.intellij.pom.PomModel
+import org.jetbrains.kotlin.com.intellij.pom.PomModelAspect
+import org.jetbrains.kotlin.com.intellij.pom.PomTransaction
+import org.jetbrains.kotlin.com.intellij.pom.impl.PomTransactionBase
+import org.jetbrains.kotlin.com.intellij.pom.tree.TreeAspect
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.TreeCopyHandler
+import sun.reflect.ReflectionFactory
+
+/**
+ * Adapted from https://github.com/pinterest/ktlint/blob/master/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
+ * Licenced under the MIT licence - https://github.com/pinterest/ktlint/blob/master/LICENSE
+ */
+class DetektPomModel(project: Project) : UserDataHolderBase(), PomModel {
+
+    init {
+        val extensionPoint = "org.jetbrains.kotlin.com.intellij.treeCopyHandler"
+        val extensionClassName = TreeCopyHandler::class.java.name!!
+        arrayOf(Extensions.getArea(project), Extensions.getArea(null))
+            .filter { !it.hasExtensionPoint(extensionPoint) }
+            .forEach { it.registerExtensionPoint(extensionPoint, extensionClassName, ExtensionPoint.Kind.INTERFACE) }
+    }
+
+    override fun runTransaction(transaction: PomTransaction) {
+        (transaction as? PomTransactionBase ?: error("PomTransactionBase type expected")).run()
+    }
+
+    override fun <T : PomModelAspect?> getModelAspect(aspect: Class<T>): T? {
+        if (aspect == TreeAspect::class.java) {
+            val constructor = ReflectionFactory.getReflectionFactory()
+                .newConstructorForSerialization(aspect, Any::class.java.getDeclaredConstructor())
+            @Suppress("UNCHECKED_CAST")
+            return constructor.newInstance() as T
+        }
+        return null
+    }
+}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/KotlinEnvironmentUtils.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/KotlinEnvironmentUtils.kt
@@ -18,6 +18,10 @@ import org.jetbrains.kotlin.config.JvmTarget
 import java.io.File
 import java.nio.file.Path
 
+/**
+ * Creates an environment instance which can be used to compile source code to KtFile's.
+ * This environment also allows to modify the resulting AST files.
+ */
 fun createKotlinCoreEnvironment(configuration: CompilerConfiguration = CompilerConfiguration()): KotlinCoreEnvironment {
     System.setProperty("idea.io.use.fallback", "true")
     configuration.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY,
@@ -36,6 +40,10 @@ fun createKotlinCoreEnvironment(configuration: CompilerConfiguration = CompilerC
     return environment
 }
 
+/**
+ * Creates a compiler configuration for the kotlin compiler with all known sources and classpath jars.
+ * Be aware that if any path of [pathsToAnalyze] is a directory it is scanned for java and kotlin files.
+ */
 fun createCompilerConfiguration(
     pathsToAnalyze: List<Path>,
     classpath: List<String>,

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/KotlinEnvironmentUtils.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/KotlinEnvironmentUtils.kt
@@ -1,6 +1,5 @@
-package io.gitlab.arturbosch.detekt.api
+package io.gitlab.arturbosch.detekt.api.internal
 
-import io.gitlab.arturbosch.detekt.api.internal.DetektPomModel
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoots
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
@@ -8,7 +8,7 @@ import org.spekframework.spek2.style.specification.describe
 
 class AnnotationExcluderSpec : Spek({
 
-    val psiFactory = KtTestCompiler.psiFactory
+    val psiFactory = KtTestCompiler.createPsiFactory()
 
     describe("a kt file with some imports") {
         val jvmFieldAnnotation = psiFactory.createAnnotationEntry("@JvmField")

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
@@ -1,11 +1,15 @@
 package io.gitlab.arturbosch.detekt.api
 
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class AnnotationExcluderSpec : Spek({
+
+    val psiFactory = KtTestCompiler.psiFactory
+
     describe("a kt file with some imports") {
         val jvmFieldAnnotation = psiFactory.createAnnotationEntry("@JvmField")
         val sinceKotlinAnnotation = psiFactory.createAnnotationEntry("@SinceKotlin")

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinter.kt
@@ -47,8 +47,8 @@ class ElementPrinter : DetektVisitor() {
 
     private val KtElement.line
         get() = PsiDiagnosticUtils.offsetToLineAndColumn(
-                containingFile.viewProvider.document,
-                textRange.startOffset).line
+            containingFile.viewProvider.document,
+            textRange.startOffset).line
 
     private val KtElement.dump
         get() = indentation + line + ": " + javaClass.simpleName
@@ -78,7 +78,7 @@ class ElementPrinter : DetektVisitor() {
     }
 
     private fun KtElement.isContainer() =
-            this is KtStatementExpression ||
-                    this is KtDeclarationContainer ||
-                    this is KtContainerNode
+        this is KtStatementExpression ||
+            this is KtDeclarationContainer ||
+            this is KtContainerNode
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
@@ -50,19 +50,15 @@ class DetektFacade(
 
         processors.forEach { it.onStart(filesToAnalyze) }
 
-        if (saveSupported) {
-            for (current in inputPaths) {
-                val files = compiler.compile(current)
+        findings.mergeSmells(detektor.run(filesToAnalyze, bindingContext))
+        val result = DetektResult(findings.toSortedMap())
 
-                KtFileModifier(current).saveModifiedFiles(files) {
-                    notifications.add(it)
-                }
+        if (saveSupported) {
+            KtFileModifier().saveModifiedFiles(filesToAnalyze) {
+                notifications.add(it)
             }
         }
 
-        findings.mergeSmells(detektor.run(filesToAnalyze, bindingContext))
-
-        val result = DetektResult(findings.toSortedMap())
         processors.forEach { it.onFinish(filesToAnalyze, result) }
         return result
     }
@@ -94,7 +90,7 @@ class DetektFacade(
         val findings = detektor.run(files)
         val detektion = DetektResult(findings.toSortedMap())
         if (saveSupported) {
-            KtFileModifier(current).saveModifiedFiles(files) {
+            KtFileModifier().saveModifiedFiles(files) {
                 detektion.add(it)
             }
         }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProviderFactory
-import java.nio.file.Path
 import java.nio.file.Paths
 
 /**
@@ -80,23 +79,6 @@ class DetektFacade(
         } else {
             BindingContext.EMPTY
         }
-    }
-
-    fun run(project: Path, files: List<KtFile>): Detektion = runOnFiles(project, files)
-
-    private fun runOnFiles(current: Path, files: List<KtFile>): DetektResult {
-        processors.forEach { it.onStart(files) }
-
-        val findings = detektor.run(files)
-        val detektion = DetektResult(findings.toSortedMap())
-        if (saveSupported) {
-            KtFileModifier().saveModifiedFiles(files) {
-                detektion.add(it)
-            }
-        }
-
-        processors.forEach { it.onFinish(files, detektion) }
-        return detektion
     }
 
     private object DetektMessageRenderer : PlainTextMessageRenderer() {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
@@ -5,8 +5,8 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import io.gitlab.arturbosch.detekt.api.createCompilerConfiguration
-import io.gitlab.arturbosch.detekt.api.createKotlinCoreEnvironment
+import io.gitlab.arturbosch.detekt.api.internal.createCompilerConfiguration
+import io.gitlab.arturbosch.detekt.api.internal.createKotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocation
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
@@ -42,9 +42,6 @@ class DetektFacade(
         val findings = HashMap<String, List<Finding>>()
 
         val filesToAnalyze = inputPaths.flatMap(compiler::compile)
-//        val filesToAnalyze = environment.getSourceFiles()
-//            .filterNot { file -> pathFilters?.isIgnored(Paths.get(file.virtualFilePath)) == true }
-//            .onEach { it.addUserData(it.virtualFilePath) }
         val bindingContext = generateBindingContext(filesToAnalyze)
 
         processors.forEach { it.onStart(filesToAnalyze) }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
@@ -5,8 +5,6 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import io.gitlab.arturbosch.detekt.api.internal.createCompilerConfiguration
-import io.gitlab.arturbosch.detekt.api.internal.createKotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocation
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
@@ -33,9 +31,8 @@ class DetektFacade(
     private val classpath = settings.classpath
     private val pathFilters = settings.pathFilters
     private val jvmTarget = settings.jvmTarget
-    private val compilerConfiguration = createCompilerConfiguration(inputPaths, classpath, jvmTarget)
-    private val environment = createKotlinCoreEnvironment(compilerConfiguration)
-    private val compiler = KtTreeCompiler(KtCompiler(environment), settings)
+    private val environment = settings.environment
+    private val compiler = KtTreeCompiler.instance(settings)
 
     fun run(): Detektion {
         val notifications = mutableListOf<Notification>()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektResult.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektResult.kt
@@ -13,17 +13,20 @@ import org.jetbrains.kotlin.com.intellij.util.keyFMap.KeyFMap
  */
 data class DetektResult(override val findings: Map<RuleSetId, List<Finding>>) : Detektion {
 
-    override val notifications: MutableCollection<Notification> = ArrayList()
-    private var userData = KeyFMap.EMPTY_MAP
+    private val _notifications = ArrayList<Notification>()
+    override val notifications: Collection<Notification> = _notifications
+
     private val _metrics = ArrayList<ProjectMetric>()
     override val metrics: Collection<ProjectMetric> = _metrics
+
+    private var userData = KeyFMap.EMPTY_MAP
 
     override fun add(projectMetric: ProjectMetric) {
         _metrics.add(projectMetric)
     }
 
     override fun add(notification: Notification) {
-        notifications.add(notification)
+        _notifications.add(notification)
     }
 
     override fun <V> getData(key: Key<V>): V? = userData.get(key)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
@@ -1,15 +1,14 @@
 package io.gitlab.arturbosch.detekt.core
 
-import io.gitlab.arturbosch.detekt.api.internal.createKotlinCoreEnvironment
 import io.gitlab.arturbosch.detekt.api.internal.ABSOLUTE_PATH
 import io.gitlab.arturbosch.detekt.api.internal.RELATIVE_PATH
+import io.gitlab.arturbosch.detekt.api.internal.createKotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
 import org.jetbrains.kotlin.com.intellij.testFramework.LightVirtualFile
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.KtPsiFactory
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -17,11 +16,10 @@ import java.nio.file.Paths
  * @author Artur Bosch
  */
 open class KtCompiler(
-    environment: KotlinCoreEnvironment = createKotlinCoreEnvironment()
+    protected val environment: KotlinCoreEnvironment = createKotlinCoreEnvironment()
 ) {
 
-    val psiFileFactory: PsiFileFactory = PsiFileFactory.getInstance(environment.project)
-    val psiFactory: KtPsiFactory = KtPsiFactory(environment.project, false)
+    protected val psiFileFactory: PsiFileFactory = PsiFileFactory.getInstance(environment.project)
 
     fun compile(root: Path, subPath: Path): KtFile {
         require(subPath.isFile()) { "Given sub path should be a regular file!" }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.core
 
-import io.gitlab.arturbosch.detekt.api.createKotlinCoreEnvironment
+import io.gitlab.arturbosch.detekt.api.internal.createKotlinCoreEnvironment
 import io.gitlab.arturbosch.detekt.api.internal.ABSOLUTE_PATH
 import io.gitlab.arturbosch.detekt.api.internal.RELATIVE_PATH
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
@@ -6,21 +6,20 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.fileClasses.javaFileFacadeFqName
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Files
-import java.nio.file.Path
+import java.nio.file.Paths
 
 /**
  * @author Artur Bosch
  */
-class KtFileModifier(private val project: Path) {
+class KtFileModifier {
 
     fun saveModifiedFiles(ktFiles: List<KtFile>, notification: (Notification) -> Unit) {
         ktFiles.filter { it.modificationStamp > 0 }
-                .map { it.absolutePath() to it.unnormalizeContent() }
-                .map { project.resolve(it.first) to it.second }
-                .forEach {
-                    notification.invoke(ModificationNotification(it.first))
-                    Files.write(it.first, it.second.toByteArray())
-                }
+            .map { Paths.get(it.absolutePath()) to it.unnormalizeContent() }
+            .forEach {
+                notification.invoke(ModificationNotification(it.first))
+                Files.write(it.first, it.second.toByteArray())
+            }
     }
 
     private fun KtFile.unnormalizeContent(): String {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
@@ -10,13 +10,13 @@ import java.util.stream.Collectors
  * @author Marvin Ramin
  */
 class KtTreeCompiler(
-    private val compiler: KtCompiler = KtCompiler(),
-    private val settings: ProcessingSettings
+    private val settings: ProcessingSettings,
+    private val compiler: KtCompiler = KtCompiler(settings.environment)
 ) {
 
     companion object {
         val KT_ENDINGS = setOf("kt", "kts")
-        fun instance(settings: ProcessingSettings): KtTreeCompiler = KtTreeCompiler(KtCompiler(), settings)
+        fun instance(settings: ProcessingSettings): KtTreeCompiler = KtTreeCompiler(settings)
     }
 
     fun compile(path: Path): List<KtFile> {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -77,6 +77,10 @@ data class ProcessingSettings @JvmOverloads constructor(
 
     val pluginUrls = pluginPaths.map { it.toUri().toURL() }.toTypedArray()
 
+    /**
+     * Lazily instantiates a Kotlin environment which can be shared between compiling and
+     * analyzing logic.
+     */
     val environment: KotlinCoreEnvironment by lazy {
         val compilerConfiguration = createCompilerConfiguration(inputPaths, classpath, jvmTarget)
         createKotlinCoreEnvironment(compilerConfiguration)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -2,6 +2,9 @@ package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
+import io.gitlab.arturbosch.detekt.api.internal.createCompilerConfiguration
+import io.gitlab.arturbosch.detekt.api.internal.createKotlinCoreEnvironment
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.config.JvmTarget
 import java.io.PrintStream
 import java.nio.file.Files
@@ -73,4 +76,9 @@ data class ProcessingSettings @JvmOverloads constructor(
     }
 
     val pluginUrls = pluginPaths.map { it.toUri().toURL() }.toTypedArray()
+
+    val environment: KotlinCoreEnvironment by lazy {
+        val compilerConfiguration = createCompilerConfiguration(inputPaths, classpath, jvmTarget)
+        createKotlinCoreEnvironment(compilerConfiguration)
+    }
 }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
@@ -39,20 +39,25 @@ class AutoCorrectLevelSpec : Spek({
 
             it("should format the test file but not print to disc") {
                 val project = Paths.get(resource("before.kt"))
+                var expectedContentBeforeRun: String? = null
                 val contentChanged = object : FileProcessListener {
+                    override fun onStart(files: List<KtFile>) {
+                        assertThat(files).hasSize(1)
+                        expectedContentBeforeRun = files[0].text
+                    }
+
                     override fun onFinish(files: List<KtFile>, result: Detektion) {
                         assertThat(files).hasSize(1)
-                        println(files[0].text)
                         assertThat(wasFormatted(files[0])).isTrue()
                     }
                 }
                 val detekt = DetektFacade.create(
                     ProcessingSettings(project, config), listOf(FormattingProvider()), listOf(contentChanged))
-                val expected = loadFile("before.kt").text
                 val findings = detekt.run().findings.flatMap { it.value }
+                val actualContentAfterRun = loadFileContent("before.kt")
 
                 assertThat(wasLinted(findings)).isTrue()
-                assertThat(loadFileContent("before.kt")).isEqualTo(expected)
+                assertThat(actualContentAfterRun).isEqualTo(expectedContentBeforeRun)
             }
         }
 

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtPsiFactory
 import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProviderFactory
 import java.io.File
 import java.nio.file.Path
@@ -60,6 +61,8 @@ object KtTestCompiler : KtCompiler() {
             EnvironmentConfigFiles.JVM_CONFIG_FILES
         )
     }
+
+    fun createPsiFactory(): KtPsiFactory = KtPsiFactory(KtTestCompiler.environment.project, false)
 
     class TestDisposable : Disposable {
         override fun dispose() {} // Don't want to dispose the test KotlinCoreEnvironment

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
@@ -32,9 +32,9 @@ object KtTestCompiler : KtCompiler() {
 
     fun compileFromContent(content: String): KtFile {
         val psiFile = psiFileFactory.createFileFromText(
-                TEST_FILENAME,
-                KotlinLanguage.INSTANCE,
-                StringUtilRt.convertLineSeparators(content))
+            TEST_FILENAME,
+            KotlinLanguage.INSTANCE,
+            StringUtilRt.convertLineSeparators(content))
         return psiFile as? KtFile ?: throw IllegalStateException("kotlin file expected")
     }
 
@@ -62,7 +62,7 @@ object KtTestCompiler : KtCompiler() {
     }
 
     class TestDisposable : Disposable {
-        override fun dispose() { } // Don't want to dispose the test KotlinCoreEnvironment
+        override fun dispose() {} // Don't want to dispose the test KotlinCoreEnvironment
     }
 }
 


### PR DESCRIPTION
@3flex now that we only use the `createKotlinCoreEnvironment` endpoint and get the KtFile's from it, we should get rid of the static `PsiProject` and `PsiFactory` in `ProjectExtension.kt`.
However I run into the problem that the AST created by this method does not make the AST mutable ( see my changes `KotlinCoreEnvironment.createForProduction(...).apply { makeMutable(...) }`.
Which beaks formatting and can break custom rules ... do you know of any params we can specify in `CompilerConfiguration` maybe?