### PR TITLE
Don't fail on master when test coverage decreases

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,3 +4,10 @@ codecov:
   notify:
     require_ci_to_pass: no
     after_n_builds: 4
+coverage:
+  status:
+    # master branch only
+    project:
+      default:
+        # Fail the status if coverage drops by >= 0.1%
+        threshold: 0.1


### PR DESCRIPTION
The build on master shouldn't fail if the test coverage drops slightly.
See commit: 7187493
