### PR TITLE
Use jansi for colorized console output

### DIFF
--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -5,6 +5,7 @@ application {
 val junitPlatformVersion: String by project
 val spekVersion: String by project
 val jcommanderVersion: String by project
+val jansiVersion: String by project
 val detektVersion: String by project
 val reflectionsVersion: String by project
 
@@ -15,6 +16,7 @@ dependencies {
     implementation(project(":detekt-core"))
     runtimeOnly(project(":detekt-rules"))
     implementation("com.beust:jcommander:$jcommanderVersion")
+    implementation("org.fusesource.jansi:jansi:$jansiVersion")
     implementation(kotlin("compiler-embeddable"))
 
     testImplementation(project(":detekt-test"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,7 @@ jcommanderVersion=1.74
 assertjVersion=3.12.2
 reflectionsVersion=0.9.11
 jacocoVersion=0.8.4
+jansiVersion=1.18
 
 kotlin.code.style=official
 


### PR DESCRIPTION
This is fix for #1694 - [Jansi](https://github.com/fusesource/jansi) library is used for colorized console output.

IMHO this PR is **more** preferable than #1701 