### PR TITLE
Update EmptyClassBlock to skip classes with comments in the body

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
@@ -7,13 +7,16 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassBody
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.psiUtil.blockExpressionsOrSingle
 import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
+import org.jetbrains.kotlin.psi.psiUtil.lastBlockStatementOrThis
 
 /**
  * @author Artur Bosch
@@ -29,7 +32,9 @@ fun KtCallExpression.isUsedForNesting(): Boolean = when (getCallNameExpression()
     else -> false
 }
 
-fun KtBlockExpression.hasCommentInside(): Boolean {
+fun KtClassOrObject.hasCommentInside() = this.body?.hasCommentInside() ?: false
+
+fun PsiElement.hasCommentInside(): Boolean {
     val commentKey = Key<Boolean>("comment")
     this.acceptChildren(object : DetektVisitor() {
         override fun visitComment(comment: PsiComment?) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
@@ -7,16 +7,13 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClass
-import org.jetbrains.kotlin.psi.KtClassBody
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
-import org.jetbrains.kotlin.psi.psiUtil.blockExpressionsOrSingle
 import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
-import org.jetbrains.kotlin.psi.psiUtil.lastBlockStatementOrThis
 
 /**
  * @author Artur Bosch

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
@@ -3,8 +3,12 @@ package io.gitlab.arturbosch.detekt.rules.empty
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.rules.asBlockExpression
+import io.gitlab.arturbosch.detekt.rules.hasCommentInside
 import io.gitlab.arturbosch.detekt.rules.isObjectOfAnonymousClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.psiUtil.blockExpressionsOrSingle
+import org.jetbrains.kotlin.psi.psiUtil.lastBlockStatementOrThis
 
 /**
  * Reports empty classes. Empty blocks of code serve no purpose and should be removed.
@@ -19,6 +23,7 @@ class EmptyClassBlock(config: Config) : EmptyRule(config) {
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
         super.visitClassOrObject(classOrObject)
         if (classOrObject.isObjectOfAnonymousClass()) return
+        if (classOrObject.hasCommentInside()) return
 
         classOrObject.body?.declarations?.let {
             if (it.isEmpty()) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
@@ -3,12 +3,9 @@ package io.gitlab.arturbosch.detekt.rules.empty
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.rules.asBlockExpression
 import io.gitlab.arturbosch.detekt.rules.hasCommentInside
 import io.gitlab.arturbosch.detekt.rules.isObjectOfAnonymousClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
-import org.jetbrains.kotlin.psi.psiUtil.blockExpressionsOrSingle
-import org.jetbrains.kotlin.psi.psiUtil.lastBlockStatementOrThis
 
 /**
  * Reports empty classes. Empty blocks of code serve no purpose and should be removed.

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
@@ -33,7 +33,7 @@ class EmptyClassBlockSpec : Spek({
         it("does not report class with multiline comments in the body") {
             val code = """
                 class SomeClass {
-                    /* 
+                    /*
                     Some comment to explain what this class is supposed to do
                     */
                 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
@@ -21,6 +21,26 @@ class EmptyClassBlockSpec : Spek({
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
+        it("does not report class with comments in the body") {
+            val code = """
+                class SomeClass {
+                    // Some comment to explain what this class is supposed to do
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it("does not report class with multiline comments in the body") {
+            val code = """
+                class SomeClass {
+                    /* 
+                    Some comment to explain what this class is supposed to do
+                    */
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
         it("reports the empty nested class body") {
             val code = """
                 class SomeClass {


### PR DESCRIPTION
This is similar to #1690 but I'm fixing the `EmptyClassBlock` rule here

Fixes #1756 

