### PR TITLE
Implement LibraryCodeMustSpecifyReturnType rule

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
@@ -29,7 +29,7 @@ class AnnotationExcluder(
      * Is true if any given annotation name is declared in the SplitPattern
      * which basically describes entries to exclude.
      */
-    fun shouldExclude(annotations: List<KtAnnotationEntry>) =
+    fun shouldExclude(annotations: List<KtAnnotationEntry>): Boolean =
             annotations.firstOrNull(::isExcluded) != null
 
     private fun isExcluded(annotation: KtAnnotationEntry): Boolean =

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -25,7 +25,7 @@ open class CodeSmell(
 
     override fun compact(): String = "$id - ${entity.compact()}"
 
-    override fun compactWithSignature() = compact() + " - Signature=" + entity.signature
+    override fun compactWithSignature(): String = compact() + " - Signature=" + entity.signature
 
     override fun toString(): String {
         return "CodeSmell(issue=$issue, " +
@@ -36,7 +36,7 @@ open class CodeSmell(
                 "id='$id')"
     }
 
-    override fun messageOrDescription() = when {
+    override fun messageOrDescription(): String = when {
         message.isEmpty() -> issue.description
         else -> message
     }
@@ -96,7 +96,7 @@ open class ThresholdedCodeSmell(
 
     override fun compact(): String = "$id - $metric - ${entity.compact()}"
 
-    override fun messageOrDescription() = when {
+    override fun messageOrDescription(): String = when {
         message.isEmpty() -> issue.description
         else -> message
     }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CompositeConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CompositeConfig.kt
@@ -19,5 +19,5 @@ class CompositeConfig(private val lookFirst: Config, private val lookSecond: Con
         return lookFirst.valueOrNull(key) ?: lookSecond.valueOrNull(key)
     }
 
-    override fun toString() = "CompositeConfig(lookFirst=$lookFirst, lookSecond=$lookSecond)"
+    override fun toString(): String = "CompositeConfig(lookFirst=$lookFirst, lookSecond=$lookSecond)"
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -46,9 +46,9 @@ interface Config {
          */
         val empty: Config = EmptyConfig
 
-        const val ACTIVE_KEY = "active"
-        const val EXCLUDES_KEY = "excludes"
-        const val INCLUDES_KEY = "includes"
+        const val ACTIVE_KEY: String = "active"
+        const val EXCLUDES_KEY: String = "excludes"
+        const val INCLUDES_KEY: String = "includes"
 
         val PRIMITIVES: Set<KClass<out Any>> = setOf(
             Int::class,
@@ -86,7 +86,7 @@ internal object EmptyConfig : HierarchicalConfig {
 
     override val parent: HierarchicalConfig.Parent? = null
 
-    override fun subConfig(key: String) = this
+    override fun subConfig(key: String): EmptyConfig = this
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : Any> valueOrDefault(key: String, default: T): T = when (key) {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigAware.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigAware.kt
@@ -52,7 +52,7 @@ interface ConfigAware : Config {
      */
     val autoCorrect: Boolean
         get() = valueOrDefault("autoCorrect", false) &&
-                ruleSetConfig.valueOrDefault("autoCorrect", true)
+            ruleSetConfig.valueOrDefault("autoCorrect", true)
 
     /**
      * Is this rule specified as active in configuration?
@@ -61,11 +61,11 @@ interface ConfigAware : Config {
     val active: Boolean get() = valueOrDefault("active", false)
 
     override fun subConfig(key: String): Config =
-            ruleConfig.subConfig(key)
+        ruleConfig.subConfig(key)
 
-    override fun <T : Any> valueOrDefault(key: String, default: T) =
-            ruleConfig.valueOrDefault(key, default)
+    override fun <T : Any> valueOrDefault(key: String, default: T): T =
+        ruleConfig.valueOrDefault(key, default)
 
     override fun <T : Any> valueOrNull(key: String): T? =
-            ruleConfig.valueOrNull(key)
+        ruleConfig.valueOrNull(key)
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -45,9 +45,9 @@ data class Debt(val days: Int = 0, val hours: Int = 0, val mins: Int = 0) {
     }
 
     companion object {
-        val TWENTY_MINS = Debt(0, 0, 20)
-        val TEN_MINS = Debt(0, 0, 10)
-        val FIVE_MINS = Debt(0, 0, 5)
+        val TWENTY_MINS: Debt = Debt(0, 0, 20)
+        val TEN_MINS: Debt = Debt(0, 0, 10)
+        val FIVE_MINS: Debt = Debt(0, 0, 5)
     }
 
     override fun toString(): String {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -60,12 +60,12 @@ data class Location(
  * Stores line and column information of a location.
  */
 data class SourceLocation(val line: Int, val column: Int) {
-    override fun toString() = "$line:$column"
+    override fun toString(): String = "$line:$column"
 }
 
 /**
  * Stores character start and end positions of an text file.
  */
 data class TextLocation(val start: Int, val end: Int) {
-    override fun toString() = "$start:$end"
+    override fun toString(): String = "$start:$end"
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Metric.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Metric.kt
@@ -36,4 +36,4 @@ data class Metric(
 /**
  * To represent a value of 0.5, use the metric value 50 and the conversion factor of 100. (50 / 100 = 0.5)
  */
-const val DEFAULT_FLOAT_CONVERSION_FACTOR = 100
+const val DEFAULT_FLOAT_CONVERSION_FACTOR: Int = 100

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/McCabeVisitor.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/McCabeVisitor.kt
@@ -34,7 +34,7 @@ class McCabeVisitor(private val ignoreSimpleWhenEntries: Boolean) : DetektVisito
         }
     }
 
-    fun isInsideObjectLiteral(function: KtNamedFunction) =
+    fun isInsideObjectLiteral(function: KtNamedFunction): Boolean =
             function.getStrictParentOfType<KtObjectLiteralExpression>() != null
 
     override fun visitIfExpression(expression: KtIfExpression) {

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -434,6 +434,8 @@ style:
     active: false
     ignoreOverridableFunction: true
     excludedFunctions: 'describeContents'
+  LibraryCodeMustSpecifyReturnType:
+    active: false
   LoopWithTooManyJumpStatements:
     active: false
     maxJumpCount: 1

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -15,6 +15,7 @@ import io.gitlab.arturbosch.detekt.rules.style.ForbiddenComment
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenImport
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenVoid
 import io.gitlab.arturbosch.detekt.rules.style.FunctionOnlyReturningConstant
+import io.gitlab.arturbosch.detekt.rules.style.LibraryCodeMustSpecifyReturnType
 import io.gitlab.arturbosch.detekt.rules.style.LoopWithTooManyJumpStatements
 import io.gitlab.arturbosch.detekt.rules.style.MagicNumber
 import io.gitlab.arturbosch.detekt.rules.style.MayBeConst
@@ -113,7 +114,8 @@ class StyleGuideProvider : RuleSetProvider {
                 UselessCallOnNotNull(config),
                 UnderscoresInNumericLiterals(config),
                 UseRequire(config),
-                UseCheckOrError(config)
+                UseCheckOrError(config),
+                LibraryCodeMustSpecifyReturnType(config)
             )
         )
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
@@ -1,0 +1,72 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.psiUtil.isPublic
+
+/**
+ * Library functions/properties should have an explicit return type.
+ * Inferred return type can easily be changed by mistake which may lead to breaking changes.
+ *
+ * <noncompliant>
+ * // code from a library
+ * val strs = listOf("foo, bar")
+ * fun bar() = 5
+ * class Parser {
+ *      fun parse() = ...
+ * }
+ * </noncompliant>
+ *
+ * <compliant>
+ * // code from a library
+ * val strs: List<String> = listOf("foo, bar")
+ * fun bar(): Int = 5
+ *
+ * class Parser {
+ *      fun parse(): ParsingResult = ...
+ * }
+ * </compliant>
+ */
+class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        this.javaClass.simpleName,
+        Severity.Style,
+        "Library functions/properties should have an explicit return type. " +
+            "Inferred return type can easily be changed by mistake which may lead to breaking changes.",
+        Debt.FIVE_MINS
+    )
+
+    override fun visitCondition(root: KtFile): Boolean =
+        super.visitCondition(root) && filters != null
+
+    override fun visitProperty(property: KtProperty) {
+        if (!property.isLocal && property.isPublic && property.typeReference == null) {
+            report(CodeSmell(
+                issue,
+                Entity.from(property),
+                "Library property '${property.nameAsSafeName}' without explicit return type."
+            ))
+        }
+        super.visitProperty(property)
+    }
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        if (!function.isLocal && function.isPublic && !function.hasDeclaredReturnType()) {
+            report(CodeSmell(
+                issue,
+                Entity.from(function),
+                "Library function '${function.nameAsSafeName}' without explicit return type."
+            ))
+        }
+        super.visitNamedFunction(function)
+    }
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
@@ -60,7 +60,7 @@ class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(con
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        if (!function.isLocal && function.isPublic && !function.hasDeclaredReturnType()) {
+        if (!function.isLocal && function.isPublic && function.hasExpressionBodyWithoutExplicitReturnType()) {
             report(CodeSmell(
                 issue,
                 Entity.from(function),
@@ -69,4 +69,7 @@ class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(con
         }
         super.visitNamedFunction(function)
     }
+
+    private fun KtNamedFunction.hasExpressionBodyWithoutExplicitReturnType(): Boolean =
+        equalsToken != null && !hasDeclaredReturnType()
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -1,0 +1,105 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
+
+    describe("library code must have explicit return types") {
+
+        it("should not report without explicit filters set") {
+            assertThat(LibraryCodeMustSpecifyReturnType().compileAndLint("""
+                fun foo() = 5
+                val bar = 5
+                class A {
+                    fun b() = 2
+                    val c = 2
+                }
+            """.trimIndent())).isEmpty()
+        }
+
+        val subject by memoized {
+            LibraryCodeMustSpecifyReturnType(TestConfig("includes" to "*.kt"))
+        }
+
+        describe("positive cases") {
+
+            it("should report a top level function") {
+                assertThat(subject.compileAndLint("""
+                    fun foo() = 5
+                """.trimIndent())).hasSize(1)
+            }
+
+            it("should report a top level property") {
+                assertThat(subject.compileAndLint("""
+                    val foo = 5
+                """.trimIndent())).hasSize(1)
+            }
+
+            it("should report a public class with public members") {
+                assertThat(subject.compileAndLint("""
+                    class A {
+                        val foo = 5
+                        fun bar() = 5
+                    }
+                """.trimIndent())).hasSize(2)
+            }
+        }
+
+        describe("negative cases with no public scope") {
+
+            it("should not report a top level function") {
+                assertThat(subject.compileAndLint("""
+                    fun foo(): Int = 5
+                """.trimIndent())).isEmpty()
+            }
+
+            it("should not report a top level property") {
+                assertThat(subject.compileAndLint("""
+                    val foo: Int = 5
+                """.trimIndent())).isEmpty()
+            }
+
+            it("should not report a public class with public members") {
+                assertThat(subject.compileAndLint("""
+                    class A {
+                        val foo: Int = 5
+                        fun bar(): Int = 5
+                    }
+                """.trimIndent())).isEmpty()
+            }
+        }
+        describe("negative cases with no public scope") {
+
+            it("should not report a private top level function") {
+                // Kotlin Script Engine reports wrongly local functions here
+                assertThat(subject.lint("""
+                    internal fun bar() = 5
+                    private fun foo() = 5
+                """.trimIndent())).isEmpty()
+            }
+
+            it("should not report a internal top level property") {
+                assertThat(subject.compileAndLint("""
+                    internal val foo = 5
+                """.trimIndent())).isEmpty()
+            }
+
+            it("should not report members and local variables") {
+                assertThat(subject.compileAndLint("""
+                    internal class A {
+                        internal val foo = 5
+                        private fun bar() {
+                            fun stuff() = Unit
+                            val a = 5
+                        }
+                    }
+                """.trimIndent())).isEmpty()
+            }
+        }
+    }
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -50,11 +50,17 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
             }
         }
 
-        describe("negative cases with no public scope") {
+        describe("negative cases with public scope") {
 
             it("should not report a top level function") {
                 assertThat(subject.compileAndLint("""
                     fun foo(): Int = 5
+                """.trimIndent())).isEmpty()
+            }
+
+            it("should not report a non expression function") {
+                assertThat(subject.compileAndLint("""
+                    fun foo() {}
                 """.trimIndent())).isEmpty()
             }
 

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.test
 
+import io.gitlab.arturbosch.detekt.api.internal.ABSOLUTE_PATH
 import io.gitlab.arturbosch.detekt.core.KtCompiler
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
@@ -32,11 +33,12 @@ object KtTestCompiler : KtCompiler() {
     fun compile(path: Path) = compile(root, path)
 
     fun compileFromContent(content: String): KtFile {
-        val psiFile = psiFileFactory.createFileFromText(
+        val file = psiFileFactory.createFileFromText(
             TEST_FILENAME,
             KotlinLanguage.INSTANCE,
-            StringUtilRt.convertLineSeparators(content))
-        return psiFile as? KtFile ?: throw IllegalStateException("kotlin file expected")
+            StringUtilRt.convertLineSeparators(content)) as? KtFile
+        file?.putUserData(ABSOLUTE_PATH, TEST_FILENAME)
+        return file ?: throw IllegalStateException("kotlin file expected")
     }
 
     fun getContextForPaths(environment: KotlinCoreEnvironment, paths: List<KtFile>) =

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -325,6 +325,38 @@ fun functionReturningConstantString() = "1"
 const val constantString = "1"
 ```
 
+### LibraryCodeMustSpecifyReturnType
+
+Library functions/properties should have an explicit return type.
+Inferred return type can easily be changed by mistake which may lead to breaking changes.
+
+**Severity**: Style
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+// code from a library
+val strs = listOf("foo, bar")
+fun bar() = 5
+class Parser {
+    fun parse() = ...
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+// code from a library
+val strs: List<String> = listOf("foo, bar")
+fun bar(): Int = 5
+
+class Parser {
+    fun parse(): ParsingResult = ...
+}
+```
+
 ### LoopWithTooManyJumpStatements
 
 Loops which contain multiple `break` or `continue` statements are hard to read and understand.

--- a/reports/failfast.yml
+++ b/reports/failfast.yml
@@ -92,4 +92,4 @@ style:
   LibraryCodeMustSpecifyReturnType:
     active: true
     excludes: "**/*.kt"
-    includes: "**/detekt-api/**"
+    includes: "**/detekt-api/src/main/**"

--- a/reports/failfast.yml
+++ b/reports/failfast.yml
@@ -89,3 +89,7 @@ style:
   UnusedPrivateMember:
     active: true
     allowedNames: "(_|ignored|expected)"
+  LibraryCodeMustSpecifyReturnType:
+    active: true
+    excludes: "**/*.kt"
+    includes: "**/detekt-api/**"


### PR DESCRIPTION
This makes use of the new path filters concept and is only activated when the user specifies filters.
For detekt internal we could use following setting.

```
LibraryCodeMustSpecifyReturnType:
    active: true
    excludes: "**/*.kt"
    includes: "**/detekt-api/**"
```