### PR TITLE
Don't check for unnecessary parentheses around lambdas

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
@@ -7,14 +7,8 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
-import org.jetbrains.kotlin.psi.KtConstructorDelegationCall
-import org.jetbrains.kotlin.psi.KtLambdaArgument
-import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtParenthesizedExpression
 import org.jetbrains.kotlin.psi.KtPsiUtil
-import org.jetbrains.kotlin.psi.KtSuperTypeCallEntry
-import org.jetbrains.kotlin.psi.KtValueArgument
-import org.jetbrains.kotlin.psi.KtValueArgumentList
 
 /**
  * This rule reports unnecessary parentheses around expressions.
@@ -51,42 +45,12 @@ class UnnecessaryParentheses(config: Config = Config.empty) : Rule(config) {
     override fun visitParenthesizedExpression(expression: KtParenthesizedExpression) {
         super.visitParenthesizedExpression(expression)
 
+        if (expression.expression == null) return
+
         if (KtPsiUtil.areParenthesesUseless(expression)) {
             val message = "Parentheses in ${expression.text} are unnecessary and can be replaced with: " +
                     "${KtPsiUtil.deparenthesize(expression)?.text}"
             report(CodeSmell(issue, Entity.from(expression), message))
         }
-    }
-
-    override fun visitArgument(argument: KtValueArgument) {
-        super.visitArgument(argument)
-        if (argument.children.any { it is KtLambdaExpression } &&
-                isSingleLambdaInArgumentList(argument) &&
-                !isArgumentInFunctionCallWithTwoLambdas(argument)) {
-            val parent = argument.parent
-            val message = "Parentheses around the lambda ${parent.text} are unnecessary and can be removed."
-            report(CodeSmell(issue, Entity.from(parent), message))
-        }
-    }
-
-    private fun isSingleLambdaInArgumentList(argument: KtValueArgument): Boolean {
-        val parent = argument.parent
-        val isOnlyArgument = parent.children.size == 1
-        val nodeBeforeArgumentList = parent.parent
-        val isSuperTypeCallEntry = nodeBeforeArgumentList is KtSuperTypeCallEntry ||
-                nodeBeforeArgumentList is KtConstructorDelegationCall
-
-        return isOnlyArgument &&
-                !isSuperTypeCallEntry &&
-                argument.equalsToken == null
-    }
-
-    private fun isArgumentInFunctionCallWithTwoLambdas(argument: KtValueArgument): Boolean {
-        val parent = argument.parent
-        val grandParent = parent.parent
-
-        return parent is KtValueArgumentList &&
-                grandParent.children.size >= 2 &&
-                grandParent.children.last() is KtLambdaArgument
     }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -36,19 +36,6 @@ class UnnecessaryParenthesesSpec : Spek({
             assertThat(subject.lint(code)).hasSize(1)
         }
 
-        it("reports unnecessary parentheses around lambdas") {
-            val code = """
-				fun function (a: (input: String) -> Unit) {
-					a.invoke("TEST")
-				}
-
-				fun test() {
-					function({ input -> println(input) })
-				}
-				"""
-            assertThat(subject.lint(code)).hasSize(1)
-        }
-
         it("doesn't report function calls containing lambdas and other parameters") {
             val code = """
 				fun function (integer: Int, a: (input: String) -> Unit) {
@@ -59,7 +46,7 @@ class UnnecessaryParenthesesSpec : Spek({
 					function(1, { input -> println(input) })
 				}
 				"""
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report unnecessary parentheses when assigning a lambda to a val") {
@@ -67,7 +54,7 @@ class UnnecessaryParenthesesSpec : Spek({
 				fun f() {
 					instance.copy(value = { false })
 				}"""
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report well behaved parentheses") {
@@ -77,7 +64,7 @@ class UnnecessaryParenthesesSpec : Spek({
 					 	println("Test")
 					}
 				}"""
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report well behaved parentheses in super constructors") {
@@ -89,7 +76,7 @@ class UnnecessaryParenthesesSpec : Spek({
 					}
 				})
 				"""
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report well behaved parentheses in constructors") {
@@ -101,7 +88,7 @@ class UnnecessaryParenthesesSpec : Spek({
 					}
 				})
 				"""
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should not report lambdas within super constructor calls") {
@@ -112,7 +99,7 @@ class UnnecessaryParenthesesSpec : Spek({
 					constructor() : this({ first, second -> true })
 				}
 			"""
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should not report call to function with two lambda parameters with one as block body") {
@@ -128,7 +115,7 @@ class UnnecessaryParenthesesSpec : Spek({
 					}
 				}
 			"""
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should not report call to function with two lambda parameters") {
@@ -144,7 +131,7 @@ class UnnecessaryParenthesesSpec : Spek({
 					}
 				}
 			"""
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should not report call to function with multiple lambdas as parameters but also other parameters") {
@@ -160,7 +147,7 @@ class UnnecessaryParenthesesSpec : Spek({
 					}
 				}
 			"""
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -36,6 +36,19 @@ class UnnecessaryParenthesesSpec : Spek({
             assertThat(subject.lint(code)).hasSize(1)
         }
 
+        it("does not report unnecessary parentheses around lambdas") {
+            val code = """
+                fun function (a: (input: String) -> Unit) {
+                    a.invoke("TEST")
+                }
+
+                fun test() {
+                    function({ input -> println(input) })
+                }
+                """
+            assertThat(subject.lint(code)).isEmpty()
+        }
+
         it("doesn't report function calls containing lambdas and other parameters") {
             val code = """
 				fun function (integer: Int, a: (input: String) -> Unit) {


### PR DESCRIPTION
Fixes #1222 

Logic of UnnecessaryParentheses rule is now identical to the IntelliJ intention provided by the Kotlin plugin: https://github.com/JetBrains/kotlin/blob/7eac7d96dc28970762da7187884fe40817700f85/idea/src/org/jetbrains/kotlin/idea/intentions/RemoveUnnecessaryParenthesesIntention.kt#L31-L32