### PR TITLE
Remove unnecessary .trimIndent() in tests

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
@@ -129,7 +129,7 @@ class ComplexMethodSpec : Spek({
 					}
 				}
 			}
-			""".trimIndent()
+			"""
 
             it("should not count these overridden functions to base functions complexity") {
                 assertThat(ComplexMethod().compileAndLint(code)).isEmpty()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
@@ -175,7 +175,7 @@ class TooManyFunctionsSpec : Spek({
                         override fun a() = Unit
                         override fun b() = Unit
                     }
-				""".trimIndent()
+				"""
                 val configuredRule = TooManyFunctions(TestConfig(mapOf(
                         TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
                         TooManyFunctions.THRESHOLD_IN_FILES to "1",
@@ -199,7 +199,7 @@ class TooManyFunctionsSpec : Spek({
                         override fun func1() = Unit
                         override fun func2() = Unit
                     }
-                """.trimIndent()
+                """
 
             it("should not report class with overridden functions, if ignoreOverridden is enabled") {
                 val configuredRule = TooManyFunctions(TestConfig(mapOf(

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
@@ -22,7 +22,7 @@ class EmptyClassBlockSpec : Spek({
                 class SomeClass {
                     // Some comment to explain what this class is supposed to do
                 }
-            """.trimIndent()
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -33,7 +33,7 @@ class EmptyClassBlockSpec : Spek({
                     Some comment to explain what this class is supposed to do
                     */
                 }
-            """.trimIndent()
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyConstructorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyConstructorSpec.kt
@@ -1,3 +1,4 @@
+
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
@@ -17,7 +18,7 @@ class EmptyConstructorSpec : Spek({
 
 			@NeedsConstructor
 			fun annotatedFunction() = Unit
-		""".trimIndent()
+		"""
 
             val findings = EmptyDefaultConstructor(Config.empty).lint(code)
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
@@ -93,7 +93,7 @@ class EmptyFunctionBlockSpec : Spek({
 
                     }
                 }
-            """.trimIndent()
+            """
             it("should not flag overridden functions with commented body") {
                 assertThat(subject.compileAndLint(code))
                     .hasExactlyLocationStrings("'{\n\n    }' at (12,31) in /$fileName")

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
@@ -59,7 +59,7 @@ class ExpressionBodySyntaxSpec : Spek({
                     }
 
                     fun callee(a: String): String = ""
-                """.trimIndent())).isEmpty()
+                """)).isEmpty()
             }
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -19,7 +19,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                     fun b() = 2
                     val c = 2
                 }
-            """.trimIndent())).isEmpty()
+            """)).isEmpty()
         }
 
         val subject by memoized {
@@ -31,13 +31,13 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
             it("should report a top level function") {
                 assertThat(subject.compileAndLint("""
                     fun foo() = 5
-                """.trimIndent())).hasSize(1)
+                """)).hasSize(1)
             }
 
             it("should report a top level property") {
                 assertThat(subject.compileAndLint("""
                     val foo = 5
-                """.trimIndent())).hasSize(1)
+                """)).hasSize(1)
             }
 
             it("should report a public class with public members") {
@@ -46,7 +46,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                         val foo = 5
                         fun bar() = 5
                     }
-                """.trimIndent())).hasSize(2)
+                """)).hasSize(2)
             }
         }
 
@@ -55,19 +55,19 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
             it("should not report a top level function") {
                 assertThat(subject.compileAndLint("""
                     fun foo(): Int = 5
-                """.trimIndent())).isEmpty()
+                """)).isEmpty()
             }
 
             it("should not report a non expression function") {
                 assertThat(subject.compileAndLint("""
                     fun foo() {}
-                """.trimIndent())).isEmpty()
+                """)).isEmpty()
             }
 
             it("should not report a top level property") {
                 assertThat(subject.compileAndLint("""
                     val foo: Int = 5
-                """.trimIndent())).isEmpty()
+                """)).isEmpty()
             }
 
             it("should not report a public class with public members") {
@@ -76,7 +76,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                         val foo: Int = 5
                         fun bar(): Int = 5
                     }
-                """.trimIndent())).isEmpty()
+                """)).isEmpty()
             }
         }
         describe("negative cases with no public scope") {
@@ -86,13 +86,13 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                 assertThat(subject.lint("""
                     internal fun bar() = 5
                     private fun foo() = 5
-                """.trimIndent())).isEmpty()
+                """)).isEmpty()
             }
 
             it("should not report a internal top level property") {
                 assertThat(subject.compileAndLint("""
                     internal val foo = 5
-                """.trimIndent())).isEmpty()
+                """)).isEmpty()
             }
 
             it("should not report members and local variables") {
@@ -104,7 +104,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                             val a = 5
                         }
                     }
-                """.trimIndent())).isEmpty()
+                """)).isEmpty()
             }
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -556,7 +556,7 @@ class MagicNumberSpec : Spek({
 					abstract class A(n: Int)
 
 					object B : A(n = 5)
-				""".trimIndent()
+				"""
                     val rule = MagicNumber(TestConfig(mapOf("ignoreNamedArgument" to "true")))
                     assertThat(rule.lint(code)).isEmpty()
                 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -219,7 +219,7 @@ class ReturnCountSpec : Spek({
 					return@flatMap Flowable.just(it[0])
 				}
     		}
-		""".trimIndent()
+		"""
 
             it("should not count labeled returns from lambda by default") {
                 val findings = ReturnCount().lint(code)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -202,7 +202,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             object TestSerializable : Serializable {
                 private val serialVersionUID = 314159L
             }
-        """.trimIndent())
+        """)
 
         it("should not be reported") {
             val findings = UnderscoresInNumericLiterals().lint(ktFile)
@@ -215,7 +215,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             object TestSerializable {
                 private val serialVersionUID = 314159L
             }
-        """.trimIndent())
+        """)
 
         it("should be reported by default") {
             val findings = UnderscoresInNumericLiterals().lint(ktFile)
@@ -228,7 +228,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             object TestSerializable {
                 private val serialVersionUID = 314_159L
             }
-        """.trimIndent())
+        """)
 
         it("should not be reported") {
             val findings = UnderscoresInNumericLiterals().lint(ktFile)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -116,13 +116,13 @@ class UnnecessaryApplySpec : Spek({
             it("is used within an assignment expr itself") {
                 assertThat(subject.lint("""
                     val content = Intent().apply { putExtra("", 1) }
