### PR TITLE
Fix reporting logic for UseRequire and UseCheckOrErrorSpec

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensions.kt
@@ -21,11 +21,10 @@ internal fun <T : Exception> KtThrowExpression.isExceptionOfType(clazz: KClass<T
 internal val KtThrowExpression.argumentCount
     get() = findDescendantOfType<KtCallExpression>()?.valueArgumentList?.children?.size ?: 0
 
-internal fun KtThrowExpression.isAfterAPreCondition(): Boolean {
+internal fun KtThrowExpression.isEnclosedByConditionalStatement(): Boolean {
     return parent is KtIfExpression || parent is KtContainerNodeForControlStructureBody
 }
 
 internal fun KtThrowExpression.isInAWhenElseBranch(): Boolean {
-    val parentExpression = parent
-    return parentExpression is KtWhenEntry && parentExpression.isElse
+    return (parent as? KtWhenEntry)?.isElse ?: false
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensions.kt
@@ -4,7 +4,6 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtContainerNodeForControlStructureBody
 import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.KtThrowExpression
-import org.jetbrains.kotlin.psi.KtWhenEntry
 import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 import kotlin.reflect.KClass
 
@@ -23,8 +22,4 @@ internal val KtThrowExpression.argumentCount
 
 internal fun KtThrowExpression.isEnclosedByConditionalStatement(): Boolean {
     return parent is KtIfExpression || parent is KtContainerNodeForControlStructureBody
-}
-
-internal fun KtThrowExpression.isInAWhenElseBranch(): Boolean {
-    return (parent as? KtWhenEntry)?.isElse ?: false
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensions.kt
@@ -1,7 +1,10 @@
 package io.gitlab.arturbosch.detekt.rules
 
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtContainerNodeForControlStructureBody
+import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.KtThrowExpression
+import org.jetbrains.kotlin.psi.KtWhenEntry
 import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 import kotlin.reflect.KClass
 
@@ -17,3 +20,12 @@ internal fun <T : Exception> KtThrowExpression.isExceptionOfType(clazz: KClass<T
 
 internal val KtThrowExpression.argumentCount
     get() = findDescendantOfType<KtCallExpression>()?.valueArgumentList?.children?.size ?: 0
+
+internal fun KtThrowExpression.isAfterAPreCondition(): Boolean {
+    return parent is KtIfExpression || parent is KtContainerNodeForControlStructureBody
+}
+
+internal fun KtThrowExpression.isInAWhenElseBranch(): Boolean {
+    val parentExpression = parent
+    return parentExpression is KtWhenEntry && parentExpression.isElse
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
@@ -48,12 +48,9 @@ class UseCheckOrError(config: Config = Config.empty) : Rule(config) {
     )
 
     override fun visitThrowExpression(expression: KtThrowExpression) {
-        if (!expression.isIllegalStateException()) return
-
         if (expression.isOnlyExpressionInLambda()) return
 
-        if (expression.argumentCount < 2 &&
-            (expression.isEnclosedByConditionalStatement() || expression.isInAWhenElseBranch())) {
+        if (expression.isIllegalStateException() && expression.argumentCount < 2) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
@@ -8,7 +8,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.argumentCount
-import io.gitlab.arturbosch.detekt.rules.isAfterAPreCondition
+import io.gitlab.arturbosch.detekt.rules.isEnclosedByConditionalStatement
 import io.gitlab.arturbosch.detekt.rules.isIllegalStateException
 import io.gitlab.arturbosch.detekt.rules.isInAWhenElseBranch
 import org.jetbrains.kotlin.psi.KtBlockExpression
@@ -52,7 +52,8 @@ class UseCheckOrError(config: Config = Config.empty) : Rule(config) {
 
         if (expression.isOnlyExpressionInLambda()) return
 
-        if (expression.argumentCount < 2 && (expression.isAfterAPreCondition() || expression.isInAWhenElseBranch())) {
+        if (expression.argumentCount < 2 &&
+            (expression.isEnclosedByConditionalStatement() || expression.isInAWhenElseBranch())) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
@@ -8,7 +8,9 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.argumentCount
+import io.gitlab.arturbosch.detekt.rules.isAfterAPreCondition
 import io.gitlab.arturbosch.detekt.rules.isIllegalStateException
+import io.gitlab.arturbosch.detekt.rules.isInAWhenElseBranch
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtFunctionLiteral
 import org.jetbrains.kotlin.psi.KtThrowExpression
@@ -46,9 +48,11 @@ class UseCheckOrError(config: Config = Config.empty) : Rule(config) {
     )
 
     override fun visitThrowExpression(expression: KtThrowExpression) {
+        if (!expression.isIllegalStateException()) return
+
         if (expression.isOnlyExpressionInLambda()) return
 
-        if (expression.isIllegalStateException() && expression.argumentCount < 2) {
+        if (expression.argumentCount < 2 && (expression.isAfterAPreCondition() || expression.isInAWhenElseBranch())) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
@@ -8,9 +8,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.argumentCount
-import io.gitlab.arturbosch.detekt.rules.isEnclosedByConditionalStatement
 import io.gitlab.arturbosch.detekt.rules.isIllegalStateException
-import io.gitlab.arturbosch.detekt.rules.isInAWhenElseBranch
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtFunctionLiteral
 import org.jetbrains.kotlin.psi.KtThrowExpression

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequire.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequire.kt
@@ -8,7 +8,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.argumentCount
-import io.gitlab.arturbosch.detekt.rules.isAfterAPreCondition
+import io.gitlab.arturbosch.detekt.rules.isEnclosedByConditionalStatement
 import io.gitlab.arturbosch.detekt.rules.isIllegalArgumentException
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -43,7 +43,7 @@ class UseRequire(config: Config = Config.empty) : Rule(config) {
 
         if (expression.isOnlyExpressionInBlock()) return
 
-        if (expression.isAfterAPreCondition() &&
+        if (expression.isEnclosedByConditionalStatement() &&
             expression.argumentCount < 2) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequire.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequire.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.argumentCount
+import io.gitlab.arturbosch.detekt.rules.isAfterAPreCondition
 import io.gitlab.arturbosch.detekt.rules.isIllegalArgumentException
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -38,9 +39,12 @@ class UseRequire(config: Config = Config.empty) : Rule(config) {
     )
 
     override fun visitThrowExpression(expression: KtThrowExpression) {
+        if (!expression.isIllegalArgumentException()) return
+
         if (expression.isOnlyExpressionInBlock()) return
 
-        if (expression.isIllegalArgumentException() && expression.argumentCount < 2) {
+        if (expression.isAfterAPreCondition() &&
+            expression.argumentCount < 2) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
@@ -85,14 +85,41 @@ class UseCheckOrErrorSpec : Spek({
             assertThat(subject.lint(code)).isEmpty()
         }
 
-        it("reports an issue if the exception thrown as the only action in a function") {
+        it("does not report an issue if the exception thrown unconditionally") {
             val code = """fun doThrow() = throw IllegalStateException("message")"""
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(0)
         }
 
-        it("reports an issue if the exception thrown as the only action in a function block") {
+        it("does not report an issue if the exception thrown unconditionally in a function block") {
             val code = """fun doThrow() { throw IllegalStateException("message") }"""
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(0)
+        }
+
+        context("throw is not after a precondition"){
+
+            it("does not report an issue if the exception is after a block") {
+                val code = """
+                    fun doSomethingOrThrow(test: Int): Int {
+                        var index = 0
+                        repeat(test){
+                            if (Math.random() == 1.0) {
+                                return it
+                            }
+                        }
+                        throw IllegalStateException("Test was too big")
+                    }""".trimIndent()
+                assertThat(subject.lint(code)).isEmpty()
+            }
+
+            it("does not report an issue if the exception is after a elvis operator") {
+                val code = """
+                    fun tryToCastOrThrow(list: List<*>) : LinkedList<*> {
+                        val subclass = list as? LinkedList
+                            ?: throw IllegalStateException("List is not a LinkedList")
+                        return subclass
+                    }""".trimIndent()
+                assertThat(subject.lint(code)).isEmpty()
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
@@ -1,12 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.TEST_FILENAME
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class UseCheckOrErrorSpec : Spek({
+
+    val fileName = TEST_FILENAME
 
     val subject by memoized { UseCheckOrError(Config.empty) }
 
@@ -18,7 +21,7 @@ class UseCheckOrErrorSpec : Spek({
                     doSomething()
                     if (a < 0) throw IllegalStateException()
                 }"""
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw IllegalStateException()' at (3,16) in /$fileName")
         }
 
         it("reports if a an IllegalStateException is thrown with an error message") {
@@ -27,7 +30,7 @@ class UseCheckOrErrorSpec : Spek({
                     doSomething()
                     if (a < 0) throw IllegalStateException("More details")
                 }"""
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw IllegalStateException(\"More details\")' at (3,16) in /$fileName")
         }
 
         it("reports if a an IllegalStateException is thrown as default case of a when expression") {
@@ -37,7 +40,7 @@ class UseCheckOrErrorSpec : Spek({
                         1 -> doSomething()
                         else -> throw IllegalStateException()
                     }"""
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw IllegalStateException()' at (4,17) in /$fileName")
         }
 
         it("reports if an IllegalStateException is thrown by its fully qualified name") {
@@ -46,7 +49,7 @@ class UseCheckOrErrorSpec : Spek({
                     doSomething()
                     if (a < 0) throw java.lang.IllegalStateException()
                 }"""
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw java.lang.IllegalStateException()' at (3,16) in /$fileName")
         }
 
         it("reports if an IllegalStateException is thrown by its fully qualified name using the kotlin type alias") {
@@ -55,7 +58,7 @@ class UseCheckOrErrorSpec : Spek({
                     doSomething()
                     if (a < 0) throw kotlin.IllegalStateException()
                 }"""
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw kotlin.IllegalStateException()' at (3,16) in /$fileName")
         }
 
         it("does not report if any other kind of exception is thrown") {
@@ -85,41 +88,14 @@ class UseCheckOrErrorSpec : Spek({
             assertThat(subject.lint(code)).isEmpty()
         }
 
-        it("does not report an issue if the exception thrown unconditionally") {
+        it("reports an issue if the exception thrown as the only action in a function") {
             val code = """fun doThrow() = throw IllegalStateException("message")"""
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw IllegalStateException(\"message\")' at (1,17) in /$fileName")
         }
 
-        it("does not report an issue if the exception thrown unconditionally in a function block") {
+        it("reports an issue if the exception thrown as the only action in a function block") {
             val code = """fun doThrow() { throw IllegalStateException("message") }"""
-            assertThat(subject.lint(code)).hasSize(0)
-        }
-
-        context("throw is not after a precondition"){
-
-            it("does not report an issue if the exception is after a block") {
-                val code = """
-                    fun doSomethingOrThrow(test: Int): Int {
-                        var index = 0
-                        repeat(test){
-                            if (Math.random() == 1.0) {
-                                return it
-                            }
-                        }
-                        throw IllegalStateException("Test was too big")
-                    }""".trimIndent()
-                assertThat(subject.lint(code)).isEmpty()
-            }
-
-            it("does not report an issue if the exception is after a elvis operator") {
-                val code = """
-                    fun tryToCastOrThrow(list: List<*>) : LinkedList<*> {
-                        val subclass = list as? LinkedList
-                            ?: throw IllegalStateException("List is not a LinkedList")
-                        return subclass
-                    }""".trimIndent()
-                assertThat(subject.lint(code)).isEmpty()
-            }
+            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw IllegalStateException(\"message\")' at (1,17) in /$fileName")
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
@@ -1,12 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.TEST_FILENAME
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class UseRequireSpec : Spek({
+
+    val fileName = TEST_FILENAME
 
     val subject by memoized { UseRequire(Config.empty) }
 
@@ -18,7 +21,7 @@ class UseRequireSpec : Spek({
                     if (a < 0) throw IllegalArgumentException()
                     doSomething()
                 }"""
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw IllegalArgumentException()' at (2,16) in /$fileName")
         }
 
         it("reports if a precondition throws an IllegalArgumentException with more details") {
@@ -27,7 +30,7 @@ class UseRequireSpec : Spek({
                     if (a < 0) throw IllegalArgumentException("More details")
                     doSomething()
                 }"""
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw IllegalArgumentException(\"More details\")' at (2,16) in /$fileName")
         }
 
         it("reports if a precondition throws a fully qualified IllegalArgumentException") {
@@ -36,7 +39,7 @@ class UseRequireSpec : Spek({
                     if (a < 0) throw java.lang.IllegalArgumentException()
                     doSomething()
                 }"""
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw java.lang.IllegalArgumentException()' at (2,16) in /$fileName")
         }
 
         it("reports if a precondition throws a fully qualified IllegalArgumentException using the kotlin type alias") {
@@ -45,7 +48,7 @@ class UseRequireSpec : Spek({
                     if (a < 0) throw kotlin.IllegalArgumentException()
                     doSomething()
                 }"""
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw kotlin.IllegalArgumentException()' at (2,16) in /$fileName")
         }
 
         it("does not report if a precondition throws a different kind of exception") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
@@ -82,5 +82,43 @@ class UseRequireSpec : Spek({
             val code = """fun doThrow() { throw IllegalArgumentException("message") }"""
             assertThat(subject.lint(code)).isEmpty()
         }
+
+        context("throw is not after a precondition"){
+
+            it("does not report an issue if the exception is inside a when") {
+                val code = """
+                    fun whenOrThrow(item : List<*>) = when(item) {
+                        is ArrayList<*> -> 1
+                        is LinkedList<*> -> 2
+                        else -> throw IllegalArgumentException("Not supported List type")
+                    }
+                    """.trimIndent()
+                assertThat(subject.lint(code)).isEmpty()
+            }
+
+            it("does not report an issue if the exception is after a block") {
+                val code = """
+                    fun doSomethingOrThrow(test: Int): Int {
+                        var index = 0
+                        repeat(test){
+                            if (Math.random() == 1.0) {
+                                return it
+                            }
+                        }
+                        throw IllegalArgumentException("Test was too big")
+                    }""".trimIndent()
+                assertThat(subject.lint(code)).isEmpty()
+            }
+
+            it("does not report an issue if the exception is after a elvis operator") {
+                val code = """
+                    fun tryToCastOrThrow(list: List<*>) : LinkedList<*> {
+                        val subclass = list as? LinkedList
+                            ?: throw IllegalArgumentException("List is not a LinkedList")
+                        return subclass
+                    }""".trimIndent()
+                assertThat(subject.lint(code)).isEmpty()
+            }
+        }
     }
 })


### PR DESCRIPTION
The two rules were too 'greedy' and were reporting the majority
of the Illegal[State|Argument]Exception in the analysed code.

I restricted the scope of the rule to raise a issue only if the
exception is used after a precondition, or in a when-else branch.

Fixes #1683