### PR TITLE
Don't fail when codecov test coverage decreases

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,3 +4,9 @@ codecov:
   notify:
     require_ci_to_pass: no
     after_n_builds: 4
+coverage:
+  status:
+    # pull-requests only
+    patch:
+      default:
+        threshold: 0.1%


### PR DESCRIPTION
This PR introduces a threshold in order to not fail the PR when the 
codecov test coverage decreases slightly by 0.1 %.
