### PR TITLE
Loosen Codecov notification criteria

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,6 @@
 codecov:
   ci:
     - !appveyor
+  notify:
+    require_ci_to_pass: no
+    after_n_builds: 4


### PR DESCRIPTION
Sometimes CI is flaky due to factors outside the project's control. This config should allow reports to be generated if CI doesn't pass but at least 4 reports are generated, which ensures all of either OS X or Linux builds pass and at least one from the other. This gives confidence that "enough" builds have succeeded and coverage can be trusted.

The problems with Codecov may be caused by CI failing on master more than it should. Reports aren't generated when CI fails so this causes cascading issues. Hopefully this will address that.

See #1754