### PR TITLE
Publish snapshots to jfrogs oss artifactory

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-detektVersion=1.0.0-RC15
+detektVersion=1.0.0-RC16
 ktlintVersion=0.33.0
 spekVersion=2.0.2
 junitPlatformVersion=1.4.1


### PR DESCRIPTION
Still needs additional documentation though.

There are two snapshots published to: https://oss.jfrog.org/artifactory/oss-snapshot-local/io/gitlab/arturbosch/detekt/

Needs maven repo: 
```
repositories {
	maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local' }
}
```

Edit: ok the gradle plugins is missing ...