### PR TITLE
Adding test for UselessCallOnNotNull and platform types

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
@@ -58,6 +58,12 @@ object UselessCallOnNotNullSpec : Spek({
             assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(1)
         }
 
+        it("reports when calling orEmpty on a list with a platform type") {
+            // System.getenv().keys will be of type List<String!>.
+            val code = """val testSequence = System.getenv().keys.toList().orEmpty()"""
+            assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(1)
+        }
+
         it("only reports on a Kotlin list") {
             val code = """
                 fun String.orEmpty(): List<Char> = this.toCharArray().asList()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
@@ -59,7 +59,7 @@ object UselessCallOnNotNullSpec : Spek({
         }
 
         it("reports when calling orEmpty on a list with a platform type") {
-            // System.getenv().keys will be of type List<String!>.
+            // System.getenv().keys.toList() will be of type List<String!>.
             val code = """val testSequence = System.getenv().keys.toList().orEmpty()"""
             assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(1)
         }


### PR DESCRIPTION
Adding a small test to verify that UselessCallOnNotNull is reported
correctly on variables that are using platform types (e.g. `List<Int!>`).

Fixes #1672
