### PR TITLE
Make all Gradle tasks cacheable

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -58,29 +58,29 @@ open class Detekt : SourceTask(), VerificationTask {
         get() = source
         set(value) = setSource(value)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     @Deprecated("Replace with setIncludes/setExcludes")
     var filters: Property<String> = project.objects.property(String::class.java)
 
-    @Classpath
+    @get:Classpath
     val detektClasspath = project.configurableFileCollection()
 
-    @Classpath
+    @get:Classpath
     val pluginClasspath = project.configurableFileCollection()
 
-    @InputFile
-    @Optional
-    @PathSensitive(PathSensitivity.RELATIVE)
+    @get:InputFile
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     var baseline: RegularFileProperty = project.fileProperty()
 
-    @InputFiles
-    @Optional
-    @PathSensitive(PathSensitivity.RELATIVE)
+    @get:InputFiles
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     var config: ConfigurableFileCollection = project.configurableFileCollection()
 
-    @Classpath
-    @Optional
+    @get:Classpath
+    @get:Optional
     val classpath = project.configurableFileCollection()
 
     @get:Input
@@ -99,8 +99,8 @@ open class Detekt : SourceTask(), VerificationTask {
         get() = jvmTargetProp.get()
         set(value) = jvmTargetProp.set(value)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     @Deprecated(
         "Set plugins using the detektPlugins configuration " +
                 "(see https://arturbosch.github.io/detekt/extensions.html#let-detekt-know-about-your-extensions)"
@@ -121,27 +121,24 @@ open class Detekt : SourceTask(), VerificationTask {
         get() = parallelProp.get()
         set(value) = parallelProp.set(value)
 
-    @get:Optional
-    @get:Input
+    @get:Internal
     internal val disableDefaultRuleSetsProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var disableDefaultRuleSets: Boolean
-        @Internal
+        @Input
         get() = disableDefaultRuleSetsProp.get()
         set(value) = disableDefaultRuleSetsProp.set(value)
 
-    @get:Optional
-    @get:Input
+    @get:Internal
     internal val buildUponDefaultConfigProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var buildUponDefaultConfig: Boolean
-        @Internal
+        @Input
         get() = buildUponDefaultConfigProp.get()
         set(value) = buildUponDefaultConfigProp.set(value)
 
-    @get:Optional
-    @get:Input
+    @get:Internal
     internal val failFastProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var failFast: Boolean
-        @Internal
+        @Input
         get() = failFastProp.get()
         set(value) = failFastProp.set(value)
 
@@ -151,20 +148,19 @@ open class Detekt : SourceTask(), VerificationTask {
     override fun getIgnoreFailures(): Boolean = ignoreFailuresProp.getOrElse(false)
     override fun setIgnoreFailures(value: Boolean) = ignoreFailuresProp.set(value)
 
-    @get:Optional
-    @get:Input
+    @get:Internal
     internal val autoCorrectProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var autoCorrect: Boolean
-        @Internal
+        @Input
         get() = autoCorrectProp.get()
         set(value) = autoCorrectProp.set(value)
 
-    @Internal
+    @get:Internal
     var reports = DetektReports(project)
 
     fun reports(configure: Action<DetektReports>) = configure.execute(reports)
 
-    @Internal
+    @get:Internal
     var reportsDir: Property<File> = project.objects.property(File::class.java)
 
     val xmlReportFile: Provider<RegularFile>

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -19,6 +19,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Console
 import org.gradle.api.tasks.Input
@@ -32,6 +33,7 @@ import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 
+@CacheableTask
 open class DetektCreateBaselineTask : SourceTask() {
 
     init {
@@ -39,7 +41,7 @@ open class DetektCreateBaselineTask : SourceTask() {
         group = LifecycleBasePlugin.VERIFICATION_GROUP
     }
 
-    @OutputFile
+    @get:OutputFile
     var baseline: RegularFileProperty = project.fileProperty()
 
     @Deprecated("Replace with getSource/setSource")
@@ -48,51 +50,54 @@ open class DetektCreateBaselineTask : SourceTask() {
         get() = source
         set(value) = setSource(value)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     @Deprecated("Replace with setIncludes/setExcludes")
     var filters: Property<String> = project.objects.property(String::class.java)
 
-    @InputFiles
-    @Optional
+    @get:InputFiles
+    @get:Optional
     @PathSensitive(PathSensitivity.RELATIVE)
     var config: ConfigurableFileCollection = project.configurableFileCollection()
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     @Deprecated(
         "Set plugins using the detektPlugins configuration " +
                 "(see https://arturbosch.github.io/detekt/extensions.html#let-detekt-know-about-your-extensions)"
     )
     var plugins: Property<String> = project.objects.property(String::class.java)
 
-    @Classpath
+    @get:Classpath
     val detektClasspath = project.configurableFileCollection()
 
-    @Classpath
+    @get:Classpath
     val pluginClasspath = project.configurableFileCollection()
 
-    @Console
+    @get:Console
     var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
-    @Internal
+    @get:Internal
     var parallel: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
-    @Internal
+    @get:Input
+    @get:Optional
     var disableDefaultRuleSets: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
-    @Internal
+    @get:Input
+    @get:Optional
     var buildUponDefaultConfig: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
-    @Internal
+    @get:Input
+    @get:Optional
     var failFast: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val ignoreFailures: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
-    @Input
-    @Optional
+    @get:Input
+    @get:Optional
     val autoCorrect: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @TaskAction

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -8,12 +8,14 @@ import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.GenerateConfigArgument
 import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 
+@CacheableTask
 open class DetektGenerateConfigTask : SourceTask() {
 
     init {
@@ -21,13 +23,15 @@ open class DetektGenerateConfigTask : SourceTask() {
         group = LifecycleBasePlugin.VERIFICATION_GROUP
     }
 
+    // When this deprecated property is removed, also stop extending SourceTask as this task does not need any file
+    // input.
     @Deprecated("Replace with getSource/setSource")
     var input: FileCollection
         @Internal
         get() = source
         set(value) = setSource(value)
 
-    @Classpath
+    @get:Classpath
     val detektClasspath = project.configurableFileCollection()
 
     @TaskAction

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaFormatTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaFormatTask.kt
@@ -4,12 +4,15 @@ import io.gitlab.arturbosch.detekt.extensions.IdeaExtension
 import io.gitlab.arturbosch.detekt.invoke.ProcessExecutor.startProcess
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Console
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 
+@CacheableTask
 open class DetektIdeaFormatTask : SourceTask() {
 
     init {
@@ -23,10 +26,10 @@ open class DetektIdeaFormatTask : SourceTask() {
         get() = source
         set(value) = setSource(value)
 
-    @Console
+    @get:Console
     var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
-    @Internal
+    @get:Nested
     lateinit var ideaExtension: IdeaExtension
 
     @TaskAction

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaInspectionTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaInspectionTask.kt
@@ -4,12 +4,15 @@ import io.gitlab.arturbosch.detekt.extensions.IdeaExtension
 import io.gitlab.arturbosch.detekt.invoke.ProcessExecutor.startProcess
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Console
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 
+@CacheableTask
 open class DetektIdeaInspectionTask : SourceTask() {
 
     init {
@@ -23,10 +26,10 @@ open class DetektIdeaInspectionTask : SourceTask() {
         get() = source
         set(value) = setSource(value)
 
-    @Console
+    @get:Console
     var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
-    @Internal
+    @get:Nested
     lateinit var ideaExtension: IdeaExtension
 
     @TaskAction

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/IdeaExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/IdeaExtension.kt
@@ -1,12 +1,30 @@
 package io.gitlab.arturbosch.detekt.extensions
 
-open class IdeaExtension(
-    open var path: String? = null,
-    open var codeStyleScheme: String? = null,
-    open var inspectionsProfile: String? = null,
-    open var report: String? = null,
-    open var mask: String = "*.kt"
-) {
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+
+open class IdeaExtension {
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    var path: String? = null
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    var codeStyleScheme: String? = null
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    var inspectionsProfile: String? = null
+
+    @get:OutputDirectory
+    var report: String? = null
+
+    @get:Input
+    var mask: String = "*.kt"
 
     fun formatArgs(input: String): Array<String> {
         require(path != null) { IDEA_PATH_ERROR }


### PR DESCRIPTION
Update annotations on tasks that were not cacheable to make them cacheable.

Using `@get:` on annotations is the style used in Gradle guides, and may in fact be required to get accurate results from `validateTaskProperties` task, so have updated existing annotations to use the `get` use-site target.

Also tweaked a couple of annotations in the Detekt task so they're correctly set on the internal & public parameters.

Fixes #1856 