### PR TITLE
Dispose KotlinCoreEnvironment to mitigate OOM errors

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
@@ -4,6 +4,8 @@ import io.gitlab.arturbosch.detekt.test.KtTestCompiler
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.com.intellij.openapi.Disposable
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -11,10 +13,13 @@ object MissingWhenCaseSpec : Spek({
 
     val subject by memoized { MissingWhenCase() }
 
-    lateinit var environment: KotlinCoreEnvironment
+    var environment: KotlinCoreEnvironment? = null
+    lateinit var disposable: Disposable
 
     beforeEachTest {
-        environment = KtTestCompiler.createEnvironment()
+        val pair = KtTestCompiler.createEnvironment()
+        disposable = pair.first
+        environment = pair.second
     }
 
     describe("MissingWhenCase rule") {
@@ -34,7 +39,7 @@ object MissingWhenCaseSpec : Spek({
                     }
                 }
                 """
-                val actual = subject.compileAndLintWithContext(environment, code)
+                val actual = subject.compileAndLintWithContext(environment!!, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
                 assertThat(actual.first().message).isEqualTo("When expression is missing cases: RED. Either add missing cases or a default `else` case.")
@@ -63,7 +68,7 @@ object MissingWhenCaseSpec : Spek({
                     }
                 }
                 """
-                assertThat(subject.compileAndLintWithContext(environment, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(environment!!, code)).isEmpty()
             }
         }
         context("sealed classes") {
@@ -82,7 +87,7 @@ object MissingWhenCaseSpec : Spek({
                         }
                     }
                 """
-                val actual = subject.compileAndLintWithContext(environment, code)
+                val actual = subject.compileAndLintWithContext(environment!!, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
                 assertThat(actual.first().message).isEqualTo("When expression is missing cases: VariantC. Either add missing cases or a default `else` case.")
@@ -112,7 +117,7 @@ object MissingWhenCaseSpec : Spek({
                         }
                     }
                 """
-                assertThat(subject.compileAndLintWithContext(environment, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(environment!!, code)).isEmpty()
             }
         }
         context("standard when") {
@@ -150,8 +155,13 @@ object MissingWhenCaseSpec : Spek({
                         }
                     }
                 """
-                assertThat(subject.compileAndLintWithContext(environment, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(environment!!, code)).isEmpty()
             }
         }
+    }
+
+    afterEachTest {
+        Disposer.dispose(disposable)
+        environment = null
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhenSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhenSpec.kt
@@ -4,6 +4,8 @@ import io.gitlab.arturbosch.detekt.test.KtTestCompiler
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.com.intellij.openapi.Disposable
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -11,10 +13,13 @@ object RedundantElseInWhenSpec : Spek({
 
     val subject by memoized { RedundantElseInWhen() }
 
-    lateinit var environment: KotlinCoreEnvironment
+    var environment: KotlinCoreEnvironment? = null
+    lateinit var disposable: Disposable
 
     beforeEachTest {
-        environment = KtTestCompiler.createEnvironment()
+        val pair = KtTestCompiler.createEnvironment()
+        disposable = pair.first
+        environment = pair.second
     }
 
     describe("RedundantElseInWhen rule") {
@@ -36,7 +41,7 @@ object RedundantElseInWhenSpec : Spek({
                     }
                 }
                 """
-                val actual = subject.compileAndLintWithContext(environment, code)
+                val actual = subject.compileAndLintWithContext(environment!!, code)
                 assertThat(actual).hasSize(1)
             }
 
@@ -57,7 +62,7 @@ object RedundantElseInWhenSpec : Spek({
                     }
                 }
                 """
-                val actual = subject.compileAndLintWithContext(environment, code)
+                val actual = subject.compileAndLintWithContext(environment!!, code)
                 assertThat(actual).hasSize(1)
             }
 
@@ -83,7 +88,7 @@ object RedundantElseInWhenSpec : Spek({
                     }
                 }
                 """
-                assertThat(subject.compileAndLintWithContext(environment, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(environment!!, code)).isEmpty()
             }
 
             it("does not report when `when` expression does not contain else case") {
@@ -115,7 +120,7 @@ object RedundantElseInWhenSpec : Spek({
                     }
                 }
                 """
-                assertThat(subject.compileAndLintWithContext(environment, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(environment!!, code)).isEmpty()
             }
         }
         context("sealed classes") {
@@ -136,7 +141,7 @@ object RedundantElseInWhenSpec : Spek({
                         }
                     }
                 """
-                val actual = subject.compileAndLintWithContext(environment, code)
+                val actual = subject.compileAndLintWithContext(environment!!, code)
                 assertThat(actual).hasSize(1)
             }
 
@@ -157,7 +162,7 @@ object RedundantElseInWhenSpec : Spek({
                         }
                     }
                 """
-                val actual = subject.compileAndLintWithContext(environment, code)
+                val actual = subject.compileAndLintWithContext(environment!!, code)
                 assertThat(actual).hasSize(1)
             }
 
@@ -183,7 +188,7 @@ object RedundantElseInWhenSpec : Spek({
                         }
                     }
                 """
-                assertThat(subject.compileAndLintWithContext(environment, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(environment!!, code)).isEmpty()
             }
             it("does not report when `when` expression does not contain else case") {
                 val code = """
@@ -200,7 +205,7 @@ object RedundantElseInWhenSpec : Spek({
                         }
                     }
                 """
-                assertThat(subject.compileAndLintWithContext(environment, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(environment!!, code)).isEmpty()
             }
         }
         context("standard when") {
@@ -238,8 +243,13 @@ object RedundantElseInWhenSpec : Spek({
                         }
                     }
                 """
-                assertThat(subject.compileAndLintWithContext(environment, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(environment!!, code)).isEmpty()
             }
         }
+    }
+
+    afterEachTest {
+        Disposer.dispose(disposable)
+        environment = null
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
@@ -4,6 +4,8 @@ import io.gitlab.arturbosch.detekt.test.KtTestCompiler
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.com.intellij.openapi.Disposable
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -11,57 +13,60 @@ object UselessCallOnNotNullSpec : Spek({
 
     val subject by memoized { UselessCallOnNotNull() }
 
-    lateinit var environment: KotlinCoreEnvironment
+    var environment: KotlinCoreEnvironment? = null
+    lateinit var disposable: Disposable
 
     beforeEachTest {
-        environment = KtTestCompiler.createEnvironment()
+        val pair = KtTestCompiler.createEnvironment()
+        disposable = pair.first
+        environment = pair.second
     }
 
     describe("UselessCallOnNotNull rule") {
         it("reports when calling orEmpty on a list") {
             val code = """val testList = listOf("string").orEmpty()"""
-            assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(environment!!, code)).hasSize(1)
         }
 
         it("reports when calling orEmpty on a nullable list") {
             val code = """val testList = listOf("string")?.orEmpty()"""
-            assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(environment!!, code)).hasSize(1)
         }
 
         it("reports when calling orEmpty in a chain") {
             val code = """val testList = listOf("string").orEmpty().map { }"""
-            assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(environment!!, code)).hasSize(1)
         }
 
         it("reports when calling isNullOrBlank on a nullable type") {
             val code = """val testString = ""?.isNullOrBlank()"""
-            assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(environment!!, code)).hasSize(1)
         }
 
         it("reports when calling isNullOrEmpty on a nullable type") {
             val code = """val testString = ""?.isNullOrEmpty()"""
-            assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(environment!!, code)).hasSize(1)
         }
 
         it("reports when calling isNullOrEmpty on a string") {
             val code = """val testString = "".isNullOrEmpty()"""
-            assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(environment!!, code)).hasSize(1)
         }
 
         it("reports when calling orEmpty on a string") {
             val code = """val testString = "".orEmpty()"""
-            assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(environment!!, code)).hasSize(1)
         }
 
         it("reports when calling orEmpty on a sequence") {
             val code = """val testSequence = listOf(1).asSequence().orEmpty()"""
-            assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(environment!!, code)).hasSize(1)
         }
 
         it("reports when calling orEmpty on a list with a platform type") {
             // System.getenv().keys.toList() will be of type List<String!>.
             val code = """val testSequence = System.getenv().keys.toList().orEmpty()"""
-            assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(environment!!, code)).hasSize(1)
         }
 
         it("only reports on a Kotlin list") {
@@ -71,7 +76,12 @@ object UselessCallOnNotNullSpec : Spek({
                 val noList = "str".orEmpty()
                 val list = listOf(1, 2, 3).orEmpty()
             """
-            assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(environment!!, code)).hasSize(1)
         }
+    }
+
+    afterEachTest {
+        Disposer.dispose(disposable)
+        environment = null
     }
 })


### PR DESCRIPTION
This mitigates OOM (java.lang.OutOfMemoryError) errors.
This PR disposes the KotlinCoreEnvironment and the associated objects.
These are disposed after each test that needs type and symbol solving.

```Kotlin
// Tests are supposed to create a single project and dispose it right after use
fun createForTests()
```
**Reference**
https://github.com/JetBrains/kotlin/blob/99972a08a1324b971624bf88ae3da138dc7e10d7/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt#L461