### PR TITLE
Trust Kotlin compiler to identify unsafe casts

### DIFF
--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
@@ -6,7 +6,6 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import java.io.File
 import java.nio.file.Paths
 
-
 fun loadFile(resourceName: String) = compileForTest(Paths.get(resource(resourceName)))
 
 fun loadFileContent(resourceName: String) =

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollector.kt
@@ -113,12 +113,12 @@ class RuleListVisitor : DetektVisitor() {
 
         // Call Expression = Constructor of rule
         ruleNames.addAll(argumentExpressions
-                .filter { it is KtCallExpression }
-                .map { (it as? KtCallExpression)?.calleeExpression?.text ?: "" })
+                .filterIsInstance<KtCallExpression>()
+                .map { it.calleeExpression?.text ?: "" })
 
         // Reference Expression = variable we need to search for
         ruleProperties.addAll(argumentExpressions
-                .filter { it is KtReferenceExpression }
-                .map { it?.text ?: "" })
+                .filterIsInstance<KtReferenceExpression>()
+                .map { it.text ?: "" })
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtClassOrObjectExtensions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtClassOrObjectExtensions.kt
@@ -5,10 +5,6 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.isAbstract
 
-fun KtClassOrObject.isInterface(): Boolean {
-    return (this as? KtClass)?.isInterface() == true
-}
-
 fun KtClass.doesNotExtendAnything() = superTypeListEntries.isEmpty()
 
 fun KtClass.isClosedForExtension() = !isAbstract() && !isOpen()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtClassOrObjectExtensions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtClassOrObjectExtensions.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules
 
 import org.jetbrains.kotlin.psi.KtClass
-import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.isAbstract
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
@@ -68,10 +68,8 @@ class EqualsWithHashCodeExist(config: Config = Config.empty) : Rule(config) {
     }
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
-        val klass = classOrObject as? KtClass
-        if (klass != null && klass.isData()) {
-            return
-        }
+        if (classOrObject is KtClass && classOrObject.isData()) return
+
         queue.push(ViolationHolder())
         super.visitClassOrObject(classOrObject)
         if (queue.pop().violation()) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
