### PR TITLE
Don't build twice when PR created from branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+    - master
 language: java
 matrix:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,10 @@
 version: '{build}'
 
 skip_tags: true
-
 skip_commits:
   message: /\[ci skip\]/
+skip_branch_with_pr: true
+
 clone_depth: 10
 
 environment:


### PR DESCRIPTION
This speeds build time when a PR is created from a branch in the detekt repo.

Currently both Travis and AppVeyor run CI checks on the branch which has commits pushed to it as well as the PR that is created from that branch.

This config changes that for both Travis and AppVeyor so CI should only run on master branch and any submitted PRs, but not on other branches in detekt repo. This saves time in CI.