### PR TITLE
Update the JavaExec Gradle task documentation

### DIFF
--- a/docs/pages/gettingstarted/gradletask.md
+++ b/docs/pages/gettingstarted/gradletask.md
@@ -26,9 +26,8 @@ task detekt(type: JavaExec) {
 	classpath = configurations.detekt
 	def input = "$projectDir"
 	def config = "$projectDir/detekt.yml"
-	def filters = ".*/build/.*,.*/resources/.*"
-	def rulesets = ""
-	def params = [ '-i', input, '-c', config, '-f', filters, '-r', rulesets]
+	def exclude = ".*/build/.*,.*/resources/.*"
+	def params = [ '-i', input, '-c', config, '-ex', exclude]
 	args(params)
 }
 


### PR DESCRIPTION
This page is using some detekt-cli flags that have been removed.
I'm cleaning it up to make sure it actually works with the
current version of Detekt.
