### PR TITLE
Add tabs check for KDoc in detekt-generator

### DIFF
--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -68,6 +68,13 @@ internal class RuleVisitor : DetektVisitor() {
         }
 
         name = classOrObject.name?.trim() ?: ""
+
+        // Use unparsed KDoc text here to check for tabs
+        // Parsed [KDocSection] element contains no tabs
+        if (classOrObject.docComment?.text?.contains('\t') == true) {
+            throw InvalidDocumentationException("KDoc for rule $name must not contain tabs")
+        }
+
         active = classOrObject.kDocSection()?.findTagByName(TAG_ACTIVE) != null
         autoCorrect = classOrObject.kDocSection()?.findTagByName(TAG_AUTO_CORRECT) != null
 

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -488,14 +488,14 @@ class RuleCollectorSpec : Spek({
             val name = "SomeRandomClass"
             val description = "\t"
             val code = """
-				package foo
+                package foo
 
-				/**
-				 * $description
-				 */
-				class $name: Rule {
-				}
-			"""
+                /**
+                 * $description
+                 */
+                class $name: Rule {
+                }
+            """
             assertThatExceptionOfType(InvalidDocumentationException::class.java)
                 .isThrownBy { subject.run(code) }
         }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -483,5 +483,21 @@ class RuleCollectorSpec : Spek({
             assertThatExceptionOfType(InvalidAliasesDeclaration::class.java)
                     .isThrownBy { subject.run(code) }
         }
+
+        it("contains tabs in KDoc") {
+            val name = "SomeRandomClass"
+            val description = "\t"
+            val code = """
+				package foo
+
+				/**
+				 * $description
+				 */
+				class $name: Rule {
+				}
+			"""
+            assertThatExceptionOfType(InvalidDocumentationException::class.java)
+                .isThrownBy { subject.run(code) }
+        }
     }
 })


### PR DESCRIPTION
This prevents the usage of tabs in KDoc to ensure correct indentation
when generating the Markdown rule documentation.
This relates to the issue described in #1871.
