### PR TITLE
Rework UnderscoresInNumericLiterals Rule

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -17,7 +17,7 @@ import java.util.Locale
  * This rule detects and reports decimal base 10 numeric literals above a certain length that should be underscore
  * separated for readability. Underscores that do not make groups of 3 digits are also reported even if their length is
  * under the `acceptableDecimalLength`. For `Serializable` classes or objects, the field `serialVersionUID` is
- * explicitly ignored.
+ * explicitly ignored. For floats and doubles, anything to the right of the decimal is ignored.
  *
  * <noncompliant>
  * object Money {
@@ -54,21 +54,17 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
             return
         }
 
-        val numberStringParts = normalizedText.split('.')
+        val numberString = normalizedText.split('.').first()
 
-        if (numberStringParts.sumBy { it.length } >= acceptableDecimalLength ||
-                numberStringParts.any { it.contains('_') }) {
-            reportIfInvalidUnderscorePattern(expression, numberStringParts)
+        if (numberString.length >= acceptableDecimalLength || numberString.contains('_')) {
+            reportIfInvalidUnderscorePattern(expression, numberString)
         }
     }
 
-    private fun reportIfInvalidUnderscorePattern(expression: KtConstantExpression, numberStringParts: List<String>) {
-        for (part in numberStringParts) {
-            if (!part.matches(underscoreNumberRegex)) {
-                report(CodeSmell(issue, Entity.from(expression), "This numeric literal should be separated " +
-                        "by underscores in order to increase readability."))
-                break
-            }
+    private fun reportIfInvalidUnderscorePattern(expression: KtConstantExpression, numberString: String) {
+        if (!numberString.matches(underscoreNumberRegex)) {
+            report(CodeSmell(issue, Entity.from(expression), "This numeric literal should be separated " +
+                    "by underscores in order to increase readability."))
         }
     }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -188,6 +188,15 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
+    describe("a hexadecimal Int of 0xFFFFFF") {
+        val ktFile = compileContentForTest("const val myHexInt = 0xFFFFFF")
+
+        it("should not be reported") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
+
     describe("a property named serialVersionUID in an object that implements Serializable") {
         val ktFile = compileContentForTest("""
             object TestSerializable : Serializable {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -208,9 +208,22 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             }
         """.trimIndent())
 
-        it("should not be reported") {
+        it("should be reported by default") {
             val findings = UnderscoresInNumericLiterals().lint(ktFile)
             assertThat(findings).isNotEmpty
+        }
+    }
+
+    describe("a property named serialVersionUID in an object that does not implement Serializable") {
+        val ktFile = compileContentForTest("""
+            object TestSerializable {
+                private val serialVersionUID = 314_159L
+            }
+        """.trimIndent())
+
+        it("should not be reported") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isEmpty()
         }
     }
 
@@ -225,6 +238,51 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         it("should not be reported if acceptableDecimalLength is 6") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "6"))
+            ).lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
+
+    describe("a Float of 30_000_000.1415926535897932385") {
+        val ktFile = compileContentForTest("val myFloat = 30_000_000.1415926535897932385f")
+
+        it("should not be reported") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
+
+    describe("a Double of 3.1415926535897932385") {
+        val ktFile = compileContentForTest("val myDouble = 3.1415926535897932385")
+
+        it("should not be reported") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isEmpty()
+        }
+    }
+
+    describe("a Double of 3000.1415926535897932385") {
+        val ktFile = compileContentForTest("val myDouble = 3000.1415926535897932385")
+
+        it("should be reported if acceptableDecimalLength is 4") {
+            val findings = UnderscoresInNumericLiterals(
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
+            ).lint(ktFile)
+            assertThat(findings).isNotEmpty
+        }
+    }
+
+    describe("a Float of 1000000.31415926535f") {
+        val ktFile = compileContentForTest("val myFloat = 1000000.31415926535f")
+
+        it("should be reported by default") {
+            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            assertThat(findings).isNotEmpty
+        }
+
+        it("should not be reported if acceptableDecimalLength is 8") {
+            val findings = UnderscoresInNumericLiterals(
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
             ).lint(ktFile)
             assertThat(findings).isEmpty()
         }

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -924,7 +924,7 @@ This rule reports lines that end with a whitespace.
 This rule detects and reports decimal base 10 numeric literals above a certain length that should be underscore
 separated for readability. Underscores that do not make groups of 3 digits are also reported even if their length is
 under the `acceptableDecimalLength`. For `Serializable` classes or objects, the field `serialVersionUID` is
-explicitly ignored.
+explicitly ignored. For floats and doubles, anything to the right of the decimal is ignored.
 
 **Severity**: Style
 


### PR DESCRIPTION
Fixes #1538.

This patch updates the `UnderscoresInNumericLiterals` rule to only consider the left side of the decimal place when running the rule through numeric literals that are a `Float` or `Double`.
