### PR TITLE
Fix TooManyFunctions report logic

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -79,21 +79,25 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
     override fun visitClass(klass: KtClass) {
         val amount = calcFunctions(klass)
         when {
-            klass.isInterface() && amount >= thresholdInInterfaces -> {
-                report(ThresholdedCodeSmell(issue,
+            klass.isInterface() -> {
+                if (amount >= thresholdInInterfaces) {
+                    report(ThresholdedCodeSmell(issue,
                         Entity.from(klass),
                         Metric("SIZE", amount, thresholdInInterfaces),
                         "Interface '${klass.name}' with '$amount' functions detected. " +
                                 "Defined threshold inside interfaces is set to " +
                                 "'$thresholdInInterfaces'"))
+                }
             }
-            klass.isEnum() && amount >= thresholdInEnums -> {
-                report(ThresholdedCodeSmell(issue,
+            klass.isEnum() -> {
+                if (amount >= thresholdInEnums) {
+                    report(ThresholdedCodeSmell(issue,
                         Entity.from(klass),
                         Metric("SIZE", amount, thresholdInEnums),
                         "Enum class '${klass.name}' with '$amount' functions detected. " +
                                 "Defined threshold inside enum classes is set to " +
                                 "'$thresholdInEnums'"))
+                }
             }
             else -> {
                 if (amount >= thresholdInClasses) {


### PR DESCRIPTION
This fixes a case where an interface or an enum reaches the threshold
check for a class due to wrong logic.
