### PR TITLE
Detect deprecations

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -376,6 +376,8 @@ performance:
 
 potential-bugs:
   active: true
+  Deprecation:
+    active: false
   DuplicateCaseInWhenExpression:
     active: true
   EqualsAlwaysReturnsTrueOrFalse:

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -101,7 +101,7 @@ internal class RuleVisitor : DetektVisitor() {
         val nonCompliantEndIndex = comment.indexOf(ENDTAG_NONCOMPLIANT)
         if (nonCompliantEndIndex == -1) {
             throw InvalidCodeExampleDocumentationException(
-                    "Rule $name contains a incorrect noncompliant code definition.")
+                    "Rule $name contains an incorrect noncompliant code definition.")
         }
         description = comment.substring(0, nonCompliantIndex).trim()
         nonCompliant = comment.substring(nonCompliantIndex + TAG_NONCOMPLIANT.length, nonCompliantEndIndex)
@@ -114,7 +114,7 @@ internal class RuleVisitor : DetektVisitor() {
         if (compliantIndex != -1) {
             if (compliantEndIndex == -1) {
                 throw InvalidCodeExampleDocumentationException(
-                        "Rule $name contains a incorrect compliant code definition.")
+                        "Rule $name contains an incorrect compliant code definition.")
             }
             compliant = comment.substring(compliantIndex + TAG_COMPLIANT.length, compliantEndIndex)
                     .trimStartingLineBreaks()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
@@ -13,30 +13,6 @@ import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * Deprecated elements are expected to be removed in future. Alternatives should be found if possible.
- *
- * <noncompliant>
- * \@Deprecated("deprecation message")
- * abstract class Foo {
- *   abstract fun bar() : Int
- *   fun baz() {}
- * }
- *
- * abstract class Oof : Foo() {
- *   fun spam() {}
- * }
- * </noncompliant>
- *
- * <compliant>
- * abstract class Foo {
- *   abstract fun bar() : Int
- *   fun baz() {}
- * }
- *
- * abstract class Oof : Foo() {
- *   fun spam() {}
- * }
- * </compliant>
- *
  */
 class Deprecation(config: Config) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
@@ -1,0 +1,57 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.diagnostics.Errors
+import org.jetbrains.kotlin.resolve.BindingContext
+
+/**
+ * Deprecated elements are expected to be removed in future. Alternatives should be found if possible.
+ *
+ * <noncompliant>
+ * @Deprecated("deprecation message")
+ * abstract class Foo {
+ *   abstract fun bar() : Int
+ *   fun baz() {}
+ * }
+ *
+ * abstract class Oof : Foo() {
+ *   fun spam() {}
+ * }
+ * </noncompliant>
+ *
+ * <compliant>
+ * abstract class Foo {
+ *   abstract fun bar() : Int
+ *   fun baz() {}
+ * }
+ *
+ * abstract class Oof : Foo() {
+ *   fun spam() {}
+ * }
+ * </compliant>
+ *
+ */
+class Deprecation(config: Config) : Rule(config) {
+
+    override val issue = Issue(
+        "Deprecation",
+        Severity.Defect,
+        "Deprecated elements should not be used.",
+        Debt.TWENTY_MINS
+    )
+
+    override fun visitElement(element: PsiElement) {
+        if (bindingContext == BindingContext.EMPTY) return
+        if (bindingContext.diagnostics.forElement(element).firstOrNull { it.factory == Errors.DEPRECATION } != null) {
+            report(CodeSmell(issue, Entity.from(element), "$element is deprecated."))
+        }
+        super.visitElement(element)
+    }
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
@@ -23,6 +23,8 @@ class Deprecation(config: Config) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
+    override val defaultRuleIdAliases = setOf("DEPRECATION")
+
     override fun visitElement(element: PsiElement) {
         if (bindingContext == BindingContext.EMPTY) return
         if (bindingContext.diagnostics.forElement(element).firstOrNull { it.factory == Errors.DEPRECATION } != null) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * Deprecated elements are expected to be removed in future. Alternatives should be found if possible.
  *
  * <noncompliant>
- * @Deprecated("deprecation message")
+ * \@Deprecated("deprecation message")
  * abstract class Foo {
  *   abstract fun bar() : Int
  *   fun baz() {}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.providers
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.rules.bugs.Deprecation
 import io.gitlab.arturbosch.detekt.rules.bugs.DuplicateCaseInWhenExpression
 import io.gitlab.arturbosch.detekt.rules.bugs.EqualsAlwaysReturnsTrueOrFalse
 import io.gitlab.arturbosch.detekt.rules.bugs.EqualsWithHashCodeExist
@@ -31,6 +32,7 @@ class PotentialBugProvider : RuleSetProvider {
 
     override fun instance(config: Config): RuleSet {
         return RuleSet(ruleSetId, listOf(
+                Deprecation(config),
                 DuplicateCaseInWhenExpression(config),
                 EqualsAlwaysReturnsTrueOrFalse(config),
                 EqualsWithHashCodeExist(config),

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DeprecationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DeprecationSpec.kt
@@ -1,0 +1,54 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object DeprecationSpec : Spek({
+    val subject by memoized { Deprecation(Config.empty) }
+
+    val wrapper by memoized(
+        factory = { KtTestCompiler.createEnvironment() },
+        destructor = { it.dispose() }
+    )
+
+    describe("Deprecation detection") {
+
+        it("reports when supertype is deprecated") {
+            val code = """
+                @Deprecated("deprecation message")
+                abstract class Foo {
+                    abstract fun bar() : Int
+
+                    fun baz() {
+                    }
+                }
+
+                abstract class Oof : Foo() {
+                    fun spam() {
+                    }
+                }
+                """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("does not report when supertype is not deprecated") {
+            val code = """
+                abstract class Oof : Foo() {
+                    fun spam() {
+                    }
+                }
+                abstract class Foo {
+                    abstract fun bar() : Int
+
+                    fun baz() {
+                    }
+                }
+                """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+        }
+    }
+})

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -8,6 +8,41 @@ folder: documentation
 ---
 The potential-bugs rule set provides rules that detect potential bugs.
 
+### Deprecation
+
+Deprecated elements are expected to be removed in future. Alternatives should be found if possible.
+
+**Severity**: Defect
+
+**Debt**: 20min
+
+#### Noncompliant Code:
+
+```kotlin
+\@Deprecated("deprecation message")
+abstract class Foo {
+abstract fun bar() : Int
+fun baz() {}
+}
+
+abstract class Oof : Foo() {
+fun spam() {}
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+abstract class Foo {
+abstract fun bar() : Int
+fun baz() {}
+}
+
+abstract class Oof : Foo() {
+fun spam() {}
+}
+```
+
 ### DuplicateCaseInWhenExpression
 
 Flags duplicate case statements in when expressions.

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -16,6 +16,7 @@ Deprecated elements are expected to be removed in future. Alternatives should be
 
 **Debt**: 20min
 
+**Aliases**: DEPRECATION
 
 ### DuplicateCaseInWhenExpression
 

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -16,32 +16,6 @@ Deprecated elements are expected to be removed in future. Alternatives should be
 
 **Debt**: 20min
 
-#### Noncompliant Code:
-
-```kotlin
-\@Deprecated("deprecation message")
-abstract class Foo {
-abstract fun bar() : Int
-fun baz() {}
-}
-
-abstract class Oof : Foo() {
-fun spam() {}
-}
-```
-
-#### Compliant Code:
-
-```kotlin
-abstract class Foo {
-abstract fun bar() : Int
-fun baz() {}
-}
-
-abstract class Oof : Foo() {
-fun spam() {}
-}
-```
 
 ### DuplicateCaseInWhenExpression
 


### PR DESCRIPTION
Closes #267 

This rule uses the diagnostic warning built into the Kotlin compiler. Earlier discussion suggested that detekt [could reimplement compiler warnings](https://github.com/arturbosch/detekt/issues/240#issuecomment-407738733), so users have control over which compiler warnings will fail the build.

Implementing rules in this way implements checks for compiler warnings with minimal effort.

One issue is that suppressions for detekt compiler warnings are separated by underscore (like "UNCHECKED_CAST") while detekt uses CamelCase.

For rules that overlay compiler checks that have names with underscores we could match the rule ID so a single suppression (`@Suppress("UNCHECKED_CAST")`) would apply to both detekt and the compiler, but then the style of the rule ID differs from the rest of the rules which have CamelCase IDs.

We should pick one option and stick to it because there are many built in warnings that would be good to implement in detekt.