### PR TITLE
Replace tabs with spaces in rule KDoc

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
@@ -36,13 +36,13 @@ import org.jetbrains.kotlin.psi.KtTypeReference
  *
  * @configuration exceptionNames - exceptions which are too generic and should not be caught
  * (default: `- ArrayIndexOutOfBoundsException
- *			 - Error
- *			 - Exception
- *			 - IllegalMonitorStateException
- *			 - NullPointerException
- *			 - IndexOutOfBoundsException
- *			 - RuntimeException
- *			 - Throwable`)
+ *            - Error
+ *            - Exception
+ *            - IllegalMonitorStateException
+ *            - NullPointerException
+ *            - IndexOutOfBoundsException
+ *            - RuntimeException
+ *            - Throwable`)
  * @configuration allowedExceptionNameRegex - ignores too generic exception types which match this regex
  * (default: `"^(_|(ignore|expected).*)"`)
  * @active since v1.0.0

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
@@ -34,9 +34,9 @@ import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
  *
  * @configuration exceptionNames - exceptions which are too generic and should not be thrown
  * (default: `- Error
- * 			 - Exception
- *			 - Throwable
- * 			 - RuntimeException`)
+ *            - Exception
+ *            - Throwable
+ *            - RuntimeException`)
  *
  * @active since v1.0.0
  */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLine.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLine.kt
@@ -17,17 +17,17 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
  *
  * <noncompliant>
  * fun stuff(): Int
- * 		= 5
+ *     = 5
  *
  * fun <V> foo(): Int where V : Int
- * 		= 5
+ *     = 5
  * </noncompliant>
  *
  * <compliant>
  * fun stuff() = 5
  *
  * fun stuff() =
- * 		foo.bar()
+ *     foo.bar()
  *
  * fun <V> foo(): Int where V : Int = 5
  * </compliant>

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
  * a?.let { it -> it.plus(1) }
  * foo.flatMapObservable { it -> Observable.fromIterable(it) }
  * listOfPairs.map(::second).forEach { it ->
- * 		it.execute()
+ *     it.execute()
  * }
  * collection.zipWithNext { it, next -> Pair(it, next) }
  * </noncompliant>
@@ -29,11 +29,15 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
  * <compliant>
  * a?.let { it.plus(1) } // Much better to use implicit it
  * foo.flatMapObservable(Observable::fromIterable) // Here we can have a method reference
- * listOfPairs.map(::second).forEach { apiRequest -> // For multiline blocks it is usually better come up with a clear and more meaningful name
- * 		apiRequest.execute()
+ *
+ * // For multiline blocks it is usually better come up with a clear and more meaningful name
+ * listOfPairs.map(::second).forEach { apiRequest ->
+ *     apiRequest.execute()
  * }
- * collection.zipWithNext { prev, next -> // Lambdas with multiple parameter should be named clearly, using it for one of them can be confusing
- * 		Pair(prev, next)
+ *
+ * // Lambdas with multiple parameter should be named clearly, using it for one of them can be confusing
+ * collection.zipWithNext { prev, next ->
+ *     Pair(prev, next)
  * }
  * </compliant>
  */

--- a/docs/pages/documentation/exceptions.md
+++ b/docs/pages/documentation/exceptions.md
@@ -379,13 +379,13 @@ exception is too broad it can lead to unintended exceptions being caught.
 #### Configuration options:
 
 * `exceptionNames` (default: `- ArrayIndexOutOfBoundsException
-- Error
-- Exception
-- IllegalMonitorStateException
-- NullPointerException
-- IndexOutOfBoundsException
-- RuntimeException
-- Throwable`)
+    - Error
+    - Exception
+    - IllegalMonitorStateException
+    - NullPointerException
+    - IndexOutOfBoundsException
+    - RuntimeException
+    - Throwable`)
 
    exceptions which are too generic and should not be caught
 
@@ -425,9 +425,9 @@ exceptions to the case that has currently occurred.
 #### Configuration options:
 
 * `exceptionNames` (default: `- Error
-- Exception
-- Throwable
-- RuntimeException`)
+    - Exception
+    - Throwable
+    - RuntimeException`)
 
    exceptions which are too generic and should not be thrown
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -129,10 +129,10 @@ rest of the function signature.
 
 ```kotlin
 fun stuff(): Int
-= 5
+    = 5
 
 fun <V> foo(): Int where V : Int
-= 5
+    = 5
 ```
 
 #### Compliant Code:
@@ -141,7 +141,7 @@ fun <V> foo(): Int where V : Int
 fun stuff() = 5
 
 fun stuff() =
-foo.bar()
+    foo.bar()
 
 fun <V> foo(): Int where V : Int = 5
 ```
@@ -164,7 +164,7 @@ makes your code misleading, especially when dealing with nested functions.
 a?.let { it -> it.plus(1) }
 foo.flatMapObservable { it -> Observable.fromIterable(it) }
 listOfPairs.map(::second).forEach { it ->
-it.execute()
+    it.execute()
 }
 collection.zipWithNext { it, next -> Pair(it, next) }
 ```
@@ -174,11 +174,15 @@ collection.zipWithNext { it, next -> Pair(it, next) }
 ```kotlin
 a?.let { it.plus(1) } // Much better to use implicit it
 foo.flatMapObservable(Observable::fromIterable) // Here we can have a method reference
-listOfPairs.map(::second).forEach { apiRequest -> // For multiline blocks it is usually better come up with a clear and more meaningful name
-apiRequest.execute()
+
+// For multiline blocks it is usually better come up with a clear and more meaningful name
+listOfPairs.map(::second).forEach { apiRequest ->
+    apiRequest.execute()
 }
-collection.zipWithNext { prev, next -> // Lambdas with multiple parameter should be named clearly, using it for one of them can be confusing
-Pair(prev, next)
+
+// Lambdas with multiple parameter should be named clearly, using it for one of them can be confusing
+collection.zipWithNext { prev, next ->
+    Pair(prev, next)
 }
 ```
 


### PR DESCRIPTION
The parsed [KDocSection] element contains no tabs.
Therefore, the indentation gets removed when generating the Markdown
rule documentation out of the rules KDoc.
This PR fixes #1871.
