### PR TITLE
Gradle plugin: Fix visibility of internal properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,8 +41,8 @@ tasks.wrapper {
     }
 }
 
-tasks.withType<Test> {
-    dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":test"))
+tasks.check {
+    dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":check"))
 }
 
 tasks.withType<Detekt> {

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -77,6 +77,7 @@ tasks.test {
 
 tasks.validateTaskProperties {
     enableStricterValidation = true
+    failOnWarning = true
 }
 
 pluginBundle {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -107,7 +107,7 @@ open class Detekt : SourceTask(), VerificationTask {
 
     @Internal
     @Optional
-    val debugProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    internal val debugProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var debug: Boolean
         @Internal
         get() = debugProp.get()
@@ -115,7 +115,7 @@ open class Detekt : SourceTask(), VerificationTask {
 
     @Internal
     @Optional
-    val parallelProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    internal val parallelProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var parallel: Boolean
         @Internal
         get() = parallelProp.get()
@@ -123,7 +123,7 @@ open class Detekt : SourceTask(), VerificationTask {
 
     @Optional
     @Input
-    val disableDefaultRuleSetsProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    internal val disableDefaultRuleSetsProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var disableDefaultRuleSets: Boolean
         @Internal
         get() = disableDefaultRuleSetsProp.get()
@@ -131,7 +131,7 @@ open class Detekt : SourceTask(), VerificationTask {
 
     @Optional
     @Input
-    val buildUponDefaultConfigProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    internal val buildUponDefaultConfigProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var buildUponDefaultConfig: Boolean
         @Internal
         get() = buildUponDefaultConfigProp.get()
@@ -139,7 +139,7 @@ open class Detekt : SourceTask(), VerificationTask {
 
     @Optional
     @Input
-    val failFastProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    internal val failFastProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var failFast: Boolean
         @Internal
         get() = failFastProp.get()
@@ -153,7 +153,7 @@ open class Detekt : SourceTask(), VerificationTask {
 
     @Optional
     @Input
-    val autoCorrectProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    internal val autoCorrectProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var autoCorrect: Boolean
         @Internal
         get() = autoCorrectProp.get()

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -53,6 +53,7 @@ open class Detekt : SourceTask(), VerificationTask {
 
     @Deprecated("Replace with getSource/setSource")
     var input: FileCollection
+        @Internal
         get() = source
         set(value) = setSource(value)
 
@@ -81,16 +82,16 @@ open class Detekt : SourceTask(), VerificationTask {
     @Optional
     val classpath = project.configurableFileCollection()
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     internal val languageVersionProp: Property<String> = project.objects.property(String::class.javaObjectType)
     var languageVersion: String
         @Internal
         get() = languageVersionProp.get()
         set(value) = languageVersionProp.set(value)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     internal val jvmTargetProp: Property<String> = project.objects.property(String::class.javaObjectType)
     var jvmTarget: String
         @Internal
@@ -105,54 +106,55 @@ open class Detekt : SourceTask(), VerificationTask {
     )
     var plugins: Property<String> = project.objects.property(String::class.java)
 
-    @Internal
-    @Optional
+    @get:Internal
+    @get:Optional
     internal val debugProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var debug: Boolean
         @Internal
         get() = debugProp.get()
         set(value) = debugProp.set(value)
 
-    @Internal
-    @Optional
+    @get:Internal
+    @get:Optional
     internal val parallelProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var parallel: Boolean
         @Internal
         get() = parallelProp.get()
         set(value) = parallelProp.set(value)
 
-    @Optional
-    @Input
+    @get:Optional
+    @get:Input
     internal val disableDefaultRuleSetsProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var disableDefaultRuleSets: Boolean
         @Internal
         get() = disableDefaultRuleSetsProp.get()
         set(value) = disableDefaultRuleSetsProp.set(value)
 
-    @Optional
-    @Input
+    @get:Optional
+    @get:Input
     internal val buildUponDefaultConfigProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var buildUponDefaultConfig: Boolean
         @Internal
         get() = buildUponDefaultConfigProp.get()
         set(value) = buildUponDefaultConfigProp.set(value)
 
-    @Optional
-    @Input
+    @get:Optional
+    @get:Input
     internal val failFastProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var failFast: Boolean
         @Internal
         get() = failFastProp.get()
         set(value) = failFastProp.set(value)
 
+    @get:Internal
     internal val ignoreFailuresProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     @Input
     @Optional
     override fun getIgnoreFailures(): Boolean = ignoreFailuresProp.getOrElse(false)
     override fun setIgnoreFailures(value: Boolean) = ignoreFailuresProp.set(value)
 
-    @Optional
-    @Input
+    @get:Optional
+    @get:Input
     internal val autoCorrectProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var autoCorrect: Boolean
         @Internal

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -97,7 +97,7 @@ open class DetektCreateBaselineTask : SourceTask() {
 
     @Optional
     @Input
-    val autoCorrectProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    internal val autoCorrectProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var autoCorrect: Boolean
         @Internal
         get() = autoCorrectProp.get()

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -44,6 +44,7 @@ open class DetektCreateBaselineTask : SourceTask() {
 
     @Deprecated("Replace with getSource/setSource")
     var input: FileCollection
+        @Internal
         get() = source
         set(value) = setSource(value)
 
@@ -95,8 +96,8 @@ open class DetektCreateBaselineTask : SourceTask() {
     @Optional
     val ignoreFailures: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
-    @Optional
-    @Input
+    @get:Optional
+    @get:Input
     internal val autoCorrectProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var autoCorrect: Boolean
         @Internal

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.invoke.GenerateConfigArgument
 import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.language.base.plugins.LifecycleBasePlugin
@@ -19,6 +20,7 @@ open class DetektGenerateConfigTask : SourceTask() {
 
     @Deprecated("Replace with getSource/setSource")
     var input: FileCollection
+        @Internal
         get() = source
         set(value) = setSource(value)
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaFormatTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaFormatTask.kt
@@ -19,6 +19,7 @@ open class DetektIdeaFormatTask : SourceTask() {
 
     @Deprecated("Replace with getSource/setSource")
     var input: FileCollection
+        @Internal
         get() = source
         set(value) = setSource(value)
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaInspectionTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaInspectionTask.kt
@@ -19,6 +19,7 @@ open class DetektIdeaInspectionTask : SourceTask() {
 
     @Deprecated("Replace with getSource/setSource")
     var input: FileCollection
+        @Internal
         get() = source
         set(value) = setSource(value)
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/CustomDetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/CustomDetektReport.kt
@@ -13,12 +13,14 @@ class CustomDetektReport(private val project: Project) {
     @Internal
     val reportIdProp: Property<String> = project.objects.property(String::class.java)
     var reportId: String
+        @Internal
         get() = reportIdProp.get()
         set(value) = reportIdProp.set(value)
 
     @OutputFile
     val destinationProperty: RegularFileProperty = project.fileProperty()
     var destination: File
+        @OutputFile
         get() = destinationProperty.get().asFile
         set(value) = destinationProperty.set(value)
 


### PR DESCRIPTION
The public API should not expose any of the internal properties directly - this fixes the issue raised here https://github.com/arturbosch/detekt/pull/1762#issuecomment-513584537.

Also changes the build config to ensure the `check` lifecycle task in the Gradle plugin is run when the main detekt build runs. This will make the [validateTaskProperties](https://docs.gradle.org/current/javadoc/org/gradle/plugin/devel/tasks/ValidateTaskProperties.html) task run to validate the annotations on the properties presented by the Gradle plugin.

Third commit fixes issues with property annotations found by the `validateTaskProperties` task.