-                """.trimIndent())).isEmpty()
+                """)).isEmpty()
             }
 
             it("is used as return type of extension function") {
                 assertThat(subject.lint("""
                     fun setColor(color: Int) = apply { initialColor = color }
-                """.trimIndent())).isEmpty()
+                """)).isEmpty()
             }
 
             it("should not flag apply when assigning property on this") {
@@ -130,14 +130,14 @@ class UnnecessaryApplySpec : Spek({
                     private val requestedInterval by lazy {
                         MutableLiveData<Int>().apply { value = UsageFragment.INTERVAL_DAY }
                     }
-                """.trimIndent())).isEmpty()
+                """)).isEmpty()
             }
 
             it("should not report apply when using it after returning something") {
                 assertThat(subject.lint("""
                     inline class Money(var amount: Int)
                     fun returnMe = (Money(5)).apply { amount = 10 }
-                """.trimIndent())).isEmpty()
+                """)).isEmpty()
             }
 
             it("should not report apply usage inside safe chained expressions") {
@@ -148,7 +148,7 @@ class UnnecessaryApplySpec : Spek({
                         ?.apply { if (true) add(4) }
                         ?: listOf(0)
                     }
-                """.trimIndent())).isEmpty()
+                """)).isEmpty()
             }
         }
 
@@ -166,7 +166,7 @@ class UnnecessaryApplySpec : Spek({
                             }
                         }
                     }
-                """.trimIndent())).isEmpty()
+                """)).isEmpty()
             }
 
             it("should report reference expressions") {
@@ -181,7 +181,7 @@ class UnnecessaryApplySpec : Spek({
                             this.propertyAccess
                         }
                     }
-                """.trimIndent())).hasSize(2)
+                """)).hasSize(2)
             }
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -111,7 +111,7 @@ class UnnecessaryParenthesesSpec : Spek({
 				) {
 					constructor() : this({ first, second -> true })
 				}
-			""".trimIndent()
+			"""
             assertThat(subject.lint(code)).hasSize(0)
         }
 
@@ -127,7 +127,7 @@ class UnnecessaryParenthesesSpec : Spek({
 						test({ println(it) }) { println(it) }
 					}
 				}
-			""".trimIndent()
+			"""
             assertThat(subject.lint(code)).hasSize(0)
         }
 
@@ -143,7 +143,7 @@ class UnnecessaryParenthesesSpec : Spek({
 						test({ println(it) }, { println(it) })
 					}
 				}
-			""".trimIndent()
+			"""
             assertThat(subject.lint(code)).hasSize(0)
         }
 
@@ -159,7 +159,7 @@ class UnnecessaryParenthesesSpec : Spek({
 						test("hello", { println(it) }) { println(it) }
 					}
 				}
