### PR TITLE
Minimise usage of Kotlin reflection

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Suppressible.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Suppressible.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.api
 
-import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
 /**
  * Checks if this psi element is suppressed by @Suppress or @SuppressWarnings annotations.
@@ -13,7 +13,7 @@ fun KtElement.isSuppressedBy(id: String, aliases: Set<String>): Boolean =
         this is KtAnnotated && this.isSuppressedBy(id, aliases) || findAnnotatedSuppressedParent(id, aliases)
 
 private fun KtElement.findAnnotatedSuppressedParent(id: String, aliases: Set<String>): Boolean {
-    val parent = PsiTreeUtil.getParentOfType(this, KtAnnotated::class.java, true)
+    val parent = getStrictParentOfType<KtAnnotated>()
 
     var suppressed = false
     if (parent != null && parent !is KtFile) {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
@@ -17,10 +17,10 @@ internal fun PsiElement.searchName(): String {
 }
 
 internal fun PsiElement.searchClass(): String {
-    val classElement = this.getNonStrictParentOfType(KtClassOrObject::class.java)
+    val classElement = this.getNonStrictParentOfType<KtClassOrObject>()
     var className = classElement?.name
     if (className != null && className == "Companion") {
-        classElement?.parent?.getNonStrictParentOfType(KtClassOrObject::class.java)?.name?.let {
+        classElement?.parent?.getNonStrictParentOfType<KtClassOrObject>()?.name?.let {
             className = "$it.$className"
         }
     }
@@ -38,7 +38,7 @@ internal fun PsiElement.buildFullSignature(): String {
 }
 
 private fun PsiElement.extractClassName() =
-        this.getNonStrictParentOfType(KtClassOrObject::class.java)?.nameAsSafeName?.asString() ?: ""
+        this.getNonStrictParentOfType<KtClassOrObject>()?.nameAsSafeName?.asString() ?: ""
 
 private fun PsiElement.searchSignature(): String {
     return when (this) {

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     implementation(kotlin("gradle-plugin"))
     implementation(kotlin("gradle-plugin-api"))
 
-    testImplementation(kotlin("reflect"))
     testImplementation("org.assertj:assertj-core:$assertjVersion")
     testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
 
     testImplementation("org.reflections:reflections:$reflectionsVersion")
     testImplementation(project(":detekt-test"))
+    testImplementation(kotlin("reflect"))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
     testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -11,7 +11,6 @@ dependencies {
 
     testImplementation("org.reflections:reflections:$reflectionsVersion")
     testImplementation(project(":detekt-test"))
-    testImplementation(kotlin("reflect"))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
     testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/IsPartOfUtils.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/IsPartOfUtils.kt
@@ -3,14 +3,13 @@ package io.gitlab.arturbosch.detekt.rules
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtStringTemplateEntry
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
-import kotlin.reflect.KClass
 
 /**
  * Tests if this element is part of given PsiElement.
  */
-fun PsiElement.isPartOf(clazz: KClass<out PsiElement>): Boolean = getNonStrictParentOfType(clazz.java) != null
+inline fun <reified T : PsiElement> PsiElement.isPartOf() = getNonStrictParentOfType<T>() != null
 
 /**
  * Tests if this element is part of a kotlin string.
  */
-fun PsiElement.isPartOfString(): Boolean = isPartOf(KtStringTemplateEntry::class)
+fun PsiElement.isPartOfString(): Boolean = isPartOf<KtStringTemplateEntry>()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/LinesOfCode.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/LinesOfCode.kt
@@ -20,14 +20,13 @@ import org.jetbrains.kotlin.kdoc.psi.impl.KDocTag
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
 import java.util.ArrayDeque
-import kotlin.reflect.KClass
 
