### PR TITLE
Enable more rules in failfast

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -67,6 +67,10 @@ naming:
     privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
 
+performance:
+  ArrayPrimitive:
+    active: true
+
 potential-bugs:
   EqualsAlwaysReturnsTrueOrFalse:
     active: true

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -59,6 +59,8 @@ formatting:
     active: false
 
 naming:
+  MemberNameEqualsClassName:
+    active: true
   VariableNaming:
     active: true
     variablePattern: '[a-z][A-Za-z0-9]*'
@@ -66,18 +68,44 @@ naming:
     excludeClassPattern: '$^'
 
 potential-bugs:
+  EqualsAlwaysReturnsTrueOrFalse:
+    active: true
+  InvalidRange:
+    active: true
+  IteratorHasNextCallsNextMethod:
+    active: true
+  IteratorNotThrowingNoSuchElementException:
+    active: true
+  MissingWhenCase:
+    active: true
+  RedundantElseInWhen:
+    active: true
+  UnsafeCallOnNullableType:
+    active: true
   UnsafeCast:
     active: true
     excludes: "**/test/**,**/*.Test.kt,**/*.Spec.kt"
   UselessPostfixExpression:
     active: true
+  WrongEqualsTypeParameter:
+    active: true
 
 style:
   CollapsibleIfStatements:
     active: true
+  EqualsNullCall:
+    active: true
   ForbiddenComment:
     active: true
     values: 'TODO:,FIXME:,STOPSHIP:,@author'
+  FunctionOnlyReturningConstant:
+    active: true
+  LoopWithTooManyJumpStatements:
+    active: true
+  LibraryCodeMustSpecifyReturnType:
+    active: true
+    excludes: "**/*.kt"
+    includes: "**/detekt-api/src/main/**/api/*.kt"
   MaxLineLength:
     excludes: "**/test/**,**/*.Test.kt,**/*.Spec.kt"
     excludeCommentStatements: true
@@ -86,21 +114,27 @@ style:
     ignorePropertyDeclaration: true
     ignoreAnnotation: true
     ignoreNumbers: '-1,0,1,2,100,1000'
-  NestedClassesVisibility:
-    active: true
   MayBeConst:
     active: true
-  SpacingBetweenPackageAndImports:
+  NestedClassesVisibility:
     active: true
-  UtilityClassWithPublicConstructor:
+  ProtectedMemberInFinalClass:
+    active: true
+  SpacingBetweenPackageAndImports:
     active: true
   VariableNaming:
     active: true
     variablePattern: '(_)?[a-z][a-zA-Z0-9]*'
+  UnnecessaryAbstractClass:
+    active: true
+  UnnecessaryInheritance:
+    active: true
+  UnusedPrivateClass:
+    active: true
   UnusedPrivateMember:
     active: true
     allowedNames: "(_|ignored|expected)"
-  LibraryCodeMustSpecifyReturnType:
+  UselessCallOnNotNull:
     active: true
-    excludes: "**/*.kt"
-    includes: "**/detekt-api/src/main/**/api/*.kt"
+  UtilityClassWithPublicConstructor:
+    active: true

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SplitPattern.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SplitPattern.kt
@@ -38,6 +38,7 @@ class SplitPattern(
         "The name 'equals' should only be used when matching the 'equals contract'.",
         replaceWith = ReplaceWith("any(value)")
     )
+    @Suppress("WrongEqualsTypeParameter")
     fun equals(value: String?): Boolean = excludes.any { value?.equals(it, ignoreCase = true) == true }
 
     /**

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/DetektPomModel.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/DetektPomModel.kt
@@ -16,6 +16,7 @@ import sun.reflect.ReflectionFactory
  * Adapted from https://github.com/pinterest/ktlint/blob/master/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt
  * Licenced under the MIT licence - https://github.com/pinterest/ktlint/blob/master/LICENSE
  */
