### PR TITLE
Dispose KotlinScriptEngine to mitigate OOM errors

### DIFF
--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEngine.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEngine.kt
@@ -11,13 +11,12 @@ object KotlinScriptEngine {
      * Compiles a given code string with the Jsr223 script engine.
      * If a compilation error occurs the script engine is recovered.
      * Afterwards this method throws a [KotlinScriptException].
-     *
-     * @param code the String to compile
-     * @throws ScriptException
      */
     fun compile(code: String) {
         try {
-            KotlinScriptEnginePool.getEngine().compile(code)
+            val engine = KotlinScriptEnginePool.getEngine()
+            engine.compile(code)
+            engine.state.dispose()
         } catch (e: ScriptException) {
             KotlinScriptEnginePool.recoverEngine()
             throw KotlinScriptException(e)


### PR DESCRIPTION
This commit tries to mitigate OOM (java.lang.OutOfMemoryError) errors.
There is code that utilizes the capacity of the Jsr223 compile engine.
Hence, the engine now disposes state memory after each compilation step.