### PR TITLE
Gradle: Upgrade the ktlint version to 0.33.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 detektVersion=1.0.0-RC15
 usedDetektVersion=1.0.0-RC15
-ktlintVersion=0.32.0
+ktlintVersion=0.33.0
 spekVersion=2.0.2
 junitPlatformVersion=1.4.1
 yamlVersion=1.24


### PR DESCRIPTION
See https://github.com/pinterest/ktlint/releases/tag/0.33.0. Note that
ktlint decided to remove the NoWildcardImportsRule from the
StandardRuleSetProvider, but the code is still present. For now, do not
change detekt's behavior in this regard to maintain the current user
experience.