### PR TITLE
[WIP] Use reflection to invoke detekt cli in gradle plugin - #1686

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 - `gradle detekt` should not report any errors
 - This repository follows the [Kotlin Coding Conventions](https://kotlinlang.org/docs/reference/coding-conventions.html) which are enforced by KtLint when running `gradle detekt`.
 - Make sure your IDE uses [KtLint](https://github.com/shyiko/ktlint) formatting rules as well as the settings in [.editorconfig](../.editorconfig)
-- We use [Spek](https://github.com/spekframework/spek) for testing. Please use the `Spec.kt`-Suffix.
+- We use [Spek](https://github.com/spekframework/spek) for testing. Please use the `Spec.kt`-Suffix. For easier testing you might want to use the [Spek IntelliJ Plugin](https://plugins.jetbrains.com/plugin/8564-spek).
 - Feel free to add your name to the contributors list at the end of the readme file when opening a pull request.
 - The code in `detekt-api` and any rule in `detekt-rules` must be documented. We generate documentation for our website based on this modules.
 - If some Kotlin code in `resources` folder (like `detekt-formatting`) shows a compilation error, right click on it and use `Mark as plain text`.

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,38 @@
+# Configuration for Lock Threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 100
+
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
+skipCreatedBefore: false
+
+# Issues and pull requests with these labels will be ignored. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically locked since there has not been
+  any recent activity after it was closed. Please open a new issue for
+  related topics.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: true
+
+# Limit to only `issues` or `pulls`
+only: issues
+
+# Optionally, specify configuration settings just for `issues` or `pulls`
+# issues:
+#   exemptLabels:
+#     - help-wanted
+#   lockLabel: outdated
+
+# pulls:
+#   daysUntilLock: 30
+
+# Repository to extend settings from
+# _extends: repo

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -14,10 +14,7 @@ exemptLabels: []
 lockLabel: false
 
 # Comment to post before locking. Set to `false` to disable
-lockComment: >
-  This thread has been automatically locked since there has not been
-  any recent activity after it was closed. Please open a new issue for
-  related topics.
+lockComment: false
 
 # Assign `resolved` as the reason for locking. Set to `false` to disable
 setLockReason: true

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Tyler Wong](https://github.com/tylerbwong) - UnderscoresInNumericLiterals rule
 - [Daniele Conti](https://github.com/fourlastor) - ObjectPropertyNaming improvement
 - [Nicola Corti](https://github.com/cortinico) - Fixed Suppress of MaxLineLenght
+- [Michael Lotkowski](https://github.com/DownMoney) - Rule improvement: False positive UnusedImport for componentN
 
 ### Mentions
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,6 @@ tasks.withType<Detekt> {
 }
 
 val detektVersion: String by project
-val usedDetektVersion: String by project
 
 allprojects {
     group = "io.gitlab.arturbosch.detekt"
@@ -90,7 +89,6 @@ subprojects {
 
     detekt {
         debug = true
-        toolVersion = usedDetektVersion
         buildUponDefaultConfig = true
         config = files(project.rootDir.resolve("reports/failfast.yml"))
         baseline = project.rootDir.resolve("reports/baseline.xml")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -256,6 +256,7 @@ fun shouldTreatCompilerWarningsAsErrors(): Boolean {
 }
 
 dependencies {
+    detekt(project(":detekt-cli"))
     detektPlugins(project(":detekt-formatting"))
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ import java.util.Date
 
 plugins {
     id("com.gradle.build-scan") version "2.3"
-    kotlin("jvm") version "1.3.31"
+    kotlin("jvm") version "1.3.40"
     id("com.jfrog.bintray") version "1.8.4"
     id("com.github.ben-manes.versions") version "0.21.0"
     id("com.github.johnrengelman.shadow") version "5.0.0" apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -265,6 +265,7 @@ val detektFormat by tasks.registering(Detekt::class) {
     buildUponDefaultConfig = true
     autoCorrect = true
     setSource(files(projectDir))
+    ignoreFailures = false
     include("**/*.kt")
     include("**/*.kts")
     exclude("**/resources/**")
@@ -282,6 +283,7 @@ val detektAll by tasks.registering(Detekt::class) {
     buildUponDefaultConfig = true
     setSource(files(projectDir))
     config = files(project.rootDir.resolve("reports/failfast.yml"))
+    ignoreFailures = false
     include("**/*.kt")
     include("**/*.kts")
     exclude("**/resources/**")

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/Colorizer.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/Colorizer.kt
@@ -12,9 +12,13 @@ private data class Color(private val value: Byte) {
         get() = "$ESC[${value}m"
 }
 
-private fun CharSequence.colorized(color: Color) = "${color.escapeSequence}$this${RESET.escapeSequence}"
+private val isColoredOutputSupported: Boolean = !System.getProperty("os.name", "").startsWith("Windows")
+private fun String.colorized(color: Color) = if (isColoredOutputSupported) {
+    "${color.escapeSequence}$this${RESET.escapeSequence}"
+} else {
+    this
+}
 
-fun CharSequence.red() = colorized(RED)
-fun CharSequence.yellow() = colorized(YELLOW)
-
-fun CharSequence.decolorized() = this.replace(escapeSequenceRegex, "")
+fun String.red() = colorized(RED).toString()
+fun String.yellow() = colorized(YELLOW).toString()
+fun String.decolorized() = this.replace(escapeSequenceRegex, "")

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
     `maven-publish`
     id("com.gradle.plugin-publish") version "0.10.1"
     id("com.jfrog.bintray") version "1.8.4"
-    kotlin("jvm") version "1.3.31"
+    kotlin("jvm") version "1.3.40"
     id("org.jetbrains.dokka") version "0.9.18"
     id("com.github.ben-manes.versions") version "0.21.0"
     id("io.gitlab.arturbosch.detekt") version "1.0.0-RC15"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -229,9 +229,9 @@ open class Detekt : SourceTask(), VerificationTask {
         DetektInvoker.invokeCli(
             project = project,
             arguments = arguments.toList(),
-            debug = debugOrDefault,
             ignoreFailures = ignoreFailuresProp.getOrElse(false),
-            classpath = detektClasspath.plus(pluginClasspath)
+            classpath = detektClasspath.plus(pluginClasspath),
+            taskName = name
         )
 
         if (xmlReportTargetFileOrNull != null) {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -129,9 +129,9 @@ open class DetektCreateBaselineTask : SourceTask() {
         DetektInvoker.invokeCli(
             project = project,
             arguments = arguments.toList(),
-            debug = debug.getOrElse(false),
             ignoreFailures = ignoreFailures.getOrElse(false),
-            classpath = detektClasspath.plus(pluginClasspath)
+            classpath = detektClasspath.plus(pluginClasspath),
+            taskName = name
         )
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -37,6 +37,6 @@ open class DetektGenerateConfigTask : SourceTask() {
             InputArgument(source)
         )
 
-        DetektInvoker.invokeCli(project, arguments.toList(), detektClasspath)
+        DetektInvoker.invokeCli(project, arguments.toList(), detektClasspath, name)
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -24,12 +24,12 @@ object DetektInvoker {
         project: Project,
         arguments: List<CliArgument>,
         classpath: FileCollection,
-        debug: Boolean = false,
+        taskName: String,
         ignoreFailures: Boolean = false
     ) {
         val cliArguments = arguments.flatMap(CliArgument::toArgument)
 
-        if (debug) println(cliArguments)
+        project.logger.debug(cliArguments.joinToString(" "))
 
         try {
             val loader = URLClassLoader(

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -24,11 +24,10 @@ object DetektInvoker {
         project: Project,
         arguments: List<CliArgument>,
         classpath: FileCollection,
-        taskName: String,
+        @Suppress("UNUSED_PARAMETER") taskName: String,
         ignoreFailures: Boolean = false
     ) {
         val cliArguments = arguments.flatMap(CliArgument::toArgument)
-
         project.logger.debug(cliArguments.joinToString(" "))
 
         try {
@@ -36,7 +35,6 @@ object DetektInvoker {
                 classpath.map { it.toURI().toURL() }.toTypedArray(),
                 DetektInvoker.javaClass.classLoader
             )
-<<<<<<< HEAD
 
             val mainClass = loader.loadClass(MAIN_CLASS_NAME)
             val parseArguments = checkNotNull(mainClass.declaredMethods
@@ -54,25 +52,6 @@ object DetektInvoker {
                 runner to runnerClass
             }
 
-=======
-
-            val mainClass = loader.loadClass(MAIN_CLASS_NAME)
-            val parseArguments = checkNotNull(mainClass.declaredMethods
-                .find { it.name == MAIN_PARSE_ARGUMENTS_METHOD_NAME })
-            parseArguments.isAccessible = true
-            val cliArgs = parseArguments.invoke(null, cliArguments.toTypedArray())
-
-            val (runner, runnerClass) = if (arguments.find { it is GenerateConfigArgument } != null) {
-                val runnerClass = loader.loadClass(CONFIG_EXPORTER_CLASS_NAME)
-                val runner = runnerClass.newInstance()
-                runner to runnerClass
-            } else {
-                val runnerClass = loader.loadClass(RUNNER_CLASS_NAME)
-                val runner = runnerClass.declaredConstructors.first().newInstance(cliArgs)
-                runner to runnerClass
-            }
-
->>>>>>> Use reflection to invoke detekt cli in gradle plugin - #1686
             val executeMethod = checkNotNull(runnerClass.declaredMethods.find { it.name == RUNNER_EXECUTE_METHOD_NAME })
 
             try {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -36,6 +36,7 @@ object DetektInvoker {
                 classpath.map { it.toURI().toURL() }.toTypedArray(),
                 DetektInvoker.javaClass.classLoader
             )
+<<<<<<< HEAD
 
             val mainClass = loader.loadClass(MAIN_CLASS_NAME)
             val parseArguments = checkNotNull(mainClass.declaredMethods
@@ -53,6 +54,25 @@ object DetektInvoker {
                 runner to runnerClass
             }
 
+=======
+
+            val mainClass = loader.loadClass(MAIN_CLASS_NAME)
+            val parseArguments = checkNotNull(mainClass.declaredMethods
+                .find { it.name == MAIN_PARSE_ARGUMENTS_METHOD_NAME })
+            parseArguments.isAccessible = true
+            val cliArgs = parseArguments.invoke(null, cliArguments.toTypedArray())
+
+            val (runner, runnerClass) = if (arguments.find { it is GenerateConfigArgument } != null) {
+                val runnerClass = loader.loadClass(CONFIG_EXPORTER_CLASS_NAME)
+                val runner = runnerClass.newInstance()
+                runner to runnerClass
+            } else {
+                val runnerClass = loader.loadClass(RUNNER_CLASS_NAME)
+                val runner = runnerClass.declaredConstructors.first().newInstance(cliArgs)
+                runner to runnerClass
+            }
+
+>>>>>>> Use reflection to invoke detekt cli in gradle plugin - #1686
             val executeMethod = checkNotNull(runnerClass.declaredMethods.find { it.name == RUNNER_EXECUTE_METHOD_NAME })
 
             try {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleConsolidationTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleConsolidationTest.kt
@@ -67,8 +67,6 @@ internal class DetektTaskMultiModuleConsolidationTest : Spek({
         it("using the kotlin dsl") {
 
             val mainBuildFileContent: String = """
-                |import io.gitlab.arturbosch.detekt.detekt
-                |
                 |plugins {
                 |   `java-library`
                 |    id("io.gitlab.arturbosch.detekt")

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleTest.kt
@@ -67,8 +67,6 @@ internal class DetektTaskMultiModuleTest : Spek({
             it("can be done using the kotlin dsl") {
 
                 val mainBuildFileContent: String = """
-				|import io.gitlab.arturbosch.detekt.detekt
-				|
 				|plugins {
 				|   `java-library`
 				|	id("io.gitlab.arturbosch.detekt")
@@ -138,8 +136,6 @@ internal class DetektTaskMultiModuleTest : Spek({
             it("can be done using the kotlin dsl") {
 
                 val mainBuildFileContent: String = """
-				|import io.gitlab.arturbosch.detekt.detekt
-				|
 				|plugins {
 				|   `java-library`
 				|	id("io.gitlab.arturbosch.detekt")
@@ -209,8 +205,6 @@ internal class DetektTaskMultiModuleTest : Spek({
             it("can be done using the kotlin dsl") {
 
                 val mainBuildFileContent: String = """
-				|import io.gitlab.arturbosch.detekt.detekt
-				|
 				|plugins {
 				|   `java-library`
 				|	id("io.gitlab.arturbosch.detekt")
@@ -288,8 +282,6 @@ internal class DetektTaskMultiModuleTest : Spek({
             it("can be done using the kotlin dsl") {
 
                 val mainBuildFileContent: String = """
-				|import io.gitlab.arturbosch.detekt.detekt
-				|
 				|plugins {
 				|   `java-library`
 				|	id("io.gitlab.arturbosch.detekt")

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
@@ -90,7 +90,7 @@ class DslGradleRunner(
     }
 
     private fun buildGradleRunner(tasks: List<String>): GradleRunner {
-        val args = listOf("--stacktrace", "--info", "--build-cache") + tasks.toList()
+        val args = listOf("--stacktrace", "--info", "--build-cache", "--debug") + tasks.toList()
 
         return GradleRunner.create().apply {
             withProjectDir(rootDir)

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
@@ -76,8 +76,6 @@ abstract class DslTestBuilder {
     private class KotlinBuilder : DslTestBuilder() {
         override val gradleBuildName: String = "build.gradle.kts"
         override val gradleBuildConfig: String = """
-                |import io.gitlab.arturbosch.detekt.detekt
-                |
                 |plugins {
                 |   `java-library`
                 |    id("io.gitlab.arturbosch.detekt")

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -20,6 +20,8 @@ import org.jetbrains.kotlin.psi.KtReferenceExpression
 
 /**
  * This rule reports unused imports. Unused imports are dead code and should be removed.
+ * Exempt from this rule are imports resulting from references to elements within KDoc and
+ * from destructuring declarations (componentN imports).
  *
  * @author Artur Bosch
  * @author Marvin Ramin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -41,6 +41,7 @@ class UnusedImports(config: Config) : Rule(config) {
         private val kotlinDocReferencesRegExp = Regex("\\[([^]]+)](?!\\[)")
         private val kotlinDocSeeReferenceRegExp = Regex("^@see (.+)")
         private val whiteSpaceRegex = Regex("\\s+")
+        private val componentNRegex = Regex("component\\d+")
     }
 
     override fun visit(root: KtFile) {
@@ -78,6 +79,7 @@ class UnusedImports(config: Config) : Rule(config) {
                     .filter { it.identifier()?.contains("*")?.not() == true }
                     .filter { it.identifier() != null }
                     .filter { !operatorSet.contains(it.identifier()) }
+                    .filter { !componentNRegex.matches(it.identifier()!!) }
             super.visitImportList(importList)
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
@@ -247,5 +247,38 @@ class UnusedImportsSpec : Spek({
                 """
             assertThat(subject.lint(code)).isEmpty()
         }
+
+        it("should not report import of componentN operator") {
+            val code = """
+                import com.example.MyClass.component1
+                import com.example.MyClass.component2
+                import com.example.MyClass.component543
+
+                val (a, b) = MyClass(1, 2)
+            """.trimIndent()
+
+            assertThat(subject.lint(code)).isEmpty()
+        }
+
+        it("should report import of identifiers with component in the name") {
+            val lint = subject.lint(
+                """
+                import com.example.TestComponent
+                import com.example.component1.Unused
+                import com.example.components
+                import com.example.component1AndSomethingElse
+
+                println("Testing")
+            """.trimIndent()
+            )
+
+            with(lint) {
+                assertThat(this).hasSize(4)
+                assertThat(this[0].entity.signature).endsWith("import com.example.TestComponent")
+                assertThat(this[1].entity.signature).endsWith("import com.example.component1.Unused")
+                assertThat(this[2].entity.signature).endsWith("import com.example.components")
+                assertThat(this[3].entity.signature).endsWith("import com.example.component1AndSomethingElse")
+            }
+        }
     }
 })

--- a/detekt-sample-extensions/build.gradle.kts
+++ b/detekt-sample-extensions/build.gradle.kts
@@ -1,13 +1,16 @@
 val assertjVersion: String by project
-val usedDetektVersion: String by project
 val junitPlatformVersion: String by project
 val spekVersion: String by project
 
 dependencies {
-    implementation("io.gitlab.arturbosch.detekt:detekt-api:$usedDetektVersion")
+    // When creating a sample extesion, change this dependency to the detekt-api version you build against, e.g.
+    // io.gitlab.arturbosch.detekt:detekt-api:1.0.0-RC15
+    implementation(project(":detekt-api"))
     implementation(kotlin("compiler-embeddable"))
 
-    testImplementation("io.gitlab.arturbosch.detekt:detekt-test:$usedDetektVersion")
+    // When creating a sample extesion, change this dependency to the detekt-test version you build against, e.g.
+    // io.gitlab.arturbosch.detekt:detekt-test:1.0.0-RC15
+    testImplementation(project(":detekt-test"))
     testImplementation("org.assertj:assertj-core:$assertjVersion")
     testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
 

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -23,22 +23,26 @@ class FindingsAssert(actual: List<Finding>) :
     override fun toAssert(value: Finding?, description: String?): FindingAssert =
             FindingAssert(value).`as`(description)
 
-    fun hasLocationStrings(vararg expected: String, trimIndent: Boolean = false) {
+    fun hasLocationStrings(vararg expected: String, trimIndent: Boolean = false) = apply {
         isNotNull
         val locationStrings = actual.asSequence().map { it.locationAsString }.sorted()
-        if (trimIndent) {
-            areEqual(locationStrings.map { it.trimIndent() }.toList(), expected.map { it.trimIndent() }.sorted())
+        val (actualLocationsList, expectedLocationsList) = if (trimIndent) {
+            locationStrings.map { it.trimIndent() }.toList() to expected.map { it.trimIndent() }.sorted()
         } else {
-            areEqual(locationStrings.toList(), expected.toList().sorted())
+            locationStrings.toList() to expected.toList().sorted()
+        }
+
+        if (!areEqual(actualLocationsList, expectedLocationsList)) {
+            failWithMessage("Expected locations string to be $expectedLocationsList but was $actualLocationsList")
         }
     }
 
-    fun hasExactlyLocationStrings(vararg expected: String, trimIndent: Boolean = false) {
+    fun hasExactlyLocationStrings(vararg expected: String, trimIndent: Boolean = false) = apply {
         hasSize(expected.size)
         hasLocationStrings(*expected, trimIndent = trimIndent)
     }
 
-    fun hasSourceLocations(vararg expected: SourceLocation) {
+    fun hasSourceLocations(vararg expected: SourceLocation) = apply {
         isNotNull
 
         val actualSources = actual.asSequence()
@@ -48,7 +52,9 @@ class FindingsAssert(actual: List<Finding>) :
         val expectedSources = expected.asSequence()
                 .sortedWith(compareBy({ it.line }, { it.column }))
 
-        areEqual(actualSources.toList(), expectedSources.toList())
+        if (!areEqual(actualSources.toList(), expectedSources.toList())) {
+            failWithMessage("Expected source locations to be ${expectedSources.toList()} but was ${actualSources.toList()}")
+        }
     }
 }
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -1121,6 +1121,8 @@ val range = 0 until 10
 ### UnusedImports
 
 This rule reports unused imports. Unused imports are dead code and should be removed.
+Exempt from this rule are imports resulting from references to elements within KDoc and
+from destructuring declarations (componentN imports).
 
 **Severity**: Style
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-detektVersion=1.0.0-RC15
+detektVersion=1.0.0-RC16-SNAPSHOT
 ktlintVersion=0.33.0
 spekVersion=2.0.2
 junitPlatformVersion=1.4.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 detektVersion=1.0.0-RC15
-usedDetektVersion=1.0.0-RC15
 ktlintVersion=0.33.0
 spekVersion=2.0.2
 junitPlatformVersion=1.4.1


### PR DESCRIPTION
Prototype to use reflection to invoke detekt.
It has the advantage that we do not need to start a new process and we do not have the limitation of too long filenames on windows.

@marschwar I've got some problems with the testcases. I'm not sure what is expected to get logged for example in `DetektTaskDslTest`. It looks like the passed arguments to the process are validated?
With this patch the normal detekt output gets printed.
```
java.lang.AssertionError: 
Expecting:
 <"The client will now receive all logging from the daemon (pid: 30403). The daemon log file: /tmp/.gradle-test-kit-abosch/test-kit-daemon/5.4.1/daemon-30403.out.log
Starting 5th build in daemon [uptime: 6.595 secs, performance: 94%, non-heap usage: 15% of 268.4 MB]
Closing daemon's stdin at end of input.
The daemon will no longer process any standard input.
Using 8 worker leases.
Starting Build
Settings evaluated using settings file '/tmp/applyPlugin7974105155632345249.tmp/settings.gradle'.
Using local directory build cache for the root build (location = /tmp/.gradle-test-kit-abosch/caches/build-cache-1, removeUnusedEntriesAfter = 7 days).
Projects loaded. Root project using build file '/tmp/applyPlugin7974105155632345249.tmp/build.gradle'.
Included projects: [root project 'rootDir-project']

> Configure project :
Evaluating root project 'rootDir-project' using build file '/tmp/applyPlugin7974105155632345249.tmp/build.gradle'.
All projects evaluated.
Selected primary task 'detekt' from project :
Tasks to be executed: [task ':detekt']
:detekt (Thread[Execution worker for ':',5,main]) started.

> Task :detekt
Build cache key for task ':detekt' is 16a72903d57a065657844231e33863a9
Task ':detekt' is not up-to-date because:
  No history is available.


1 kotlin file was analyzed.

Ruleset: comments
Ruleset: complexity
Ruleset: empty-blocks
Ruleset: exceptions
Ruleset: naming
Ruleset: performance
Ruleset: potential-bugs
Ruleset: style

Complexity Report:
	- 6 lines of code (loc)
	- 5 source lines of code (sloc)
	- 4 logical lines of code (lloc)
	- 0 comment lines of code (cloc)
	- 0 McCabe complexity (mcc)
	- 0 number of total code smells
	- 0 % comment source ratio
	- 0 mcc per 1000 lloc
	- 0 code smells per 1000 lloc

Project Statistics:
	- number of properties: 1
	- number of functions: 0
	- number of classes: 1
	- number of packages: 1
	- number of kt files: 1

Successfully generated HTML report at /tmp/applyPlugin7974105155632345249.tmp/build/reports/detekt/detekt.html
Successfully generated Checkstyle XML report at /tmp/applyPlugin7974105155632345249.tmp/build/reports/detekt/detekt.xml

detekt finished in 181 ms.
Successfully run detekt via reflection
Packing task ':detekt'
:detekt (Thread[Execution worker for ':',5,main]) completed. Took 0.368 secs.

BUILD SUCCESSFUL in 0s
1 actionable task: 1 executed
">
to contain:
 <"--input /tmp/applyPlugin7974105155632345249.tmp/gensrc/kotlin"> 
	at io.gitlab.arturbosch.detekt.DetektTaskDslTest$1$1$1$1$5$1.invoke(DetektTaskDslTest.kt:95)
	at io.gitlab.arturbosch.detekt.DetektTaskDslTest$1$1$1$1$5$1.invoke(DetektTaskDslTest.kt:15)
	at io.gitlab.arturbosch.detekt.DslGradleRunner$runDetektTaskAndCheckResult$1.invoke(DslGradleRunner.kt:109)
	at io.gitlab.arturbosch.detekt.DslGradleRunner$runDetektTaskAndCheckResult$1.invoke(DslGradleRunner.kt:8)
	at io.gitlab.arturbosch.detekt.DslGradleRunner.runTasksAndCheckResult(DslGradleRunner.kt:105)
	at io.gitlab.arturbosch.detekt.DslGradleRunner.runDetektTaskAndCheckResult(DslGradleRunner.kt:109)
	at io.gitlab.arturbosch.detekt.DetektTaskDslTest$1$1$1$1$5.invoke(DetektTaskDslTest.kt:91)
	at io.gitlab.arturbosch.detekt.DetektTaskDslTest$1$1$1$1$5.invoke(DetektTaskDslTest.kt:15)
	at org.spekframework.spek2.runtime.scope.TestScopeImpl.execute(Scopes.kt:92)
	at org.spekframework.spek2.runtime.Executor.execute(Executor.kt:28)
	at org.spekframework.spek2.runtime.Executor.execute(Executor.kt:31)
	at org.spekframework.spek2.runtime.Executor.execute(Executor.kt:31)
	at org.spekframework.spek2.runtime.Executor.execute(Executor.kt:31)
	at org.spekframework.spek2.runtime.Executor.execute(Executor.kt:15)
	at org.spekframework.spek2.runtime.SpekRuntime.execute(SpekRuntime.kt:33)
	at org.spekframework.ide.Spek2ConsoleLauncher.run(console.kt:24)
	at org.spekframework.ide.ConsoleKt$main$1.invoke(console.kt:35)
	at org.spekframework.ide.ConsoleKt$main$1.invoke(console.kt)
	at shadow.com.xenomachina.argparser.SystemExitExceptionKt.mainBody(SystemExitException.kt:74)
	at shadow.com.xenomachina.argparser.SystemExitExceptionKt.mainBody$default(SystemExitException.kt:72)
	at org.spekframework.ide.ConsoleKt.main(console.kt:33)
```