### PR TITLE
 Fix MaxLineLength and suppressing issues with multiline strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Andrew Arnott](https://github.com/andrew-arnott) - UnusedPrivateMember improvement
 - [Tyler Wong](https://github.com/tylerbwong) - UnderscoresInNumericLiterals rule
 - [Daniele Conti](https://github.com/fourlastor) - ObjectPropertyNaming improvement
+- [Nicola Corti](https://github.com/cortinico) - Fixed Suppress of MaxLineLenght
 
 ### Mentions
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -115,9 +115,11 @@ abstract class BaseConfig : HierarchicalConfig {
                 default
             }
         } catch (_: ClassCastException) {
-            error("Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of required type ${default::class.simpleName}.")
+            error("Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of" +
+                    " required type ${default::class.simpleName}.")
         } catch (_: NumberFormatException) {
-            error("Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of required type ${default::class.simpleName}.")
+            error("Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of" +
+                    " required type ${default::class.simpleName}.")
         }
     }
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFacade.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFacade.kt
@@ -21,7 +21,9 @@ class BaselineFacade(val baselineFile: Path) {
     fun filter(smells: List<Finding>) =
             if (listings != null) {
                 val whiteFiltered = smells.filterNot { finding -> listings.first.ids.contains(finding.baselineId) }
-                val blackFiltered = whiteFiltered.filterNot { finding -> listings.second.ids.contains(finding.baselineId) }
+                val blackFiltered = whiteFiltered.filterNot { finding ->
+                    listings.second.ids.contains(finding.baselineId)
+                }
                 blackFiltered
             } else smells
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportGenerator.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportGenerator.kt
@@ -10,7 +10,8 @@ class ComplexityReportGenerator(private val complexityMetric: ComplexityMetric) 
     private var commentSourceRatio = 0
 
     companion object Factory {
-        fun create(detektion: Detektion): ComplexityReportGenerator = ComplexityReportGenerator(ComplexityMetric(detektion))
+        fun create(detektion: Detektion): ComplexityReportGenerator =
+            ComplexityReportGenerator(ComplexityMetric(detektion))
     }
 
     fun generate(): String? {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
@@ -55,8 +55,8 @@ class IteratorNotThrowingNoSuchElementException(config: Config = Config.empty) :
             val nextMethod = classOrObject.getMethod("next")
             if (nextMethod != null && !nextMethod.throwsNoSuchElementExceptionThrown()) {
                 report(CodeSmell(issue, Entity.from(classOrObject),
-                        "This implementation of Iterator does not correctly implement the next() method " +
-                                "as it doesn't throw a NoSuchElementException when no elements remain in the Iterator."))
+                        "This implementation of Iterator does not correctly implement the next() method as " +
+                                "it doesn't throw a NoSuchElementException when no elements remain in the Iterator."))
             }
         }
         super.visitClassOrObject(classOrObject)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
@@ -34,7 +34,9 @@ class ThrowingExceptionInMain(config: Config = Config.empty) : Rule(config) {
             "The main method should not throw an exception.", Debt.TWENTY_MINS)
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        if (function.isMainFunction() && hasArgsParameter(function.valueParameters) && containsThrowExpression(function)) {
+        if (function.isMainFunction() &&
+            hasArgsParameter(function.valueParameters) &&
+            containsThrowExpression(function)) {
             report(CodeSmell(issue, Entity.from(function), issue.description))
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
@@ -50,7 +50,8 @@ class TooGenericExceptionThrown(config: Config) : Rule(config) {
             "Thrown exception is too generic. Prefer throwing project specific exceptions to handle error cases.",
             Debt.TWENTY_MINS)
 
-    private val exceptions: Set<String> = valueOrDefault(THROWN_EXCEPTIONS_PROPERTY, thrownExceptionDefaults).toHashSet()
+    private val exceptions: Set<String> =
+        valueOrDefault(THROWN_EXCEPTIONS_PROPERTY, thrownExceptionDefaults).toHashSet()
 
     override fun visitThrowExpression(expression: KtThrowExpression) {
         expression.thrownExpression?.referenceExpression()?.text?.let {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
@@ -45,7 +45,8 @@ class ConstructorParameterNaming(config: Config = Config.empty) : Rule(config) {
                 report(CodeSmell(
                         issue,
                         Entity.from(parameter),
-                        message = "Constructor private parameter names should match the pattern: $privateParameterPattern"))
+                        message = "Constructor private parameter names should " +
+                                "match the pattern: $privateParameterPattern"))
             }
         } else {
             if (!identifier.matches(parameterPattern)) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/Junk.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/Junk.kt
@@ -2,12 +2,17 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.psi.KtAnnotated
+import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.elementsInRange
+import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 
-internal fun findAnnotatedStatementInLine(file: KtFile, offset: Int, line: String): PsiElement? {
+/**
+ * Util function to search for the first [KtElement] in the parents of
+ * the given [line] from a given offset in a [KtFile].
+ */
+internal fun findFirstKtElementInParents(file: KtFile, offset: Int, line: String): PsiElement? {
     return file.elementsInRange(TextRange.create(offset - line.length, offset))
-            .mapNotNull { it as? KtAnnotated ?: if (it.parent is KtAnnotated) it.parent else null }
+            .mapNotNull { it.getNonStrictParentOfType<KtElement>() }
             .firstOrNull()
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -52,7 +52,7 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
         for (line in lines) {
             offset += line.length
             if (!isValidLine(line)) {
-                val ktElement = findAnnotatedStatementInLine(file, offset, line)
+                val ktElement = findFirstKtElementInParents(file, offset, line)
                 if (ktElement != null) {
                     report(CodeSmell(issue, Entity.from(ktElement), issue.description))
                 } else {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
@@ -36,9 +36,12 @@ import org.jetbrains.kotlin.psi.psiUtil.isProtected
  */
 class ProtectedMemberInFinalClass(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Warning,
-            "Member with protected visibility in final class is private. Consider using private or internal as modifier.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Warning,
+        "Member with protected visibility in final class is private. " +
+                "Consider using private or internal as modifier.",
+        Debt.FIVE_MINS
+    )
 
     private val visitor = DeclarationVisitor()
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespace.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespace.kt
@@ -27,7 +27,7 @@ class TrailingWhitespace(config: Config = Config.empty) : Rule(config) {
             offset += line.length
             if (hasTrailingWhitespace(line)) {
                 val file = fileContent.file
-                val ktElement = findAnnotatedStatementInLine(file, offset, line)
+                val ktElement = findFirstKtElementInParents(file, offset, line)
                 if (ktElement != null) {
                     report(CodeSmell(issue, Entity.from(ktElement), createMessage(index)))
                 } else {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -35,8 +35,8 @@ class UnusedImports(config: Config) : Rule(config) {
 
     companion object {
         private val operatorSet = setOf("unaryPlus", "unaryMinus", "not", "inc", "dec", "plus", "minus", "times", "div",
-                "mod", "rangeTo", "contains", "get", "set", "invoke", "plusAssign", "minusAssign", "timesAssign", "divAssign",
-                "modAssign", "equals", "compareTo", "iterator", "getValue", "setValue", "provideDelegate")
+                "mod", "rangeTo", "contains", "get", "set", "invoke", "plusAssign", "minusAssign", "timesAssign",
+                "divAssign", "modAssign", "equals", "compareTo", "iterator", "getValue", "setValue", "provideDelegate")
 
         private val kotlinDocReferencesRegExp = Regex("\\[([^]]+)](?!\\[)")
         private val kotlinDocSeeReferenceRegExp = Regex("^@see (.+)")

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -209,7 +209,8 @@ private class UnusedPropertyVisitor(allowedNames: Regex) : UnusedMemberVisitor(a
     override fun getUnusedReports(issue: Issue): List<CodeSmell> {
         return properties
                 .filter { it.nameAsSafeName.identifier !in nameAccesses }
-                .map { CodeSmell(issue, Entity.from(it), "Private property ${it.nameAsSafeName.identifier} is unused.") }
+                .map { CodeSmell(issue, Entity.from(it),
+                    "Private property ${it.nameAsSafeName.identifier} is unused.") }
     }
 
     override fun visitParameter(parameter: KtParameter) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -28,7 +28,7 @@ class MaxLineLengthSpec : Spek({
                 val rule = MaxLineLength()
 
                 rule.visit(fileContent)
-                assertThat(rule.findings).hasSize(5)
+                assertThat(rule.findings).hasSize(6)
             }
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -28,7 +28,7 @@ class MaxLineLengthSpec : Spek({
                 val rule = MaxLineLength()
 
                 rule.visit(fileContent)
-                assertThat(rule.findings).hasSize(3)
+                assertThat(rule.findings).hasSize(5)
             }
         }
 

--- a/detekt-rules/src/test/resources/cases/MaxLineLength.kt
+++ b/detekt-rules/src/test/resources/cases/MaxLineLength.kt
@@ -18,6 +18,12 @@ class MaxLineLength {
             very long multiline String that will break the MaxLineLength
         """.trimIndent()
 
+    val longMultiLineFieldWithLineBreaks =
+        """
+            This is anotehr very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very
+            very long multiline String with Line Break that will break the MaxLineLength
+        """.trimIndent()
+
     fun main() {
         val thisIsAVeryLongValName = "This is a very, very long String that will break the MaxLineLength"
 

--- a/detekt-rules/src/test/resources/cases/MaxLineLength.kt
+++ b/detekt-rules/src/test/resources/cases/MaxLineLength.kt
@@ -4,9 +4,19 @@ package cases
 class MaxLineLength {
     companion object {
         val LOREM_IPSUM = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+
+        val A_VERY_LONG_MULTI_LINE = """
+            This is anotehr very very very very very very very very, very long multiline String that will break the MaxLineLength"
+        """.trimIndent()
     }
 
     val loremIpsumField = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+
+    val longMultiLineField = """
+            This is anotehr very very very very very very very very
+            very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very
+            very long multiline String that will break the MaxLineLength
+        """.trimIndent()
 
     fun main() {
         val thisIsAVeryLongValName = "This is a very, very long String that will break the MaxLineLength"

--- a/detekt-rules/src/test/resources/cases/MaxLineLengthSuppressed.kt
+++ b/detekt-rules/src/test/resources/cases/MaxLineLengthSuppressed.kt
@@ -22,6 +22,13 @@ class MaxLineLengthSuppressed {
             very long multiline String that will break the MaxLineLength
         """.trimIndent()
 
+    @Suppress("MaxLineLength")
+    val longMultiLineFieldWithLineBreaks =
+        """
+            This is anotehr very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very
+            very long multiline String with Line Break that will break the MaxLineLength
+        """.trimIndent()
+
     fun main() {
         val thisIsAVeryLongValName = "This is a very, very long String that will break the MaxLineLength"
 

--- a/detekt-rules/src/test/resources/cases/MaxLineLengthSuppressed.kt
+++ b/detekt-rules/src/test/resources/cases/MaxLineLengthSuppressed.kt
@@ -5,10 +5,22 @@ class MaxLineLengthSuppressed {
     companion object {
         @Suppress("MaxLineLength")
         val LOREM_IPSUM = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+
+        @Suppress("MaxLineLength")
+        val A_VERY_LONG_MULTI_LINE = """
+            This is anotehr very very very very very very very very, very long multiline String that will break the MaxLineLength"
+        """.trimIndent()
     }
 
     @Suppress("MaxLineLength")
     val loremIpsumField = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+
+    @Suppress("MaxLineLength")
+    val longMultiLineField = """
+            This is anotehr very very very very very very very very
+            very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very
+            very long multiline String that will break the MaxLineLength
+        """.trimIndent()
 
     fun main() {
         val thisIsAVeryLongValName = "This is a very, very long String that will break the MaxLineLength"

--- a/reports/baseline.xml
+++ b/reports/baseline.xml
@@ -3,19 +3,6 @@
   <Blacklist></Blacklist>
   <Whitelist>
     <ID>LargeClass:UnusedPrivateMemberSpec.kt$UnusedPrivateMemberSpec : Spek</ID>
-    <ID>MaxLineLength:BaselineFacade.kt$BaselineFacade$val blackFiltered = whiteFiltered.filterNot { finding -&gt; listings.second.ids.contains(finding.baselineId) }</ID>
-    <ID>MaxLineLength:ComplexityReportGenerator.kt$ComplexityReportGenerator.Factory$fun create(detektion: Detektion): ComplexityReportGenerator</ID>
-    <ID>MaxLineLength:Config.kt$io.gitlab.arturbosch.detekt.api.Config.kt</ID>
-    <ID>MaxLineLength:ConstructorParameterNaming.kt$io.gitlab.arturbosch.detekt.rules.naming.ConstructorParameterNaming.kt</ID>
-    <ID>MaxLineLength:Detektor.kt$io.gitlab.arturbosch.detekt.core.Detektor.kt</ID>
-    <ID>MaxLineLength:ForbiddenImport.kt$io.gitlab.arturbosch.detekt.rules.style.ForbiddenImport.kt</ID>
-    <ID>MaxLineLength:IteratorNotThrowingNoSuchElementException.kt$io.gitlab.arturbosch.detekt.rules.bugs.IteratorNotThrowingNoSuchElementException.kt</ID>
-    <ID>MaxLineLength:ProtectedMemberInFinalClass.kt$io.gitlab.arturbosch.detekt.rules.style.ProtectedMemberInFinalClass.kt</ID>
-    <ID>MaxLineLength:SwallowedException.kt$SwallowedException$val parameterNameReferences = throwExpr.thrownExpression?.collectByType&lt;KtNameReferenceExpression&gt;()?.filter { it.text == parameterName }</ID>
-    <ID>MaxLineLength:ThrowingExceptionInMain.kt$io.gitlab.arturbosch.detekt.rules.exceptions.ThrowingExceptionInMain.kt</ID>
-    <ID>MaxLineLength:TooGenericExceptionThrown.kt$TooGenericExceptionThrown$private val exceptions: Set&lt;String&gt; = valueOrDefault(THROWN_EXCEPTIONS_PROPERTY, thrownExceptionDefaults).toHashSet()</ID>
-    <ID>MaxLineLength:UnusedImports.kt$io.gitlab.arturbosch.detekt.rules.style.UnusedImports.kt</ID>
-    <ID>MaxLineLength:UnusedPrivateMember.kt$io.gitlab.arturbosch.detekt.rules.style.UnusedPrivateMember.kt</ID>
     <ID>NewLineAtEndOfFile:PluginVersion.kt$io.gitlab.arturbosch.detekt.PluginVersion.kt</ID>
   </Whitelist>
 </SmellBaseline>


### PR DESCRIPTION
This PR replaces/fixes the function `findAnnotatedStatementInLine`
that  is used for reporting the `MaxLineLenght` issue. Now the function is
searching  for the first `KtElement` in the parents of the affected line.

This will fix a bug that prevents suppressing `MaxLineLenght` other than
at the File level. (See 7c5aec4)

Moreover I've cleaned up the baseline file from all the `MaxLineLenght` and fixed them (See 8947d18)

Fixes #1667 