### PR TITLE
Deprecate debug in IDEA tasks

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaFormatTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaFormatTask.kt
@@ -27,6 +27,7 @@ open class DetektIdeaFormatTask : SourceTask() {
         set(value) = setSource(value)
 
     @get:Console
+    @get:Deprecated("Has no effect - will be removed in future release.")
     var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @get:Nested

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaInspectionTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektIdeaInspectionTask.kt
@@ -27,6 +27,7 @@ open class DetektIdeaInspectionTask : SourceTask() {
         set(value) = setSource(value)
 
     @get:Console
+    @get:Deprecated("Has no effect - will be removed in future release.")
     var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @get:Nested


### PR DESCRIPTION
These parameters don't do anything in the IDEA tasks, so are deprecated and can be removed in future.