### PR TITLE
Add option to ignore guard clauses in ReturnCount rule

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -497,6 +497,7 @@ style:
     excludedFunctions: "equals"
     excludeLabeled: false
     excludeReturnFromLambda: true
+    excludeGuardClauses: false
   SafeCast:
     active: true
   SerialVersionUIDInSerializableClass:

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -497,7 +497,7 @@ style:
     excludedFunctions: "equals"
     excludeLabeled: false
     excludeReturnFromLambda: true
-    excludeGuardClauses: false
+    excludeGuardClauses: true
   SafeCast:
     active: true
   SerialVersionUIDInSerializableClass:

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -497,7 +497,7 @@ style:
     excludedFunctions: "equals"
     excludeLabeled: false
     excludeReturnFromLambda: true
-    excludeGuardClauses: true
+    excludeGuardClauses: false
   SafeCast:
     active: true
   SerialVersionUIDInSerializableClass:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -54,7 +54,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isFirstStatement
  * (default: `false`)
  * @configuration excludeReturnFromLambda - if labeled return from a lambda should be ignored
  * (default: `true`)
- * @configuration excludeGuardClauses - if true guard clauses at the beginning of a method will be ignored
+ * @configuration excludeGuardClauses - if true guard clauses at the beginning of a method should be ignored
  * (default: `false`)
  * @active since v1.0.0
  */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -1,9 +1,24 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.DetektVisitor
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.SplitPattern
 import io.gitlab.arturbosch.detekt.rules.parentsOfTypeUntil
 import org.jetbrains.kotlin.lexer.KtSingleValueToken
-import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtReturnExpression
+import org.jetbrains.kotlin.psi.psiUtil.isFirstStatement
 
 /**
  * Restrict the number of return methods allowed in methods.
@@ -109,7 +124,7 @@ class ReturnCount(config: Config = Config.empty) : Rule(config) {
     private fun isIfConditionGuardClause(expression: KtReturnExpression): Boolean {
         val ifConditionParent = expression.parent?.parent as? KtIfExpression
         ifConditionParent?.let {
-            return it.`else` == null
+            return it.isFirstStatement() && it.`else` == null
         }
 
         return false
@@ -118,7 +133,8 @@ class ReturnCount(config: Config = Config.empty) : Rule(config) {
     private fun isElvisOperatorGuardClause(expression: KtReturnExpression): Boolean {
         val ktBinaryExpression = expression.parent as? KtBinaryExpression
         ktBinaryExpression?.let {
-            return (it.operationToken as? KtSingleValueToken)?.value == "?:"
+            return (it.parent as? KtElement)?.isFirstStatement() ?: false
+                    && (it.operationToken as? KtSingleValueToken)?.value == "?:"
         }
 
         return false

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -54,6 +54,8 @@ import org.jetbrains.kotlin.psi.psiUtil.isFirstStatement
  * (default: `false`)
  * @configuration excludeReturnFromLambda - if labeled return from a lambda should be ignored
  * (default: `true`)
+ * @configuration excludeGuardClauses - if true guard clauses at the beginning of a method will be ignored
+ * (default: `false`)
  * @active since v1.0.0
  */
 class ReturnCount(config: Config = Config.empty) : Rule(config) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -55,7 +55,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isFirstStatement
  * @configuration excludeReturnFromLambda - if labeled return from a lambda should be ignored
  * (default: `true`)
  * @configuration excludeGuardClauses - if true guard clauses at the beginning of a method should be ignored
