### PR TITLE
Fix TimeoutCancellationException - downgrade Spek

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ jcommanderVersion=1.78
 junitPlatformVersion=1.4.1
 ktlintVersion=0.34.2
 reflectionsVersion=0.9.11
-spekVersion=2.0.7
+spekVersion=2.0.2
 yamlVersion=1.24
 
 # Gradle plugins


### PR DESCRIPTION
Spek 2.0.3 introduced test timeouts.
(https://github.com/spekframework/spek/releases/tag/2.0.3)

The default timeout is 10 seconds per test case.
Detekt's rule-tests easily reach this limit when

1. setting up 8 `KotlinScriptEngine's` for compiling test snippets.
2. the (CI) machines are under heavy load

This results in the following exception as happened in commit 9691e0d.
kotlinx.coroutines.TimeoutCancellationException: 
Timed out waiting for 10000 ms

Unfortunately, Spek doesn't allow to set a global timeout (yet).
See: https://github.com/spekframework/spek/issues/769
Setting a custom timeout on each test block is not what we want.
Therefore, this commit downgrades Spek to version 2.0.2.
