### PR TITLE
Add RedundantExplicitType rule

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -489,6 +489,8 @@ style:
     active: false
   ProtectedMemberInFinalClass:
     active: false
+  RedundantExplicitType:
+    active: false
   RedundantVisibilityModifierRule:
     active: false
   ReturnCount:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -25,6 +25,7 @@ import io.gitlab.arturbosch.detekt.rules.style.NewLineAtEndOfFile
 import io.gitlab.arturbosch.detekt.rules.style.OptionalAbstractKeyword
 import io.gitlab.arturbosch.detekt.rules.style.OptionalWhenBraces
 import io.gitlab.arturbosch.detekt.rules.style.ProtectedMemberInFinalClass
+import io.gitlab.arturbosch.detekt.rules.style.RedundantExplicitType
 import io.gitlab.arturbosch.detekt.rules.style.RedundantVisibilityModifierRule
 import io.gitlab.arturbosch.detekt.rules.style.ReturnCount
 import io.gitlab.arturbosch.detekt.rules.style.SafeCast
@@ -116,6 +117,7 @@ class StyleGuideProvider : RuleSetProvider {
                 UseRequire(config),
                 UseCheckOrError(config),
                 UseIfInsteadOfWhen(),
+                RedundantExplicitType(config),
                 LibraryCodeMustSpecifyReturnType(config)
             )
         )

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitType.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitType.kt
@@ -1,0 +1,94 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.KtNodeTypes
+import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.descriptors.VariableDescriptor
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtConstantExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.types.AbbreviatedType
+import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.typeUtil.isBoolean
+import org.jetbrains.kotlin.types.typeUtil.isChar
+import org.jetbrains.kotlin.types.typeUtil.isDouble
+import org.jetbrains.kotlin.types.typeUtil.isFloat
+import org.jetbrains.kotlin.types.typeUtil.isInt
+import org.jetbrains.kotlin.types.typeUtil.isLong
+
+/**
+ * Local properties do not need their type to be explicitly provided when the inferred type matches the explicit type.
+ *
+ * <noncompliant>
+ * fun function() {
+ *   val x: String = "string"
+ * }
+ * </noncompliant>
+ *
+ * <compliant>
+ * fun function() {
+ *   val x = "string"
+ * }
+ * </compliant>
+ *
+ * Based on code from Kotlin compiler:
+ * https://github.com/JetBrains/kotlin/blob/v1.3.50/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantExplicitTypeInspection.kt
+ */
+class RedundantExplicitType(config: Config) : Rule(config) {
+
+    override val issue = Issue(
+        "RedundantExplicitType", Severity.Style,
+        "Type does not need to be stated explicitly and can be removed.",
+        Debt.FIVE_MINS
+    )
+
+    @Suppress("ReturnCount", "ComplexMethod")
+    override fun visitProperty(property: KtProperty) {
+        if (bindingContext == BindingContext.EMPTY) return
+        if (!property.isLocal) return
+        val typeReference = property.typeReference ?: return
+        val type =
+            (bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, property] as? VariableDescriptor)?.type ?: return
+        if (type is AbbreviatedType) return
+
+        when (val initializer = property.initializer) {
+            is KtConstantExpression -> if (!initializer.typeIsSameAs(type)) return
+            is KtStringTemplateExpression -> if (!KotlinBuiltIns.isString(type)) return
+            is KtNameReferenceExpression -> if (typeReference.text != initializer.getReferencedName()) return
+            is KtCallExpression -> if (typeReference.text != initializer.calleeExpression?.text) return
+            else -> return
+        }
+        report(CodeSmell(issue, Entity.from(property), issue.description))
+        super.visitProperty(property)
+    }
+
+    private fun KtConstantExpression.typeIsSameAs(type: KotlinType) =
+        when (node.elementType) {
+            KtNodeTypes.BOOLEAN_CONSTANT -> type.isBoolean()
+            KtNodeTypes.CHARACTER_CONSTANT -> type.isChar()
+            KtNodeTypes.INTEGER_CONSTANT -> {
+                if (text.endsWith("L")) {
+                    type.isLong()
+                } else {
+                    type.isInt()
+                }
+            }
+            KtNodeTypes.FLOAT_CONSTANT -> {
+                if (text.endsWith("f") || text.endsWith("F")) {
+                    type.isFloat()
+                } else {
+                    type.isDouble()
+                }
+            }
+            else -> false
+        }
+}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitTypeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitTypeSpec.kt
@@ -1,0 +1,129 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.com.intellij.openapi.Disposable
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object RedundantExplicitTypeSpec : Spek({
+    val subject by memoized { RedundantExplicitType(Config.empty) }
+
+    val wrapper by memoized(
+        factory = { KtTestCompiler.createEnvironment() },
+        destructor = { it.dispose() }
+    )
+
+    describe("RedundantExplicitType") {
+
+        it("reports explicit type for boolean") {
+            val code = """
+                fun function() {
+                    val x: Boolean = true
+                }
+            """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("reports explicit type for integer") {
+            val code = """
+                fun function() {
+                    val x: Int = 3
+                }
+            """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("reports explicit type for long") {
+            val code = """
+                fun function() {
+                    val x: Long = 3L
+                }
+            """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("reports explicit type for float") {
+            val code = """
+                fun function() {
+                    val x: Float = 3.0f
+                }
+            """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("reports explicit type for double") {
+            val code = """
+                fun function() {
+                    val x: Double = 3.0
+                }
+            """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("reports explicit type for char") {
+            val code = """
+                fun function() {
+                    val x: Char = 'f'
+                }
+            """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("reports explicit type for string template") {
+            val substitute = "\$x"
+            val code = """
+                fun function() {
+                    val x = 3
+                    val y: String = "$substitute"
+                }
+            """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("reports explicit type for name reference expression") {
+            val code = """
+                object Test
+
+                fun foo() {
+                    val o: Test = Test
+                }
+            """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("reports explicit type for call expression") {
+            val code = """
+                interface Person {
+                    val firstName: String
+                }
+
+                class TallPerson(override val firstName: String, val height: Int): Person
+
+                fun tallPerson() {
+                    val t: TallPerson = TallPerson("first", 3)
+                }
+            """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("does not report explicit type for call expression when type is an interface") {
+            val code = """
+                interface Person {
+                    val firstName: String
+                }
+
+                class TallPerson(override val firstName: String, val height: Int): Person
+
+                fun tallPerson() {
+                    val t: Person = TallPerson("first", 3)
+                }
+            """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+        }
+    }
+})

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -751,6 +751,30 @@ class ProtectedMemberInFinalClass {
 }
 ```
 
+### RedundantExplicitType
+
+Local properties do not need their type to be explicitly provided when the inferred type matches the explicit type.
+
+**Severity**: Style
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+fun function() {
+val x: String = "string"
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+fun function() {
+val x = "string"
+}
+```
+
 ### RedundantVisibilityModifierRule
 
 This rule checks for redundant visibility modifiers.


### PR DESCRIPTION
Closes #336 

Since this is just a port of the IntelliJ rule this uses identical logic, meaning this only checks local properties - it doesn't check for types that don't need to be declared for any other element. I think this conservative posture makes sense and there shouldn't be any false positives.

A future config option could be to enable or disable checking on top-level properties, but that's not required for now.

Blocked by #1880 