### PR TITLE
Gradle plugin: Pass arguments to detekt in a file

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -230,7 +230,8 @@ open class Detekt : SourceTask(), VerificationTask {
             project = project,
             arguments = arguments.toList(),
             ignoreFailures = ignoreFailuresProp.getOrElse(false),
-            classpath = detektClasspath.plus(pluginClasspath)
+            classpath = detektClasspath.plus(pluginClasspath),
+            taskName = name
         )
 
         if (xmlReportTargetFileOrNull != null) {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -229,7 +229,6 @@ open class Detekt : SourceTask(), VerificationTask {
         DetektInvoker.invokeCli(
             project = project,
             arguments = arguments.toList(),
-            debug = debugOrDefault,
             ignoreFailures = ignoreFailuresProp.getOrElse(false),
             classpath = detektClasspath.plus(pluginClasspath)
         )

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -130,7 +130,8 @@ open class DetektCreateBaselineTask : SourceTask() {
             project = project,
             arguments = arguments.toList(),
             ignoreFailures = ignoreFailures.getOrElse(false),
-            classpath = detektClasspath.plus(pluginClasspath)
+            classpath = detektClasspath.plus(pluginClasspath),
+            taskName = name
         )
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -129,7 +129,6 @@ open class DetektCreateBaselineTask : SourceTask() {
         DetektInvoker.invokeCli(
             project = project,
             arguments = arguments.toList(),
-            debug = debug.getOrElse(false),
             ignoreFailures = ignoreFailures.getOrElse(false),
             classpath = detektClasspath.plus(pluginClasspath)
         )

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -37,6 +37,6 @@ open class DetektGenerateConfigTask : SourceTask() {
             InputArgument(source)
         )
 
-        DetektInvoker.invokeCli(project, arguments.toList(), detektClasspath)
+        DetektInvoker.invokeCli(project, arguments.toList(), detektClasspath, name)
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -16,14 +16,19 @@ object DetektInvoker {
         debug: Boolean = false,
         ignoreFailures: Boolean = false
     ) {
+        val detektTmpDir = project.mkdir("${project.buildDir}/tmp/detekt")
+        val argsFile = project.file("$detektTmpDir/args")
+
         val cliArguments = arguments.flatMap(CliArgument::toArgument)
+
+        argsFile.writeText(cliArguments.joinToString("\n"))
 
         if (debug) println(cliArguments)
 
         val proc = project.javaexec {
             it.main = DETEKT_MAIN
             it.classpath = classpath
-            it.args = cliArguments
+            it.args = listOf("@${argsFile.absolutePath}")
             it.isIgnoreExitValue = true
         }
         val exitValue = proc.exitValue

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -13,10 +13,11 @@ object DetektInvoker {
         project: Project,
         arguments: List<CliArgument>,
         classpath: FileCollection,
+        taskName: String,
         ignoreFailures: Boolean = false
     ) {
         val detektTmpDir = project.mkdir("${project.buildDir}/tmp/detekt")
-        val argsFile = project.file("$detektTmpDir/args")
+        val argsFile = project.file("$detektTmpDir/$taskName.args")
 
         val cliArguments = arguments.flatMap(CliArgument::toArgument)
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -13,7 +13,6 @@ object DetektInvoker {
         project: Project,
         arguments: List<CliArgument>,
         classpath: FileCollection,
-        debug: Boolean = false,
         ignoreFailures: Boolean = false
     ) {
         val detektTmpDir = project.mkdir("${project.buildDir}/tmp/detekt")
@@ -23,7 +22,7 @@ object DetektInvoker {
 
         argsFile.writeText(cliArguments.joinToString("\n"))
 
-        if (debug) println(cliArguments)
+        project.logger.debug(cliArguments.joinToString(" "))
 
         val proc = project.javaexec {
             it.main = DETEKT_MAIN
@@ -32,7 +31,7 @@ object DetektInvoker {
             it.isIgnoreExitValue = true
         }
         val exitValue = proc.exitValue
-        if (debug) println("Detekt finished with exit value $exitValue")
+        project.logger.debug("Detekt finished with exit value $exitValue")
 
         when (exitValue) {
             1 -> throw GradleException("There was a problem running detekt.")

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -1,7 +1,5 @@
 package io.gitlab.arturbosch.detekt.invoke
 
-import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT
-import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT_PLUGINS
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleConsolidationTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleConsolidationTest.kt
@@ -67,8 +67,6 @@ internal class DetektTaskMultiModuleConsolidationTest : Spek({
         it("using the kotlin dsl") {
 
             val mainBuildFileContent: String = """
-                |import io.gitlab.arturbosch.detekt.detekt
-                |
                 |plugins {
                 |   `java-library`
                 |    id("io.gitlab.arturbosch.detekt")

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleTest.kt
@@ -67,8 +67,6 @@ internal class DetektTaskMultiModuleTest : Spek({
             it("can be done using the kotlin dsl") {
 
                 val mainBuildFileContent: String = """
-				|import io.gitlab.arturbosch.detekt.detekt
-				|
 				|plugins {
 				|   `java-library`
 				|	id("io.gitlab.arturbosch.detekt")
@@ -138,8 +136,6 @@ internal class DetektTaskMultiModuleTest : Spek({
             it("can be done using the kotlin dsl") {
 
                 val mainBuildFileContent: String = """
-				|import io.gitlab.arturbosch.detekt.detekt
-				|
 				|plugins {
 				|   `java-library`
 				|	id("io.gitlab.arturbosch.detekt")
@@ -209,8 +205,6 @@ internal class DetektTaskMultiModuleTest : Spek({
             it("can be done using the kotlin dsl") {
 
                 val mainBuildFileContent: String = """
-				|import io.gitlab.arturbosch.detekt.detekt
-				|
 				|plugins {
 				|   `java-library`
 				|	id("io.gitlab.arturbosch.detekt")
@@ -288,8 +282,6 @@ internal class DetektTaskMultiModuleTest : Spek({
             it("can be done using the kotlin dsl") {
 
                 val mainBuildFileContent: String = """
-				|import io.gitlab.arturbosch.detekt.detekt
-				|
 				|plugins {
 				|   `java-library`
 				|	id("io.gitlab.arturbosch.detekt")

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
@@ -90,7 +90,7 @@ class DslGradleRunner(
     }
 
     private fun buildGradleRunner(tasks: List<String>): GradleRunner {
-        val args = listOf("--stacktrace", "--info", "--build-cache") + tasks.toList()
+        val args = listOf("--stacktrace", "--info", "--build-cache", "--debug") + tasks.toList()
 
         return GradleRunner.create().apply {
             withProjectDir(rootDir)

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
@@ -76,8 +76,6 @@ abstract class DslTestBuilder {
     private class KotlinBuilder : DslTestBuilder() {
         override val gradleBuildName: String = "build.gradle.kts"
         override val gradleBuildConfig: String = """
-                |import io.gitlab.arturbosch.detekt.detekt
-                |
                 |plugins {
                 |   `java-library`
                 |    id("io.gitlab.arturbosch.detekt")


### PR DESCRIPTION
This will hopefully fix #1686.

Note that passing arguments in a file is only supported on Java 9+, so introducing this may mean dropping support for running detekt on Java 1.8.