- * (default: `false`)
+ * (default: `true`)
  * @active since v1.0.0
  */
 class ReturnCount(config: Config = Config.empty) : Rule(config) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -13,7 +13,7 @@ class ReturnCountSpec : Spek({
         context("a file with an if condition guard clause and 2 returns") {
             val code = """
 			fun test(x: Int): Int {
-                if (x < 4) return 0
+				if (x < 4) return 0
 				when (x) {
 					5 -> return 5
 					4 -> return 4
@@ -31,7 +31,7 @@ class ReturnCountSpec : Spek({
         context("a file with an ELVIS operator guard clause and 2 returns") {
             val code = """
 			fun test(x: Int): Int {
-                val y = x ?: return 0
+				val y = x ?: return 0
 				when (x) {
 					5 -> return 5
 					4 -> return 4
@@ -53,7 +53,7 @@ class ReturnCountSpec : Spek({
 					5 -> return 5
 					4 -> return 4
 				}
-                if (x < 4) return 0
+				if (x < 4) return 0
 			}
 		"""
 
@@ -71,7 +71,7 @@ class ReturnCountSpec : Spek({
 					5 -> return 5
 					4 -> return 4
 				}
-                val y = x ?: return 0
+				val y = x ?: return 0
 			}
 		"""
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -31,7 +31,6 @@ class ReturnCountSpec : Spek({
         context("a file with an ELVIS operator guard clause and 2 returns") {
             val code = """
 			fun test(x: Int): Int {
-                val x = null
                 val y = x ?: return 0
 				when (x) {
 					5 -> return 5
@@ -44,6 +43,42 @@ class ReturnCountSpec : Spek({
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
                     .lint(code)
                 assertThat(findings).hasSize(0)
+            }
+        }
+
+        context("a file with 2 returns and an if condition guard clause which is not the first statement") {
+            val code = """
+			fun test(x: Int): Int {
+				when (x) {
+					5 -> return 5
+					4 -> return 4
+				}
+                if (x < 4) return 0
+			}
+		"""
+
+            it("should get flagged for an if condition guard clause which is not the first statement") {
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
+                    .lint(code)
+                assertThat(findings).hasSize(1)
+            }
+        }
+
+        context("a file with 2 returns and an ELVIS guard clause which is not the first statement") {
+            val code = """
+			fun test(x: Int): Int {
+				when (x) {
+					5 -> return 5
+					4 -> return 4
+				}
+                val y = x ?: return 0
+			}
+		"""
+
+            it("should get flagged for an ELVIS guard clause which is not the first statement") {
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
+                    .lint(code)
+                assertThat(findings).hasSize(1)
             }
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -10,6 +10,43 @@ class ReturnCountSpec : Spek({
 
     describe("ReturnCount rule") {
 
+        context("a file with an if condition guard clause and 2 returns") {
+            val code = """
+			fun test(x: Int): Int {
+                if (x < 4) return 0
+				when (x) {
+					5 -> return 5
+					4 -> return 4
+				}
+			}
+		"""
+
+            it("should not get flagged for if condition guard clauses") {
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
+                    .lint(code)
+                assertThat(findings).hasSize(0)
+            }
+        }
+
+        context("a file with an ELVIS operator guard clause and 2 returns") {
+            val code = """
+			fun test(x: Int): Int {
+                val x = null
+                val y = x ?: return 0
+				when (x) {
+					5 -> return 5
+					4 -> return 4
+				}
+			}
+		"""
+
+            it("should not get flagged for ELVIS operator guard clauses") {
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
+                    .lint(code)
+                assertThat(findings).hasSize(0)
+            }
+        }
+
         context("a file with 3 returns") {
             val code = """
 			fun test(x: Int): Int {
@@ -235,8 +272,8 @@ class ReturnCountSpec : Spek({
             it("should be empty when labeled returns are de-activated") {
                 val findings = ReturnCount(
                         TestConfig(mapOf(
-                                "excludeLabeled" to "true",
-                                "excludeReturnFromLambda" to "false"
+                                ReturnCount.EXCLUDE_LABELED to "true",
+                                ReturnCount.EXCLUDE_RETURN_FROM_LAMBDA to "false"
                         ))).lint(code)
                 assertThat(findings).isEmpty()
             }

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -806,7 +806,7 @@ code.
 
    if labeled return from a lambda should be ignored
 
-* `excludeGuardClauses` (default: `true`)
+* `excludeGuardClauses` (default: `false`)
 
    if true guard clauses at the beginning of a method should be ignored
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -806,6 +806,10 @@ code.
 
    if labeled return from a lambda should be ignored
 
+* `excludeGuardClauses` (default: `false`)
+
+   if true guard clauses at the beginning of a method will be ignored
+
 #### Noncompliant Code:
 
 ```kotlin

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -806,9 +806,9 @@ code.
 
    if labeled return from a lambda should be ignored
 
-* `excludeGuardClauses` (default: `false`)
+* `excludeGuardClauses` (default: `true`)
 
-   if true guard clauses at the beginning of a method will be ignored
+   if true guard clauses at the beginning of a method should be ignored
 
 #### Noncompliant Code:
 


### PR DESCRIPTION
This PR is in relation to the issue #1868 

The following changes have been done:
 - Add option to ignore guard clauses in ReturnCount rule by using the config `excludeGuardClauses`, default value of the config is `false`
- The guard clauses include two types, namely `if condition` and `Elvis operator`
- The guard clauses are only ignored if they are the first statement in a function
- Fun fact: one of the commit fixes `ReturnCount` debt in `ReturnCount.kt` file :)