### PR TITLE
Silence report if containing no notifications

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/NotificationReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/NotificationReport.kt
@@ -9,6 +9,10 @@ class NotificationReport : ConsoleReport() {
     // This allows to compute intermediate messages based on detekt results and do not rely on 'println'.
     override val priority: Int = Int.MIN_VALUE + 1
 
-    override fun render(detektion: Detektion): String? =
-        detektion.notifications.joinToString("\n") { it.message }
+    override fun render(detektion: Detektion): String? {
+        if (detektion.notifications.isEmpty()) {
+            return null
+        }
+        return detektion.notifications.joinToString("\n") { it.message }
+    }
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/NotificationReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/NotificationReportSpec.kt
@@ -21,5 +21,10 @@ class NotificationReportSpec : Spek({
             }
             assertThat(subject.render(detektion)).isEqualTo("File $path was modified.\nFile $path was modified.")
         }
+
+        it("reports no findings") {
+            val detektion = TestDetektion()
+            assertThat(subject.render(detektion)).isNull()
+        }
     }
 })


### PR DESCRIPTION
The `NotificationsReport` should not produce any output if there are no
notifications.
This is related to #1854