### PR TITLE
Print to console the count of weighted issues if above 0

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/BuildFailureReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/BuildFailureReport.kt
@@ -59,6 +59,10 @@ class BuildFailureReport : ConsoleReport() {
                         "Warning threshold is $warningThreshold and fail threshold is $failThreshold!"
                 message.yellow()
             }
+            amount > 0 && maxIssues != -1 -> {
+                val message = "Build succeeded with $amount weighted issues (threshold defined was $maxIssues)."
+                message.yellow()
+            }
             else -> null
         }
     }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/BuildFailureReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/BuildFailureReportSpec.kt
@@ -64,6 +64,20 @@ internal class BuildFailureReportSpec : Spek({
                     assertThat(e.stackTrace).isEmpty()
                 }
             }
+
+            it("should print a warning in yellow if weighted issues are not zero but below threshold") {
+                subject.init(TestConfig(mapOf("maxIssues" to "10")))
+                val report = subject.render(detektion)
+                val expectedMessage = "Build succeeded with 1 weighted issues (threshold defined was 10)."
+                assertThat(report).isEqualTo(expectedMessage.yellow())
+            }
+
+            it("should not print a warning if weighted issues are zero") {
+                subject.init(TestConfig(mapOf("maxIssues" to "10")))
+                val report = subject.render(TestDetektion())
+                assertThat(report).isNull()
+            }
+
         }
     }
 


### PR DESCRIPTION
Adding a report of the number of weighted issues if
the total weight is above zero but below the maxIssues field.
Previously this information was omitted in case of successful build.

Fixes #1723