### PR TITLE
Check for actual usage of java.lang.Void in ForbiddenVoid rule

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoid.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoid.kt
@@ -45,6 +45,7 @@ class ForbiddenVoid(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
+    @Suppress("ReturnCount")
     override fun visitTypeReference(typeReference: KtTypeReference) {
         if (bindingContext == BindingContext.EMPTY) return
         val kotlinType = typeReference.getAbbreviatedTypeOrType(bindingContext) ?: return

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoid.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoid.kt
@@ -9,13 +9,14 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import io.gitlab.arturbosch.detekt.rules.parentOfType
-import org.jetbrains.kotlin.psi.KtClassLiteralExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameter
-import org.jetbrains.kotlin.psi.KtSimpleNameExpression
 import org.jetbrains.kotlin.psi.KtTypeArgumentList
+import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
-import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.bindingContextUtil.getAbbreviatedTypeOrType
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 
 /**
  * This rule detects usages of `Void` and reports them as forbidden.
@@ -44,44 +45,42 @@ class ForbiddenVoid(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    override fun visitSimpleNameExpression(expression: KtSimpleNameExpression) {
-        if (expression.isReferencingVoid()) {
-            if (ruleSetConfig.valueOrDefault(IGNORE_OVERRIDDEN, false) && expression.isPartOfOverriddenSignature()) {
+    override fun visitTypeReference(typeReference: KtTypeReference) {
+        if (bindingContext == BindingContext.EMPTY) return
+        val kotlinType = typeReference.getAbbreviatedTypeOrType(bindingContext) ?: return
+
+        if (kotlinType.constructor.declarationDescriptor?.fqNameOrNull()?.asString() == VOID_CLASS_NAME) {
+            if (ruleSetConfig.valueOrDefault(IGNORE_OVERRIDDEN, false) && typeReference.isPartOfOverriddenSignature()) {
                 return
             }
-            if (ruleSetConfig.valueOrDefault(IGNORE_USAGE_IN_GENERICS, false) && expression.isGenericArgument()) {
+            if (ruleSetConfig.valueOrDefault(IGNORE_USAGE_IN_GENERICS, false) && typeReference.isGenericArgument()) {
                 return
             }
-            report(CodeSmell(issue, Entity.from(expression), message = "'Void' should be replaced with 'Unit'."))
+            report(CodeSmell(issue, Entity.from(typeReference), message = "'Void' should be replaced with 'Unit'."))
         }
 
-        super.visitSimpleNameExpression(expression)
+        super.visitTypeReference(typeReference)
     }
 
-    private fun KtSimpleNameExpression.isReferencingVoid() =
-        getReferencedName() == Void::class.java.simpleName && !isClassLiteral
-
-    private val KtSimpleNameExpression.isClassLiteral: Boolean
-        get() = getStrictParentOfType<KtClassLiteralExpression>() != null
-
-    private fun KtSimpleNameExpression.isPartOfOverriddenSignature() =
+    private fun KtTypeReference.isPartOfOverriddenSignature() =
         (isPartOfReturnTypeOfFunction() || isParameterTypeOfFunction()) &&
                 parentOfType<KtNamedFunction>()?.isOverride() == true
 
-    private fun KtSimpleNameExpression.isPartOfReturnTypeOfFunction() =
+    private fun KtTypeReference.isPartOfReturnTypeOfFunction() =
         parentOfType<KtNamedFunction>()
             ?.typeReference
-            ?.collectDescendantsOfType<KtSimpleNameExpression>()
+            ?.collectDescendantsOfType<KtTypeReference>()
             ?.any { it == this } ?: false
 
-    private fun KtSimpleNameExpression.isParameterTypeOfFunction() =
+    private fun KtTypeReference.isParameterTypeOfFunction() =
         parentOfType<KtParameter>() != null
 
-    private fun KtSimpleNameExpression.isGenericArgument() =
+    private fun KtTypeReference.isGenericArgument() =
         parentOfType<KtTypeArgumentList>() != null
 
     companion object {
         const val IGNORE_OVERRIDDEN = "ignoreOverridden"
         const val IGNORE_USAGE_IN_GENERICS = "ignoreUsageInGenerics"
+        const val VOID_CLASS_NAME = "java.lang.Void"
     }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
@@ -1,16 +1,24 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class ForbiddenVoidSpec : Spek({
     val subject by memoized { ForbiddenVoid(Config.empty) }
 
+    lateinit var environment: KotlinCoreEnvironment
+
     describe("ForbiddenVoid rule") {
+        beforeEachTest {
+            environment = KtTestCompiler.createEnvironment()
+        }
         it("should report all Void type usage") {
             val code = """
                 lateinit var c: () -> Void
@@ -21,7 +29,7 @@ class ForbiddenVoidSpec : Spek({
                 }
             """
 
-            assertThat(subject.compileAndLint(code)).hasSize(4)
+            assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(4)
         }
 
         it("should not report Void class literal") {
@@ -48,7 +56,7 @@ class ForbiddenVoidSpec : Spek({
                 }
 			"""
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(environment, code)).isEmpty()
         }
 
         describe("ignoreOverridden is enabled") {
@@ -68,11 +76,11 @@ class ForbiddenVoidSpec : Spek({
                     }
                 """
 
-                val findings = ForbiddenVoid(config).compileAndLint(code)
+                val findings = ForbiddenVoid(config).compileAndLintWithContext(environment, code)
                 assertThat(findings).isEmpty()
             }
 
-            it("should not report Void in overriding function declarations with parametrized types") {
+            it("should not report Void in overriding function declarations with parameterized types") {
                 val code = """
                     class Foo<T> {}
 
@@ -88,7 +96,7 @@ class ForbiddenVoidSpec : Spek({
                     }
                 """
 
-                val findings = ForbiddenVoid(config).compileAndLint(code)
+                val findings = ForbiddenVoid(config).compileAndLintWithContext(environment, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -105,7 +113,7 @@ class ForbiddenVoidSpec : Spek({
                     }
                 """
 
-                val findings = ForbiddenVoid(config).compileAndLint(code)
+                val findings = ForbiddenVoid(config).compileAndLintWithContext(environment, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -116,7 +124,7 @@ class ForbiddenVoidSpec : Spek({
                     }
                 """
 
-                val findings = ForbiddenVoid(config).compileAndLint(code)
+                val findings = ForbiddenVoid(config).compileAndLintWithContext(environment, code)
                 assertThat(findings).hasSize(2)
             }
         }
@@ -140,7 +148,7 @@ class ForbiddenVoidSpec : Spek({
                     class D : A<Void>
                 """
 
-                val findings = ForbiddenVoid(config).compileAndLint(code)
+                val findings = ForbiddenVoid(config).compileAndLintWithContext(environment, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -151,7 +159,7 @@ class ForbiddenVoidSpec : Spek({
                     class C : A<B<Void>>
                 """
 
-                val findings = ForbiddenVoid(config).compileAndLint(code)
+                val findings = ForbiddenVoid(config).compileAndLintWithContext(environment, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -160,7 +168,7 @@ class ForbiddenVoidSpec : Spek({
                     val foo = mutableMapOf<Int, Void>()
                 """
 
-                val findings = ForbiddenVoid(config).compileAndLint(code)
+                val findings = ForbiddenVoid(config).compileAndLintWithContext(environment, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -174,7 +182,7 @@ class ForbiddenVoidSpec : Spek({
                     }
                 """
 
-                assertThat(subject.compileAndLint(code)).hasSize(4)
+                assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(4)
             }
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
@@ -37,9 +37,14 @@ class ForbiddenVoidSpec : Spek({
             val code = """
 				class Void {
                     fun void() {}
+                    val void = "string"
                 }
                 enum class E {
                     Void;
+                }
+                abstract class Test {
+                    fun myFun2(): E = E.Void
+                    abstract fun myFun(): Void
                 }
 			"""
 


### PR DESCRIPTION
Rule now requires type resolution, but should not trigger false positives anymore.

Fixes #1642 