### PR TITLE
Disable colors on Windows OS

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/Colorizer.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/Colorizer.kt
@@ -12,7 +12,12 @@ private data class Color(private val value: Byte) {
         get() = "$ESC[${value}m"
 }
 
-private fun CharSequence.colorized(color: Color) = "${color.escapeSequence}$this${RESET.escapeSequence}"
+private val isColoredOutputSupported: Boolean = !System.getProperty("os.name", "").contains("win", true)
+private fun CharSequence.colorized(color: Color): String = if (isColoredOutputSupported) {
+    "${color.escapeSequence}$this${RESET.escapeSequence}"
+} else {
+    this.toString()
+}
 
 fun CharSequence.red() = colorized(RED)
 fun CharSequence.yellow() = colorized(YELLOW)

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/Colorizer.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/Colorizer.kt
@@ -12,12 +12,15 @@ private data class Color(private val value: Byte) {
         get() = "$ESC[${value}m"
 }
 
-private val isColoredOutputSupported: Boolean = !System.getProperty("os.name", "").contains("win", true)
+
+private val isColoredOutputSupported: Boolean = !System.getProperty("os.name", "").startsWith("Windows")
+
 private fun CharSequence.colorized(color: Color): CharSequence = if (isColoredOutputSupported) {
     "${color.escapeSequence}$this${RESET.escapeSequence}"
 } else {
     this
 }
+
 
 fun CharSequence.red() = colorized(RED)
 fun CharSequence.yellow() = colorized(YELLOW)

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/Colorizer.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/Colorizer.kt
@@ -13,16 +13,12 @@ private data class Color(private val value: Byte) {
 }
 
 private val isColoredOutputSupported: Boolean = !System.getProperty("os.name", "").startsWith("Windows")
-private fun CharSequence.colorized(color: Color): CharSequence = if (isColoredOutputSupported) {
+private fun String.colorized(color: Color) = if (isColoredOutputSupported) {
     "${color.escapeSequence}$this${RESET.escapeSequence}"
 } else {
     this
 }
 
-fun CharSequence.red(): CharSequence = colorized(RED)
-fun CharSequence.yellow(): CharSequence = colorized(YELLOW)
-fun CharSequence.decolorized(): CharSequence = this.replace(escapeSequenceRegex, "")
-
-fun String.red(): String = colorized(RED).toString()
-fun String.yellow(): String = colorized(YELLOW).toString()
-fun String.decolorized(): String = this.replace(escapeSequenceRegex, "")
+fun String.red() = colorized(RED).toString()
+fun String.yellow() = colorized(YELLOW).toString()
+fun String.decolorized() = this.replace(escapeSequenceRegex, "")

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/Colorizer.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/Colorizer.kt
@@ -12,17 +12,17 @@ private data class Color(private val value: Byte) {
         get() = "$ESC[${value}m"
 }
 
-
 private val isColoredOutputSupported: Boolean = !System.getProperty("os.name", "").startsWith("Windows")
-
 private fun CharSequence.colorized(color: Color): CharSequence = if (isColoredOutputSupported) {
     "${color.escapeSequence}$this${RESET.escapeSequence}"
 } else {
     this
 }
 
+fun CharSequence.red(): CharSequence = colorized(RED)
+fun CharSequence.yellow(): CharSequence = colorized(YELLOW)
+fun CharSequence.decolorized(): CharSequence = this.replace(escapeSequenceRegex, "")
 
-fun CharSequence.red() = colorized(RED)
-fun CharSequence.yellow() = colorized(YELLOW)
-
-fun CharSequence.decolorized() = this.replace(escapeSequenceRegex, "")
+fun String.red(): String = colorized(RED).toString()
+fun String.yellow(): String = colorized(YELLOW).toString()
+fun String.decolorized(): String = this.replace(escapeSequenceRegex, "")

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/Colorizer.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/Colorizer.kt
@@ -13,10 +13,10 @@ private data class Color(private val value: Byte) {
 }
 
 private val isColoredOutputSupported: Boolean = !System.getProperty("os.name", "").contains("win", true)
-private fun CharSequence.colorized(color: Color): String = if (isColoredOutputSupported) {
+private fun CharSequence.colorized(color: Color): CharSequence = if (isColoredOutputSupported) {
     "${color.escapeSequence}$this${RESET.escapeSequence}"
 } else {
-    this.toString()
+    this
 }
 
 fun CharSequence.red() = colorized(RED)


### PR DESCRIPTION
This is simple and a bit dirty fix for #1694 - remove color chars in console output for Windows OS.

IMHO this PR is **less** preferable than #1702 