### PR TITLE
Remove <pluginrepository> from maventask.md

### DIFF
--- a/docs/pages/gettingstarted/mavenanttask.md
+++ b/docs/pages/gettingstarted/mavenanttask.md
@@ -54,22 +54,4 @@ summary:
         </plugin>
     </plugins>
 </build>
-
-<!-- You need this repository as detekt is not yet on MavenCentral -->
-<pluginRepositories>
-  <pluginRepository>
-    <id>arturbosch-code-analysis</id>
-    <name>arturbosch-code-analysis (for detekt)</name>
-    <url>https://dl.bintray.com/arturbosch/code-analysis/</url>
-    <layout>default</layout>
-    <releases>
-      <enabled>true</enabled>
-      <updatePolicy>never</updatePolicy>
-    </releases>
-    <snapshots>
-      <enabled>false</enabled>
-      <updatePolicy>never</updatePolicy>
-    </snapshots>
-  </pluginRepository>
-</pluginRepositories>
 ```


### PR DESCRIPTION
With the next release there's also no need to use the jcenter repo anymore.