### PR TITLE
Rule: UseIfInsteadOfWhen

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -33,10 +33,7 @@ open class CodeSmell(
             "id='$id')"
     }
 
-    override fun messageOrDescription(): String = when {
-        message.isEmpty() -> issue.description
-        else -> message
-    }
+    override fun messageOrDescription(): String = if (message.isEmpty()) issue.description else message
 }
 
 /**
@@ -93,8 +90,5 @@ open class ThresholdedCodeSmell(
 
     override fun compact(): String = "$id - $metric - ${entity.compact()}"
 
-    override fun messageOrDescription(): String = when {
-        message.isEmpty() -> issue.description
-        else -> message
-    }
+    override fun messageOrDescription(): String = if (message.isEmpty()) issue.description else message
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -86,10 +86,7 @@ internal object EmptyConfig : HierarchicalConfig {
     override fun subConfig(key: String): EmptyConfig = this
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T : Any> valueOrDefault(key: String, default: T): T = when (key) {
-        "active" -> true as T
-        else -> default
-    }
+    override fun <T : Any> valueOrDefault(key: String, default: T): T = if (key == "active") true as T else default
 
     override fun <T : Any> valueOrNull(key: String): T? = null
 }

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -536,6 +536,8 @@ style:
   UseDataClass:
     active: false
     excludeAnnotatedClasses: ""
+  UseIfInsteadOfWhen:
+    active: false
   UseRequire:
     active: false
   UselessCallOnNotNull:

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/OffsetsToLineColumn.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/OffsetsToLineColumn.kt
@@ -49,14 +49,11 @@ internal class SegmentTree(sortedArray: Array<Int>) {
     fun get(i: Int): Segment = segments[i]
     fun indexOf(v: Int): Int = binarySearch(v, 0, this.segments.size - 1)
 
-    private fun binarySearch(v: Int, l: Int, r: Int): Int = when {
-        l > r -> -1
-        else -> {
-            val i = l + (r - l) / 2
-            val s = segments[i]
-            if (v < s.left) binarySearch(v, l, i - 1)
-            else (if (s.right < v) binarySearch(v, i + 1, r) else i)
-        }
+    private fun binarySearch(v: Int, l: Int, r: Int): Int = if (l > r) -1 else {
+        val i = l + (r - l) / 2
+        val s = segments[i]
+        if (v < s.left) binarySearch(v, l, i - 1)
+        else (if (s.right < v) binarySearch(v, i + 1, r) else i)
     }
 
     init {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -43,6 +43,7 @@ import io.gitlab.arturbosch.detekt.rules.style.UnusedPrivateClass
 import io.gitlab.arturbosch.detekt.rules.style.UnusedPrivateMember
 import io.gitlab.arturbosch.detekt.rules.style.UseCheckOrError
 import io.gitlab.arturbosch.detekt.rules.style.UseDataClass
+import io.gitlab.arturbosch.detekt.rules.style.UseIfInsteadOfWhen
 import io.gitlab.arturbosch.detekt.rules.style.UseRequire
 import io.gitlab.arturbosch.detekt.rules.style.UselessCallOnNotNull
 import io.gitlab.arturbosch.detekt.rules.style.UtilityClassWithPublicConstructor
@@ -114,6 +115,7 @@ class StyleGuideProvider : RuleSetProvider {
                 UnderscoresInNumericLiterals(config),
                 UseRequire(config),
                 UseCheckOrError(config),
+                UseIfInsteadOfWhen(),
                 LibraryCodeMustSpecifyReturnType(config)
             )
         )

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -184,11 +184,9 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
     private fun KtConstantExpression.isPartOfRange(): Boolean {
         val theParent = parent
         val rangeOperators = setOf("downTo", "until", "step")
-        return when (theParent is KtBinaryExpression) {
-            true -> theParent.operationToken == KtTokens.RANGE ||
-                    theParent.operationReference.getReferencedName() in rangeOperators
-            else -> false
-        }
+        return if (theParent is KtBinaryExpression) theParent.operationToken == KtTokens.RANGE ||
+                theParent.operationReference.getReferencedName() in rangeOperators
+        else false
     }
 
     private fun KtConstantExpression.isPartOfHashCode(): Boolean {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
@@ -52,9 +52,7 @@ class UseCheckOrError(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun KtThrowExpression.isOnlyExpressionInLambda(): Boolean {
-        return when (val p = parent) {
-            is KtBlockExpression -> p.statements.size == 1 && p.parent is KtFunctionLiteral
-            else -> false
-        }
+        val p = parent
+        return if (p is KtBlockExpression) p.statements.size == 1 && p.parent is KtFunctionLiteral else false
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
@@ -9,7 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtWhenExpression
 
 /**
- * Binary expressions are better expressed using an 'if' expression than a 'when' expression.
+ * Binary expressions are better expressed using an `if` expression than a `when` expression.
  *
  * See https://kotlinlang.org/docs/reference/coding-conventions.html#if-versus-when
  *

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
@@ -1,0 +1,49 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtWhenExpression
+
+/**
+ * Binary expressions are better expressed using an 'if' expression than a 'when' expression.
+ *
+ * See https://kotlinlang.org/docs/reference/coding-conventions.html#if-versus-when
+ *
+ * <noncompliant>
+ * when (x) {
+ *   null -> true
+ *   else -> false
+ * }
+ * </noncompliant>
+ *
+ * <compliant>
+ * if (x == null) true else false
+ * </compliant>
+ */
+class UseIfInsteadOfWhen : Rule() {
+
+    override val issue: Issue = Issue("UseIfInsteadOfWhen",
+            Severity.Style,
+            "Binary expressions are better expressed using an 'if' expression than a 'when' expression.",
+            Debt.FIVE_MINS)
+
+    override fun visitWhenExpression(expression: KtWhenExpression) {
+        super.visitWhenExpression(expression)
+
+        if (expression.entries.size == 2 &&
+            expression.entries.find { it.isElse } != null &&
+            expression.entries.none { it.conditions.size > 1 }) {
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(expression),
+                    "Prefer using 'if' for binary conditions instead of 'when'."
+                )
+            )
+        }
+    }
+}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhenSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhenSpec.kt
@@ -1,0 +1,67 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object UseIfInsteadOfWhenSpec : Spek({
+
+    val subject by memoized { UseIfInsteadOfWhen() }
+
+    describe("UseIfInsteadOfWhen rule") {
+
+        it("reports when using two branches") {
+            val code = """
+                fun function(): Boolean? {
+                    val x = null
+                    when (x) {
+                        null -> return true
+                        else -> return false
+                    }
+                }
+                """
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        it("does not report when using one branch") {
+            val code = """
+                fun function(): Boolean? {
+                    val x = null
+                    when (x) {
+                        else -> return false
+                    }
+                }
+                """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it("does not report when using more than two branches") {
+            val code = """
+                fun function(): Boolean? {
+                    val x = null
+                    when (x) {
+                        null -> return true
+                        3 -> return null
+                        else -> return false
+                    }
+                }
+                """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it ("does not report when second branch is not 'else'") {
+            val code = """
+                fun function(): Boolean? {
+                    val x = null
+                    when (x) {
+                        null -> return true
+                        3 -> return null
+                    }
+                    return false
+                }
+                """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+    }
+})

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
@@ -11,20 +11,16 @@ open class TestConfig(
 
     override fun subConfig(key: String) = this
 
-    override fun <T : Any> valueOrDefault(key: String, default: T) = when (key) {
-        "active" -> getActiveValue(default) as T
-        else -> valueOrDefaultInternal(key, values[key], default) as T
-    }
+    override fun <T : Any> valueOrDefault(key: String, default: T) = if (key == "active") getActiveValue(default) as T
+    else valueOrDefaultInternal(key, values[key], default) as T
 
     private fun <T : Any> getActiveValue(default: T): Any {
         val active = values["active"]
         return if (active != null) valueOrDefaultInternal("active", active, default) else true
     }
 
-    override fun <T : Any> valueOrNull(key: String): T? = when (key) {
-        "active" -> (values["active"] ?: true) as T?
-        else -> values[key] as? T
-    }
+    override fun <T : Any> valueOrNull(key: String): T? = if (key == "active") (values["active"] ?: true) as T?
+    else values[key] as? T
 
     override fun tryParseBasedOnDefault(result: String, defaultResult: Any): Any = when (defaultResult) {
         is List<*> -> parseList(result)

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -1261,6 +1261,31 @@ class DataClassCandidate(val i: Int) {
 data class DataClass(val i: Int, val i2: Int)
 ```
 
+### UseIfInsteadOfWhen
+
+Binary expressions are better expressed using an 'if' expression than a 'when' expression.
+
+See https://kotlinlang.org/docs/reference/coding-conventions.html#if-versus-when
+
+**Severity**: Style
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+when (x) {
+null -> true
+else -> false
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+if (x == null) true else false
+```
+
 ### UseRequire
 
 Kotlin provides a much more concise way to check preconditions than to manually throw an

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -1263,7 +1263,7 @@ data class DataClass(val i: Int, val i2: Int)
 
 ### UseIfInsteadOfWhen
 
-Binary expressions are better expressed using an 'if' expression than a 'when' expression.
+Binary expressions are better expressed using an `if` expression than a `when` expression.
 
 See https://kotlinlang.org/docs/reference/coding-conventions.html#if-versus-when
 


### PR DESCRIPTION
Suggests replacing simple when `expressions` with an equivalent `if` `else` in line with this recommendation: https://kotlinlang.org/docs/reference/coding-conventions.html#if-versus-when

Ran the rule on detekt's codebase and fixed the resulting issues.

Only `when` expressions with two entries (one of them being `else` and the other a single condition) are flagged. I tried other versions that also allowed for flagging multiple conditions in a single entry but the rewritten code was no clearer, so made it more conservative. It should be quite safe to enable by default but that can be changed later.