### PR TITLE
Prevent Lockbot from commenting when locking issues

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -14,10 +14,7 @@ exemptLabels: []
 lockLabel: false
 
 # Comment to post before locking. Set to `false` to disable
-lockComment: >
-  This thread has been automatically locked since there has not been
-  any recent activity after it was closed. Please open a new issue for
-  related topics.
+lockComment: false
 
 # Assign `resolved` as the reason for locking. Set to `false` to disable
 setLockReason: true


### PR DESCRIPTION
Lockbot is closing/blocking a lot of issues and is flooding the inboxes
of watchers of the repo. Let's turn off the commenting feature of it.

See #1709 for more context.