+@Suppress("UnsafeCallOnNullableType")
 class DetektPomModel(project: Project) : UserDataHolderBase(), PomModel {
 
     init {

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/MultiRuleSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/MultiRuleSpec.kt
@@ -40,6 +40,7 @@ internal class MultiRuleSpec : Spek({
     }
 })
 
+@Suppress("UnusedPrivateClass") // bug: doesn't resolve usage as generic type
 private class MultiRuleProvider : RuleSetProvider {
     override val ruleSetId: String = "TestMultiRule"
     override fun instance(config: Config): RuleSet = RuleSet(ruleSetId, listOf(TestMultiRule(config)))

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -17,6 +17,7 @@ fun CliArgs.createClasspath(): List<String> = classpath.letIfNonEmpty { split(";
 private fun <T> String?.letIfNonEmpty(init: String.() -> List<T>): List<T> =
     if (this == null || this.isEmpty()) listOf() else this.init()
 
+@Suppress("UnsafeCallOnNullableType")
 fun CliArgs.loadConfiguration(): Config {
     var declaredConfig: Config? = when {
         !config.isNullOrBlank() -> parsePathConfig(config!!)

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporter.kt
@@ -8,7 +8,7 @@ import java.io.File
 class ConfigExporter(private val arguments: CliArgs) : Executable {
 
     override fun execute() {
-        val configPath = if (arguments.config != null) arguments.config!! else DEFAULT_CONFIG
+        val configPath = arguments.config ?: DEFAULT_CONFIG
         val defaultConfig = ClasspathResourceConverter().convert(DEFAULT_CONFIG).openStream()
         defaultConfig.copyTo(File(configPath).outputStream())
         println("Successfully copied default config to ${File(configPath).absolutePath}")

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektResult.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektResult.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.api.RuleSetId
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.util.keyFMap.KeyFMap
 
+@Suppress("DataClassShouldBeImmutable")
 data class DetektResult(override val findings: Map<RuleSetId, List<Finding>>) : Detektion {
 
     private val _notifications = ArrayList<Notification>()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/processors/util/LLOC.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/processors/util/LLOC.kt
@@ -9,9 +9,9 @@ object LLOC {
         lines: List<String>,
         isCommentMode: Boolean = false,
         isFullMode: Boolean = false
-    ): Int = Counter(lines, isCommentMode, isFullMode).run()
+    ): Int = LLOCCounter(lines, isCommentMode, isFullMode).run()
 
-    private class Counter(
+    private class LLOCCounter(
         private val lines: List<String>,
         private val isCommentMode: Boolean = false,
         private val isFullMode: Boolean = false
@@ -22,6 +22,7 @@ object LLOC {
         private var closedBrackets = 0
         private var escape: Boolean = false
 
+        @Suppress("LoopWithTooManyJumpStatements")
         internal fun run(): Int {
             for (line in lines) {
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/OffsetsToLineColumn.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/OffsetsToLineColumn.kt
@@ -15,7 +15,7 @@ internal fun calculateLineColByOffset(text: String): (offset: Int) -> Pair<Int, 
         i = text.indexOf('\n', i + 1)
     } while (i != -1)
     arr.add(e + if (arr.last() == e) 1 else 0)
-    val segmentTree = SegmentTree(arr.toTypedArray())
+    val segmentTree = SegmentTree(arr.toIntArray())
     return { offset ->
         val line = segmentTree.indexOf(offset)
         if (line != -1) {
@@ -36,13 +36,13 @@ internal fun calculateLineBreakOffset(fileContent: String): (offset: Int) -> Int
     } while (i != -1)
     arr.add(fileContent.length)
     return if (arr.size != 2) {
-        SegmentTree(arr.toTypedArray()).let { return { offset -> it.indexOf(offset) } }
+        SegmentTree(arr.toIntArray()).let { return { offset -> it.indexOf(offset) } }
     } else { _ ->
         0
     }
 }
 
-internal class SegmentTree(sortedArray: Array<Int>) {
+internal class SegmentTree(sortedArray: IntArray) {
 
     private val segments: List<Segment>
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/IdeaExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/IdeaExtension.kt
@@ -6,6 +6,7 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 
+@Suppress("UnsafeCallOnNullableType")
 open class IdeaExtension {
 
     @get:InputFile

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
@@ -30,7 +30,7 @@ class CommentOverPrivateFunction(config: Config = Config.empty) : Rule(config) {
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.hasCommentInPrivateMember()) {
-            report(CodeSmell(issue, Entity.from(function.docComment!!), "The function ${function.nameAsSafeName} " +
+            report(CodeSmell(issue, Entity.from(function), "The function ${function.nameAsSafeName} " +
                     "has a comment. Prefer renaming the function giving it a more self-explanatory name."))
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
@@ -28,7 +28,7 @@ class CommentOverPrivateProperty(config: Config = Config.empty) : Rule(config) {
 
     override fun visitProperty(property: KtProperty) {
         if (property.hasCommentInPrivateMember()) {
-            report(CodeSmell(issue, Entity.from(property.docComment!!), issue.description))
+            report(CodeSmell(issue, Entity.from(property), issue.description))
         }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
@@ -32,6 +32,7 @@ class KDocStyle(config: Config = Config.empty) : MultiRule() {
  * @configuration endOfSentenceFormat - regular expression which should match the end of the first sentence in the KDoc
  * (default: `([.?!][ \t\n\r\f<])|([.?!:]$)`)
  */
+@Suppress("MemberNameEqualsClassName")
 class EndOfSentenceFormat(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -25,6 +25,7 @@ data class KtFileContent(val file: KtFile, val content: Sequence<String>)
  *
  * @active since v1.0.0
  */
+@Suppress("MemberNameEqualsClassName")
 class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(javaClass.simpleName,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -72,6 +72,7 @@ class UnusedImports(config: Config) : Rule(config) {
             super.visitPackageDirective(directive)
         }
 
+        @Suppress("UnsafeCallOnNullableType")
         override fun visitImportList(importList: KtImportList) {
             imports = importList.imports.filter { it.isValidImport }
                     .filter { it.identifier()?.contains("*")?.not() == true }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -216,6 +216,7 @@ class ObjectPropertyNamingSpec : Spek({
     }
 })
 
+@Suppress("UnnecessaryAbstractClass")
 abstract class NamingSnippet(private val isPrivate: Boolean, private val isConst: Boolean) {
 
     val negative = """

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
@@ -74,6 +74,7 @@ class KotlinCoreEnvironmentWrapper(
     private val disposable: Disposable
 ) {
 
+    @Suppress("UnsafeCallOnNullableType")
     val env get() = environment!!
 
     fun dispose() {


### PR DESCRIPTION
This enables more rules when running the detekt task on detekt itself.
This PR fixes warnings that are reported by the newly activated rules.
Related issue #1911
