### PR TITLE
Removed extra quote in the Extensions Doc page

### DIFF
--- a/docs/pages/extensions.md
+++ b/docs/pages/extensions.md
@@ -204,7 +204,7 @@ dependencies {
 - By default all rules not marked with `@active` in their `KDoc` are disabled.
 That means your custom rules are also disabled if you have not explicitly enabled
 them in the `detekt` yaml configuration file.
-- If your extension is part of your project and you integrate it like `detektPlugins project(":my-rules"")` make sure that this
+- If your extension is part of your project and you integrate it like `detektPlugins project(":my-rules")` make sure that this
 subproject is build before `gradle detekt` is run.
 In the `kotlin-dsl` you could add something like `tasks.withType<Detekt> { dependsOn(":my-rules:assemble") }` to explicitly run `detekt` only 
 after your extension sub project is built.


### PR DESCRIPTION
Looks like we do have an extra quote in the Extensions Doc page here:
https://arturbosch.github.io/detekt/extensions.html#pitfalls