### PR TITLE
Set ignoreFailures on all sourceset tasks

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -96,6 +96,7 @@ class DetektPlugin : Plugin<Project> {
             it.classpath.setFrom(sourceSet.compileClasspath, sourceSet.output.classesDirs)
             it.reports.xml.destination = File(extension.reportsDir, sourceSet.name + ".xml")
             it.reports.html.destination = File(extension.reportsDir, sourceSet.name + ".html")
+            it.setIgnoreFailures(project.provider { extension.ignoreFailures })
             it.description =
                 "EXPERIMENTAL & SLOW: Run detekt analysis for ${sourceSet.name} classes with type resolution"
         }


### PR DESCRIPTION
The #1600 PR missed setting this on the auto-generated sourceset tasks.