### PR TITLE
Don't use provider value that may not have been set

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -244,7 +244,7 @@ open class Detekt : SourceTask(), VerificationTask {
 
         DetektInvoker.create(project).invokeCli(
             arguments = arguments.toList(),
-            ignoreFailures = ignoreFailuresProp.get(),
+            ignoreFailures = ignoreFailures,
             classpath = detektClasspath.plus(pluginClasspath),
             taskName = name
         )


### PR DESCRIPTION
Should have been done in #1787 

Without this change the value can be referenced before it's been set with a value, since it doesn't use the `getOrElse()` variant.