### PR TITLE
Clarify `WildcardImport` rule configuration

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -16,6 +16,10 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  *
  * Library updates can introduce naming clashes with your own classes which might result in compilation errors.
  *
+ * **NOTE:** This rule is effectively overridden by the `NoWildcardImports` formatting rule (a wrapped KtLint rule).
+ * That rule will fail the check regardless of the whitelist configured here.
+ * Therefore if whitelist is needed `NoWildcardImports` rule should be disabled.
+ *
  * <noncompliant>
  * package test
  *

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -1399,6 +1399,10 @@ which classes are imported and helps prevent naming conflicts.
 
 Library updates can introduce naming clashes with your own classes which might result in compilation errors.
 
+**NOTE:** This rule is effectively overridden by the `NoWildcardImports` formatting rule (a wrapped KtLint rule).
+That rule will fail the check regardless of the whitelist configured here.
+Therefore if whitelist is needed `NoWildcardImports` rule should be disabled.
+
 **Severity**: Style
 
 **Debt**: 5min
@@ -1409,12 +1413,6 @@ Library updates can introduce naming clashes with your own classes which might r
 
    Define a whitelist of package names that should be allowed to be imported
 with wildcard imports.
-
-**NOTE:** This rule is effectively overriden by `NoWildcardImports`
-formatting rule (a wrapper of a KtLint rule).
-That rule will fail the check regardless of the whitelist
-configured here.
-Therefore if whitelist is needed `NoWildcardImports` rule should be disabled.
 
 #### Noncompliant Code:
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -1410,8 +1410,9 @@ Library updates can introduce naming clashes with your own classes which might r
    Define a whitelist of package names that should be allowed to be imported
 with wildcard imports.
 
-**NOTE:** This rule conflicts with `NoWildcardImports` formatting rule.
-Effectively that rule will fail the check regardless of the whitelist
+**NOTE:** This rule is effectively overriden by `NoWildcardImports`
+formatting rule (a wrapper of a KtLint rule).
+That rule will fail the check regardless of the whitelist
 configured here.
 Therefore if whitelist is needed `NoWildcardImports` rule should be disabled.
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -1410,6 +1410,11 @@ Library updates can introduce naming clashes with your own classes which might r
    Define a whitelist of package names that should be allowed to be imported
 with wildcard imports.
 
+**NOTE:** This rule conflicts with `NoWildcardImports` formatting rule.
+Effectively that rule will fail the check regardless of the whitelist
+configured here.
+Therefore if whitelist is needed `NoWildcardImports` rule should be disabled.
+
 #### Noncompliant Code:
 
 ```kotlin


### PR DESCRIPTION
Add information about conflict between `formatting:` `NoWildcardImports` and `style:` `WildcardImport` rules.

There is a conflict between `formatting:` `NoWildcardImports` and `style:` `WildcardImport` , effectively the latter and its configuration do not matter when former is enabled. This PR adds a note about the fact to the documentation.