### PR TITLE
Rule improvement: False positive UnusedImport for componentN

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Tyler Wong](https://github.com/tylerbwong) - UnderscoresInNumericLiterals rule
 - [Daniele Conti](https://github.com/fourlastor) - ObjectPropertyNaming improvement
 - [Nicola Corti](https://github.com/cortinico) - Fixed Suppress of MaxLineLenght
+- [Michael Lotkowski](https://github.com/DownMoney) - Rule improvement: False positive UnusedImport for componentN
 
 ### Mentions
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -41,6 +41,7 @@ class UnusedImports(config: Config) : Rule(config) {
         private val kotlinDocReferencesRegExp = Regex("\\[([^]]+)](?!\\[)")
         private val kotlinDocSeeReferenceRegExp = Regex("^@see (.+)")
         private val whiteSpaceRegex = Regex("\\s+")
+        private val componentNRegex = Regex("component\\d+")
     }
 
     override fun visit(root: KtFile) {
@@ -78,6 +79,7 @@ class UnusedImports(config: Config) : Rule(config) {
                     .filter { it.identifier()?.contains("*")?.not() == true }
                     .filter { it.identifier() != null }
                     .filter { !operatorSet.contains(it.identifier()) }
+                    .filter { !componentNRegex.matches(it.identifier()!!) }
             super.visitImportList(importList)
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
@@ -247,5 +247,38 @@ class UnusedImportsSpec : Spek({
                 """
             assertThat(subject.lint(code)).isEmpty()
         }
+
+        it("should not report import of componentN operator") {
+            val code = """
+                import com.example.MyClass.component1
+                import com.example.MyClass.component2
+                import com.example.MyClass.component543
+
+                val (a, b) = MyClass(1, 2)
+            """.trimIndent()
+
+            assertThat(subject.lint(code)).isEmpty()
+        }
+
+        it("should report import of identifiers with component in the name") {
+            val lint = subject.lint(
+                """
+                import com.example.TestComponent
+                import com.example.component1.Unused
+                import com.example.components
+                import com.example.component1AndSomethingElse
+
+                println("Testing")
+            """.trimIndent()
+            )
+
+            with(lint) {
+                assertThat(this).hasSize(4)
+                assertThat(this[0].entity.signature).endsWith("import com.example.TestComponent")
+                assertThat(this[1].entity.signature).endsWith("import com.example.component1.Unused")
+                assertThat(this[2].entity.signature).endsWith("import com.example.components")
+                assertThat(this[3].entity.signature).endsWith("import com.example.component1AndSomethingElse")
+            }
+        }
     }
 })


### PR DESCRIPTION
When using Scala/Java classes it's useful to implement `componentN` operator functions to allow [destructuring](https://kotlinlang.org/docs/reference/multi-declarations.html) an object in to individual variables.

This change adds a regex matching `component\d+` to avoid flagging the imports as unused, similar to how other operator functions are handled.