### PR TITLE
Fix SpacingBetweenPackageAndImports issue for KTS

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
@@ -44,8 +44,10 @@ class SpacingBetweenPackageAndImports(config: Config = Config.empty) : Rule(conf
             Debt.FIVE_MINS)
 
     override fun visitKtFile(file: KtFile) {
-        containsClassOrObject = file.collectDescendantsOfType<KtClassOrObject>().any() == true
-        super.visitKtFile(file)
+        if (!file.isScript()) {
+            containsClassOrObject = file.collectDescendantsOfType<KtClassOrObject>().any() == true
+            super.visitKtFile(file)
+        }
     }
 
     override fun visitImportList(importList: KtImportList) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
@@ -64,6 +65,12 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
         it("has package declarations in same line") {
             val code = "package test;import a.b;class A {}"
             assertThat(subject.lint(code)).hasSize(2)
+        }
+
+        it("does not report for Kotlin script file") {
+            val code = "package test\nimport a.b\nclass A {}"
+            val ktsFile = KtTestCompiler.compileFromContent(code, "Test.kts")
+            assertThat(subject.lint(ktsFile)).hasSize(0)
         }
 
         it("has multiple imports in file") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
@@ -15,36 +15,36 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
 
         it("has no blank lines violation") {
             val code = "package test\n\nimport a.b\n\nclass A {}"
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("has a package and import declaration") {
             val code = "package test\n\nimport a.b"
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("has no import declaration") {
             val code = "package test\n\nclass A {}"
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("has no package declaration") {
             val code = "import a.b\n\nclass A {}"
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("has no package and import declaration") {
             val code = "class A {}"
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("has a comment declaration") {
             val code = "import a.b\n\n// a comment"
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("is an empty kt file") {
-            assertThat(subject.lint("")).hasSize(0)
+            assertThat(subject.lint("")).isEmpty()
         }
 
         it("has code on new line") {
@@ -70,7 +70,7 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
         it("does not report for Kotlin script file") {
             val code = "package test\nimport a.b\nclass A {}"
             val ktsFile = KtTestCompiler.compileFromContent(code, "Test.kts")
-            assertThat(subject.lint(ktsFile)).hasSize(0)
+            assertThat(subject.lint(ktsFile)).isEmpty()
         }
 
         it("has multiple imports in file") {
@@ -82,7 +82,7 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
 
 				class A { }
 				"""
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("has no class") {
@@ -92,7 +92,7 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
 				import kotlin.collections.List
 				import kotlin.collections.Set
 				"""
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
@@ -31,12 +31,12 @@ object KtTestCompiler : KtCompiler() {
 
     fun compile(path: Path) = compile(root, path)
 
-    fun compileFromContent(content: String): KtFile {
+    fun compileFromContent(content: String, filename: String = TEST_FILENAME): KtFile {
         val file = psiFileFactory.createFileFromText(
-            TEST_FILENAME,
+            filename,
             KotlinLanguage.INSTANCE,
             StringUtilRt.convertLineSeparators(content)) as? KtFile
-        file?.putUserData(ABSOLUTE_PATH, TEST_FILENAME)
+        file?.putUserData(ABSOLUTE_PATH, filename)
         return file ?: throw IllegalStateException("kotlin file expected")
     }
 


### PR DESCRIPTION
SpacingBetweenPackageAndImports does not report for Kotlin script files.
That is because Kotlin scripts have no package directive.
This closes #1937

