### PR TITLE
Implement dry-run option for detekt gradle tasks.

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -120,8 +120,7 @@ open class DetektCreateBaselineTask : SourceTask() {
             DisableDefaultRuleSetArgument(disableDefaultRuleSets.getOrElse(false))
         )
 
-        DetektInvoker.invokeCli(
-            project = project,
+        DetektInvoker.create(project).invokeCli(
             arguments = arguments.toList(),
             ignoreFailures = ignoreFailures.getOrElse(false),
             classpath = detektClasspath.plus(pluginClasspath),

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -32,6 +32,6 @@ open class DetektGenerateConfigTask : SourceTask() {
             InputArgument(source)
         )
 
-        DetektInvoker.invokeCli(project, arguments.toList(), detektClasspath, name)
+        DetektInvoker.create(project).invokeCli(arguments.toList(), detektClasspath, name)
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
@@ -2,8 +2,8 @@ package io.gitlab.arturbosch.detekt.extensions
 
 import groovy.lang.Closure
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType.HTML
-import io.gitlab.arturbosch.detekt.extensions.DetektReportType.XML
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType.TXT
+import io.gitlab.arturbosch.detekt.extensions.DetektReportType.XML
 import org.gradle.api.Project
 import org.gradle.util.ConfigureUtil
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -4,13 +4,37 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 
-object DetektInvoker {
-    internal fun invokeCli(
-        project: Project,
+internal interface DetektInvoker {
+    fun invokeCli(
         arguments: List<CliArgument>,
         classpath: FileCollection,
         taskName: String,
         ignoreFailures: Boolean = false
+    )
+
+    companion object {
+        fun create(project: Project): DetektInvoker =
+            if (project.isDryRunEnabled()) {
+                DryRunInvoker(project)
+            } else {
+                DefaultCliInvoker(project)
+            }
+
+        private fun Project.isDryRunEnabled(): Boolean {
+            return hasProperty(DRY_RUN_PROPERTY) && property(DRY_RUN_PROPERTY) == "true"
+        }
+
+        private const val DRY_RUN_PROPERTY = "detekt-dry-run"
+    }
+}
+
+private class DefaultCliInvoker(private val project: Project) : DetektInvoker {
+
+    override fun invokeCli(
+        arguments: List<CliArgument>,
+        classpath: FileCollection,
+        taskName: String,
+        ignoreFailures: Boolean
     ) {
         val detektTmpDir = project.mkdir("${project.buildDir}/tmp/detekt")
         val argsFile = project.file("$detektTmpDir/$taskName.args")
@@ -35,6 +59,25 @@ object DetektInvoker {
             2 -> if (!ignoreFailures) throw GradleException("MaxIssues or failThreshold count was reached.")
         }
     }
+
+    companion object {
+        private const val DETEKT_MAIN = "io.gitlab.arturbosch.detekt.cli.Main"
+    }
 }
 
-private const val DETEKT_MAIN = "io.gitlab.arturbosch.detekt.cli.Main"
+private class DryRunInvoker(private val project: Project) : DetektInvoker {
+
+    override fun invokeCli(
+        arguments: List<CliArgument>,
+        classpath: FileCollection,
+        taskName: String,
+        ignoreFailures: Boolean
+    ) {
+        val cliArguments = arguments.flatMap(CliArgument::toArgument)
+        project.logger.info("Invoking detekt with dry-run.")
+        project.logger.info("Task: $taskName")
+        project.logger.info("Arguments: ${cliArguments.joinToString(" ")}")
+        project.logger.info("Classpath: ${classpath.files}")
+        project.logger.info("Ignore failures: $ignoreFailures")
+    }
+}

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -4,146 +4,163 @@ import io.gitlab.arturbosch.detekt.DslTestBuilder.Companion.groovy
 import io.gitlab.arturbosch.detekt.DslTestBuilder.Companion.kotlin
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType
 import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
-internal class DetektTaskDslTest : Spek({
+internal object DetektTaskDslTest : Spek({
 
     describe("When applying the detekt gradle plugin") {
-        listOf(groovy(), kotlin()).forEach { builder ->
-            describe("using ${builder.gradleBuildName}") {
-                it("can be applied without any configuration using its task name") {
+        lateinit var gradleRunner: DslGradleRunner
+        lateinit var result: BuildResult
 
-                    val gradleRunner = builder.build()
-                    gradleRunner.runDetektTaskAndCheckResult { result ->
+        listOf(groovy().dryRun(), kotlin().dryRun()).forEach { builder ->
+            context("using ${builder.gradleBuildName}") {
+                describe("without detekt config") {
+
+                    before {
+                        gradleRunner = builder.build()
+                        result = gradleRunner.runDetektTask()
+                    }
+
+                    it("completes successfully") {
                         assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        assertThat(result.output).contains("number of classes: 1")
-                        assertThat(projectFile("build/reports/detekt/detekt.xml")).exists()
-                        assertThat(projectFile("build/reports/detekt/detekt.html")).exists()
-                        assertThat(projectFile("build/reports/detekt/detekt.txt")).exists()
+                    }
+
+                    it("enables xml report to default location") {
+                        val xmlReportFile = gradleRunner.projectFile("build/reports/detekt/detekt.xml")
+                        assertThat(result.output).contains("--report xml:$xmlReportFile")
+                    }
+
+                    it("enables html report to default location") {
+                        val htmlReportFile = gradleRunner.projectFile("build/reports/detekt/detekt.html")
+                        assertThat(result.output).contains("--report html:$htmlReportFile")
+                    }
+
+                    it("enables text report to default location") {
+                        val textReportFile = gradleRunner.projectFile("build/reports/detekt/detekt.txt")
+                        assertThat(result.output).contains("--report txt:$textReportFile")
                     }
                 }
 
-                it("can be applied without any configuration using the check task") {
+                describe("without multiple detekt configs") {
 
-                    val gradleRunner = builder.build()
-                    gradleRunner.runTasksAndCheckResult("check") { result ->
-                        assertThat(result.task(":check")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        assertThat(result.output).contains("number of classes: 1")
-                        assertThat(result.output).contains("Ruleset: comments")
-                    }
-                }
-
-                it("can use a custom tool version") {
-
-                    val customVersion = "1.0.0.RC8"
-                    val config = """
-                        |detekt {
-                        |    toolVersion = "$customVersion"
-                        |}
-                        """
-
-                    val gradleRunner = builder.withDetektConfig(config).build()
-                    gradleRunner.runTasksAndCheckResult("dependencies", "--configuration", "detekt") { result ->
-                        assertThat(result.task(":dependencies")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        assertThat(result.output).contains("io.gitlab.arturbosch.detekt:detekt-cli:$customVersion")
-                    }
-                }
-
-                it("can be applied with multiple config files") {
-
-                    val config = """
+                    before {
+                        val config = """
                         |detekt {
                         |    config = files("firstConfig.yml", "secondConfig.yml")
                         |}
                         """
 
-                    val gradleRunner = builder.withDetektConfig(config).build()
+                        gradleRunner = builder.withDetektConfig(config).build()
 
-                    val firstConfig = gradleRunner.projectFile("firstConfig.yml").apply { createNewFile() }
-                    val secondConfig = gradleRunner.projectFile("secondConfig.yml").apply { createNewFile() }
+                        result = gradleRunner.runDetektTask()
+                    }
 
-                    gradleRunner.runDetektTaskAndCheckResult { result ->
-                        assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        val expectedConfigParam = "--config ${firstConfig.canonicalPath},${secondConfig.canonicalPath}"
+                    it("passes absolute filename of both config files to detekt cli") {
+                        val firstConfig = gradleRunner.projectFile("firstConfig.yml")
+                        val secondConfig = gradleRunner.projectFile("secondConfig.yml")
+
+                        val expectedConfigParam = "--config $firstConfig,$secondConfig"
                         assertThat(result.output).contains(expectedConfigParam)
                     }
                 }
 
-                it("can be applied with custom input directories ignoring non existent") {
+                describe("with custom baseline file") {
+                    val baselineFilename = "detekt-baseline.xml"
 
-                    val customSrc = "gensrc/kotlin"
-                    val config = """
+                    before {
+
+                        val config = """
                         |detekt {
-                        |    input = files("$customSrc", "folder_that_does_not_exist")
+                        |   baseline = file("$baselineFilename")
                         |}
                         """
 
-                    val gradleRunner = builder
-                        .withProjectLayout(ProjectLayout(1, srcDirs = listOf(customSrc)))
-                        .withDetektConfig(config)
-                        .build()
+                        gradleRunner = builder
+                            .withDetektConfig(config)
+                            .withBaseline(baselineFilename)
+                            .build()
+                        result = gradleRunner.runDetektTask()
+                    }
 
-                    gradleRunner.runDetektTaskAndCheckResult { result ->
+                    it("sets baseline parameter with absolute filename") {
+                        val baselineFile = gradleRunner.projectFile(baselineFilename)
+                        val expectedBaselineArgument = "--baseline $baselineFile"
+                        assertThat(result.output).contains(expectedBaselineArgument)
+                    }
+                }
 
-                        assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        val expectedInputParam = "--input ${projectFile(customSrc).canonicalPath}"
+                describe("with custom input directories") {
+                    val customSrc1 = "gensrc/kotlin"
+                    val customSrc2 = "src/main/kotlin"
+
+                    before {
+
+                        val config = """
+                        |detekt {
+                        |    input = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
+                        |}
+                        """
+
+                        val projectLayout = ProjectLayout(1, srcDirs = listOf(customSrc1, customSrc2))
+                        gradleRunner = builder
+                            .withProjectLayout(projectLayout)
+                            .withDetektConfig(config)
+                            .build()
+                        result = gradleRunner.runDetektTask()
+                    }
+
+                    it("sets input parameter to absolute filenames of all source files") {
+                        val file1 = gradleRunner.projectFile("$customSrc1/MyRoot0Class.kt")
+                        val file2 = gradleRunner.projectFile("$customSrc2/MyRoot0Class.kt")
+                        val expectedInputParam = "--input $file1,$file2"
                         assertThat(result.output).contains(expectedInputParam)
+                    }
+
+                    it("ignores input directories that do not exist") {
                         assertThat(result.output).doesNotContain("folder_that_does_not_exist")
                     }
                 }
 
-                it("can be applied with classes in multiple custom input directories") {
+                describe("with custom reports dir") {
 
-                    val customSrc1 = "gensrc/kotlin"
-                    val customSrc2 = "src/main/kotlin"
-                    val config = """
-                        |detekt {
-                        |    input = files("$customSrc1", "$customSrc2")
-                        |}
-                        """
+                    before {
 
-                    val projectLayout = ProjectLayout(1, srcDirs = listOf(customSrc1, customSrc2))
-                    val gradleRunner = builder
-                        .withProjectLayout(projectLayout)
-                        .withDetektConfig(config)
-                        .build()
-
-                    gradleRunner.runDetektTaskAndCheckResult { result ->
-
-                        assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        val file1 = projectFile("$customSrc1/MyRoot0Class.kt").canonicalPath
-                        val file2 = projectFile("$customSrc2/MyRoot0Class.kt").canonicalPath
-                        val expectedInputParam = "--input $file1,$file2"
-                        assertThat(result.output).contains(expectedInputParam)
-                        assertThat(result.output).contains("number of classes: 2")
-                    }
-                }
-
-                it("can change the general reports dir") {
-
-                    val config = """
+                        val config = """
                         |detekt {
                         |    reportsDir = file("build/detekt-reports")
                         |}
                         """
 
-                    val gradleRunner = builder
-                        .withDetektConfig(config)
-                        .build()
+                        gradleRunner = builder
+                            .withDetektConfig(config)
+                            .build()
+                        result = gradleRunner.runDetektTask()
+                    }
 
-                    gradleRunner.runDetektTaskAndCheckResult { result ->
-                        assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        assertThat(projectFile("build/detekt-reports/detekt.xml")).exists()
-                        assertThat(projectFile("build/detekt-reports/detekt.html")).exists()
-                        assertThat(projectFile("build/detekt-reports/detekt.txt")).exists()
+                    it("configures xml report to custom directory") {
+                        val xmlReportFile = gradleRunner.projectFile("build/detekt-reports/detekt.xml")
+                        assertThat(result.output).contains("--report xml:$xmlReportFile")
+                    }
+
+                    it("configures html report to custom directory") {
+                        val htmlReportFile = gradleRunner.projectFile("build/detekt-reports/detekt.html")
+                        assertThat(result.output).contains("--report html:$htmlReportFile")
+                    }
+
+                    it("configures text report to custom directory") {
+                        val textReportFile = gradleRunner.projectFile("build/detekt-reports/detekt.txt")
+                        assertThat(result.output).contains("--report txt:$textReportFile")
                     }
                 }
 
-                it("can change the general reports dir but overwrite single report") {
+                describe("with custom reports dir and custom report filename") {
 
-                    val config = """
+                    before {
+
+                        val config = """
                         |detekt {
                         |    reportsDir = file("build/detekt-reports")
                         |    reports {
@@ -152,21 +169,33 @@ internal class DetektTaskDslTest : Spek({
                         |}
                         """
 
-                    val gradleRunner = builder
-                        .withDetektConfig(config)
-                        .build()
+                        gradleRunner = builder
+                            .withDetektConfig(config)
+                            .build()
+                        result = gradleRunner.runDetektTask()
+                    }
 
-                    gradleRunner.runDetektTaskAndCheckResult { result ->
-                        assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        assertThat(projectFile("build/xml-reports/custom-detekt.xml")).exists()
-                        assertThat(projectFile("build/detekt-reports/detekt.html")).exists()
-                        assertThat(projectFile("build/detekt-reports/detekt.txt")).exists()
+                    it("configures xml report to specific absolute filename") {
+                        val xmlReportFile = gradleRunner.projectFile("build/xml-reports/custom-detekt.xml")
+                        assertThat(result.output).contains("--report xml:$xmlReportFile")
+                    }
+
+                    it("configures html report to default name in custom directory") {
+                        val htmlReportFile = gradleRunner.projectFile("build/detekt-reports/detekt.html")
+                        assertThat(result.output).contains("--report html:$htmlReportFile")
+                    }
+
+                    it("configures text report to default name in custom directory") {
+                        val textReportFile = gradleRunner.projectFile("build/detekt-reports/detekt.txt")
+                        assertThat(result.output).contains("--report txt:$textReportFile")
                     }
                 }
 
-                it("can disable reports") {
+                describe("with disabled reports") {
 
-                    val config = """
+                    before {
+
+                        val config = """
                         |detekt {
                         |    reports {
                         |        xml.enabled = false
@@ -180,21 +209,148 @@ internal class DetektTaskDslTest : Spek({
                         |}
                         """
 
-                    val gradleRunner = builder
-                        .withDetektConfig(config)
-                        .build()
+                        gradleRunner = builder
+                            .withDetektConfig(config)
+                            .build()
+                        result = gradleRunner.runDetektTask()
+                    }
 
-                    gradleRunner.runDetektTaskAndCheckResult { result ->
-                        assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        assertThat(projectFile("build/reports/detekt/detekt.xml")).doesNotExist()
-                        assertThat(projectFile("build/reports/detekt/detekt.html")).doesNotExist()
-                        assertThat(projectFile("build/reports/detekt/detekt.txt")).doesNotExist()
+                    it("no report param is set") {
+                        assertThat(result.output).doesNotContain("--report")
                     }
                 }
 
-                it("can change all flags") {
+                describe("with custom report types") {
+                    describe("configured correctly") {
+                        before {
 
-                    val config = """
+                            val config = """
+                                |detekt {
+                                |    reports {
+                                |        custom {
+                                |           reportId = "customXml"
+                                |           destination = file("build/reports/custom.xml")
+                                |       }
+                                |        custom {
+                                |           reportId = "customJson"
+                                |           destination = file("build/reports/custom.json")
+                                |       }
+                                |    }
+                                |}
+                                """
+
+                            gradleRunner = builder.withDetektConfig(config).build()
+                            result = gradleRunner.runDetektTask()
+                        }
+
+                        it("configures custom xml report to absolute filename") {
+                            val xmlReportFile = gradleRunner.projectFile("build/reports/custom.xml")
+                            assertThat(result.output).contains("--report customXml:$xmlReportFile")
+                        }
+
+                        it("configures custom json report to absolute filename") {
+                            val xmlReportFile = gradleRunner.projectFile("build/reports/custom.json")
+                            assertThat(result.output).contains("--report customJson:$xmlReportFile")
+                        }
+                    }
+
+                    describe("report id is missing") {
+                        before {
+
+                            val config = """
+                                |detekt {
+                                |    reports {
+                                |        custom {
+                                |           destination = file("build/reports/custom.xml")
+                                |       }
+                                |    }
+                                |}
+                                """
+
+                            gradleRunner = builder.withDetektConfig(config).build()
+                        }
+
+                        it("fails the build") {
+                            gradleRunner.runDetektTaskAndExpectFailure()
+                        }
+                    }
+
+                    describe("report filename is missing") {
+                        before {
+
+                            val config = """
+                                |detekt {
+                                |    reports {
+                                |        custom {
+                                |           reportId = "customJson"
+                                |       }
+                                |    }
+                                |}
+                                """
+
+                            gradleRunner = builder.withDetektConfig(config).build()
+                        }
+
+                        it("fails the build") {
+                            gradleRunner.runDetektTaskAndExpectFailure()
+                        }
+                    }
+
+                    describe("report filename is a directory") {
+                        before {
+
+                            val aDirectory = "\${rootDir}/src"
+
+                            val config = """
+                                |detekt {
+                                |    reports {
+                                |        custom {
+                                |           reportId = "foo"
+                                |           destination = file("$aDirectory")
+                                |       }
+                                |    }
+                                |}
+                                """
+
+                            gradleRunner = builder.withDetektConfig(config).build()
+                        }
+
+                        it("fails the build") {
+                            gradleRunner.runDetektTaskAndExpectFailure()
+                        }
+                    }
+
+                    describe("using the report id of a well known type") {
+                        DetektReportType.values().forEach { wellKnownType ->
+                            context(wellKnownType.name) {
+                                before {
+
+                                    val config = """
+                                        |detekt {
+                                        |    reports {
+                                        |        custom {
+                                        |           reportId = "${wellKnownType.reportId}"
+                                        |           destination = file("build/reports/custom.xml")
+                                        |       }
+                                        |    }
+                                        |}
+                                        """
+
+                                    gradleRunner = builder.withDetektConfig(config).build()
+                                }
+                            }
+                            it("fails the build") {
+                                gradleRunner.runDetektTaskAndExpectFailure()
+                            }
+                        }
+                    }
+                }
+
+                describe("with flags") {
+
+                    before {
+
+                        val config = """
                         |detekt {
                         |    debug = true
                         |    parallel = true
@@ -203,285 +359,228 @@ internal class DetektTaskDslTest : Spek({
                         |}
                         """
 
-                    val gradleRunner = builder
-                        .withDetektConfig(config)
-                        .build()
+                        gradleRunner = builder
+                            .withDetektConfig(config)
+                            .build()
+                        result = gradleRunner.runDetektTask()
+                    }
 
-                    gradleRunner.runDetektTaskAndCheckResult { result ->
-                        assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        assertThat(result.output).contains("--debug", "--parallel", "--disable-default-rulesets")
+                    it("enables debug mode") {
+                        assertThat(result.output).contains("--debug")
+                    }
+
+                    it("enables parallel processing") {
+                        assertThat(result.output).contains("--parallel")
+                    }
+
+                    it("disables default ruleset") {
+                        assertThat(result.output).contains("--disable-default-rulesets")
+                    }
+
+                    it("ignores failures") {
+                        assertThat(result.output).contains("Ignore failures: true")
                     }
                 }
 
-                it("allows setting a baseline file") {
+                describe("with an additional plugin") {
+                    before {
+                        val config = """
+                            |dependencies {
+                            |   detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$VERSION_UNDER_TEST")
+                            |}
+                            """
 
-                    val baselineFilename = "detekt-baseline.xml"
-
-                    val config = """
-                        |detekt {
-                        |    baseline = file("$baselineFilename")
-                        |}
-                        """
-
-                    val gradleRunner = builder
-                        .withDetektConfig(config)
-                        .withBaseline(baselineFilename)
-                        .build()
-
-                    gradleRunner.runDetektTaskAndCheckResult { result ->
-                        assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        val expectedBaselineArgument = "--baseline ${projectFile(baselineFilename).canonicalPath}"
-                        assertThat(result.output).contains(expectedBaselineArgument)
+                        gradleRunner = builder
+                            .withDetektConfig(config)
+                            .build()
+                        result = gradleRunner.runTasks("dependencies", "--configuration", "detektPlugins")
                     }
-                }
-                it("can be used with formatting plugin") {
 
-                    val config = """
-                    |dependencies {
-                    | detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$VERSION_UNDER_TEST")
-                    |}
-                        """
-
-                    val gradleRunner = builder
-                        .withDetektConfig(config)
-                        .build()
-
-                    gradleRunner.runTasksAndCheckResult("dependencies", "--configuration", "detektPlugins") { result ->
+                    it("successfully checks dependencies") {
                         assertThat(result.task(":dependencies")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                    }
+
+                    it("adds the formatting lib to the project dependencies") {
                         assertThat(result.output).contains("io.gitlab.arturbosch.detekt:detekt-formatting:$VERSION_UNDER_TEST")
                     }
                 }
 
-                describe("with custom reports") {
-                    it("passes multiple custom report params to cli") {
-
+                describe("with a custom tool version") {
+                    val customVersion = "1.0.0.RC8"
+                    before {
                         val config = """
-                        |detekt {
-                        |    reports {
-                        |        custom {
-                        |           reportId = "customXml"
-                        |           destination = file("build/reports/custom.xml")
-                        |       }
-                        |        custom {
-                        |           reportId = "customJson"
-                        |           destination = file("build/reports/custom.json")
-                        |       }
-                        |    }
-                        |}
-                        """
+                            |detekt {
+                            |    toolVersion = "$customVersion"
+                            |}
+                            """
 
-                        val gradleRunner = builder
+                        gradleRunner = builder
                             .withDetektConfig(config)
                             .build()
-
-                        val customXmlReportFilePath = gradleRunner.projectFile("build/reports/custom.xml").canonicalPath
-                        val customJsonReportFilePath =
-                            gradleRunner.projectFile("build/reports/custom.json").canonicalPath
-
-                        gradleRunner.runDetektTaskAndCheckResult { result ->
-                            assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                            assertThat(result.output).contains("--report customXml:$customXmlReportFilePath")
-                            assertThat(result.output).contains("--report customJson:$customJsonReportFilePath")
-                        }
-                    }
-                    it("fails if reportId of custom report is missing") {
-
-                        val config = """
-                        |detekt {
-                        |    reports {
-                        |        custom {
-                        |           destination = file("build/reports/custom.xml")
-                        |       }
-                        |    }
-                        |}
-                        """
-
-                        val gradleRunner = builder
-                            .withDetektConfig(config)
-                            .build()
-
-                        gradleRunner.runDetektTaskAndExpectFailure()
-                    }
-                    it("fails if destination of custom report is missing") {
-
-                        val config = """
-                        |detekt {
-                        |    reports {
-                        |        custom {
-                        |           reportId = "foo"
-                        |       }
-                        |    }
-                        |}
-                        """
-
-                        val gradleRunner = builder
-                            .withDetektConfig(config)
-                            .build()
-
-                        gradleRunner.runDetektTaskAndExpectFailure()
+                        result = gradleRunner.runTasks("dependencies", "--offline", "--configuration", "detekt")
                     }
 
-                    it("fails if the destination is a directory") {
-                        val aDirectory = "\${rootDir}/src"
-
-                        val config = """
-                        |detekt {
-                        |    reports {
-                        |        custom {
-                        |           reportId = "foo"
-                        |           destination = file("$aDirectory")
-                        |       }
-                        |    }
-                        |}
-                        """
-
-                        val gradleRunner = builder
-                            .withDetektConfig(config)
-                            .build()
-
-                        gradleRunner.runDetektTaskAndExpectFailure()
+                    it("successfully checks dependencies") {
+                        assertThat(result.task(":dependencies")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
                     }
 
-                    DetektReportType.values().forEach { wellKnownType ->
-                        it("fails if reportId of custom report is $wellKnownType") {
-
-                            val config = """
-                                |detekt {
-                                |    reports {
-                                |        custom {
-                                |           reportId = "${wellKnownType.reportId}"
-                                |           destination = file("build/reports/custom.xml")
-                                |       }
-                                |    }
-                                |}
-                                """
-
-                            val gradleRunner = builder
-                                .withDetektConfig(config)
-                                .build()
-
-                            gradleRunner.runDetektTaskAndExpectFailure()
-                        }
-                    }
-                }
-
-                describe("using the ignoreFailures toggle") {
-                    val projectLayoutWithTooManyIssues = ProjectLayout(
-                        numberOfSourceFilesInRootPerSourceDir = 15,
-                        numberOfCodeSmellsInRootPerSourceDir = 15
-                    )
-
-                    it("build succeeds with more issues than threshold if enabled") {
-
-                        val config = """
-                        |detekt {
-                        |   ignoreFailures = true
-                        |}
-                        """
-
-                        val gradleRunner = builder
-                            .withProjectLayout(projectLayoutWithTooManyIssues)
-                            .withDetektConfig(config)
-                            .build()
-
-                        gradleRunner.runDetektTaskAndCheckResult { result ->
-                            assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        }
-                    }
-                    it("build fails with more issues than threshold successfully if disabled") {
-
-                        val config = """
-                        |detekt {
-                        |   ignoreFailures = false
-                        |}
-                        """
-
-                        val gradleRunner = builder
-                            .withProjectLayout(projectLayoutWithTooManyIssues)
-                            .withDetektConfig(config)
-                            .build()
-
-                        gradleRunner.runDetektTaskAndExpectFailure()
+                    it("adds the custom detekt version to the dependencies") {
+                        assertThat(result.output).contains("io.gitlab.arturbosch.detekt:detekt-cli:$customVersion")
                     }
                 }
             }
         }
 
         describe("and creating a custom task") {
-            it("can be done using the groovy dsl") {
+            context("using the groovy dsl") {
+                val builder = groovy().dryRun()
+                before {
+                    val config = """
+                        |task detektFailFast(type: io.gitlab.arturbosch.detekt.Detekt) {
+                        |    description = "Runs a failfast detekt build."
+                        |
+                        |    input = files("${"$"}projectDir")
+                        |    config = files("config.yml")
+                        |    includes = ["**/*.kt", "**/*.kts"]
+                        |    excludes = ["build/"]
+                        |    debug = true
+                        |    parallel = true
+                        |    disableDefaultRuleSets = true
+                        |    buildUponDefaultConfig = true
+                        |    failFast = false
+                        |    ignoreFailures = false
+                        |    autoCorrect = false
+                        |    reports {
+                        |        xml {
+                        |            enabled = true
+                        |            destination = file("build/reports/failfast.xml")
+                        |        }
+                        |        html.destination = file("build/reports/failfast.html")
+                        |        txt.destination = file("build/reports/failfast.txt")
+                        |    }
+                        |}
+                        """
 
-                val config = """
-                    |task detektFailFast(type: io.gitlab.arturbosch.detekt.Detekt) {
-                    |    description = "Runs a failfast detekt build."
-                    |
-                    |    input = files("${"$"}projectDir")
-                    |    config = files("config.yml")
-                    |    includes = ["**/*.kt", "**/*.kts"]
-                    |    excludes = ["build/"]
-                    |    debug = true
-                    |    parallel = true
-                    |    disableDefaultRuleSets = true
-                    |    buildUponDefaultConfig = true
-                    |    failFast = false
-                    |    ignoreFailures = false
-                    |    autoCorrect = false
-                    |    reports {
-                    |        xml {
-                    |            enabled = true
-                    |            destination = file("build/reports/failfast.xml")
-                    |        }
-                    |        html.destination = file("build/reports/failfast.html")
-                    |        txt.destination = file("build/reports/failfast.txt")
-                    |    }
-                    |}
-                """
+                    gradleRunner = builder
+                        .withDetektConfig(config)
+                        .build()
+                        .apply { writeProjectFile("config.yml", "") }
 
-                val gradleRunner = groovy().withDetektConfig(config).build()
-                gradleRunner.writeProjectFile("config.yml", "")
+                    result = gradleRunner.runTasks("detektFailFast")
+                }
 
-                gradleRunner.runTasksAndCheckResult("detektFailFast") { result ->
+                it("completes successfully") {
                     assertThat(result.task(":detektFailFast")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                    assertThat(projectFile("build/reports/failfast.xml")).exists()
-                    assertThat(projectFile("build/reports/failfast.html")).exists()
-                    assertThat(projectFile("build/reports/failfast.txt")).exists()
+                }
+
+                it("enables xml report to specified location") {
+                    val xmlReportFile = gradleRunner.projectFile("build/reports/failfast.xml")
+                    assertThat(result.output).contains("--report xml:$xmlReportFile")
+                }
+
+                it("enables html report to specified location") {
+                    val htmlReportFile = gradleRunner.projectFile("build/reports/failfast.html")
+                    assertThat(result.output).contains("--report html:$htmlReportFile")
+                }
+
+                it("enables text report to specified location") {
+                    val textReportFile = gradleRunner.projectFile("build/reports/failfast.txt")
+                    assertThat(result.output).contains("--report txt:$textReportFile")
+                }
+
+                it("sets absolute filename of both config file to detekt cli") {
+                    val config = gradleRunner.projectFile("config.yml")
+
+                    val expectedConfigParam = "--config $config"
+                    assertThat(result.output).contains(expectedConfigParam)
+                }
+
+                it("enables debug mode") {
+                    assertThat(result.output).contains("--debug")
+                }
+
+                it("enables parallel processing") {
+                    assertThat(result.output).contains("--parallel")
+                }
+
+                it("disables the default ruleset") {
+                    assertThat(result.output).contains("--disable-default-rulesets")
                 }
             }
 
-            it("can be done using the kotlin dsl") {
+            context("using the kotlin dsl") {
+                val builder = kotlin().dryRun()
+                before {
+                    val config = """
+                        |task<io.gitlab.arturbosch.detekt.Detekt>("detektFailFast") {
+                        |    description = "Runs a failfast detekt build."
+                        |
+                        |    input = files("${"$"}projectDir")
+                        |    setIncludes(listOf("**/*.kt", "**/*.kts"))
+                        |    setExcludes(listOf("build/"))
+                        |    config = files("config.yml")
+                        |    debug = true
+                        |    parallel = true
+                        |    disableDefaultRuleSets = true
+                        |    buildUponDefaultConfig = true
+                        |    failFast = false
+                        |    ignoreFailures = false
+                        |    autoCorrect = false
+                        |    reports {
+                        |        xml {
+                        |            enabled = true
+                        |            destination = file("build/reports/failfast.xml")
+                        |        }
+                        |        html.destination = file("build/reports/failfast.html")
+                        |        txt.destination = file("build/reports/failfast.txt")
+                        |    }
+                        |}
+                        """
 
-                val config = """
-                    |task<io.gitlab.arturbosch.detekt.Detekt>("detektFailFast") {
-                    |    description = "Runs a failfast detekt build."
-                    |
-                    |    input = files("${"$"}projectDir")
-                    |    setIncludes(listOf("**/*.kt", "**/*.kts"))
-                    |    setExcludes(listOf("build/"))
-                    |    config = files("config.yml")
-                    |    debug = true
-                    |    parallel = true
-                    |    disableDefaultRuleSets = true
-                    |    buildUponDefaultConfig = true
-                    |    failFast = false
-                    |    ignoreFailures = false
-                    |    autoCorrect = false
-                    |    reports {
-                    |        xml {
-                    |            enabled = true
-                    |            destination = file("build/reports/failfast.xml")
-                    |        }
-                    |        html.destination = file("build/reports/failfast.html")
-                    |        txt.destination = file("build/reports/failfast.txt")
-                    |    }
-                    |}
-                """
+                    gradleRunner = builder
+                        .withDetektConfig(config)
+                        .build()
+                        .apply { writeProjectFile("config.yml", "") }
 
-                val gradleRunner = kotlin().withDetektConfig(config).build()
-                gradleRunner.writeProjectFile("config.yml", "")
-                gradleRunner.runTasksAndCheckResult("detektFailFast") { result ->
+                    result = gradleRunner.runTasks("detektFailFast")
+                }
+
+                it("completes successfully") {
                     assertThat(result.task(":detektFailFast")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                    assertThat(gradleRunner.projectFile("build/reports/failfast.xml")).exists()
-                    assertThat(gradleRunner.projectFile("build/reports/failfast.html")).exists()
-                    assertThat(gradleRunner.projectFile("build/reports/failfast.txt")).exists()
+                }
+
+                it("enables xml report to specified location") {
+                    val xmlReportFile = gradleRunner.projectFile("build/reports/failfast.xml")
+                    assertThat(result.output).contains("--report xml:$xmlReportFile")
+                }
+
+                it("enables html report to specified location") {
+                    val htmlReportFile = gradleRunner.projectFile("build/reports/failfast.html")
+                    assertThat(result.output).contains("--report html:$htmlReportFile")
+                }
+
+                it("enables text report to specified location") {
+                    val textReportFile = gradleRunner.projectFile("build/reports/failfast.txt")
+                    assertThat(result.output).contains("--report txt:$textReportFile")
+                }
+
+                it("sets absolute filename of both config file to detekt cli") {
+                    val config = gradleRunner.projectFile("config.yml")
+
+                    val expectedConfigParam = "--config $config"
+                    assertThat(result.output).contains(expectedConfigParam)
+                }
+
+                it("enables debug mode") {
+                    assertThat(result.output).contains("--debug")
+                }
+
+                it("enables parallel processing") {
+                    assertThat(result.output).contains("--parallel")
+                }
+
+                it("disables the default ruleset") {
+                    assertThat(result.output).contains("--disable-default-rulesets")
                 }
             }
         }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskIntegrationTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskIntegrationTest.kt
@@ -1,0 +1,61 @@
+package io.gitlab.arturbosch.detekt
+
+import io.gitlab.arturbosch.detekt.DslTestBuilder.Companion.groovy
+import io.gitlab.arturbosch.detekt.DslTestBuilder.Companion.kotlin
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+/**
+ * @author Marvin Ramin
+ * @author Markus Schwarz
+ */
+internal class DetektTaskIntegrationTest : Spek({
+
+    describe("When applying the detekt gradle plugin") {
+        listOf(groovy(), kotlin()).forEach { builder ->
+            context(builder.gradleBuildName) {
+                describe("using the ignoreFailures toggle") {
+                    val projectLayoutWithTooManyIssues = ProjectLayout(
+                        numberOfSourceFilesInRootPerSourceDir = 15,
+                        numberOfCodeSmellsInRootPerSourceDir = 15
+                    )
+
+                    it("build succeeds with more issues than threshold if enabled") {
+
+                        val config = """
+                            |detekt {
+                            |   ignoreFailures = true
+                            |}
+                            """
+
+                        val gradleRunner = builder
+                            .withProjectLayout(projectLayoutWithTooManyIssues)
+                            .withDetektConfig(config)
+                            .build()
+
+                        gradleRunner.runDetektTaskAndCheckResult { result ->
+                            assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                        }
+                    }
+                    it("build fails with more issues than threshold successfully if disabled") {
+
+                        val config = """
+                            |detekt {
+                            |   ignoreFailures = false
+                            |}
+                            """
+
+                        val gradleRunner = builder
+                            .withProjectLayout(projectLayoutWithTooManyIssues)
+                            .withDetektConfig(config)
+                            .build()
+
+                        gradleRunner.runDetektTaskAndExpectFailure()
+                    }
+                }
+            }
+        }
+    }
+})

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleIntegrationTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleIntegrationTest.kt
@@ -7,7 +7,7 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
-internal class DetektTaskMultiModuleTest : Spek({
+internal class DetektTaskMultiModuleIntegrationTest : Spek({
     describe("The Detekt Gradle plugin used in a multi module project") {
         listOf(groovy(), kotlin()).forEach { builder ->
             describe("using ${builder.gradleBuildName}") {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
@@ -13,6 +13,7 @@ abstract class DslTestBuilder {
     private var baselineFile: String? = null
     private var configFile: String? = null
     private var gradleVersion: String? = null
+    private var dryRun: Boolean = false
 
     fun withDetektConfig(config: String): DslTestBuilder {
         detektConfig = config
@@ -39,6 +40,11 @@ abstract class DslTestBuilder {
         return this
     }
 
+    fun dryRun(): DslTestBuilder {
+        dryRun = true
+        return this
+    }
+
     fun build(): DslGradleRunner {
         val mainBuildFileContent = """
             |$gradleBuildConfig
@@ -50,7 +56,8 @@ abstract class DslTestBuilder {
             mainBuildFileContent,
             configFile,
             baselineFile,
-            gradleVersion
+            gradleVersion,
+            dryRun
         )
         runner.setupProject()
         return runner

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/MultiVersionTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/MultiVersionTest.kt
@@ -12,7 +12,7 @@ object MultiVersionTest : Spek({
     val testedGradleVersions = listOf("4.9", "5.4")
 
     describe("detekt plugin running on different Gradle versions") {
-        listOf(groovy(), kotlin()).forEach { builder ->
+        listOf(groovy().dryRun(), kotlin().dryRun()).forEach { builder ->
             describe("using ${builder.gradleBuildName}") {
                 testedGradleVersions.forEach { gradleVersion ->
                     it("runs on version $gradleVersion of Gradle") {


### PR DESCRIPTION
This is sort of related to #1710 

Right now there are tests that check that the correct parameters are passed to the CLI by scraping the task output. Since the arguments are now written to a file to work around limitations on Windows, the somewhat dirty fix was to log the arguments with debug level and run gradle with the --debug option. Unfortunately this makes the output useless for actual debugging in the tests.

I opened this PR to make a suggestion for a possible solution and to gather feedback.
This dry-run option would if enabled simply print the arguments without actually invoking the CLI. In most cases this should be sufficient since we want to test the gradle task and not the CLI as well.

A different solution would be check the arguments from the `detekt.args` file.