### PR TITLE
Use notifications instead of println

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/SimpleNotification.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/SimpleNotification.kt
@@ -1,0 +1,5 @@
+package io.gitlab.arturbosch.detekt.api.internal
+
+import io.gitlab.arturbosch.detekt.api.Notification
+
+data class SimpleNotification(override val message: String) : Notification

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/BuildFailure.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/BuildFailure.kt
@@ -1,0 +1,50 @@
+package io.gitlab.arturbosch.detekt.cli
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Detektion
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.RuleSetId
+import org.jetbrains.kotlin.com.intellij.openapi.util.Key
+import java.util.HashMap
+
+class BuildFailure(override val message: String?) : RuntimeException(message, null, true, false)
+
+private val WEIGHTED_ISSUES_COUNT_KEY = Key.create<Int>("WEIGHTED_ISSUES_COUNT")
+private const val BUILD = "build"
+private const val WEIGHTS = "weights"
+private const val MAX_ISSUES = "maxIssues"
+
+fun Config.maxIssues(): Int = subConfig(BUILD).valueOrDefault(MAX_ISSUES, -1)
+
+fun Int.isValidAndSmallerOrEqual(amount: Int): Boolean =
+    !(this == 0 && amount == 0) && this != -1 && this <= amount
+
+fun Detektion.getOrComputeWeightedAmountOfIssues(config: Config): Int {
+    val maybeAmount = this.getData(WEIGHTED_ISSUES_COUNT_KEY)
+    if (maybeAmount != null) {
+        return maybeAmount
+    }
+
+    val smells = findings.flatMap { it.value }
+    val ruleToRuleSetId = extractRuleToRuleSetIdMap(this)
+    val weightsConfig = config.weightsConfig()
+
+    fun Finding.weighted(): Int {
+        val key = ruleToRuleSetId[id] // entry of ID > entry of RuleSet ID > default weight 1
+        return weightsConfig.valueOrDefault(
+            id,
+            if (key != null) weightsConfig.valueOrDefault(key, 1) else 1
+        )
+    }
+
+    val amount = smells.sumBy { it.weighted() }
+    this.addData(WEIGHTED_ISSUES_COUNT_KEY, amount)
+    return amount
+}
+
+private fun Config.weightsConfig(): Config = subConfig(BUILD).subConfig(WEIGHTS)
+
+private fun extractRuleToRuleSetIdMap(detektion: Detektion): HashMap<RuleSetId, String> =
+    detektion.findings.mapValues { it.value.map(Finding::id).toSet() }
+        .map { map -> map.value.map { it to map.key }.toMap() }
+        .fold(HashMap()) { result, map -> result.putAll(map); result }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -9,7 +9,6 @@ interface Args {
     var help: Boolean
 }
 
