### PR TITLE
HasPlatformType rule

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -387,6 +387,8 @@ potential-bugs:
     active: true
   ExplicitGarbageCollectionCall:
     active: true
+  HasPlatformType:
+    active: false
   InvalidRange:
     active: false
   IteratorHasNextCallsNextMethod:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformType.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformType.kt
@@ -47,8 +47,8 @@ class HasPlatformType(config: Config) : Rule(config) {
     override fun visitKtElement(element: KtElement) {
         super.visitKtElement(element)
 
-        if (bindingContext == BindingContext.EMPTY) return
-        if (element is KtCallableDeclaration && element.hasImplicitPlatformType()) {
+        if (bindingContext != BindingContext.EMPTY && element is KtCallableDeclaration &&
+            element.hasImplicitPlatformType()) {
             report(
                 CodeSmell(
                     issue,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformType.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformType.kt
@@ -1,0 +1,77 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.descriptors.CallableDescriptor
+import org.jetbrains.kotlin.psi.KtCallableDeclaration
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.types.isFlexible
+
+/**
+ * Platform types must be declared explicitly in public APIs to prevent unexpected errors.
+ *
+ * Based on code from Kotlin project:
+ * https://github.com/JetBrains/kotlin/blob/1.3.50/idea/src/org/jetbrains/kotlin/idea/intentions/SpecifyTypeExplicitlyIntention.kt#L86-L107
+ *
+ * <noncompliant>
+ * class Person {
+ *   fun apiCall() = System.getProperty("propertyName")
+ * }
+ * </noncompliant>
+ *
+ * <compliant>
+ * class Person {
+ *   fun apiCall(): String = System.getProperty("propertyName")
+ * }
+ * </compliant>
+ */
+
+class HasPlatformType(config: Config) : Rule(config) {
+
+    override val issue = Issue(
+        "HasPlatformType",
+        Severity.Maintainability,
+        "Platform types must be declared explicitly in public APIs.",
+        Debt.FIVE_MINS
+    )
+
+    override fun visitKtElement(element: KtElement) {
+        super.visitKtElement(element)
+
+        if (bindingContext == BindingContext.EMPTY) return
+        if (element is KtCallableDeclaration && element.hasImplicitPlatformType()) {
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(element),
+                    "$element has implicit platform type. Type must be declared explicitly."
+                )
+            )
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun KtCallableDeclaration.hasImplicitPlatformType(): Boolean {
+        when (this) {
+            is KtFunction -> if (isLocal || hasDeclaredReturnType()) return false
+            is KtProperty -> if (isLocal || typeReference != null) return false
+            else -> return false
+        }
+
+        if (containingClassOrObject?.isLocal == true) return false
+
+        val callable =
+            bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, this] as? CallableDescriptor ?: return false
+        if (!callable.visibility.isPublicAPI) return false
+        return callable.returnType?.isFlexible() ?: return false
+    }
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.rules.bugs.DuplicateCaseInWhenExpression
 import io.gitlab.arturbosch.detekt.rules.bugs.EqualsAlwaysReturnsTrueOrFalse
 import io.gitlab.arturbosch.detekt.rules.bugs.EqualsWithHashCodeExist
 import io.gitlab.arturbosch.detekt.rules.bugs.ExplicitGarbageCollectionCall
+import io.gitlab.arturbosch.detekt.rules.bugs.HasPlatformType
 import io.gitlab.arturbosch.detekt.rules.bugs.InvalidRange
 import io.gitlab.arturbosch.detekt.rules.bugs.IteratorHasNextCallsNextMethod
 import io.gitlab.arturbosch.detekt.rules.bugs.IteratorNotThrowingNoSuchElementException
@@ -36,6 +37,7 @@ class PotentialBugProvider : RuleSetProvider {
                 DuplicateCaseInWhenExpression(config),
                 EqualsAlwaysReturnsTrueOrFalse(config),
                 EqualsWithHashCodeExist(config),
+                HasPlatformType(config),
                 IteratorNotThrowingNoSuchElementException(config),
                 IteratorHasNextCallsNextMethod(config),
                 UselessPostfixExpression(config),

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformTypeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformTypeSpec.kt
@@ -1,0 +1,74 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object HasPlatformTypeSpec : Spek({
+    val subject by memoized { HasPlatformType(Config.empty) }
+
+    val wrapper by memoized(
+        factory = { KtTestCompiler.createEnvironment() },
+        destructor = { it.dispose() }
+    )
+
+    describe("Deprecation detection") {
+
+        it("reports when public function returns expression of platform type") {
+            val code = """
+                class Person {
+                    fun apiCall() = System.getProperty("propertyName")
+                }
+                """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("does not report when private") {
+            val code = """
+                class Person {
+                    private fun apiCall() = System.getProperty("propertyName")
+                }
+                """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+        }
+
+        it("does not report when public function returns expression of platform type and type explicitly declared") {
+            val code = """
+                class Person {
+                    fun apiCall(): String = System.getProperty("propertyName")
+                }
+                """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+        }
+
+        it("reports when property initiated with platform type") {
+            val code = """
+                class Person {
+                    val name = System.getProperty("name")
+                }
+                """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("does not report when private") {
+            val code = """
+                class Person {
+                    private val name = System.getProperty("name")
+                }
+                """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+        }
+
+        it("does not report when property initiated with platform type and type explicitly declared") {
+            val code = """
+                class Person {
+                    val name: String = System.getProperty("name")
+                }
+                """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+        }
+    }
+})

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -132,6 +132,33 @@ Runtime.getRuntime().gc()
 System.runFinalization()
 ```
 
+### HasPlatformType
+
+Platform types must be declared explicitly in public APIs to prevent unexpected errors.
+
+Based on code from Kotlin project:
+https://github.com/JetBrains/kotlin/blob/1.3.50/idea/src/org/jetbrains/kotlin/idea/intentions/SpecifyTypeExplicitlyIntention.kt#L86-L107
+
+**Severity**: Maintainability
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+class Person {
+fun apiCall() = System.getProperty("propertyName")
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+class Person {
+fun apiCall(): String = System.getProperty("propertyName")
+}
+```
+
 ### InvalidRange
 
 Reports ranges which are empty.


### PR DESCRIPTION
Closes #556 

Rule is quite conservative and picks up usage in public APIs only. Future enhancement could be to add a config option to detect implicit usage of platform types anywhere they're found.