### PR TITLE
Use Ubuntu 18.04 for JDK 11 & 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,13 @@ language: java
 matrix:
   include:
     - os: linux
+      dist: xenial
       jdk: openjdk8
     - os: linux
+      dist: bionic
       jdk: openjdk11
     - os: linux
+      dist: bionic
       jdk: openjdk12
     # JDK 8 - see https://docs.travis-ci.com/user/reference/osx/#jdk-and-macos
     - os: osx


### PR DESCRIPTION
JDK 8 is not supported on Ubuntu 18.04 so remains on 16.04 (Xenial)

Seems to address issue on JDK 12 that was causing some previous builds to fail.