### PR TITLE
Silence report if containing no findings

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/FindingsReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/FindingsReport.kt
@@ -8,27 +8,32 @@ class FindingsReport : ConsoleReport() {
     override val priority: Int = 40
 
     override fun render(detektion: Detektion): String? {
+        val findings = detektion
+            .findings
+            .filter { it.value.isNotEmpty() }
+        if (findings.isEmpty()) {
+            return null
+        }
+
         val totalDebt = DebtSumming()
         return with(StringBuilder()) {
-            detektion.findings
-                .filter { it.value.isNotEmpty() }
-                .forEach { (ruleSetId, issues) ->
-                    val debtSumming = DebtSumming()
-                    val issuesString = issues.joinToString("") {
-                        debtSumming.add(it.issue.debt)
-                        it.compact().format("\t")
-                    }
-                    val debt = debtSumming.calculateDebt()
-                    val debtString =
-                        if (debt != null) {
-                            totalDebt.add(debt)
-                            " - $debt debt".format()
-                        } else {
-                            "\n"
-                        }
-                    append(ruleSetId.format(prefix = "Ruleset: ", suffix = debtString))
-                    append(issuesString.yellow())
+            findings.forEach { (ruleSetId, issues) ->
+                val debtSumming = DebtSumming()
+                val issuesString = issues.joinToString("") {
+                    debtSumming.add(it.issue.debt)
+                    it.compact().format("\t")
                 }
+                val debt = debtSumming.calculateDebt()
+                val debtString =
+                    if (debt != null) {
+                        totalDebt.add(debt)
+                        " - $debt debt".format()
+                    } else {
+                        "\n"
+                    }
+                append(ruleSetId.format(prefix = "Ruleset: ", suffix = debtString))
+                append(issuesString.yellow())
+            }
             val debt = totalDebt.calculateDebt()
             if (debt != null) {
                 append("Overall debt: $debt".format("\n"))

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/FindingsReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/FindingsReportSpec.kt
@@ -37,7 +37,15 @@ class FindingsReportSpec : Spek({
 
         it("reports no findings") {
             val detektion = TestDetektion()
-            assertThat(subject.render(detektion)).isEmpty()
+            assertThat(subject.render(detektion)).isNull()
+        }
+
+        it("reports no findings with rule set containing no smells") {
+            val detektion = object : TestDetektion() {
+                override val findings: Map<String, List<Finding>> = mapOf(
+                    Pair("EmptySmells", emptyList()))
+            }
+            assertThat(subject.render(detektion)).isNull()
         }
     }
 })


### PR DESCRIPTION
The `FindingsReport` should not produce any output if there are no
code smells at all.
This fixes #1854