-@Suppress("MaxLineLength")
 class CliArgs : Args {
 
     @Parameter(
@@ -48,7 +47,7 @@ class CliArgs : Args {
     @Parameter(
         names = ["--generate-config", "-gc"],
         description = "Export default config. " +
-                "Path can be specified with --config option (default path: default-detekt-config.yml)"
+            "Path can be specified with --config option (default path: default-detekt-config.yml)"
     )
     var generateConfig: Boolean = false
 
@@ -187,5 +186,11 @@ class CliArgs : Args {
          * of the arguments should be used.
          */
         operator fun invoke(init: CliArgs.() -> Unit): CliArgs = CliArgs().apply(init)
+
+        /**
+         * Creates an instance of [CliArgs]. Verification if the settings are sound
+         * must be made by the caller.
+         */
+        fun parse(args: Array<String>): CliArgs = parseArguments<CliArgs>(args).first
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/DetektProgressListener.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/DetektProgressListener.kt
@@ -7,11 +7,11 @@ import org.jetbrains.kotlin.psi.KtFile
 class DetektProgressListener : FileProcessListener {
 
     override fun onProcess(file: KtFile) {
-        kotlin.io.print(".")
+        print(".")
     }
 
     override fun onFinish(files: List<KtFile>, result: Detektion) {
         val middlePart = if (files.size == 1) "file was" else "files were"
-        kotlin.io.println("\n\n${files.size} kotlin $middlePart analyzed.")
+        println("\n\n${files.size} kotlin $middlePart analyzed.")
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -2,7 +2,6 @@
 
 package io.gitlab.arturbosch.detekt.cli
 
-import io.gitlab.arturbosch.detekt.cli.console.BuildFailure
 import io.gitlab.arturbosch.detekt.cli.runners.AstPrinter
 import io.gitlab.arturbosch.detekt.cli.runners.ConfigExporter
 import io.gitlab.arturbosch.detekt.cli.runners.Executable
@@ -16,7 +15,7 @@ fun main(args: Array<String>) {
     try {
         buildRunner(args).execute()
     } catch (e: BuildFailure) {
-        // Exit with status code 2 when maxIssues or failThreshold count was reached in BuildFailureReport.
+        // Exit with status code 2 when maxIssues value from configuration was reached.
         e.printStackTrace()
         exitProcess(2)
     } catch (e: Exception) {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/OutputFacade.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/OutputFacade.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.cli
 import io.gitlab.arturbosch.detekt.api.ConsoleReport
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.OutputReport
+import io.gitlab.arturbosch.detekt.api.internal.SimpleNotification
 import io.gitlab.arturbosch.detekt.cli.baseline.BaselineFacade
 import io.gitlab.arturbosch.detekt.cli.console.BuildFailureReport
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
@@ -47,7 +48,7 @@ class OutputFacade(
         val filePath = reportPaths[report.id]
         if (filePath != null) {
             report.write(filePath, result)
-            settings.info("Successfully generated ${report.name} at $filePath")
+            result.add(SimpleNotification("Successfully generated ${report.name} at $filePath"))
         }
     }
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/BuildFailureReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/BuildFailureReport.kt
@@ -3,65 +3,32 @@ package io.gitlab.arturbosch.detekt.cli.console
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.ConsoleReport
 import io.gitlab.arturbosch.detekt.api.Detektion
-import io.gitlab.arturbosch.detekt.api.Finding
-import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.SingleAssign
-import java.util.HashMap
+import io.gitlab.arturbosch.detekt.cli.getOrComputeWeightedAmountOfIssues
+import io.gitlab.arturbosch.detekt.cli.isValidAndSmallerOrEqual
+import io.gitlab.arturbosch.detekt.cli.maxIssues
 
 class BuildFailureReport : ConsoleReport() {
 
     override val priority: Int = Int.MIN_VALUE
 
-    private var weightsConfig: Config by SingleAssign()
-    private var buildConfig: Config by SingleAssign()
-    private var maxIssues: Int by SingleAssign()
-
-    companion object {
-        private const val BUILD = "build"
-        private const val WEIGHTS = "weights"
-        private const val MAX_ISSUES = "maxIssues"
-    }
+    private var config: Config by SingleAssign()
 
     override fun init(config: Config) {
-        buildConfig = config.subConfig(BUILD)
-        weightsConfig = buildConfig.subConfig(WEIGHTS)
-        maxIssues = buildConfig.valueOrDefault(MAX_ISSUES, -1)
+        this.config = config
     }
 
     override fun render(detektion: Detektion): String? {
-        val smells = detektion.findings.flatMap { it.value }
-        val ruleToRuleSetId = extractRuleToRuleSetIdMap(detektion)
-        val amount = smells.map { it.weighted(ruleToRuleSetId) }.sum()
-
+        val amount = detektion.getOrComputeWeightedAmountOfIssues(config)
+        val maxIssues = config.maxIssues()
         return when {
-            maxIssues.reached(amount) -> {
-                val message = "Build failed with $amount weighted issues (threshold defined was $maxIssues)."
-                println(message.red())
-                throw BuildFailure(message)
+            maxIssues.isValidAndSmallerOrEqual(amount) -> {
+                "Build failed with $amount weighted issues (threshold defined was $maxIssues).".red()
             }
             amount > 0 && maxIssues != -1 -> {
-                val message = "Build succeeded with $amount weighted issues (threshold defined was $maxIssues)."
-                message.yellow()
+                "Build succeeded with $amount weighted issues (threshold defined was $maxIssues).".yellow()
             }
             else -> null
         }
     }
-
-    private fun extractRuleToRuleSetIdMap(detektion: Detektion): HashMap<RuleSetId, String> {
-        return detektion.findings.mapValues { it.value.map(Finding::id).toSet() }
-            .map { map -> map.value.map { it to map.key }.toMap() }
-            .fold(HashMap()) { result, map -> result.putAll(map); result }
-    }
-
-    private fun Finding.weighted(ids: Map<String, String>): Int {
-        val key = ids[id] // entry of ID > entry of RuleSet ID > default weight 1
-        return weightsConfig.valueOrDefault(
-            id,
-            if (key != null) weightsConfig.valueOrDefault(key, 1) else 1
-        )
-    }
-
-    fun Int.reached(amount: Int): Boolean = !(this == 0 && amount == 0) && this != -1 && this <= amount
 }
-
-class BuildFailure(override val message: String?) : RuntimeException(message, null, true, false)

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/Colorizer.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/Colorizer.kt
@@ -19,6 +19,6 @@ private fun String.colorized(color: Color) = if (isColoredOutputSupported) {
     this
 }
 
-fun String.red() = colorized(RED).toString()
-fun String.yellow() = colorized(YELLOW).toString()
+fun String.red() = colorized(RED)
+fun String.yellow() = colorized(YELLOW)
 fun String.decolorized() = this.replace(escapeSequenceRegex, "")

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/FindingsReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/FindingsReport.kt
@@ -8,26 +8,27 @@ class FindingsReport : ConsoleReport() {
     override val priority: Int = 40
 
     override fun render(detektion: Detektion): String? {
-        val findings = detektion.findings
         val totalDebt = DebtSumming()
         return with(StringBuilder()) {
-            findings.forEach { rulesetFindings ->
-                val debtSumming = DebtSumming()
-                val issuesString = rulesetFindings.value.joinToString("") {
-                    debtSumming.add(it.issue.debt)
-                    it.compact().format("\t")
-                }
-                val debt = debtSumming.calculateDebt()
-                val debtString =
+            detektion.findings
+                .filter { it.value.isNotEmpty() }
+                .forEach { (ruleSetId, issues) ->
+                    val debtSumming = DebtSumming()
+                    val issuesString = issues.joinToString("") {
+                        debtSumming.add(it.issue.debt)
+                        it.compact().format("\t")
+                    }
+                    val debt = debtSumming.calculateDebt()
+                    val debtString =
                         if (debt != null) {
                             totalDebt.add(debt)
                             " - $debt debt".format()
                         } else {
                             "\n"
                         }
-                append(rulesetFindings.key.format(prefix = "Ruleset: ", suffix = debtString))
-                append(issuesString.yellow())
-            }
+                    append(ruleSetId.format(prefix = "Ruleset: ", suffix = debtString))
+                    append(issuesString.yellow())
+                }
             val debt = totalDebt.calculateDebt()
             if (debt != null) {
                 append("Overall debt: $debt".format("\n"))

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/NotificationReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/NotificationReport.kt
@@ -5,10 +5,10 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 
 class NotificationReport : ConsoleReport() {
 
-    override val priority: Int = 50
+    // Print notifications before the build failure report but after all other reports.
+    // This allows to compute intermediate messages based on detekt results and do not rely on 'println'.
+    override val priority: Int = Int.MIN_VALUE + 1
 
-    override fun render(detektion: Detektion): String? {
-        val notifications = detektion.notifications
-        return notifications.joinToString("\n") { it.message }
-    }
+    override fun render(detektion: Detektion): String? =
+        detektion.notifications.joinToString("\n") { it.message }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.cli.runners
 
+import io.gitlab.arturbosch.detekt.api.internal.SimpleNotification
 import io.gitlab.arturbosch.detekt.cli.CliArgs
 import io.gitlab.arturbosch.detekt.cli.OutputFacade
 import io.gitlab.arturbosch.detekt.cli.createClasspath
@@ -8,19 +9,20 @@ import io.gitlab.arturbosch.detekt.cli.createPlugins
 import io.gitlab.arturbosch.detekt.cli.loadConfiguration
 import io.gitlab.arturbosch.detekt.core.DetektFacade
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
-import kotlin.system.measureTimeMillis
 
 class Runner(private val arguments: CliArgs) : Executable {
 
     override fun execute() {
         val settings = createSettings()
+        val (time, result) = measure { DetektFacade.create(settings).run() }
+        result.add(SimpleNotification("detekt finished in $time ms."))
+        OutputFacade(arguments, result, settings).run()
+    }
 
-        val time = measureTimeMillis {
-            val detektion = DetektFacade.create(settings).run()
-            OutputFacade(arguments, detektion, settings).run()
-        }
-
-        println("\ndetekt finished in $time ms.")
+    inline fun <T> measure(block: () -> T): Pair<Long, T> {
+        val start = System.currentTimeMillis()
+        val result = block()
+        return System.currentTimeMillis() - start to result
     }
 
     private fun createSettings(): ProcessingSettings = with(arguments) {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
@@ -37,6 +37,8 @@ class SingleRuleRunner(private val arguments: CliArgs) : Executable {
             ?: throw IllegalArgumentException("There was no rule set with id '$ruleSet'.")
 
         val provider = RuleProducingProvider(rule, realProvider)
+        assert(provider.instance(settings.config).rules.size == 1) { "Eager testing if rule exists failed." }
+
         val detektion = DetektFacade.create(
             settings,
             listOf(provider),

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
@@ -37,7 +37,8 @@ class SingleRuleRunner(private val arguments: CliArgs) : Executable {
             ?: throw IllegalArgumentException("There was no rule set with id '$ruleSet'.")
 
         val provider = RuleProducingProvider(rule, realProvider)
-        assert(provider.instance(settings.config).rules.size == 1) { "Eager testing if rule exists failed." }
+
+        assertRuleExistsBeforeRunningItLater(provider, settings)
 
         val detektion = DetektFacade.create(
             settings,
@@ -45,6 +46,13 @@ class SingleRuleRunner(private val arguments: CliArgs) : Executable {
             listOf(DetektProgressListener())
         ).run()
         OutputFacade(arguments, detektion, settings).run()
+    }
+
+    private fun assertRuleExistsBeforeRunningItLater(
+        provider: RuleProducingProvider,
+        settings: ProcessingSettings
+    ) {
+        assert(provider.instance(settings.config).rules.size == 1) { "Expected a single rule to be loaded." }
     }
 }
 

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -9,6 +9,7 @@ build:
 processors:
   active: true
   exclude:
+  # - 'DetektProgressListener'
   # - 'FunctionCountProcessor'
   # - 'PropertyCountProcessor'
   # - 'ClassCountProcessor'

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/BuildFailureSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/BuildFailureSpec.kt
@@ -1,0 +1,19 @@
+package io.gitlab.arturbosch.detekt.cli
+
+import org.assertj.core.api.Assertions
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class BuildFailureSpec : Spek({
+
+    describe("isValidAndSmallerOrEqual extension function tests") {
+        Assertions.assertThat(0.isValidAndSmallerOrEqual(0)).isEqualTo(false)
+        Assertions.assertThat((-1).isValidAndSmallerOrEqual(0)).isEqualTo(false)
+        Assertions.assertThat(1.isValidAndSmallerOrEqual(0)).isEqualTo(false)
+        Assertions.assertThat(1.isValidAndSmallerOrEqual(1)).isEqualTo(true)
+        Assertions.assertThat(1.isValidAndSmallerOrEqual(2)).isEqualTo(true)
+        Assertions.assertThat(12.isValidAndSmallerOrEqual(11)).isEqualTo(false)
+        Assertions.assertThat(12.isValidAndSmallerOrEqual(12)).isEqualTo(true)
+        Assertions.assertThat(12.isValidAndSmallerOrEqual(13)).isEqualTo(true)
+    }
+})

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/TestDetektion.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/TestDetektion.kt
@@ -5,16 +5,21 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
+import org.jetbrains.kotlin.com.intellij.util.keyFMap.KeyFMap
 
 open class TestDetektion(vararg findings: Finding) : Detektion {
 
     override val metrics: Collection<ProjectMetric> = listOf()
     override val findings: Map<String, List<Finding>> = findings.groupBy { it.id }
     override val notifications: List<Notification> = listOf()
+    private var userData = KeyFMap.EMPTY_MAP
+
+    override fun <V> getData(key: Key<V>): V? = userData.get(key)
+
+    override fun <V> addData(key: Key<V>, value: V) {
+        userData = userData.plus(key, value)
+    }
 
     override fun add(notification: Notification) = throw UnsupportedOperationException("not implemented")
     override fun add(projectMetric: ProjectMetric) = throw UnsupportedOperationException("not implemented")
-
-    override fun <V> getData(key: Key<V>) = throw UnsupportedOperationException("not implemented")
-    override fun <V> addData(key: Key<V>, value: V) = throw UnsupportedOperationException("not implemented")
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/BuildFailureReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/BuildFailureReportSpec.kt
@@ -5,9 +5,7 @@ import io.gitlab.arturbosch.detekt.cli.TestDetektion
 import io.gitlab.arturbosch.detekt.cli.createFinding
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
-import org.assertj.core.api.Assertions.fail
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -30,26 +28,16 @@ internal class BuildFailureReportSpec : Spek({
                 assertThat(report).isNull()
             }
 
-            it("should throw a build failure error when maxIssues met") {
+            it("should print an error in red ") {
                 subject.init(TestConfig(mapOf("maxIssues" to "-2")))
-                assertThatExceptionOfType(BuildFailure::class.java).isThrownBy { subject.render(detektion) }
-            }
-
-            it("should contain no stacktrace on fail") {
-                subject.init(TestConfig(mapOf("maxIssues" to "-2")))
-                try {
-                    subject.render(detektion)
-                    fail("Render should throw")
-                } catch (e: BuildFailure) {
-                    assertThat(e.stackTrace).isEmpty()
-                }
+                val expectedMessage = "Build failed with 1 weighted issues (threshold defined was -2)."
+                assertThat(subject.render(detektion)).isEqualTo(expectedMessage.red())
             }
 
             it("should print a warning in yellow if weighted issues are not zero but below threshold") {
                 subject.init(TestConfig(mapOf("maxIssues" to "10")))
-                val report = subject.render(detektion)
                 val expectedMessage = "Build succeeded with 1 weighted issues (threshold defined was 10)."
-                assertThat(report).isEqualTo(expectedMessage.yellow())
+                assertThat(subject.render(detektion)).isEqualTo(expectedMessage.yellow())
             }
 
             it("should not print a warning if weighted issues are zero") {
@@ -57,22 +45,6 @@ internal class BuildFailureReportSpec : Spek({
                 val report = subject.render(TestDetektion())
                 assertThat(report).isNull()
             }
-        }
-    }
-
-    describe("reached extension function tests") {
-        subject.apply {
-            assertThat(0.reached(0)).isEqualTo(false)
-
-            assertThat((-1).reached(0)).isEqualTo(false)
-
-            assertThat(1.reached(0)).isEqualTo(false)
-            assertThat(1.reached(1)).isEqualTo(true)
-            assertThat(1.reached(2)).isEqualTo(true)
-
-            assertThat(12.reached(11)).isEqualTo(false)
-            assertThat(12.reached(12)).isEqualTo(true)
-            assertThat(12.reached(13)).isEqualTo(true)
         }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/FindingsReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/FindingsReportSpec.kt
@@ -13,23 +13,31 @@ class FindingsReportSpec : Spek({
 
     describe("findings report") {
 
-        context("several detekt findings") {
+        describe("reports the debt per rule set and the overall debt") {
+            val expectedContent = readResource("findings-report.txt")
+            val detektion = object : TestDetektion() {
+                override val findings: Map<String, List<Finding>> = mapOf(
+                    Pair("TestSmell", listOf(createFinding(), createFinding())),
+                    Pair("EmptySmells", emptyList()))
+            }
+            val output = subject.render(detektion)?.trimEnd()?.decolorized()
 
-            it("reports the debt per ruleset and the overall debt") {
-                val expectedContent = readResource("findings-report.txt")
-                val detektion = object : TestDetektion() {
-                    override val findings: Map<String, List<Finding>> = mapOf(
-                            Pair("TestSmell", listOf(createFinding(), createFinding())),
-                            Pair("EmptySmells", emptyList()))
-                }
-                val output = subject.render(detektion)?.trimEnd()?.decolorized()
+            it("has the reference content") {
                 assertThat(output).isEqualTo(expectedContent)
             }
 
-            it("reports no findings") {
-                val detektion = TestDetektion()
-                assertThat(subject.render(detektion)).isEmpty()
+            it("does not print rule set ids when no findings of this rule set is found") {
+                assertThat(output).doesNotContain("EmptySmells")
             }
+
+            it("does contain the rule set id of rule sets with findings") {
+                assertThat(output).contains("TestSmell")
+            }
+        }
+
+        it("reports no findings") {
+            val detektion = TestDetektion()
+            assertThat(subject.render(detektion)).isEmpty()
         }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.cli.CliArgs
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.assertj.core.api.Assertions.fail
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.nio.file.Files
@@ -48,9 +47,9 @@ class RunnerSpec : Spek({
                 "--config-resource", "/configs/max-issues--1.yml"
             ))
 
-            runCatching { Runner(cliArgs).execute() }
-                .onSuccess { assertThat(Files.readAllLines(tmpReport)).hasSize(1) }
-                .onFailure { fail("should not fail with a BuildFailure exception") }
+            Runner(cliArgs).execute()
+
+            assertThat(Files.readAllLines(tmpReport)).hasSize(1)
         }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -1,0 +1,56 @@
+package io.gitlab.arturbosch.detekt.cli.runners
+
+import io.gitlab.arturbosch.detekt.cli.BuildFailure
+import io.gitlab.arturbosch.detekt.cli.CliArgs
+import io.gitlab.arturbosch.detekt.test.resource
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.api.Assertions.fail
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class RunnerSpec : Spek({
+
+    val inputPath: Path = Paths.get(resource("/cases/Poko.kt"))
+
+    describe("executes the runner with different maxIssues configurations") {
+
+        it("should report one issue when maxIssues=2") {
+            val tmpReport = Files.createTempFile("RunnerSpec", ".txt")
+            val cliArgs = CliArgs.parse(arrayOf(
+                "--input", inputPath.toString(),
+                "--report", "txt:$tmpReport",
+                "--config-resource", "/configs/max-issues-2.yml"
+            ))
+
+            Runner(cliArgs).execute()
+
+            assertThat(Files.readAllLines(tmpReport)).hasSize(1)
+        }
+
+        it("should throw on maxIssues=0") {
+            val cliArgs = CliArgs.parse(arrayOf(
+                "--input", inputPath.toString(),
+                "--config-resource", "/configs/max-issues-0.yml"
+            ))
+
+            assertThatThrownBy { Runner(cliArgs).execute() }.isExactlyInstanceOf(BuildFailure::class.java)
+        }
+
+        it("should never throw on maxIssues=-1") {
+            val tmpReport = Files.createTempFile("RunnerSpec", ".txt")
+            val cliArgs = CliArgs.parse(arrayOf(
+                "--input", inputPath.toString(),
+                "--report", "txt:$tmpReport",
+                "--config-resource", "/configs/max-issues--1.yml"
+            ))
+
+            runCatching { Runner(cliArgs).execute() }
+                .onSuccess { assertThat(Files.readAllLines(tmpReport)).hasSize(1) }
+                .onFailure { fail("should not fail with a BuildFailure exception") }
+        }
+    }
+})

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/TestRules.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/TestRules.kt
@@ -1,0 +1,24 @@
+package io.gitlab.arturbosch.detekt.cli.runners
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtClass
+
+class TestProvider : RuleSetProvider {
+    override val ruleSetId: String = "test"
+    override fun instance(config: Config): RuleSet = RuleSet(ruleSetId, listOf(TestRule()))
+}
+
+class TestRule : Rule() {
+    override val issue = Issue("test", Severity.Minor, "", Debt.FIVE_MINS)
+    override fun visitClass(klass: KtClass) {
+        report(CodeSmell(issue, Entity.from(klass), issue.description))
+    }
+}

--- a/detekt-cli/src/test/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.ConsoleReport
+++ b/detekt-cli/src/test/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.ConsoleReport
@@ -1,1 +1,0 @@
-io.gitlab.arturbosch.detekt.cli.runners.TestConsoleReport

--- a/detekt-cli/src/test/resources/configs/max-issues--1.yml
+++ b/detekt-cli/src/test/resources/configs/max-issues--1.yml
@@ -1,0 +1,2 @@
+build:
+  maxIssues: -1

--- a/detekt-cli/src/test/resources/configs/max-issues-0.yml
+++ b/detekt-cli/src/test/resources/configs/max-issues-0.yml
@@ -1,0 +1,2 @@
+build:
+  maxIssues: 0

--- a/detekt-cli/src/test/resources/configs/max-issues-2.yml
+++ b/detekt-cli/src/test/resources/configs/max-issues-2.yml
@@ -1,0 +1,2 @@
+build:
+  maxIssues: 2

--- a/detekt-cli/src/test/resources/findings-report.txt
+++ b/detekt-cli/src/test/resources/findings-report.txt
@@ -1,6 +1,5 @@
 Ruleset: TestSmell - 10min debt
 	TestSmell - [TestEntity] at TestFile.kt:1:1
 	TestSmell - [TestEntity] at TestFile.kt:1:1
-Ruleset: EmptySmells
 
 Overall debt: 10min

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -63,47 +63,43 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
         }
     }
 
-    private fun defaultBuildConfiguration(): String {
-        return """
-			build:
-			  maxIssues: 10
-			  weights:
-			    # complexity: 2
-			    # LongParameterList: 1
-			    # style: 1
-			    # comments: 1
-			""".trimIndent()
-    }
+    private fun defaultBuildConfiguration(): String = """
+      build:
+        maxIssues: 10
+        weights:
+          # complexity: 2
+          # LongParameterList: 1
+          # style: 1
+          # comments: 1
+    """.trimIndent()
 
-    private fun defaultProcessorsConfiguration(): String {
-        return """
-			processors:
-			  active: true
-			  exclude:
-			  # - 'FunctionCountProcessor'
-			  # - 'PropertyCountProcessor'
-			  # - 'ClassCountProcessor'
-			  # - 'PackageCountProcessor'
-			  # - 'KtFileCountProcessor'
-			""".trimIndent()
-    }
+    private fun defaultProcessorsConfiguration(): String = """
+      processors:
+        active: true
+        exclude:
+        # - 'DetektProgressListener'
+        # - 'FunctionCountProcessor'
+        # - 'PropertyCountProcessor'
+        # - 'ClassCountProcessor'
+        # - 'PackageCountProcessor'
+        # - 'KtFileCountProcessor'
+    """.trimIndent()
 
-    private fun defaultConsoleReportsConfiguration(): String {
-        return """
-			console-reports:
-			  active: true
-			  exclude:
-			  #  - 'ProjectStatisticsReport'
-			  #  - 'ComplexityReport'
-			  #  - 'NotificationReport'
-			  #  - 'FindingsReport'
-			  #  - 'BuildFailureReport'
-			""".trimIndent()
-    }
+    private fun defaultConsoleReportsConfiguration(): String = """
+      console-reports:
+        active: true
+        exclude:
+        #  - 'ProjectStatisticsReport'
+        #  - 'ComplexityReport'
+        #  - 'NotificationReport'
+        #  - 'FindingsReport'
+        #  - 'BuildFailureReport'
+    """.trimIndent()
 
     private fun String.isYamlList() = trim().startsWith("-")
 
-    private fun String.toList(): List<String> {
-        return split("\n").map { it.replace("-", "") }.map { it.trim() }
-    }
+    private fun String.toList(): List<String> =
+        split("\n")
+            .map { it.replace("-", "") }
+            .map { it.trim() }
 }


### PR DESCRIPTION
Closes - #1797

a config like:
```
processors:
  active: true
  exclude:
    - 'DetektProgressListener'
    - 'FunctionCountProcessor'
    - 'PropertyCountProcessor'
    - 'ClassCountProcessor'
    - 'PackageCountProcessor'
    - 'KtFileCountProcessor'

console-reports:
  active: true
  exclude:
    - 'ProjectStatisticsReport'
    - 'ComplexityReport'
    - 'NotificationReport'
    - 'FindingsReport'
    - 'BuildFailureReport'
```
won't print anything.

I will write a guide on how to turn detekt silent for your CI in a separate PR.