-fun ASTNode.tokenSequence(skipTreesOf: Set<KClass<out PsiElement>>): Sequence<ASTNode> = sequence {
+fun ASTNode.tokenSequence(skipTreesOf: Set<Class<out PsiElement>>): Sequence<ASTNode> = sequence {
     val queue = ArrayDeque<ASTNode>()
     queue.add(this@tokenSequence)
     do {
         val curr = queue.pop()
-        if (curr.psi::class !in skipTreesOf) {
+        if (curr.psi::class.java !in skipTreesOf) {
             // Yields only tokens which can be identified in the source code.
             // Composite elements, e.g. classes or files, are abstractions over many leaf nodes.
             if (curr is LeafElement) {
@@ -45,18 +44,18 @@ fun KtElement.linesOfCode(inFile: KtFile = this.containingKtFile): Int = node.to
 
 fun ASTNode.line(inFile: KtFile) = DiagnosticUtils.getLineAndColumnInPsiFile(inFile, this.textRange).line
 
-private val comments: Set<KClass<out PsiElement>> = setOf(
-        PsiWhiteSpace::class,
-        PsiWhiteSpaceImpl::class,
-        PsiComment::class,
-        PsiCommentImpl::class,
-        PsiCoreCommentImpl::class,
-        KDoc::class,
-        KDocImpl::class,
-        KDocElementImpl::class,
-        KDocElement::class,
-        KDocLink::class,
-        KDocSection::class,
-        KDocTag::class,
-        KDocName::class
+private val comments: Set<Class<out PsiElement>> = setOf(
+        PsiWhiteSpace::class.java,
+        PsiWhiteSpaceImpl::class.java,
+        PsiComment::class.java,
+        PsiCommentImpl::class.java,
+        PsiCoreCommentImpl::class.java,
+        KDoc::class.java,
+        KDocImpl::class.java,
+        KDocElementImpl::class.java,
+        KDocElement::class.java,
+        KDocLink::class.java,
+        KDocSection::class.java,
+        KDocTag::class.java,
+        KDocName::class.java
 )

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensions.kt
@@ -5,16 +5,15 @@ import org.jetbrains.kotlin.psi.KtContainerNodeForControlStructureBody
 import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.KtThrowExpression
 import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
-import kotlin.reflect.KClass
 
 internal fun KtThrowExpression.isIllegalStateException() =
-    isExceptionOfType(IllegalStateException::class)
+    isExceptionOfType<IllegalStateException>()
 
 internal fun KtThrowExpression.isIllegalArgumentException() =
-    isExceptionOfType(IllegalArgumentException::class)
+    isExceptionOfType<IllegalArgumentException>()
 
-internal fun <T : Exception> KtThrowExpression.isExceptionOfType(clazz: KClass<T>): Boolean {
-    return findDescendantOfType<KtCallExpression>()?.firstChild?.text == clazz.java.simpleName
+inline fun <reified T : Exception> KtThrowExpression.isExceptionOfType(): Boolean {
+    return findDescendantOfType<KtCallExpression>()?.firstChild?.text == T::class.java.simpleName
 }
 
 internal val KtThrowExpression.argumentCount

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensions.kt
@@ -12,7 +12,7 @@ internal fun KtThrowExpression.isIllegalStateException() =
 internal fun KtThrowExpression.isIllegalArgumentException() =
     isExceptionOfType<IllegalArgumentException>()
 
-inline fun <reified T : Exception> KtThrowExpression.isExceptionOfType(): Boolean {
+internal inline fun <reified T : Exception> KtThrowExpression.isExceptionOfType(): Boolean {
     return findDescendantOfType<KtCallExpression>()?.firstChild?.text == T::class.java.simpleName
 }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
@@ -94,7 +94,7 @@ class StringLiteralDuplication(
         override fun visitStringTemplateExpression(expression: KtStringTemplateExpression) {
             val text = expression.plainText()
             when {
-                ignoreAnnotation && expression.isPartOf(KtAnnotationEntry::class) -> pass
+                ignoreAnnotation && expression.isPartOf<KtAnnotationEntry>() -> pass
                 excludeStringsWithLessThan5Characters && text.length < STRING_EXCLUSION_LENGTH -> pass
                 text.matches(ignoreStringsRegex) -> pass
                 else -> add(expression)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -74,7 +74,7 @@ class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
 
     private fun KtClass.isInnerInterface() = !isTopLevel() && isInterface() && searchInInnerInterface
 
-    private fun KtClassOrObject.notEnumEntry() = this::class != KtEnumEntry::class
+    private fun KtClassOrObject.notEnumEntry() = this !is KtEnumEntry
 
     companion object {
         const val SEARCH_IN_NESTED_CLASS = "searchInNestedClass"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -133,9 +133,9 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
         ignoreLocalVariables && (expression.isLocalProperty()) -> true
         ignoreConstantDeclaration && expression.isConstantProperty() -> true
         ignoreCompanionObjectPropertyDeclaration && expression.isCompanionObjectProperty() -> true
-        ignoreAnnotation && expression.isPartOf(KtAnnotationEntry::class) -> true
+        ignoreAnnotation && expression.isPartOf<KtAnnotationEntry>() -> true
         ignoreHashCodeFunction && expression.isPartOfHashCode() -> true
-        ignoreEnums && expression.isPartOf(KtEnumEntry::class) -> true
+        ignoreEnums && expression.isPartOf<KtEnumEntry>() -> true
         ignoreNamedArgument && expression.isNamedArgument() -> true
         ignoreRanges && expression.isPartOfRange() -> true
         else -> false
@@ -168,7 +168,7 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun KtConstantExpression.isNamedArgument() =
-        parent is KtValueArgument && (parent as? KtValueArgument)?.isNamed() == true && isPartOf(KtCallElement::class)
+        (parent as? KtValueArgument)?.isNamed() == true && isPartOf<KtCallElement>()
 
     private fun KtConstantExpression.isPartOfFunctionReturnConstant() =
         parent is KtNamedFunction || parent is KtReturnExpression && parent.parent.children.size == 1

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabs.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabs.kt
@@ -52,5 +52,5 @@ class NoTabs(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun PsiWhiteSpace.isStringInterpolated(): Boolean =
-            this.isPartOf(KtStringTemplateEntryWithExpression::class)
+            this.isPartOf<KtStringTemplateEntryWithExpression>()
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -83,7 +83,7 @@ class UnusedImports(config: Config) : Rule(config) {
 
         override fun visitReferenceExpression(expression: KtReferenceExpression) {
             expression
-                    .takeIf { !it.isPartOf(KtImportDirective::class) && !it.isPartOf(KtPackageDirective::class) }
+                    .takeIf { !it.isPartOf<KtImportDirective>() && !it.isPartOf<KtPackageDirective>() }
                     ?.takeIf { it.children.isEmpty() }
                     ?.run { namedReferences.add(text.trim('`')) }
             super.visitReferenceExpression(expression)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
@@ -8,11 +8,11 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.isOverride
-import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
 /**
  * It is not necessary to define a return type of `Unit` on functions or to specify a lone Unit statement.
@@ -82,7 +82,7 @@ class OptionalUnit(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun isInInterface(function: KtNamedFunction): Boolean {
-        val parent = PsiTreeUtil.getParentOfType(function, KtClass::class.java, true)
+        val parent = function.getStrictParentOfType<KtClass>()
         return parent is KtClass && parent.isInterface()
     }
 


### PR DESCRIPTION
Remaining usage is in detekt-api (KClass is used in a public API, and there are some property delegates which require it).