### PR TITLE
Add auto correct flag to detekt extension

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -96,13 +96,9 @@ open class DetektCreateBaselineTask : SourceTask() {
     @Optional
     val ignoreFailures: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
-    @get:Optional
-    @get:Input
-    internal val autoCorrectProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
-    var autoCorrect: Boolean
-        @Internal
-        get() = autoCorrectProp.get()
-        set(value) = autoCorrectProp.set(value)
+    @Input
+    @Optional
+    val autoCorrect: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @TaskAction
     fun baseline() {
@@ -122,7 +118,7 @@ open class DetektCreateBaselineTask : SourceTask() {
             ParallelArgument(parallel.getOrElse(false)),
             BuildUponDefaultConfigArgument(buildUponDefaultConfig.getOrElse(false)),
             FailFastArgument(failFast.getOrElse(false)),
-            AutoCorrectArgument(autoCorrectProp.getOrElse(false)),
+            AutoCorrectArgument(autoCorrect.getOrElse(false)),
             DisableDefaultRuleSetArgument(disableDefaultRuleSets.getOrElse(false))
         )
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
@@ -51,6 +53,7 @@ class DetektPlugin : Plugin<Project> {
             it.disableDefaultRuleSetsProp.set(project.provider { extension.disableDefaultRuleSets })
             it.buildUponDefaultConfigProp.set(project.provider { extension.buildUponDefaultConfig })
             it.failFastProp.set(project.provider { extension.failFast })
+            it.autoCorrectProp.set(project.provider { extension.autoCorrect })
             it.config.setFrom(project.provider { extension.config })
             it.baseline.set(project.layout.file(project.provider { extension.baseline }))
             it.plugins.set(project.provider { extension.plugins })
@@ -76,6 +79,7 @@ class DetektPlugin : Plugin<Project> {
             it.disableDefaultRuleSetsProp.set(project.provider { extension.disableDefaultRuleSets })
             it.buildUponDefaultConfigProp.set(project.provider { extension.buildUponDefaultConfig })
             it.failFastProp.set(project.provider { extension.failFast })
+            it.autoCorrectProp.set(project.provider { extension.autoCorrect })
             it.config.setFrom(project.provider { extension.config })
             it.baseline.set(project.layout.file(project.provider { extension.baseline }))
             it.plugins.set(project.provider { extension.plugins })
@@ -99,6 +103,7 @@ class DetektPlugin : Plugin<Project> {
             it.disableDefaultRuleSets.set(project.provider { extension.disableDefaultRuleSets })
             it.buildUponDefaultConfig.set(project.provider { extension.buildUponDefaultConfig })
             it.failFast.set(project.provider { extension.failFast })
+            it.autoCorrect.set(project.provider { extension.autoCorrect })
             it.plugins.set(project.provider { extension.plugins })
             it.setSource(existingInputDirectoriesProvider(project, extension))
             it.setIncludes(defaultIncludes)
@@ -148,7 +153,6 @@ class DetektPlugin : Plugin<Project> {
             configuration.description = "The $CONFIGURATION_DETEKT dependencies to be used for this project."
 
             configuration.defaultDependencies { dependencySet ->
-                @Suppress("USELESS_ELVIS")
                 val version = extension.toolVersion ?: DEFAULT_DETEKT_VERSION
                 dependencySet.add(project.dependencies.create("io.gitlab.arturbosch.detekt:detekt-cli:$version"))
             }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -13,7 +13,9 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
         @JvmName("ignoreFailures_")
         get() = isIgnoreFailures
         @JvmName("ignoreFailures_")
-        set(value) = setIgnoreFailures(value)
+        set(value) {
+            isIgnoreFailures = value
+        }
 
     val customReportsDir: File?
         get() = reportsDir
@@ -41,6 +43,8 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
 
     var disableDefaultRuleSets: Boolean = DEFAULT_DISABLE_RULESETS_VALUE
 
+    var autoCorrect: Boolean = DEFAULT_AUTO_CORRECT_VALUE
+
     @Deprecated("Replace with task setIncludes/setExcludes")
     var filters: String? = null
 
@@ -53,6 +57,7 @@ open class DetektExtension(project: Project) : CodeQualityExtension() {
         const val DEFAULT_SRC_DIR_KOTLIN = "src/main/kotlin"
         const val DEFAULT_DEBUG_VALUE = false
         const val DEFAULT_PARALLEL_VALUE = false
+        const val DEFAULT_AUTO_CORRECT_VALUE = false
         const val DEFAULT_DISABLE_RULESETS_VALUE = false
         const val DEFAULT_REPORT_ENABLED_VALUE = true
         const val DEFAULT_FAIL_FAST_VALUE = false

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -355,6 +355,9 @@ internal object DetektTaskDslTest : Spek({
                         |    debug = true
                         |    parallel = true
                         |    disableDefaultRuleSets = true
+                        |    failFast = true
+                        |    autoCorrect = true
+                        |    buildUponDefaultConfig = true
                         |    ignoreFailures = true
                         |}
                         """
@@ -379,6 +382,18 @@ internal object DetektTaskDslTest : Spek({
 
                     it("ignores failures") {
                         assertThat(result.output).contains("Ignore failures: true")
+                    }
+
+                    it("enables fail fast") {
+                        assertThat(result.output).contains("--fail-fast")
+                    }
+
+                    it("enables auto correcting") {
+                        assertThat(result.output).contains("--auto-correct")
+                    }
+
+                    it("enables using default config as baseline") {
+                        assertThat(result.output).contains("--build-upon-default-config")
                     }
                 }
 


### PR DESCRIPTION
It could only be configured when creating a new detekt task.