### PR TITLE
Update FunctionNaming to support factory funcs

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -15,6 +15,8 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
  * Reports when function names which do not follow the specified naming convention are used.
+ * One exception are factory functions used to create instances of classes.
+ * These factory functions can have the same name as the class being created.
  *
  * @configuration functionPattern - naming pattern (default: `'^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'`)
  * @configuration excludeClassPattern - ignores functions in classes which match this regex (default: `'$^'`)
@@ -45,7 +47,8 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
         }
 
         if (!function.isContainingExcludedClassOrObject(excludeClassPattern) &&
-                !function.identifierName().matches(functionPattern)) {
+                !function.identifierName().matches(functionPattern) &&
+                function.identifierName() != function.typeReference?.name) {
             report(CodeSmell(
                     issue,
                     Entity.from(function),

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -52,6 +52,19 @@ class FunctionNamingSpec : Spek({
             assertThat(FunctionNaming().lint(code)).isEmpty()
         }
 
+
+
+        it("does not report when the function name is identical to the type of the result") {
+            val code = """
+            interface Foo
+            private class FooImpl : Foo
+
+			fun Foo(): Foo = FooImpl()
+		"""
+            val config = TestConfig(mapOf("ignoreOverridden" to "false"))
+            assertThat(FunctionNaming(config).lint(code))
+        }
+
         it("flags functions with bad names inside overridden functions by default") {
             val code = """
 			override fun SHOULD_NOT_BE_FLAGGED() {

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -105,6 +105,8 @@ Reports when very short function names are used.
 ### FunctionNaming
 
 Reports when function names which do not follow the specified naming convention are used.
+One exception are factory functions used to create instances of classes.
+These factory functions can have the same name as the class being created.
 
 **Severity**: Style
 


### PR DESCRIPTION
FunctionNaming does not report factory functions when the function name
is identical to the type of the result.
These factory functions can have the same name as the class being
created.
This closes #1639