-			""".trimIndent()
+			"""
             assertThat(subject.lint(code)).hasSize(0)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
@@ -224,7 +224,7 @@ class UnusedImportsSpec : Spek({
 				fun f() : Boolean {
 					return myFoo() == otherFoo()
 				}
-			""".trimIndent()
+			"""
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -249,7 +249,7 @@ class UnusedImportsSpec : Spek({
                 import com.example.MyClass.component543
 
                 val (a, b) = MyClass(1, 2)
-            """.trimIndent()
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -263,7 +263,7 @@ class UnusedImportsSpec : Spek({
                 import com.example.component1AndSomethingElse
 
                 println("Testing")
-            """.trimIndent()
+            """
             )
 
             with(lint) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
@@ -250,7 +250,7 @@ class UnusedPrivateClassSpec : Spek({
             val code = """
 				private class Foo
 				fun bar(clazz: KClass<*>) = Unit
-			""".trimIndent()
+			"""
 
             val findings = UnusedPrivateClass().lint(code)
 
@@ -270,7 +270,7 @@ class UnusedPrivateClassSpec : Spek({
 						B("B"),
 						C("C")
 					}
-				""".trimIndent()
+				"""
 
             val findings = UnusedPrivateClass().lint(code)
 
@@ -294,7 +294,7 @@ class UnusedPrivateClassSpec : Spek({
                         fun getSomeObject(): ((String) -> Any) = ::InternalClass
                         private class InternalClass(val param: String)
 					}
-				""".trimIndent()
+				"""
 
             val findings = UnusedPrivateClass().lint(code)
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -477,7 +477,7 @@ class UnusedPrivateMemberSpec : Spek({
                     }
                 }
                 private fun doSomethingElse() {}
-            """.trimIndent()
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -950,7 +950,7 @@ class UnusedPrivateMemberSpec : Spek({
 						println("b")
 					}
 				}
-			""".trimIndent()
+			"""
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -959,7 +959,7 @@ class UnusedPrivateMemberSpec : Spek({
 				fun main(args: Array<String>) {
 					println("b")
 				}
-			""".trimIndent()
+			"""
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -975,7 +975,7 @@ class UnusedPrivateMemberSpec : Spek({
 						private operator fun Date.plus(diff: Long): Date = Date(this.time + diff)
 					}
 				}
-			""".trimIndent()
+			"""
             assertThat(subject.lint(code)).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
@@ -95,7 +95,7 @@ class UseRequireSpec : Spek({
                         is LinkedList<*> -> 2
                         else -> throw IllegalArgumentException("Not supported List type")
                     }
-                    """.trimIndent()
+                    """
                 assertThat(subject.lint(code)).isEmpty()
             }
 
@@ -109,7 +109,7 @@ class UseRequireSpec : Spek({
                             }
                         }
                         throw IllegalArgumentException("Test was too big")
-                    }""".trimIndent()
+                    }"""
                 assertThat(subject.lint(code)).isEmpty()
             }
 
@@ -119,7 +119,7 @@ class UseRequireSpec : Spek({
                         val subclass = list as? LinkedList
                             ?: throw IllegalArgumentException("List is not a LinkedList")
                         return subclass
-                    }""".trimIndent()
+                    }"""
                 assertThat(subject.lint(code)).isEmpty()
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructorSpec.kt
@@ -49,7 +49,7 @@ class UtilityClassWithPublicConstructorSpec : Spek({
 						const val FEMALE = "female"
 					}
 				}
-			""".trimIndent()
+			"""
                 assertThat(subject.lint(code)).isEmpty()
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -122,7 +122,7 @@ class VarCouldBeValSpec : Spek({
 						var myVar = value
 					}
 				}
-			""".trimIndent()
+			"""
             assertThat(subject.lint(code)).hasSize(2)
         }
 
@@ -134,7 +134,7 @@ class VarCouldBeValSpec : Spek({
 						this.myVar = value
 					}
 				}
-			""".trimIndent()
+			"""
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -147,7 +147,7 @@ class VarCouldBeValSpec : Spek({
 						this.myVar = value
 					}
 				}
-			""".trimIndent()
+			"""
             with(subject.lint(code)[0]) {
                 // we accept wrong entity reporting here due to no symbol solving
                 // false reporting with shadowed vars vs false positives


### PR DESCRIPTION
The .trimIndent() function is called in `BaseRule.lint()` and
`Base.compileAndLint()` anyways. Therefore, there's no need to call
.trimIndent() when creating test snippets.
