### PR TITLE
Fix SpacingBetweenPackageAndImports issue for scripts without packages

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
@@ -44,8 +44,10 @@ class SpacingBetweenPackageAndImports(config: Config = Config.empty) : Rule(conf
             Debt.FIVE_MINS)
 
     override fun visitKtFile(file: KtFile) {
-        containsClassOrObject = file.collectDescendantsOfType<KtClassOrObject>().any() == true
-        super.visitKtFile(file)
+        if (file.packageDirective != null) {
+            containsClassOrObject = file.collectDescendantsOfType<KtClassOrObject>().any() == true
+            super.visitKtFile(file)
+        }
     }
 
     override fun visitImportList(importList: KtImportList) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
@@ -44,7 +44,7 @@ class SpacingBetweenPackageAndImports(config: Config = Config.empty) : Rule(conf
             Debt.FIVE_MINS)
 
     override fun visitKtFile(file: KtFile) {
-        if (file.packageDirective != null) {
+        if (file.packageDirective?.name?.isNotEmpty() == true) {
             containsClassOrObject = file.collectDescendantsOfType<KtClassOrObject>().any() == true
             super.visitKtFile(file)
         }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
@@ -44,10 +44,8 @@ class SpacingBetweenPackageAndImports(config: Config = Config.empty) : Rule(conf
             Debt.FIVE_MINS)
 
     override fun visitKtFile(file: KtFile) {
-        if (!file.isScript()) {
-            containsClassOrObject = file.collectDescendantsOfType<KtClassOrObject>().any() == true
-            super.visitKtFile(file)
-        }
+        containsClassOrObject = file.collectDescendantsOfType<KtClassOrObject>().any() == true
+        super.visitKtFile(file)
     }
 
     override fun visitImportList(importList: KtImportList) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
@@ -14,36 +15,57 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
 
         it("has no blank lines violation") {
             val code = "package test\n\nimport a.b\n\nclass A {}"
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("has a package and import declaration") {
             val code = "package test\n\nimport a.b"
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("has no import declaration") {
             val code = "package test\n\nclass A {}"
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("has no package declaration") {
             val code = "import a.b\n\nclass A {}"
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("has no package and import declaration") {
             val code = "class A {}"
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("has a comment declaration") {
             val code = "import a.b\n\n// a comment"
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("is an empty kt file") {
-            assertThat(subject.lint("")).hasSize(0)
+            assertThat(subject.lint("")).isEmpty()
+        }
+
+        describe("Kotlin scripts") {
+
+            it("has no package declaration in script") {
+                val code = "import a.b\n\nprint(1)"
+                val ktsFile = KtTestCompiler.compileFromContent(code, "Test.kts")
+                assertThat(subject.lint(ktsFile)).isEmpty()
+            }
+
+            it("has no package and import declaration in script") {
+                val code = "print(1)"
+                val ktsFile = KtTestCompiler.compileFromContent(code, "Test.kts")
+                assertThat(subject.lint(ktsFile)).isEmpty()
+            }
+
+            it("has import declarations separated by new line in script") {
+                val code = "import a.b\n\nimport a.c\n\nprint(1)"
+                val ktsFile = KtTestCompiler.compileFromContent(code, "Test.kts")
+                assertThat(subject.lint(ktsFile)).isEmpty()
+            }
         }
 
         it("has code on new line") {
@@ -75,7 +97,7 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
 
 				class A { }
 				"""
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("has no class") {
@@ -85,7 +107,7 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
 				import kotlin.collections.List
 				import kotlin.collections.Set
 				"""
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.KtTestCompiler
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
@@ -15,36 +14,36 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
 
         it("has no blank lines violation") {
             val code = "package test\n\nimport a.b\n\nclass A {}"
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lint(code)).hasSize(0)
         }
 
         it("has a package and import declaration") {
             val code = "package test\n\nimport a.b"
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lint(code)).hasSize(0)
         }
 
         it("has no import declaration") {
             val code = "package test\n\nclass A {}"
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lint(code)).hasSize(0)
         }
 
         it("has no package declaration") {
             val code = "import a.b\n\nclass A {}"
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lint(code)).hasSize(0)
         }
 
         it("has no package and import declaration") {
             val code = "class A {}"
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lint(code)).hasSize(0)
         }
 
         it("has a comment declaration") {
             val code = "import a.b\n\n// a comment"
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lint(code)).hasSize(0)
         }
 
         it("is an empty kt file") {
-            assertThat(subject.lint("")).isEmpty()
+            assertThat(subject.lint("")).hasSize(0)
         }
 
         it("has code on new line") {
@@ -67,12 +66,6 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
             assertThat(subject.lint(code)).hasSize(2)
         }
 
-        it("does not report for Kotlin script file") {
-            val code = "package test\nimport a.b\nclass A {}"
-            val ktsFile = KtTestCompiler.compileFromContent(code, "Test.kts")
-            assertThat(subject.lint(ktsFile)).isEmpty()
-        }
-
         it("has multiple imports in file") {
             val code = """
 				package com.my
@@ -82,7 +75,7 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
 
 				class A { }
 				"""
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).hasSize(0)
         }
 
         it("has no class") {
@@ -92,7 +85,7 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
 				import kotlin.collections.List
 				import kotlin.collections.Set
 				"""
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).hasSize(0)
         }
     }
 })

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
@@ -31,12 +31,12 @@ object KtTestCompiler : KtCompiler() {
 
     fun compile(path: Path) = compile(root, path)
 
-    fun compileFromContent(content: String, filename: String = TEST_FILENAME): KtFile {
+    fun compileFromContent(content: String): KtFile {
         val file = psiFileFactory.createFileFromText(
-            filename,
+            TEST_FILENAME,
             KotlinLanguage.INSTANCE,
             StringUtilRt.convertLineSeparators(content)) as? KtFile
-        file?.putUserData(ABSOLUTE_PATH, filename)
+        file?.putUserData(ABSOLUTE_PATH, TEST_FILENAME)
         return file ?: throw IllegalStateException("kotlin file expected")
     }
 

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
@@ -31,12 +31,12 @@ object KtTestCompiler : KtCompiler() {
 
     fun compile(path: Path) = compile(root, path)
 
-    fun compileFromContent(content: String): KtFile {
+    fun compileFromContent(content: String, filename: String = TEST_FILENAME): KtFile {
         val file = psiFileFactory.createFileFromText(
-            TEST_FILENAME,
+            filename,
             KotlinLanguage.INSTANCE,
             StringUtilRt.convertLineSeparators(content)) as? KtFile
-        file?.putUserData(ABSOLUTE_PATH, TEST_FILENAME)
+        file?.putUserData(ABSOLUTE_PATH, filename)
         return file ?: throw IllegalStateException("kotlin file expected")
     }
 


### PR DESCRIPTION
Both a Kotlin file and a Kotlin script can be declared with and without
a package declaration. This commit checks if the class even contains a
package declaration for both .kt and .kts files.
Closes #1937
