### PR TITLE
Gradle deprecations

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -187,6 +187,7 @@ open class Detekt : SourceTask(), VerificationTask {
 
     private val effectiveReportsDir = project.provider { reportsDir.getOrElse(defaultReportsDir.asFile) }
 
+    @Deprecated("Use reports {} to configure custom reports")
     val customReports: Provider<Collection<CustomDetektReport>>
         @Nested
         get() = project.provider { reports.custom }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -73,11 +73,13 @@ open class Detekt : SourceTask(), VerificationTask {
     @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
     var baseline: RegularFileProperty = project.fileProperty()
+        @Deprecated("Use baseline.set()") set
 
     @get:InputFiles
     @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
     var config: ConfigurableFileCollection = project.configurableFileCollection()
+        @Deprecated("Use config.setFrom()") set
 
     @get:Classpath
     @get:Optional
@@ -162,6 +164,7 @@ open class Detekt : SourceTask(), VerificationTask {
 
     @get:Internal
     var reportsDir: Property<File> = project.objects.property(File::class.java)
+        @Deprecated("Use reportsDir.set()") set
 
     val xmlReportFile: Provider<RegularFile>
         @OutputFile

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -204,10 +204,6 @@ open class Detekt : SourceTask(), VerificationTask {
                         "at the same time."
             )
         }
-        val xmlReportTargetFileOrNull = xmlReportFile.orNull
-        val htmlReportTargetFileOrNull = htmlReportFile.orNull
-        val txtReportTargetFileOrNull = txtReportFile.orNull
-        val debugOrDefault = debugProp.getOrElse(false)
         val arguments = mutableListOf(
             InputArgument(source),
             ClasspathArgument(classpath),
@@ -216,10 +212,10 @@ open class Detekt : SourceTask(), VerificationTask {
             ConfigArgument(config),
             PluginsArgument(plugins.orNull),
             BaselineArgument(baseline.orNull),
-            DefaultReportArgument(DetektReportType.XML, xmlReportTargetFileOrNull),
-            DefaultReportArgument(DetektReportType.HTML, htmlReportTargetFileOrNull),
-            DefaultReportArgument(DetektReportType.TXT, txtReportTargetFileOrNull),
-            DebugArgument(debugOrDefault),
+            DefaultReportArgument(DetektReportType.XML, xmlReportFile.orNull),
+            DefaultReportArgument(DetektReportType.HTML, htmlReportFile.orNull),
+            DefaultReportArgument(DetektReportType.TXT, txtReportFile.orNull),
+            DebugArgument(debugProp.getOrElse(false)),
             ParallelArgument(parallelProp.getOrElse(false)),
             BuildUponDefaultConfigArgument(buildUponDefaultConfigProp.getOrElse(false)),
             FailFastArgument(failFastProp.getOrElse(false)),

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -43,6 +43,7 @@ open class DetektCreateBaselineTask : SourceTask() {
 
     @get:OutputFile
     var baseline: RegularFileProperty = project.fileProperty()
+        @Deprecated("Use baseline.set()") set
 
     @Deprecated("Replace with getSource/setSource")
     var input: FileCollection
@@ -59,6 +60,7 @@ open class DetektCreateBaselineTask : SourceTask() {
     @get:Optional
     @PathSensitive(PathSensitivity.RELATIVE)
     var config: ConfigurableFileCollection = project.configurableFileCollection()
+        @Deprecated("Use config.setFrom()") set
 
     @get:Input
     @get:Optional
@@ -76,21 +78,26 @@ open class DetektCreateBaselineTask : SourceTask() {
 
     @get:Console
     var debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+        @Deprecated("Use debug.set()") set
 
     @get:Internal
     var parallel: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+        @Deprecated("Use parallel.set()") set
 
     @get:Input
     @get:Optional
     var disableDefaultRuleSets: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+        @Deprecated("Use disableDefaultRuleSets.set()") set
 
     @get:Input
     @get:Optional
     var buildUponDefaultConfig: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+        @Deprecated("Use buildUponDefaultConfig.set()") set
 
     @get:Input
     @get:Optional
     var failFast: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+        @Deprecated("Use failFast.set()") set
 
     @get:Input
     @get:Optional


### PR DESCRIPTION
Deprecating some properties that will be changed from `var` to `val` in future or will be removed from public scope.

There may be more in future, but safe to start with these.