@@ -57,7 +57,7 @@ class MatchingDeclarationName(config: Config = Config.empty) : Rule(config) {
                 .filterIsInstance<KtClassOrObject>()
                 .filterNot { it.isPrivate() }
         if (declarations.size == 1) {
-            val declaration = declarations[0] as? KtClassOrObject
+            val declaration = declarations.firstOrNull()
             val declarationName = declaration?.name ?: return
             val filename = file.name.removeSuffix(KOTLIN_SUFFIX)
             if (declarationName != filename &&

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -72,8 +72,7 @@ class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config
         if (expression is KtConstantExpression) {
             return true
         }
-        val stringTemplate = expression as? KtStringTemplateExpression
-        return stringTemplate?.hasInterpolation() == false
+        return expression is KtStringTemplateExpression && !expression.hasInterpolation()
     }
 
     private fun returnsConstant(function: KtNamedFunction): Boolean {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConst.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConst.kt
@@ -114,10 +114,10 @@ class MayBeConst(config: Config = Config.empty) : Rule(config) {
             (expression as? KtParenthesizedExpression)?.expression?.isConstantExpression() == true
 
     private fun isBinaryExpression(expression: KtExpression): Boolean {
-        val binaryExpression = expression as? KtBinaryExpression ?: return false
-        return expression.node.elementType == KtNodeTypes.BINARY_EXPRESSION &&
-                binaryTokens.contains(binaryExpression.operationToken) &&
-                binaryExpression.left?.isConstantExpression() == true &&
-                binaryExpression.right?.isConstantExpression() == true
+        return expression is KtBinaryExpression &&
+                expression.node.elementType == KtNodeTypes.BINARY_EXPRESSION &&
+                binaryTokens.contains(expression.operationToken) &&
+                expression.left?.isConstantExpression() == true &&
+                expression.right?.isConstantExpression() == true
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -114,7 +114,7 @@ class ReturnCount(config: Config = Config.empty) : Rule(config) {
         if (label != null) {
             return this.parentsOfTypeUntil<KtCallExpression, KtNamedFunction>()
                     .map { it.calleeExpression }
-                    .mapNotNull { it as? KtNameReferenceExpression }
+                    .filterIsInstance<KtNameReferenceExpression>()
                     .map { it.text }
                     .any { it in label.text }
         }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
@@ -44,10 +44,10 @@ class SafeCast(config: Config = Config.empty) : Rule(config) {
     )
 
     override fun visitIfExpression(expression: KtIfExpression) {
-        val condition = expression.condition as? KtIsExpression
-        if (condition != null) {
-            val leftHandSide = condition.leftHandSide as? KtNameReferenceExpression
-            if (leftHandSide != null) {
+        val condition = expression.condition
+        if (condition is KtIsExpression) {
+            val leftHandSide = condition.leftHandSide
+            if (leftHandSide is KtNameReferenceExpression) {
                 val identifier = leftHandSide.text
                 val thenClause = expression.then
                 val elseClause = expression.`else`

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -97,12 +97,8 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
             }
         }
 
-        private fun indexOfFirstMember(isAbstract: Boolean, members: List<PsiElement> = this.namedMembers): Int {
-            return members.indexOfFirst {
-                val namedDeclaration = it as? KtNamedDeclaration
-                namedDeclaration != null && namedDeclaration.isAbstract() == isAbstract
-            }
-        }
+        private fun indexOfFirstMember(isAbstract: Boolean, members: List<PsiElement> = this.namedMembers) =
+            members.indexOfFirst { it is KtNamedDeclaration && it.isAbstract() == isAbstract }
 
         private fun isAbstractClassWithoutConcreteMembers(indexOfFirstAbstractMember: Int) =
                 indexOfFirstAbstractMember == 0 && hasNoConcreteMemberLeft() && hasNoConstructorParameter(klass)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
@@ -91,7 +91,7 @@ class UnusedPrivateClass(config: Config = Config.empty) : Rule(config) {
                     ?.forEach {
                         namedClasses.add(it.text)
                         // Recursively register for nested generic types (e.g. List<List<Foo>>)
-                        (it as? KtTypeReference)?.run { registerAccess(it) }
+                        if (it is KtTypeReference) registerAccess(it)
                     }
         }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -11,14 +11,13 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.isAbstract
 import io.gitlab.arturbosch.detekt.rules.isExternal
-import io.gitlab.arturbosch.detekt.rules.isInterface
 import io.gitlab.arturbosch.detekt.rules.isMainFunction
 import io.gitlab.arturbosch.detekt.rules.isOpen
 import io.gitlab.arturbosch.detekt.rules.isOperator
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import io.gitlab.arturbosch.detekt.rules.parentOfType
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
@@ -103,7 +102,7 @@ private class UnusedFunctionVisitor(allowedNames: Regex) : UnusedMemberVisitor(a
     }
 
     private fun isDeclaredInsideAnInterface(function: KtNamedFunction) =
-        function.parentOfType<KtClassOrObject>(strict = true)?.isInterface() == true
+        function.parentOfType<KtClass>(strict = true)?.isInterface() == true
 
     private fun collectFunction(function: KtNamedFunction) {
         val name = function.nameAsSafeName.identifier
@@ -146,11 +145,10 @@ private class UnusedParameterVisitor(allowedNames: Regex) : UnusedMemberVisitor(
         }
     }
 
-    override fun visitClassOrObject(classOrObject: KtClassOrObject) {
-        if (classOrObject.isInterface()) {
-            return
-        }
-        super.visitClassOrObject(classOrObject)
+    override fun visitClass(klass: KtClass) {
+        if (klass.isInterface()) return
+
+        super.visitClassOrObject(klass)
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
@@ -3,18 +3,16 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.test.KtTestCompiler
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class UnsafeCastSpec : Spek({
     val subject by memoized { UnsafeCast() }
 
-    lateinit var environment: KotlinCoreEnvironment
-
-    beforeEachTest {
-        environment = KtTestCompiler.createEnvironment()
-    }
+    val wrapper by memoized(
+        factory = { KtTestCompiler.createEnvironment() },
+        destructor = { it.dispose() }
+    )
 
     describe("check safe and unsafe casts") {
 
@@ -23,7 +21,7 @@ class UnsafeCastSpec : Spek({
                 fun test(s: String) {
                     println(s as Int)
                 }"""
-            assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
         }
 
         it("reports 'safe' cast that cannot succeed") {
@@ -31,7 +29,7 @@ class UnsafeCastSpec : Spek({
                 fun test(s: String) {
                     println((s as? Int) ?: 0)
                 }"""
-            assertThat(subject.compileAndLintWithContext(environment, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
         }
 
         it("does not report cast that might succeed") {
@@ -39,7 +37,7 @@ class UnsafeCastSpec : Spek({
 				fun test(s: Any) {
 					println(s as Int)
 				}"""
-            assertThat(subject.compileAndLintWithContext(environment, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
         }
 
         it("does not report 'safe' cast that might succeed") {
@@ -47,7 +45,7 @@ class UnsafeCastSpec : Spek({
 				fun test(s: Any) {
 					println((s as? Int) ?: 0)
 				}"""
-            assertThat(subject.compileAndLintWithContext(environment, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
         }
     }
 })

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert.kt
@@ -8,7 +8,6 @@ import org.assertj.core.api.AbstractAssert
 
 fun assertThat(thresholdedCodeSmell: ThresholdedCodeSmell) = ThresholdedCodeSmellAssert(thresholdedCodeSmell)
 
-@Suppress("UnsafeCast") // False positive, see issue #1137
 fun FindingAssert.isThresholded(): ThresholdedCodeSmellAssert {
     isNotNull
     assert(actual is ThresholdedCodeSmell) { "The finding '$actual' is not a ThresholdedCodeSmell" }
@@ -21,7 +20,6 @@ class ThresholdedCodeSmellAssert(actual: ThresholdedCodeSmell?) :
 
     fun withValue(expected: Int) = hasValue(expected).let { this }
 
-    @Suppress("UnsafeCast") // False positive, see issue #1137
     fun hasValue(expected: Int) {
         isNotNull
 
@@ -33,7 +31,6 @@ class ThresholdedCodeSmellAssert(actual: ThresholdedCodeSmell?) :
 
     fun withThreshold(expected: Int) = hasThreshold(expected).let { this }
 
-    @Suppress("UnsafeCast") // False positive, see issue #1137
     fun hasThreshold(expected: Int) {
         isNotNull
 


### PR DESCRIPTION
UnsafeCast now trusts the Kotlin compiler to identify casts that won't succeed. This should eliminate false positives though the detection rate for actual issues will drop, as some "safe" casts that the compiler cannot always tell will fail may still cause problems.

Now requires type/symbol resolution enabled in the detekt run for the rule to work.

Fixes #1601
Fixes #1137 (I couldn't replicate the original issue by just removing the suppression lines in `ThresholdedCodeSmellAssert` and rerunning CI in AppVeyor, though this should resolve it anyway).