### PR TITLE
Gradle 5.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ buildScan {
 }
 
 tasks.wrapper {
-    gradleVersion = "5.4"
+    gradleVersion = "5.6"
     distributionType = Wrapper.DistributionType.ALL
     doLast {
         /*

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,18 +9,18 @@ import org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig
 import java.util.Date
 
 plugins {
-    // Plugin versions for these plugins are defined in gradle.properties and applied in settings.gradle.kts
-    id("com.gradle.build-scan")
-    kotlin("jvm")
-    id("com.jfrog.bintray")
-    id("com.jfrog.artifactory") apply false
-    id("com.github.ben-manes.versions")
-    id("com.github.johnrengelman.shadow") apply false
-    id("org.sonarqube")
     id("io.gitlab.arturbosch.detekt")
-    id("org.jetbrains.dokka") apply false
     jacoco
     `maven-publish`
+    // Plugin versions for these plugins are defined in gradle.properties and applied in settings.gradle.kts
+    id("com.jfrog.artifactory") apply false
+    id("com.jfrog.bintray")
+    id("com.gradle.build-scan")
+    id("org.jetbrains.dokka") apply false
+    id("com.github.ben-manes.versions")
+    kotlin("jvm")
+    id("com.github.johnrengelman.shadow") apply false
+    id("org.sonarqube")
 }
 
 buildScan {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,15 +9,16 @@ import org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig
 import java.util.Date
 
 plugins {
-    id("com.gradle.build-scan") version "2.4"
-    kotlin("jvm") version "1.3.41"
-    id("com.jfrog.bintray") version "1.8.4"
-    id("com.jfrog.artifactory") version "4.9.8" apply false
-    id("com.github.ben-manes.versions") version "0.22.0"
-    id("com.github.johnrengelman.shadow") version "5.1.0" apply false
-    id("org.sonarqube") version "2.7"
+    // Plugin versions for these plugins are defined in gradle.properties and applied in settings.gradle.kts
+    id("com.gradle.build-scan")
+    kotlin("jvm")
+    id("com.jfrog.bintray")
+    id("com.jfrog.artifactory") apply false
+    id("com.github.ben-manes.versions")
+    id("com.github.johnrengelman.shadow") apply false
+    id("org.sonarqube")
     id("io.gitlab.arturbosch.detekt")
-    id("org.jetbrains.dokka") version "0.9.18" apply false
+    id("org.jetbrains.dokka") apply false
     jacoco
     `maven-publish`
 }
@@ -28,7 +29,8 @@ buildScan {
 }
 
 tasks.wrapper {
-    gradleVersion = "5.6"
+    val gradleVersion: String by project
+    this.gradleVersion = gradleVersion
     distributionType = Wrapper.DistributionType.ALL
     doLast {
         /*

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -315,7 +315,7 @@ val detektFormat by tasks.registering(Detekt::class) {
     include("**/*.kts")
     exclude("**/resources/**")
     exclude("**/build/**")
-    config = files("$rootDir/config/detekt/format.yml")
+    config.setFrom(files("$rootDir/config/detekt/format.yml"))
     reports {
         xml.enabled = false
         html.enabled = false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -315,7 +315,7 @@ val detektFormat by tasks.registering(Detekt::class) {
     include("**/*.kts")
     exclude("**/resources/**")
     exclude("**/build/**")
-    config.setFrom(files("$rootDir/config/detekt/format.yml"))
+    config = files("$rootDir/config/detekt/format.yml")
     reports {
         xml.enabled = false
         html.enabled = false

--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 }
 
 tasks.withType<Jar>().configureEach {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE // allow duplicates
     from(
         configurations.implementation.get()
             .filter { "com.pinterest.ktlint" in it.toString() }

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -65,7 +65,6 @@ tasks.test {
 
 tasks.validateTaskProperties {
     enableStricterValidation = true
-    failOnWarning = true
 }
 
 pluginBundle {

--- a/detekt-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/detekt-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -33,6 +33,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Console
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
@@ -60,7 +61,7 @@ open class Detekt : SourceTask(), VerificationTask {
     @Input
     @Optional
     @Deprecated("Replace with setIncludes/setExcludes")
-    var filters: Property<String> = project.objects.property(String::class.java)
+    val filters: Property<String> = project.objects.property(String::class.java)
 
     @Classpath
     val detektClasspath = project.configurableFileCollection()
@@ -71,12 +72,12 @@ open class Detekt : SourceTask(), VerificationTask {
     @InputFile
     @Optional
     @PathSensitive(PathSensitivity.RELATIVE)
-    var baseline: RegularFileProperty = project.fileProperty()
+    val baseline: RegularFileProperty = project.fileProperty()
 
     @InputFiles
     @Optional
     @PathSensitive(PathSensitivity.RELATIVE)
-    var config: ConfigurableFileCollection = project.configurableFileCollection()
+    val config: ConfigurableFileCollection = project.configurableFileCollection()
 
     @Classpath
     @Optional
@@ -104,21 +105,19 @@ open class Detekt : SourceTask(), VerificationTask {
         "Set plugins using the detektPlugins configuration " +
                 "(see https://arturbosch.github.io/detekt/extensions.html#let-detekt-know-about-your-extensions)"
     )
-    var plugins: Property<String> = project.objects.property(String::class.java)
+    val plugins: Property<String> = project.objects.property(String::class.java)
 
     @get:Internal
-    @get:Optional
     internal val debugProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var debug: Boolean
-        @Internal
+        @Input
         get() = debugProp.get()
         set(value) = debugProp.set(value)
 
     @get:Internal
-    @get:Optional
     internal val parallelProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var parallel: Boolean
-        @Internal
+        @Console
         get() = parallelProp.get()
         set(value) = parallelProp.set(value)
 
@@ -149,7 +148,6 @@ open class Detekt : SourceTask(), VerificationTask {
     @get:Internal
     internal val ignoreFailuresProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     @Input
-    @Optional
     override fun getIgnoreFailures(): Boolean = ignoreFailuresProp.getOrElse(false)
     override fun setIgnoreFailures(value: Boolean) = ignoreFailuresProp.set(value)
 
@@ -168,7 +166,7 @@ open class Detekt : SourceTask(), VerificationTask {
 
     @Internal
     @Optional
-    var reportsDir: Property<File> = project.objects.property(File::class.java)
+    val reportsDir: Property<File> = project.objects.property(File::class.java)
 
     val xmlReportFile: Provider<RegularFile>
         @OutputFile

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -61,7 +61,7 @@ open class Detekt : SourceTask(), VerificationTask {
     @Input
     @Optional
     @Deprecated("Replace with setIncludes/setExcludes")
-    val filters: Property<String> = project.objects.property(String::class.java)
+    var filters: Property<String> = project.objects.property(String::class.java)
 
     @Classpath
     val detektClasspath = project.configurableFileCollection()
@@ -72,12 +72,12 @@ open class Detekt : SourceTask(), VerificationTask {
     @InputFile
     @Optional
     @PathSensitive(PathSensitivity.RELATIVE)
-    val baseline: RegularFileProperty = project.fileProperty()
+    var baseline: RegularFileProperty = project.fileProperty()
 
     @InputFiles
     @Optional
     @PathSensitive(PathSensitivity.RELATIVE)
-    val config: ConfigurableFileCollection = project.configurableFileCollection()
+    var config: ConfigurableFileCollection = project.configurableFileCollection()
 
     @Classpath
     @Optional
@@ -105,19 +105,19 @@ open class Detekt : SourceTask(), VerificationTask {
         "Set plugins using the detektPlugins configuration " +
                 "(see https://arturbosch.github.io/detekt/extensions.html#let-detekt-know-about-your-extensions)"
     )
-    val plugins: Property<String> = project.objects.property(String::class.java)
+    var plugins: Property<String> = project.objects.property(String::class.java)
 
     @get:Internal
     internal val debugProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var debug: Boolean
-        @Input
+        @Console
         get() = debugProp.get()
         set(value) = debugProp.set(value)
 
     @get:Internal
     internal val parallelProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var parallel: Boolean
-        @Console
+        @Internal
         get() = parallelProp.get()
         set(value) = parallelProp.set(value)
 
@@ -166,7 +166,7 @@ open class Detekt : SourceTask(), VerificationTask {
 
     @Internal
     @Optional
-    val reportsDir: Property<File> = project.objects.property(File::class.java)
+    var reportsDir: Property<File> = project.objects.property(File::class.java)
 
     val xmlReportFile: Provider<RegularFile>
         @OutputFile

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -165,7 +165,6 @@ open class Detekt : SourceTask(), VerificationTask {
     fun reports(configure: Action<DetektReports>) = configure.execute(reports)
 
     @Internal
-    @Optional
     var reportsDir: Property<File> = project.objects.property(File::class.java)
 
     val xmlReportFile: Provider<RegularFile>

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -39,8 +39,7 @@ open class DetektCreateBaselineTask : SourceTask() {
     }
 
     @OutputFile
-    @PathSensitive(PathSensitivity.RELATIVE)
-    var baseline: RegularFileProperty = project.fileProperty()
+    val baseline: RegularFileProperty = project.fileProperty()
 
     @Deprecated("Replace with getSource/setSource")
     var input: FileCollection
@@ -51,12 +50,12 @@ open class DetektCreateBaselineTask : SourceTask() {
     @Input
     @Optional
     @Deprecated("Replace with setIncludes/setExcludes")
-    var filters: Property<String> = project.objects.property(String::class.java)
+    val filters: Property<String> = project.objects.property(String::class.java)
 
     @InputFiles
     @Optional
     @PathSensitive(PathSensitivity.RELATIVE)
-    var config: ConfigurableFileCollection = project.configurableFileCollection()
+    val config: ConfigurableFileCollection = project.configurableFileCollection()
 
     @Input
     @Optional
@@ -64,7 +63,7 @@ open class DetektCreateBaselineTask : SourceTask() {
         "Set plugins using the detektPlugins configuration " +
                 "(see https://arturbosch.github.io/detekt/extensions.html#let-detekt-know-about-your-extensions)"
     )
-    var plugins: Property<String> = project.objects.property(String::class.java)
+    val plugins: Property<String> = project.objects.property(String::class.java)
 
     @Classpath
     val detektClasspath = project.configurableFileCollection()
@@ -74,23 +73,23 @@ open class DetektCreateBaselineTask : SourceTask() {
 
     @Internal
     @Optional
-    var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    val debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Internal
     @Optional
-    var parallel: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    val parallel: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Internal
     @Optional
-    var disableDefaultRuleSets: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    val disableDefaultRuleSets: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Internal
     @Optional
-    var buildUponDefaultConfig: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    val buildUponDefaultConfig: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Internal
     @Optional
-    var failFast: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    val failFast: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Input
     @Optional

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -20,6 +20,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Console
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
@@ -39,7 +40,7 @@ open class DetektCreateBaselineTask : SourceTask() {
     }
 
     @OutputFile
-    val baseline: RegularFileProperty = project.fileProperty()
+    var baseline: RegularFileProperty = project.fileProperty()
 
     @Deprecated("Replace with getSource/setSource")
     var input: FileCollection
@@ -50,12 +51,12 @@ open class DetektCreateBaselineTask : SourceTask() {
     @Input
     @Optional
     @Deprecated("Replace with setIncludes/setExcludes")
-    val filters: Property<String> = project.objects.property(String::class.java)
+    var filters: Property<String> = project.objects.property(String::class.java)
 
     @InputFiles
     @Optional
     @PathSensitive(PathSensitivity.RELATIVE)
-    val config: ConfigurableFileCollection = project.configurableFileCollection()
+    var config: ConfigurableFileCollection = project.configurableFileCollection()
 
     @Input
     @Optional
@@ -63,7 +64,7 @@ open class DetektCreateBaselineTask : SourceTask() {
         "Set plugins using the detektPlugins configuration " +
                 "(see https://arturbosch.github.io/detekt/extensions.html#let-detekt-know-about-your-extensions)"
     )
-    val plugins: Property<String> = project.objects.property(String::class.java)
+    var plugins: Property<String> = project.objects.property(String::class.java)
 
     @Classpath
     val detektClasspath = project.configurableFileCollection()
@@ -71,25 +72,24 @@ open class DetektCreateBaselineTask : SourceTask() {
     @Classpath
     val pluginClasspath = project.configurableFileCollection()
 
-    @Internal
-    @Optional
-    val debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    @Console
+    var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Internal
     @Optional
-    val parallel: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    var parallel: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Internal
     @Optional
-    val disableDefaultRuleSets: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    var disableDefaultRuleSets: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Internal
     @Optional
-    val buildUponDefaultConfig: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    var buildUponDefaultConfig: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Internal
     @Optional
-    val failFast: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    var failFast: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Input
     @Optional

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -76,19 +76,15 @@ open class DetektCreateBaselineTask : SourceTask() {
     var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Internal
-    @Optional
     var parallel: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Internal
-    @Optional
     var disableDefaultRuleSets: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Internal
-    @Optional
     var buildUponDefaultConfig: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Internal
-    @Optional
     var failFast: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Input

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaFormatTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaFormatTask.kt
@@ -25,7 +25,7 @@ open class DetektIdeaFormatTask : SourceTask() {
 
     @Internal
     @Optional
-    var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    val debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Internal
     lateinit var ideaExtension: IdeaExtension

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaFormatTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaFormatTask.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.extensions.IdeaExtension
 import io.gitlab.arturbosch.detekt.invoke.ProcessExecutor.startProcess
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Console
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.SourceTask
@@ -23,9 +24,8 @@ open class DetektIdeaFormatTask : SourceTask() {
         get() = source
         set(value) = setSource(value)
 
-    @Internal
-    @Optional
-    val debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    @Console
+    var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Internal
     lateinit var ideaExtension: IdeaExtension

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaInspectionTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaInspectionTask.kt
@@ -25,7 +25,7 @@ open class DetektIdeaInspectionTask : SourceTask() {
 
     @Internal
     @Optional
-    var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    val debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Internal
     lateinit var ideaExtension: IdeaExtension

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaInspectionTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaInspectionTask.kt
@@ -4,8 +4,8 @@ import io.gitlab.arturbosch.detekt.extensions.IdeaExtension
 import io.gitlab.arturbosch.detekt.invoke.ProcessExecutor
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Console
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.language.base.plugins.LifecycleBasePlugin
@@ -23,9 +23,8 @@ open class DetektIdeaInspectionTask : SourceTask() {
         get() = source
         set(value) = setSource(value)
 
-    @Internal
-    @Optional
-    val debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    @Console
+    var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @Internal
     lateinit var ideaExtension: IdeaExtension

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/MultiVersionTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/MultiVersionTest.kt
@@ -9,7 +9,7 @@ import org.spekframework.spek2.style.specification.describe
 
 object MultiVersionTest : Spek({
 
-    val testedGradleVersions = listOf("4.9", "5.4")
+    val testedGradleVersions = listOf("4.9", "5.6")
 
     describe("detekt plugin running on different Gradle versions") {
         listOf(groovy().dryRun(), kotlin().dryRun()).forEach { builder ->

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,6 @@
 detektVersion=1.0.0
+
+# Project dependencies
 ktlintVersion=0.34.2
 spekVersion=2.0.2
 junitPlatformVersion=1.4.1
@@ -6,7 +8,20 @@ yamlVersion=1.24
 jcommanderVersion=1.78
 assertjVersion=3.13.2
 reflectionsVersion=0.9.11
+
+# Gradle plugins
+buildScanVersion=2.4
+kotlinVersion=1.3.41
+bintrayVersion=1.8.4
+artifactoryVersion=4.9.8
+gradleVersionsPluginVersion=0.22.0
+shadowVersion=5.1.0
+sonarQubeVersion=2.7
+dokkaVersion=0.9.18
 jacocoVersion=0.8.4
+
+# Gradle version
+gradleVersion=5.6
 
 kotlin.code.style=official
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,24 +1,24 @@
 detektVersion=1.0.0
 
 # Project dependencies
-ktlintVersion=0.34.2
-spekVersion=2.0.2
-junitPlatformVersion=1.4.1
-yamlVersion=1.24
+assertjVersion=3.12.2
 jcommanderVersion=1.78
-assertjVersion=3.13.2
+junitPlatformVersion=1.4.1
+ktlintVersion=0.34.2
 reflectionsVersion=0.9.11
+spekVersion=2.0.2
+yamlVersion=1.24
 
 # Gradle plugins
-buildScanVersion=2.4
-kotlinVersion=1.3.41
-bintrayVersion=1.8.4
 artifactoryVersion=4.9.8
+bintrayVersion=1.8.4
+buildScanVersion=2.4
+dokkaVersion=0.9.18
 gradleVersionsPluginVersion=0.22.0
+jacocoVersion=0.8.4
+kotlinVersion=1.3.41
 shadowVersion=5.1.0
 sonarQubeVersion=2.7
-dokkaVersion=0.9.18
-jacocoVersion=0.8.4
 
 # Gradle version
 gradleVersion=5.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ buildScanVersion=2.4
 dokkaVersion=0.9.18
 gradleVersionsPluginVersion=0.22.0
 jacocoVersion=0.8.4
-kotlinVersion=1.3.41
+kotlinVersion=1.3.50
 shadowVersion=5.1.0
 sonarQubeVersion=2.7
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -125,8 +125,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,24 +10,24 @@ include("detekt-api",
 
 includeBuild("detekt-gradle-plugin")
 
-val buildScanVersion: String by settings
-val kotlinVersion: String by settings
-val bintrayVersion: String by settings
 val artifactoryVersion: String by settings
+val bintrayVersion: String by settings
+val buildScanVersion: String by settings
+val dokkaVersion: String by settings
 val gradleVersionsPluginVersion: String by settings
+val kotlinVersion: String by settings
 val shadowVersion: String by settings
 val sonarQubeVersion: String by settings
-val dokkaVersion: String by settings
 
 pluginManagement {
         plugins {
-                id("com.gradle.build-scan") version buildScanVersion
-                kotlin("jvm") version kotlinVersion
-                id("com.jfrog.bintray") version bintrayVersion
                 id("com.jfrog.artifactory") version artifactoryVersion
+                id("com.jfrog.bintray") version bintrayVersion
+                id("com.gradle.build-scan") version buildScanVersion
+                id("org.jetbrains.dokka") version dokkaVersion
                 id("com.github.ben-manes.versions") version gradleVersionsPluginVersion
+                kotlin("jvm") version kotlinVersion
                 id("com.github.johnrengelman.shadow") version shadowVersion
                 id("org.sonarqube") version sonarQubeVersion
-                id("org.jetbrains.dokka") version dokkaVersion
         }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,3 +9,25 @@ include("detekt-api",
         "detekt-formatting")
 
 includeBuild("detekt-gradle-plugin")
+
+val buildScanVersion: String by settings
+val kotlinVersion: String by settings
+val bintrayVersion: String by settings
+val artifactoryVersion: String by settings
+val gradleVersionsPluginVersion: String by settings
+val shadowVersion: String by settings
+val sonarQubeVersion: String by settings
+val dokkaVersion: String by settings
+
+pluginManagement {
+        plugins {
+                id("com.gradle.build-scan") version buildScanVersion
+                kotlin("jvm") version kotlinVersion
+                id("com.jfrog.bintray") version bintrayVersion
+                id("com.jfrog.artifactory") version artifactoryVersion
+                id("com.github.ben-manes.versions") version gradleVersionsPluginVersion
+                id("com.github.johnrengelman.shadow") version shadowVersion
+                id("org.sonarqube") version sonarQubeVersion
+                id("org.jetbrains.dokka") version dokkaVersion
+        }
+}


### PR DESCRIPTION
Takes advantage of a new feature in Gradle 5.6 so all dependency versions can be declared in the same file (though not for the Gradle plugin, which would require copying the gradle.properties file around).

Also explicitly sets the DuplicateStrategy for the formatting jar creation to `INCLUDE` which is the default in Gradle 5.6 but is changing to `FAIL` in Gradle 6. This works around that issue and makes the desired behaviour explicit.