### PR TITLE
Add configuration to allow patterns for forbidden comment

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -433,6 +433,7 @@ style:
   ForbiddenComment:
     active: true
     values: 'TODO:,FIXME:,STOPSHIP:'
+    allowedPatterns: ""
   ForbiddenImport:
     active: false
     imports: ''

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -19,7 +19,8 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiComment
  * </noncompliant>
  *
  * @configuration values - forbidden comment strings (default: `'TODO:,FIXME:,STOPSHIP:'`)
- * @configuration allowedPatterns - ignores comments which match any of specified regex (default: `""`)
+ * @configuration allowedPatterns - ignores comments which match any of the specified regular expressions.
+   The regular expressions are separated by `,`, like for instance `\\s*Ticket\\s*, \\s*Task\\s*`. (default: `""`)
  * @active since v1.0.0
  */
 class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
@@ -38,7 +39,7 @@ class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
             valueOrDefault(ALLOWED_PATTERNS, "")
                 .split(",")
                 .filter { it.isNotBlank() }
-                .map { r -> r.toRegex(RegexOption.IGNORE_CASE) }
+                .map { r -> r.toRegex() }
 
     override fun visitComment(comment: PsiComment) {
         super.visitComment(comment)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -19,8 +19,8 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiComment
  * </noncompliant>
  *
  * @configuration values - forbidden comment strings (default: `'TODO:,FIXME:,STOPSHIP:'`)
- * @configuration allowedPatterns - ignores comments which match any of the specified regular expressions.
-   The regular expressions are separated by `,`, like for instance `\\s*Ticket\\s*, \\s*Task\\s*`. (default: `""`)
+ * @configuration allowedPatterns - ignores comments which match the specified regular expression.
+   For example `Ticket|Task`. (default: `""`)
  * @active since v1.0.0
  */
 class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
@@ -35,18 +35,14 @@ class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
                     .split(",")
                     .filter { it.isNotBlank() }
 
-    private val allowedPatterns: List<Regex> =
-            valueOrDefault(ALLOWED_PATTERNS, "")
-                .split(",")
-                .filter { it.isNotBlank() }
-                .map { r -> r.toRegex() }
+    private val allowedPatterns: Regex = Regex(valueOrDefault(ALLOWED_PATTERNS, ""))
 
     override fun visitComment(comment: PsiComment) {
         super.visitComment(comment)
 
         val text = comment.text
 
-        if (allowedPatterns.find { it.containsMatchIn(text) } != null) return
+        if (allowedPatterns.pattern.isNotEmpty() && allowedPatterns.containsMatchIn(text)) return
 
         values.forEach {
             if (text.contains(it, ignoreCase = true)) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -108,12 +108,6 @@ class ForbiddenCommentSpec : Spek({
                 assertThat(findings).hasSize(0)
             }
 
-            it("should not report Comment usages when pattern is present irrespective ofcase") {
-                val comment = "// Comment TASK - 568."
-                val findings = ForbiddenComment(patternsConfig).compileAndLint(comment)
-                assertThat(findings).hasSize(0)
-            }
-
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -87,7 +87,7 @@ class ForbiddenCommentSpec : Spek({
             val patternsConfig = TestConfig(
                 mapOf(
                     ForbiddenComment.VALUES to "Comment",
-                    ForbiddenComment.ALLOWED_PATTERNS to "\\s*Ticket\\s*, \\s*Task\\s*"
+                    ForbiddenComment.ALLOWED_PATTERNS to "Ticket|Task"
                 )
             )
 
@@ -99,13 +99,13 @@ class ForbiddenCommentSpec : Spek({
             it("should not report Comment usages when any one pattern is present") {
                 val comment = "// Comment Ticket:234."
                 val findings = ForbiddenComment(patternsConfig).compileAndLint(comment)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
 
             it("should not report Comment usages when all patterns are present") {
                 val comment = "// Comment Ticket:123 Task:456 comment."
                 val findings = ForbiddenComment(patternsConfig).compileAndLint(comment)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
 
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -82,5 +82,38 @@ class ForbiddenCommentSpec : Spek({
                 assertThat(findings).hasSize(1)
             }
         }
+
+        context("custom default values with allowed patterns are configured") {
+            val patternsConfig = TestConfig(
+                mapOf(
+                    ForbiddenComment.VALUES to "Comment",
+                    ForbiddenComment.ALLOWED_PATTERNS to "\\s*Ticket\\s*, \\s*Task\\s*"
+                )
+            )
+
+            it("should report Comment usages when regex does not match") {
+                val comment = "// Comment is added here."
+                val findings = ForbiddenComment(patternsConfig).compileAndLint(comment)
+                assertThat(findings).hasSize(1)
+            }
+            it("should not report Comment usages when any one pattern is present") {
+                val comment = "// Comment Ticket:234."
+                val findings = ForbiddenComment(patternsConfig).compileAndLint(comment)
+                assertThat(findings).hasSize(0)
+            }
+
+            it("should not report Comment usages when all patterns are present") {
+                val comment = "// Comment Ticket:123 Task:456 comment."
+                val findings = ForbiddenComment(patternsConfig).compileAndLint(comment)
+                assertThat(findings).hasSize(0)
+            }
+
+            it("should not report Comment usages when pattern is present irrespective ofcase") {
+                val comment = "// Comment TASK - 568."
+                val findings = ForbiddenComment(patternsConfig).compileAndLint(comment)
+                assertThat(findings).hasSize(0)
+            }
+
+        }
     }
 })

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -239,7 +239,8 @@ development. Offending code comments will then be reported.
 
 * `allowedPatterns` (default: `""`)
 
-   ignores comments which match any of specified regex
+   ignores comments which match any of the specified regular expressions.
+The regular expressions are separated by `,`, like for instance `\\s*Ticket\\s*, \\s*Task\\s*`.
 
 #### Noncompliant Code:
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -239,8 +239,8 @@ development. Offending code comments will then be reported.
 
 * `allowedPatterns` (default: `""`)
 
-   ignores comments which match any of the specified regular expressions.
-The regular expressions are separated by `,`, like for instance `\\s*Ticket\\s*, \\s*Task\\s*`.
+   ignores comments which match the specified regular expression.
+For example `Ticket|Task`.
 
 #### Noncompliant Code:
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -237,6 +237,10 @@ development. Offending code comments will then be reported.
 
    forbidden comment strings
 
+* `allowedPatterns` (default: `""`)
+
+   ignores comments which match any of specified regex
+
 #### Noncompliant Code:
 
 ```kotlin


### PR DESCRIPTION
Fixes [#959](https://github.com/arturbosch/detekt/issues/959).
- Introduce configuration `allowedPatterns` to specify allowed regex (Comma separated) .
- Do not report comments that match any of the configured patterns