### PR TITLE
Remove unnecessary .trimMargin() in tests

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
@@ -21,10 +21,10 @@ internal class InvalidPackageDeclarationSpec : Spek({
 
         it("should pass if package declaration is correct") {
             val source = """
-                |package foo.bar
-                |
-                |class C
-                |""".trimMargin()
+                package foo.bar
+                
+                class C
+                """
             val ktFile = compileContentForTest(source)
             ktFile.setAbsolutePath("project/src/foo/bar/File.kt")
             val findings = InvalidPackageDeclaration().lint(ktFile)
@@ -39,10 +39,10 @@ internal class InvalidPackageDeclarationSpec : Spek({
 
         it("should report if package declaration does not match source location") {
             val source = """
-                |package foo
-                |
-                |class C
-                |""".trimMargin()
+                package foo
+                
+                class C
+                """
             val ktFile = compileContentForTest(source)
             ktFile.setAbsolutePath("project/src/bar/File.kt")
             val findings = InvalidPackageDeclaration().lint(ktFile)
@@ -54,10 +54,10 @@ internal class InvalidPackageDeclarationSpec : Spek({
 
             it("should pass if file is located within the root package") {
                 val source = """
-                |package com.example
-                |
-                |class C
-                |""".trimMargin()
+                    package com.example
+                    
+                    class C
+                    """
                 val ktFile = compileContentForTest(source).apply { setAbsolutePath("src/File.kt") }
                 val findings = InvalidPackageDeclaration(config).lint(ktFile)
                 assertThat(findings).isEmpty()
@@ -65,10 +65,10 @@ internal class InvalidPackageDeclarationSpec : Spek({
 
             it("should pass if file is located relative to root package") {
                 val source = """
-                |package com.example.foo.bar
-                |
-                |class C
-                |""".trimMargin()
+                    package com.example.foo.bar
+                    
+                    class C
+                    """
                 val ktFile = compileContentForTest(source)
                 ktFile.setAbsolutePath("src/foo/bar/File.kt")
                 val findings = InvalidPackageDeclaration(config).lint(ktFile)
@@ -77,10 +77,10 @@ internal class InvalidPackageDeclarationSpec : Spek({
 
             it("should pass if file is located in directory corresponding to package declaration") {
                 val source = """
-                |package com.example.foo.bar
-                |
-                |class C
-                |""".trimMargin()
+                    package com.example.foo.bar
+                    
+                    class C
+                    """
                 val ktFile = compileContentForTest(source)
                 ktFile.setAbsolutePath("src/com/example/foo/bar/File.kt")
                 val findings = InvalidPackageDeclaration(config).lint(ktFile)
@@ -89,10 +89,10 @@ internal class InvalidPackageDeclarationSpec : Spek({
 
             it("should report if package declaration does not match") {
                 val source = """
-                |package com.example.foo.baz
-                |
-                |class C
-                |""".trimMargin()
+                    package com.example.foo.baz
+                    
+                    class C
+                    """
                 val ktFile = compileContentForTest(source)
                 ktFile.setAbsolutePath("src/foo/bar/File.kt")
                 val findings = InvalidPackageDeclaration(config).lint(ktFile)
@@ -100,10 +100,10 @@ internal class InvalidPackageDeclarationSpec : Spek({
             }
             it("should report if file path matches root package but package declaration differs") {
                 val source = """
-                |package io.foo.bar
-                |
-                |class C
-                |""".trimMargin()
+                    package io.foo.bar
+                    
+                    class C
+                    """
                 val ktFile = compileContentForTest(source)
                 ktFile.setAbsolutePath("src/com/example/File.kt")
                 val findings = InvalidPackageDeclaration(config).lint(ktFile)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -290,11 +290,11 @@ class MagicNumberSpec : Spek({
 			fun test(x: Int) {
 				val i = 5
 			}
-		""".trimMargin())
+		""")
 
             it("should be reported") {
                 val findings = MagicNumber().lint(ktFile)
-                assertThat(findings).hasLocationStrings("'5' at (2,13) in /$fileName")
+                assertThat(findings).hasSize(1)
             }
         }
 
@@ -303,7 +303,7 @@ class MagicNumberSpec : Spek({
 			fun test() : Boolean {
 				return true;
 			}
-		""".trimMargin())
+		""")
 
             it("should not be reported") {
                 val findings = MagicNumber().lint(ktFile)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
@@ -203,7 +203,7 @@ class MayBeConstSpec : Spek({
 				class Test {
 					@JvmField val a = 3
 				}
-			""".trimMargin()
+			"""
                 subject.lint(code)
                 assertThat(subject.findings).isEmpty()
             }
@@ -213,7 +213,7 @@ class MayBeConstSpec : Spek({
 				annotation class A
 
 				@A val a = 55
-			""".trimMargin()
+			"""
                 subject.lint(code)
                 assertThat(subject.findings).isEmpty()
             }
@@ -227,7 +227,7 @@ class MayBeConstSpec : Spek({
 				object Derived : Base {
 					override val property = 1
 				}
-			""".trimMargin()
+			"""
                 subject.lint(code)
                 assertThat(subject.findings).isEmpty()
             }


### PR DESCRIPTION
* Removes the '|' at the start of each quoted line.
* Removes .trimMargin() where no report messages are checked
* Succeeding #1850
