### PR TITLE
Report PreferToOverPairSyntax only for kotlin.Pair

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
@@ -18,7 +18,7 @@ class AnnotationExcluder(
             ?.asSequence()
             ?.filterNot { it.isAllUnder }
             ?.mapNotNull { it.importedFqName?.asString() }
-            ?.map { Pair(it.substringAfterLast('.'), it) }
+            ?.map { it.substringAfterLast('.') to it }
             ?.toMap()
 
     /**

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntaxSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntaxSpec.kt
@@ -1,13 +1,19 @@
 package io.gitlab.arturbosch.detekt.rules.style.optional
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
-class PreferToOverPairSyntaxSpec : Spek({
+object PreferToOverPairSyntaxSpec : Spek({
     val subject by memoized { PreferToOverPairSyntax(Config.empty) }
+
+    val wrapper by memoized(
+        factory = { KtTestCompiler.createEnvironment() },
+        destructor = { it.dispose() }
+    )
 
     describe("PreferToOverPairSyntax rule") {
 
@@ -17,12 +23,23 @@ class PreferToOverPairSyntaxSpec : Spek({
                 val pair2: Pair<Int, Int> = Pair(1, 2)
                 val pair3 = Pair(Pair(1, 2), Pair(3, 4))
             """
-            assertThat(subject.compileAndLint(code)).hasSize(5)
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(5)
         }
 
         it("does not report if it is created using the to syntax") {
             val code = "val pair = 1 to 2"
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+        }
+
+        it("does not report if a non-Kotlin Pair class was used") {
+            val code = """
+                val pair1 = Pair(1, 2)
+                val pair2: Pair<Int, Int> = Pair(1, 2)
+                val pair3 = Pair(Pair(1, 2), Pair(3, 4))
+
+                data class Pair<T, Z>(val int1: T, val int2: Z)
+            """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
         }
     }
 })

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -24,7 +24,10 @@ fun BaseRule.lint(path: Path): List<Finding> {
     return findingsAfterVisit(ktFile)
 }
 
-fun BaseRule.compileAndLintWithContext(environment: KotlinCoreEnvironment, content: String): List<Finding> {
+fun BaseRule.compileAndLintWithContext(
+    environment: KotlinCoreEnvironment,
+    @Language("kotlin") content: String
+): List<Finding> {
     KotlinScriptEngine.compile(content)
     val ktFile = KtTestCompiler.compileFromContent(content.trimIndent())
     val bindingContext = KtTestCompiler.getContextForPaths(environment, listOf(ktFile))


### PR DESCRIPTION
Fixes #1066 

Rule now requires type resolution.

Blocked by #1880.