### PR TITLE
Fix missing report file issue.

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt
 
+import io.gitlab.arturbosch.detekt.DetektPlugin.Companion.DETEKT_TASK_NAME
 import io.gitlab.arturbosch.detekt.extensions.CustomDetektReport
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType
 import io.gitlab.arturbosch.detekt.extensions.DetektReports
@@ -234,10 +235,13 @@ open class Detekt : SourceTask(), VerificationTask {
             taskName = name
         )
 
-        if (xmlReportTargetFileOrNull != null) {
+        if (name == DETEKT_TASK_NAME && xmlReportTargetFileOrNull != null) {
             val xmlReports = project.subprojects.flatMap { subproject ->
                 subproject.tasks.mapNotNull { task ->
-                    if (task is Detekt) task.xmlReportFile.orNull?.asFile else null
+                    if (task is Detekt && task.name == DETEKT_TASK_NAME)
+                        task.xmlReportFile.orNull?.asFile
+                    else
+                        null
                 }
             }
             if (!xmlReports.isEmpty() && debugOrDefault) {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -26,7 +26,7 @@ class DetektPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         project.pluginManager.apply(ReportingBasePlugin::class.java)
-        val extension = project.extensions.create(DETEKT, DetektExtension::class.java, project)
+        val extension = project.extensions.create(DETEKT_TASK_NAME, DetektExtension::class.java, project)
         extension.reportsDir = project.extensions.getByType(ReportingExtension::class.java).file("detekt")
 
         configurePluginDependencies(project, extension)
@@ -52,7 +52,7 @@ class DetektPlugin : Plugin<Project> {
     }
 
     private fun registerOldDetektTask(project: Project, extension: DetektExtension) {
-        val detektTaskProvider = project.tasks.register(DETEKT, Detekt::class.java) {
+        val detektTaskProvider = project.tasks.register(DETEKT_TASK_NAME, Detekt::class.java) {
             it.debugProp.set(project.provider { extension.debug })
             it.parallelProp.set(project.provider { extension.parallel })
             it.disableDefaultRuleSetsProp.set(project.provider { extension.disableDefaultRuleSets })
@@ -69,7 +69,7 @@ class DetektPlugin : Plugin<Project> {
             it.setIgnoreFailures(project.provider { extension.ignoreFailures })
 
             project.subprojects.forEach { subProject ->
-                subProject.tasks.firstOrNull { t -> t is Detekt }?.let { subprojectTask ->
+                subProject.tasks.firstOrNull { t -> t is Detekt && t.name == DETEKT_TASK_NAME }?.let { subprojectTask ->
                     it.dependsOn(subprojectTask)
                 }
             }
@@ -83,7 +83,7 @@ class DetektPlugin : Plugin<Project> {
     private fun registerDetektTask(project: Project, extension: DetektExtension, sourceSet: SourceSet) {
         val kotlinSourceSet = (sourceSet as HasConvention).convention.plugins["kotlin"] as? KotlinSourceSet
             ?: throw GradleException("Kotlin source set not found. Please report on detekt's issue tracker")
-        project.tasks.register(DETEKT + sourceSet.name.capitalize(), Detekt::class.java) {
+        project.tasks.register(DETEKT_TASK_NAME + sourceSet.name.capitalize(), Detekt::class.java) {
             it.debugProp.set(project.provider { extension.debug })
             it.parallelProp.set(project.provider { extension.parallel })
             it.disableDefaultRuleSetsProp.set(project.provider { extension.disableDefaultRuleSets })
@@ -184,7 +184,7 @@ class DetektPlugin : Plugin<Project> {
     }
 
     companion object {
-        private const val DETEKT = "detekt"
+        const val DETEKT_TASK_NAME = "detekt"
         private const val IDEA_FORMAT = "detektIdeaFormat"
         private const val IDEA_INSPECT = "detektIdeaInspect"
         private const val GENERATE_CONFIG = "detektGenerateConfig"

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleConsolidationTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleConsolidationTest.kt
@@ -43,11 +43,9 @@ internal class DetektTaskMultiModuleConsolidationTest : Spek({
         it("using the groovy dsl") {
 
             val mainBuildFileContent: String = """
-                |import io.gitlab.arturbosch.detekt.DetektPlugin
-                |
                 |plugins {
-                |   id "java-library"
                 |   id "io.gitlab.arturbosch.detekt"
+                |   id "org.jetbrains.kotlin.jvm"
                 |}
                 |
                 |allprojects {
@@ -57,8 +55,8 @@ internal class DetektTaskMultiModuleConsolidationTest : Spek({
                 |    }
                 |}
                 |subprojects {
-                |    apply plugin: "java-library"
                 |    apply plugin: "io.gitlab.arturbosch.detekt"
+                |    apply plugin: "kotlin"
                 |}
                 """.trimMargin()
 
@@ -68,7 +66,7 @@ internal class DetektTaskMultiModuleConsolidationTest : Spek({
 
             val mainBuildFileContent: String = """
                 |plugins {
-                |   `java-library`
+                |    kotlin("jvm")
                 |    id("io.gitlab.arturbosch.detekt")
                 |}
                 |
@@ -79,7 +77,7 @@ internal class DetektTaskMultiModuleConsolidationTest : Spek({
                 |    }
                 |}
                 |subprojects {
-                |    plugins.apply("java-library")
+                |    plugins.apply("kotlin")
                 |    plugins.apply("io.gitlab.arturbosch.detekt")
                 |}
                 """.trimMargin()

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleConsolidationTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleConsolidationTest.kt
@@ -9,80 +9,49 @@ import org.spekframework.spek2.style.specification.describe
  * @author Markus Schwarz
  */
 internal class DetektTaskMultiModuleConsolidationTest : Spek({
-    describe("The Detekt Gradle plugin consolidates xml reports in a multi module project") {
-        val projectLayout = ProjectLayout(
-            numberOfSourceFilesInRootPerSourceDir = 1,
-            numberOfCodeSmellsInRootPerSourceDir = 1
-        )
-            .withSubmodule(name = "child1", numberOfSourceFilesPerSourceDir = 2, numberOfCodeSmells = 1)
-            .withSubmodule(name = "child2", numberOfSourceFilesPerSourceDir = 4, numberOfCodeSmells = 1)
+    listOf(DslTestBuilder.groovy(), DslTestBuilder.kotlin()).forEach { builder ->
+        describe("using ${builder.gradleBuildName}") {
+            it("The Detekt Gradle plugin consolidates xml reports in a multi module project") {
+                val projectLayout = ProjectLayout(
+                    numberOfSourceFilesInRootPerSourceDir = 1,
+                    numberOfCodeSmellsInRootPerSourceDir = 1
+                )
+                    .withSubmodule(name = "child1", numberOfSourceFilesPerSourceDir = 2, numberOfCodeSmells = 1)
+                    .withSubmodule(name = "child2", numberOfSourceFilesPerSourceDir = 4, numberOfCodeSmells = 1)
 
-        lateinit var gradleRunner: DslGradleRunner
+                val mainBuildFileContent: String = """
+                        |${builder.gradlePluginsSection}
+                        |
+                        |allprojects {
+                        |   ${builder.gradleRepositoriesSection}
+                        |}
+                        |subprojects {
+                        |   ${builder.gradleApplyPlugins}
+                        |}
+                        |""".trimMargin()
 
-        afterEachTest {
-            gradleRunner.setupProject()
-            gradleRunner.runDetektTaskAndCheckResult { result ->
-                assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                projectLayout.submodules.forEach { submodule ->
-                    assertThat(result.task(":${submodule.name}:detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
+
+                gradleRunner.setupProject()
+                gradleRunner.runDetektTaskAndCheckResult { result ->
+                    assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                    projectLayout.submodules.forEach { submodule ->
+                        assertThat(result.task(":${submodule.name}:detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                    }
+
+                    val consolidatedReport = projectFile("build/reports/detekt/detekt.xml").readLines()
+                    val codeSmellsPerProject = 1
+                    val headerAndFooter = 3
+                    val linesPerSubModule = 3 * codeSmellsPerProject
+                    val linesInMainProject = 3 * codeSmellsPerProject
+
+                    val expectedLinesInConsolidatedReport =
+                        headerAndFooter +
+                            linesInMainProject +
+                            (projectLayout.submodules.size * linesPerSubModule)
+                    assertThat(consolidatedReport).hasSize(expectedLinesInConsolidatedReport)
                 }
-
-                val consolidatedReport = projectFile("build/reports/detekt/detekt.xml").readLines()
-                val codeSmellsPerProject = 1
-                val headerAndFooter = 3
-                val linesPerSubModule = 3 * codeSmellsPerProject
-                val linesInMainProject = 3 * codeSmellsPerProject
-
-                val expectedLinesInConsolidatedReport =
-                    headerAndFooter +
-                        linesInMainProject +
-                        (projectLayout.submodules.size * linesPerSubModule)
-                assertThat(consolidatedReport).hasSize(expectedLinesInConsolidatedReport)
             }
-        }
-        it("using the groovy dsl") {
-
-            val mainBuildFileContent: String = """
-                |plugins {
-                |   id "io.gitlab.arturbosch.detekt"
-                |   id "org.jetbrains.kotlin.jvm"
-                |}
-                |
-                |allprojects {
-                |    repositories {
-                |        mavenLocal()
-                |        jcenter()
-                |    }
-                |}
-                |subprojects {
-                |    apply plugin: "io.gitlab.arturbosch.detekt"
-                |    apply plugin: "kotlin"
-                |}
-                """.trimMargin()
-
-            gradleRunner = DslGradleRunner(projectLayout, "build.gradle", mainBuildFileContent)
-        }
-        it("using the kotlin dsl") {
-
-            val mainBuildFileContent: String = """
-                |plugins {
-                |    kotlin("jvm")
-                |    id("io.gitlab.arturbosch.detekt")
-                |}
-                |
-                |allprojects {
-                |    repositories {
-                |        mavenLocal()
-                |        jcenter()
-                |    }
-                |}
-                |subprojects {
-                |    plugins.apply("kotlin")
-                |    plugins.apply("io.gitlab.arturbosch.detekt")
-                |}
-                """.trimMargin()
-
-            gradleRunner = DslGradleRunner(projectLayout, "build.gradle.kts", mainBuildFileContent)
         }
     }
 })

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleTest.kt
@@ -13,9 +13,8 @@ import org.spekframework.spek2.style.specification.describe
 internal class DetektTaskMultiModuleTest : Spek({
     describe("The Detekt Gradle plugin used in a multi module project") {
         describe(
-            "is applied with defaults to all subprojects individually without sources in root project using the" +
-                " " +
-                "subprojects block"
+            "is applied with defaults to all subprojects individually without sources in root project " +
+                "using the subprojects block"
         ) {
             val projectLayout = ProjectLayout(0)
                 .withSubmodule("child1", 2)
@@ -43,46 +42,29 @@ internal class DetektTaskMultiModuleTest : Spek({
             it("can be done using the groovy dsl") {
 
                 val mainBuildFileContent: String = """
-				|import io.gitlab.arturbosch.detekt.DetektPlugin
-				|
-				|plugins {
-				|   id "java-library"
-				|   id "io.gitlab.arturbosch.detekt"
-				|}
-				|
-				|allprojects {
-				|	repositories {
-				|		mavenLocal()
-				|		jcenter()
-				|	}
-				|}
-				|subprojects {
-				|	apply plugin: "java-library"
-				|	apply plugin: "io.gitlab.arturbosch.detekt"
-				|}
-				""".trimMargin()
+                |$GROOVY_PLUGINS_SECTION
+                |allprojects {
+                |   $REPOSITORIES_SECTION
+                |}
+                |subprojects {
+                |   $GROOVY_APPLY_PLUGINS
+                |}
+                |""".trimMargin()
 
                 gradleRunner = DslGradleRunner(projectLayout, "build.gradle", mainBuildFileContent)
             }
             it("can be done using the kotlin dsl") {
 
                 val mainBuildFileContent: String = """
-				|plugins {
-				|   `java-library`
-				|	id("io.gitlab.arturbosch.detekt")
-				|}
-				|
-				|allprojects {
-				|	repositories {
-				|		mavenLocal()
-				|		jcenter()
-				|	}
-				|}
-				|subprojects {
-				|	plugins.apply("java-library")
-				|	plugins.apply("io.gitlab.arturbosch.detekt")
-				|}
-				""".trimMargin()
+                |$KOTLIN_PLUGINS_SECTION
+                |
+                |allprojects {
+                |   $REPOSITORIES_SECTION
+                |}
+                |subprojects {
+                |   $KOTLIN_APPLY_PLUGINS
+                |}
+                |""".trimMargin()
 
                 gradleRunner = DslGradleRunner(projectLayout, "build.gradle.kts", mainBuildFileContent)
             }
@@ -114,42 +96,28 @@ internal class DetektTaskMultiModuleTest : Spek({
             it("can be done using the groovy dsl") {
 
                 val mainBuildFileContent: String = """
-				|import io.gitlab.arturbosch.detekt.DetektPlugin
-				|
-				|plugins {
-				|   id "java-library"
-				|   id "io.gitlab.arturbosch.detekt"
-				|}
-				|
-				|allprojects {
-				|	repositories {
-				|		mavenLocal()
-				|		jcenter()
-				|	}
-				|	apply plugin: "java-library"
-				|	apply plugin: "io.gitlab.arturbosch.detekt"
-				|}
-				""".trimMargin()
+                |$GROOVY_PLUGINS_SECTION
+                |
+                |allprojects {
+                |   $REPOSITORIES_SECTION
+                |
+                |   $GROOVY_APPLY_PLUGINS
+                |}
+                |""".trimMargin()
 
                 gradleRunner = DslGradleRunner(projectLayout, "build.gradle", mainBuildFileContent)
             }
             it("can be done using the kotlin dsl") {
 
                 val mainBuildFileContent: String = """
-				|plugins {
-				|   `java-library`
-				|	id("io.gitlab.arturbosch.detekt")
-				|}
-				|
-				|allprojects {
-				|	repositories {
-				|		mavenLocal()
-				|		jcenter()
-				|	}
-				|	plugins.apply("java-library")
-				|	plugins.apply("io.gitlab.arturbosch.detekt")
-				|}
-				""".trimMargin()
+                |$KOTLIN_PLUGINS_SECTION
+                |
+                |allprojects {
+                |   $REPOSITORIES_SECTION
+                |
+                |   $KOTLIN_APPLY_PLUGINS
+                |}
+                """.trimMargin()
 
                 gradleRunner = DslGradleRunner(projectLayout, "build.gradle.kts", mainBuildFileContent)
             }
@@ -180,58 +148,46 @@ internal class DetektTaskMultiModuleTest : Spek({
             it("can be done using the groovy dsl") {
 
                 val mainBuildFileContent: String = """
-				|import io.gitlab.arturbosch.detekt.DetektPlugin
-				|
-				|plugins {
-				|   id "java-library"
-				|   id "io.gitlab.arturbosch.detekt"
-				|}
-				|
-				|allprojects {
-				|	repositories {
-				|		mavenLocal()
-				|		jcenter()
-				|	}
-				|	apply plugin: "java-library"
-				|	apply plugin: "io.gitlab.arturbosch.detekt"
-				|	detekt {
-				|		reportsDir = file("build/detekt-reports")
-				|	}
-				|}
-				""".trimMargin()
+                |$GROOVY_PLUGINS_SECTION
+                |
+                |allprojects {
+                |   $REPOSITORIES_SECTION
+                |
+                |   $GROOVY_APPLY_PLUGINS
+                |
+                |   detekt {
+                |       reportsDir = file("build/detekt-reports")
+                |   }
+                |}
+                """.trimMargin()
 
                 gradleRunner = DslGradleRunner(projectLayout, "build.gradle", mainBuildFileContent)
             }
             it("can be done using the kotlin dsl") {
 
                 val mainBuildFileContent: String = """
-				|plugins {
-				|   `java-library`
-				|	id("io.gitlab.arturbosch.detekt")
-				|}
-				|
-				|allprojects {
-				|	repositories {
-				|		mavenLocal()
-				|		jcenter()
-				|	}
-				|	plugins.apply("java-library")
-				|	plugins.apply("io.gitlab.arturbosch.detekt")
-				|	detekt {
-				|		reportsDir = file("build/detekt-reports")
-				|	}
-				|}
-				""".trimMargin()
+                |$KOTLIN_PLUGINS_SECTION
+                |
+                |allprojects {
+                |   $REPOSITORIES_SECTION
+                |
+                |   $KOTLIN_APPLY_PLUGINS
+                |
+                |   detekt {
+                |       reportsDir = file("build/detekt-reports")
+                |   }
+                |}
+                """.trimMargin()
 
                 gradleRunner = DslGradleRunner(projectLayout, "build.gradle.kts", mainBuildFileContent)
             }
         }
         describe("allows changing defaults in allprojects block that can be overwritten in subprojects") {
             val child2DetektConfig = """
-				| detekt {
-				| 	reportsDir = file("build/custom")
-				| }
-			""".trimMargin()
+                |detekt {
+                |   reportsDir = file("build/custom")
+                |}
+                |""".trimMargin()
             val projectLayout = ProjectLayout(1)
                 .withSubmodule("child1", 2)
                 .withSubmodule("child2", 4, detektConfig = child2DetektConfig)
@@ -257,48 +213,36 @@ internal class DetektTaskMultiModuleTest : Spek({
             it("can be done using the groovy dsl") {
 
                 val mainBuildFileContent: String = """
-				|import io.gitlab.arturbosch.detekt.DetektPlugin
-				|
-				|plugins {
-				|   id "java-library"
-				|   id "io.gitlab.arturbosch.detekt"
-				|}
-				|
-				|allprojects {
-				|	repositories {
-				|		mavenLocal()
-				|		jcenter()
-				|	}
-				|	apply plugin: "java-library"
-				|	apply plugin: "io.gitlab.arturbosch.detekt"
-				|	detekt {
-				|		reportsDir = file("build/detekt-reports")
-				|	}
-				|}
-				""".trimMargin()
+                |$GROOVY_PLUGINS_SECTION
+                |
+                |allprojects {
+                |   $REPOSITORIES_SECTION
+                |
+                |   $GROOVY_APPLY_PLUGINS
+                |
+                |   detekt {
+                |       reportsDir = file("build/detekt-reports")
+                |   }
+                |}
+                """.trimMargin()
 
                 gradleRunner = DslGradleRunner(projectLayout, "build.gradle", mainBuildFileContent)
             }
             it("can be done using the kotlin dsl") {
 
                 val mainBuildFileContent: String = """
-				|plugins {
-				|   `java-library`
-				|	id("io.gitlab.arturbosch.detekt")
-				|}
-				|
-				|allprojects {
-				|	repositories {
-				|		mavenLocal()
-				|		jcenter()
-				|	}
-				|	plugins.apply("java-library")
-				|	plugins.apply("io.gitlab.arturbosch.detekt")
-				|	detekt {
-				|		reportsDir = file("build/detekt-reports")
-				|	}
-				|}
-				""".trimMargin()
+                |$KOTLIN_PLUGINS_SECTION
+                |
+                |allprojects {
+                |   $REPOSITORIES_SECTION
+                |
+                |   $KOTLIN_APPLY_PLUGINS
+                |
+                |   detekt {
+                |       reportsDir = file("build/detekt-reports")
+                |   }
+                |}
+                """.trimMargin()
 
                 gradleRunner = DslGradleRunner(projectLayout, "build.gradle.kts", mainBuildFileContent)
             }
@@ -309,10 +253,10 @@ internal class DetektTaskMultiModuleTest : Spek({
                 .withSubmodule("child2", 4)
 
             val detektConfig: String = """
-				|detekt {
-				|	input = files("${"$"}projectDir/src", "${"$"}projectDir/child1/src", "${"$"}projectDir/child2/src")
-				|}
-				""".trimMargin()
+                |detekt {
+                |    input = files("${"$"}projectDir/src", "${"$"}projectDir/child1/src", "${"$"}projectDir/child2/src")
+                |}
+                """.trimMargin()
             val gradleRunner = builder
                 .withProjectLayout(projectLayout)
                 .withDetektConfig(detektConfig)
@@ -339,4 +283,37 @@ internal class DetektTaskMultiModuleTest : Spek({
             }
         }
     }
-})
+}) {
+    companion object {
+        private const val GROOVY_PLUGINS_SECTION = """
+            |plugins {
+            |   id "org.jetbrains.kotlin.jvm"
+            |   id "io.gitlab.arturbosch.detekt"
+            |}
+            |"""
+
+        private const val KOTLIN_PLUGINS_SECTION = """
+            |plugins {
+            |   kotlin("jvm")
+            |   id("io.gitlab.arturbosch.detekt")
+            |}
+            |"""
+
+        private const val REPOSITORIES_SECTION = """
+            |repositories {
+            |   mavenLocal()
+            |   mavenCentral()
+            |}
+            |"""
+
+        private const val GROOVY_APPLY_PLUGINS = """
+            |apply plugin: "kotlin"
+            |apply plugin: "io.gitlab.arturbosch.detekt"
+            |"""
+
+        private const val KOTLIN_APPLY_PLUGINS = """
+            |plugins.apply("kotlin")
+            |plugins.apply("io.gitlab.arturbosch.detekt")
+            |"""
+    }
+}

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleTest.kt
@@ -12,258 +12,167 @@ import org.spekframework.spek2.style.specification.describe
  */
 internal class DetektTaskMultiModuleTest : Spek({
     describe("The Detekt Gradle plugin used in a multi module project") {
-        describe(
-            "is applied with defaults to all subprojects individually without sources in root project " +
-                "using the subprojects block"
-        ) {
-            val projectLayout = ProjectLayout(0)
-                .withSubmodule("child1", 2)
-                .withSubmodule("child2", 4)
-
-            lateinit var gradleRunner: DslGradleRunner
-
-            afterEachTest {
-                gradleRunner.setupProject()
-                gradleRunner.runDetektTaskAndCheckResult { result ->
-                    assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.NO_SOURCE)
-                    projectLayout.submodules.forEach { submodule ->
-                        assertThat(result.task(":${submodule.name}:detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        assertThat(result.output).contains("number of classes: ${submodule.numberOfSourceFilesPerSourceDir}")
-                    }
-
-                    assertThat(projectFile("build/reports/detekt/detekt.xml")).doesNotExist()
-                    assertThat(projectFile("build/reports/detekt/detekt.html")).doesNotExist()
-                    projectLayout.submodules.forEach {
-                        assertThat(projectFile("${it.name}/build/reports/detekt/detekt.xml")).exists()
-                        assertThat(projectFile("${it.name}/build/reports/detekt/detekt.html")).exists()
-                    }
-                }
-            }
-            it("can be done using the groovy dsl") {
-
-                val mainBuildFileContent: String = """
-                |$GROOVY_PLUGINS_SECTION
-                |allprojects {
-                |   $REPOSITORIES_SECTION
-                |}
-                |subprojects {
-                |   $GROOVY_APPLY_PLUGINS
-                |}
-                |""".trimMargin()
-
-                gradleRunner = DslGradleRunner(projectLayout, "build.gradle", mainBuildFileContent)
-            }
-            it("can be done using the kotlin dsl") {
-
-                val mainBuildFileContent: String = """
-                |$KOTLIN_PLUGINS_SECTION
-                |
-                |allprojects {
-                |   $REPOSITORIES_SECTION
-                |}
-                |subprojects {
-                |   $KOTLIN_APPLY_PLUGINS
-                |}
-                |""".trimMargin()
-
-                gradleRunner = DslGradleRunner(projectLayout, "build.gradle.kts", mainBuildFileContent)
-            }
-        }
-        describe("is applied with defaults to main project and subprojects individually using the allprojects block") {
-            val projectLayout = ProjectLayout(1)
-                .withSubmodule("child1", 2)
-                .withSubmodule("child2", 4)
-
-            lateinit var gradleRunner: DslGradleRunner
-
-            afterEachTest {
-                gradleRunner.setupProject()
-                gradleRunner.runDetektTaskAndCheckResult { result ->
-                    assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                    projectLayout.submodules.forEach { submodule ->
-                        assertThat(result.task(":${submodule.name}:detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        assertThat(result.output).contains("number of classes: ${submodule.numberOfSourceFilesPerSourceDir}")
-                    }
-
-                    assertThat(projectFile("build/reports/detekt/detekt.xml")).exists()
-                    assertThat(projectFile("build/reports/detekt/detekt.html")).exists()
-                    projectLayout.submodules.forEach {
-                        assertThat(projectFile("${it.name}/build/reports/detekt/detekt.xml")).exists()
-                        assertThat(projectFile("${it.name}/build/reports/detekt/detekt.html")).exists()
-                    }
-                }
-            }
-            it("can be done using the groovy dsl") {
-
-                val mainBuildFileContent: String = """
-                |$GROOVY_PLUGINS_SECTION
-                |
-                |allprojects {
-                |   $REPOSITORIES_SECTION
-                |
-                |   $GROOVY_APPLY_PLUGINS
-                |}
-                |""".trimMargin()
-
-                gradleRunner = DslGradleRunner(projectLayout, "build.gradle", mainBuildFileContent)
-            }
-            it("can be done using the kotlin dsl") {
-
-                val mainBuildFileContent: String = """
-                |$KOTLIN_PLUGINS_SECTION
-                |
-                |allprojects {
-                |   $REPOSITORIES_SECTION
-                |
-                |   $KOTLIN_APPLY_PLUGINS
-                |}
-                """.trimMargin()
-
-                gradleRunner = DslGradleRunner(projectLayout, "build.gradle.kts", mainBuildFileContent)
-            }
-        }
-        describe("uses custom configs when configured in allprojects block") {
-            val projectLayout = ProjectLayout(1)
-                .withSubmodule("child1", 2)
-                .withSubmodule("child2", 4)
-
-            lateinit var gradleRunner: DslGradleRunner
-
-            afterEachTest {
-                gradleRunner.setupProject()
-                gradleRunner.runDetektTaskAndCheckResult { result ->
-                    assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                    projectLayout.submodules.forEach { submodule ->
-                        assertThat(result.task(":${submodule.name}:detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                    }
-
-                    assertThat(projectFile("build/detekt-reports/detekt.xml")).exists()
-                    assertThat(projectFile("build/detekt-reports/detekt.html")).exists()
-                    projectLayout.submodules.forEach {
-                        assertThat(projectFile("${it.name}/build/detekt-reports/detekt.xml")).exists()
-                        assertThat(projectFile("${it.name}/build/detekt-reports/detekt.html")).exists()
-                    }
-                }
-            }
-            it("can be done using the groovy dsl") {
-
-                val mainBuildFileContent: String = """
-                |$GROOVY_PLUGINS_SECTION
-                |
-                |allprojects {
-                |   $REPOSITORIES_SECTION
-                |
-                |   $GROOVY_APPLY_PLUGINS
-                |
-                |   detekt {
-                |       reportsDir = file("build/detekt-reports")
-                |   }
-                |}
-                """.trimMargin()
-
-                gradleRunner = DslGradleRunner(projectLayout, "build.gradle", mainBuildFileContent)
-            }
-            it("can be done using the kotlin dsl") {
-
-                val mainBuildFileContent: String = """
-                |$KOTLIN_PLUGINS_SECTION
-                |
-                |allprojects {
-                |   $REPOSITORIES_SECTION
-                |
-                |   $KOTLIN_APPLY_PLUGINS
-                |
-                |   detekt {
-                |       reportsDir = file("build/detekt-reports")
-                |   }
-                |}
-                """.trimMargin()
-
-                gradleRunner = DslGradleRunner(projectLayout, "build.gradle.kts", mainBuildFileContent)
-            }
-        }
-        describe("allows changing defaults in allprojects block that can be overwritten in subprojects") {
-            val child2DetektConfig = """
-                |detekt {
-                |   reportsDir = file("build/custom")
-                |}
-                |""".trimMargin()
-            val projectLayout = ProjectLayout(1)
-                .withSubmodule("child1", 2)
-                .withSubmodule("child2", 4, detektConfig = child2DetektConfig)
-
-            lateinit var gradleRunner: DslGradleRunner
-
-            afterEachTest {
-                gradleRunner.setupProject()
-                gradleRunner.runDetektTaskAndCheckResult { result ->
-                    assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                    projectLayout.submodules.forEach { submodule ->
-                        assertThat(result.task(":${submodule.name}:detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                    }
-
-                    assertThat(projectFile("build/detekt-reports/detekt.xml")).exists()
-                    assertThat(projectFile("build/detekt-reports/detekt.html")).exists()
-                    assertThat(projectFile("child1/build/detekt-reports/detekt.xml")).exists()
-                    assertThat(projectFile("child1/build/detekt-reports/detekt.html")).exists()
-                    assertThat(projectFile("child2/build/custom/detekt.xml")).exists()
-                    assertThat(projectFile("child2/build/custom/detekt.html")).exists()
-                }
-            }
-            it("can be done using the groovy dsl") {
-
-                val mainBuildFileContent: String = """
-                |$GROOVY_PLUGINS_SECTION
-                |
-                |allprojects {
-                |   $REPOSITORIES_SECTION
-                |
-                |   $GROOVY_APPLY_PLUGINS
-                |
-                |   detekt {
-                |       reportsDir = file("build/detekt-reports")
-                |   }
-                |}
-                """.trimMargin()
-
-                gradleRunner = DslGradleRunner(projectLayout, "build.gradle", mainBuildFileContent)
-            }
-            it("can be done using the kotlin dsl") {
-
-                val mainBuildFileContent: String = """
-                |$KOTLIN_PLUGINS_SECTION
-                |
-                |allprojects {
-                |   $REPOSITORIES_SECTION
-                |
-                |   $KOTLIN_APPLY_PLUGINS
-                |
-                |   detekt {
-                |       reportsDir = file("build/detekt-reports")
-                |   }
-                |}
-                """.trimMargin()
-
-                gradleRunner = DslGradleRunner(projectLayout, "build.gradle.kts", mainBuildFileContent)
-            }
-        }
         listOf(groovy(), kotlin()).forEach { builder ->
-            val projectLayout = ProjectLayout(1)
-                .withSubmodule("child1", 2)
-                .withSubmodule("child2", 4)
+            describe("using ${builder.gradleBuildName}") {
+                it(
+                    "is applied with defaults to all subprojects individually without sources in root project " +
+                        "using the subprojects block"
+                ) {
+                    val projectLayout = ProjectLayout(0)
+                        .withSubmodule("child1", 2)
+                        .withSubmodule("child2", 4)
 
-            val detektConfig: String = """
-                |detekt {
-                |    input = files("${"$"}projectDir/src", "${"$"}projectDir/child1/src", "${"$"}projectDir/child2/src")
-                |}
-                """.trimMargin()
-            val gradleRunner = builder
-                .withProjectLayout(projectLayout)
-                .withDetektConfig(detektConfig)
-                .build()
+                    val mainBuildFileContent: String = """
+                        |${builder.gradlePluginsSection}
+                        |
+                        |allprojects {
+                        |   ${builder.gradleRepositoriesSection}
+                        |}
+                        |subprojects {
+                        |   ${builder.gradleApplyPlugins}
+                        |}
+                        |""".trimMargin()
 
-            describe("can be used in ${builder.gradleBuildName}") {
+                    val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
+
+                    gradleRunner.setupProject()
+                    gradleRunner.runDetektTaskAndCheckResult { result ->
+                        assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.NO_SOURCE)
+                        projectLayout.submodules.forEach { submodule ->
+                            assertThat(result.task(":${submodule.name}:detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                            assertThat(result.output).contains("number of classes: ${submodule.numberOfSourceFilesPerSourceDir}")
+                        }
+
+                        assertThat(projectFile("build/reports/detekt/detekt.xml")).doesNotExist()
+                        assertThat(projectFile("build/reports/detekt/detekt.html")).doesNotExist()
+                        projectLayout.submodules.forEach {
+                            assertThat(projectFile("${it.name}/build/reports/detekt/detekt.xml")).exists()
+                            assertThat(projectFile("${it.name}/build/reports/detekt/detekt.html")).exists()
+                        }
+                    }
+                }
+                it("is applied with defaults to main project and subprojects individually using the allprojects block") {
+                    val projectLayout = ProjectLayout(1)
+                        .withSubmodule("child1", 2)
+                        .withSubmodule("child2", 4)
+
+                    val mainBuildFileContent: String = """
+                        |${builder.gradlePluginsSection}
+                        |
+                        |allprojects {
+                        |   ${builder.gradleRepositoriesSection}
+                        |   ${builder.gradleApplyPlugins}
+                        |}
+                        |""".trimMargin()
+
+                    val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
+
+                    gradleRunner.setupProject()
+                    gradleRunner.runDetektTaskAndCheckResult { result ->
+                        assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                        projectLayout.submodules.forEach { submodule ->
+                            assertThat(result.task(":${submodule.name}:detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                            assertThat(result.output).contains("number of classes: ${submodule.numberOfSourceFilesPerSourceDir}")
+                        }
+
+                        assertThat(projectFile("build/reports/detekt/detekt.xml")).exists()
+                        assertThat(projectFile("build/reports/detekt/detekt.html")).exists()
+                        projectLayout.submodules.forEach {
+                            assertThat(projectFile("${it.name}/build/reports/detekt/detekt.xml")).exists()
+                            assertThat(projectFile("${it.name}/build/reports/detekt/detekt.html")).exists()
+                        }
+                    }
+                }
+                it("uses custom configs when configured in allprojects block") {
+                    val projectLayout = ProjectLayout(1)
+                        .withSubmodule("child1", 2)
+                        .withSubmodule("child2", 4)
+
+                    val mainBuildFileContent: String = """
+                        |${builder.gradlePluginsSection}
+                        |
+                        |allprojects {
+                        |   ${builder.gradleRepositoriesSection}
+                        |   ${builder.gradleApplyPlugins}
+                        |
+                        |   detekt {
+                        |       reportsDir = file("build/detekt-reports")
+                        |   }
+                        |}
+                        |""".trimMargin()
+
+                    val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
+                    gradleRunner.setupProject()
+                    gradleRunner.runDetektTaskAndCheckResult { result ->
+                        assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                        projectLayout.submodules.forEach { submodule ->
+                            assertThat(result.task(":${submodule.name}:detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                        }
+
+                        assertThat(projectFile("build/detekt-reports/detekt.xml")).exists()
+                        assertThat(projectFile("build/detekt-reports/detekt.html")).exists()
+                        projectLayout.submodules.forEach {
+                            assertThat(projectFile("${it.name}/build/detekt-reports/detekt.xml")).exists()
+                            assertThat(projectFile("${it.name}/build/detekt-reports/detekt.html")).exists()
+                        }
+                    }
+                }
+                it("allows changing defaults in allprojects block that can be overwritten in subprojects") {
+                    val child2DetektConfig = """
+                        |detekt {
+                        |   reportsDir = file("build/custom")
+                        |}
+                        |""".trimMargin()
+
+                    val projectLayout = ProjectLayout(1)
+                        .withSubmodule("child1", 2)
+                        .withSubmodule("child2", 4, detektConfig = child2DetektConfig)
+
+                    val mainBuildFileContent: String = """
+                        |${builder.gradlePluginsSection}
+                        |
+                        |allprojects {
+                        |   ${builder.gradleRepositoriesSection}
+                        |   ${builder.gradleApplyPlugins}
+                        |
+                        |   detekt {
+                        |       reportsDir = file("build/detekt-reports")
+                        |   }
+                        |}
+                        |""".trimMargin()
+
+                    val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
+
+                    gradleRunner.setupProject()
+                    gradleRunner.runDetektTaskAndCheckResult { result ->
+                        assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                        projectLayout.submodules.forEach { submodule ->
+                            assertThat(result.task(":${submodule.name}:detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                        }
+
+                        assertThat(projectFile("build/detekt-reports/detekt.xml")).exists()
+                        assertThat(projectFile("build/detekt-reports/detekt.html")).exists()
+                        assertThat(projectFile("child1/build/detekt-reports/detekt.xml")).exists()
+                        assertThat(projectFile("child1/build/detekt-reports/detekt.html")).exists()
+                        assertThat(projectFile("child2/build/custom/detekt.xml")).exists()
+                        assertThat(projectFile("child2/build/custom/detekt.html")).exists()
+                    }
+                }
                 it("can be applied to all files in entire project resulting in 1 report") {
+                    val projectLayout = ProjectLayout(1)
+                        .withSubmodule("child1", 2)
+                        .withSubmodule("child2", 4)
+
+                    val detektConfig: String = """
+                        |detekt {
+                        |    input = files("${"$"}projectDir/src", "${"$"}projectDir/child1/src", "${"$"}projectDir/child2/src")
+                        |}
+                        """.trimMargin()
+                    val gradleRunner = builder
+                        .withProjectLayout(projectLayout)
+                        .withDetektConfig(detektConfig)
+                        .build()
+
                     gradleRunner.runDetektTaskAndCheckResult { result ->
                         assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
                         projectLayout.submodules.forEach { submodule ->
@@ -283,37 +192,4 @@ internal class DetektTaskMultiModuleTest : Spek({
             }
         }
     }
-}) {
-    companion object {
-        private const val GROOVY_PLUGINS_SECTION = """
-            |plugins {
-            |   id "org.jetbrains.kotlin.jvm"
-            |   id "io.gitlab.arturbosch.detekt"
-            |}
-            |"""
-
-        private const val KOTLIN_PLUGINS_SECTION = """
-            |plugins {
-            |   kotlin("jvm")
-            |   id("io.gitlab.arturbosch.detekt")
-            |}
-            |"""
-
-        private const val REPOSITORIES_SECTION = """
-            |repositories {
-            |   mavenLocal()
-            |   mavenCentral()
-            |}
-            |"""
-
-        private const val GROOVY_APPLY_PLUGINS = """
-            |apply plugin: "kotlin"
-            |apply plugin: "io.gitlab.arturbosch.detekt"
-            |"""
-
-        private const val KOTLIN_APPLY_PLUGINS = """
-            |plugins.apply("kotlin")
-            |plugins.apply("io.gitlab.arturbosch.detekt")
-            |"""
-    }
-}
+})

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
@@ -59,16 +59,19 @@ abstract class DslTestBuilder {
     private class GroovyBuilder : DslTestBuilder() {
         override val gradleBuildName: String = "build.gradle"
         override val gradleBuildConfig: String = """
-                |import io.gitlab.arturbosch.detekt.DetektPlugin
-                |
                 |plugins {
-                |   id "java-library"
-                |   id "io.gitlab.arturbosch.detekt"
+                |   id 'org.jetbrains.kotlin.jvm' version '1.3.41'
+                |   id 'io.gitlab.arturbosch.detekt'
                 |}
                 |
                 |repositories {
-                |    jcenter()
-                |    mavenLocal()
+                |   mavenLocal()
+                |   mavenCentral()
+                |   jcenter()
+                |}
+                |
+                |dependencies {
+                |   implementation "org.jetbrains.kotlin:kotlin-stdlib"
                 |}
                 """.trimMargin()
     }
@@ -77,13 +80,18 @@ abstract class DslTestBuilder {
         override val gradleBuildName: String = "build.gradle.kts"
         override val gradleBuildConfig: String = """
                 |plugins {
-                |   `java-library`
-                |    id("io.gitlab.arturbosch.detekt")
+                |   kotlin("jvm") version "1.3.41"
+                |   id("io.gitlab.arturbosch.detekt")
                 |}
                 |
                 |repositories {
-                |    jcenter()
-                |    mavenLocal()
+                |   mavenLocal()
+                |   mavenCentral()
+                |   jcenter()
+                |}
+                |
+                |dependencies {
+                |   implementation(kotlin("stdlib"))
                 |}
                 """.trimMargin()
     }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
@@ -7,6 +7,9 @@ abstract class DslTestBuilder {
 
     abstract val gradleBuildConfig: String
     abstract val gradleBuildName: String
+    abstract val gradlePluginsSection: String
+    val gradleRepositoriesSection = REPOSITORIES_SECTION
+    abstract val gradleApplyPlugins: String
 
     private var detektConfig: String = ""
     private var projectLayout: ProjectLayout = ProjectLayout(1)
@@ -41,9 +44,9 @@ abstract class DslTestBuilder {
 
     fun build(): DslGradleRunner {
         val mainBuildFileContent = """
-            | $gradleBuildConfig
-            | $detektConfig
-        """.trimMargin()
+            |$gradleBuildConfig
+            |$detektConfig
+            """.trimMargin()
         val runner = DslGradleRunner(
             projectLayout,
             gradleBuildName,
@@ -58,46 +61,68 @@ abstract class DslTestBuilder {
 
     private class GroovyBuilder : DslTestBuilder() {
         override val gradleBuildName: String = "build.gradle"
+        override val gradlePluginsSection = GROOVY_PLUGINS_SECTION
+        override val gradleApplyPlugins = GROOVY_APPLY_PLUGINS
         override val gradleBuildConfig: String = """
-                |plugins {
-                |   id 'org.jetbrains.kotlin.jvm' version '1.3.41'
-                |   id 'io.gitlab.arturbosch.detekt'
-                |}
-                |
-                |repositories {
-                |   mavenLocal()
-                |   mavenCentral()
-                |   jcenter()
-                |}
-                |
-                |dependencies {
-                |   implementation "org.jetbrains.kotlin:kotlin-stdlib"
-                |}
-                """.trimMargin()
+            |$gradlePluginsSection
+            |
+            |$gradleRepositoriesSection
+            |
+            |dependencies {
+            |   implementation "org.jetbrains.kotlin:kotlin-stdlib"
+            |}
+            """.trimMargin()
     }
 
     private class KotlinBuilder : DslTestBuilder() {
         override val gradleBuildName: String = "build.gradle.kts"
+        override val gradlePluginsSection = KOTLIN_PLUGINS_SECTION
+        override val gradleApplyPlugins = KOTLIN_APPLY_PLUGINS
         override val gradleBuildConfig: String = """
-                |plugins {
-                |   kotlin("jvm") version "1.3.41"
-                |   id("io.gitlab.arturbosch.detekt")
-                |}
-                |
-                |repositories {
-                |   mavenLocal()
-                |   mavenCentral()
-                |   jcenter()
-                |}
-                |
-                |dependencies {
-                |   implementation(kotlin("stdlib"))
-                |}
-                """.trimMargin()
+            |$gradlePluginsSection
+            |
+            |$gradleRepositoriesSection
+            |
+            |dependencies {
+            |   implementation(kotlin("stdlib"))
+            |}
+            """.trimMargin()
     }
 
     companion object {
         fun kotlin(): DslTestBuilder = KotlinBuilder()
         fun groovy(): DslTestBuilder = GroovyBuilder()
+
+        private const val GROOVY_PLUGINS_SECTION = """
+            |plugins {
+            |   id "org.jetbrains.kotlin.jvm"
+            |   id "io.gitlab.arturbosch.detekt"
+            |}
+            |"""
+
+        private const val KOTLIN_PLUGINS_SECTION = """
+            |plugins {
+            |   kotlin("jvm")
+            |   id("io.gitlab.arturbosch.detekt")
+            |}
+            |"""
+
+        private const val REPOSITORIES_SECTION = """
+            |repositories {
+            |   mavenLocal()
+            |   mavenCentral()
+            |   jcenter()
+            |}
+            |"""
+
+        private const val GROOVY_APPLY_PLUGINS = """
+            |apply plugin: "kotlin"
+            |apply plugin: "io.gitlab.arturbosch.detekt"
+            |"""
+
+        private const val KOTLIN_APPLY_PLUGINS = """
+            |plugins.apply("kotlin")
+            |plugins.apply("io.gitlab.arturbosch.detekt")
+            |"""
     }
 }


### PR DESCRIPTION
Closes #1757 and closes #1685 

Consolidation may only be triggered for the 'old' detekt task because they are configured to depend on the detekt tasks of all subprojects. For tasks with type resolution such as detektMain this is not the case.

The issue was not detected in the tests because we did not use the kotlin gradle plugin in the integration tests. 