### PR TITLE
ForbiddenMethod Rule

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -440,6 +440,9 @@ style:
   ForbiddenImport:
     active: false
     imports: ''
+  ForbiddenMethod:
+    active: false
+    methods: ''
   ForbiddenVoid:
     active: false
     ignoreOverridden: false

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -13,6 +13,7 @@ import io.gitlab.arturbosch.detekt.rules.style.ExpressionBodySyntax
 import io.gitlab.arturbosch.detekt.rules.style.FileParsingRule
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenComment
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenImport
+import io.gitlab.arturbosch.detekt.rules.style.ForbiddenMethod
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenVoid
 import io.gitlab.arturbosch.detekt.rules.style.FunctionOnlyReturningConstant
 import io.gitlab.arturbosch.detekt.rules.style.LibraryCodeMustSpecifyReturnType
@@ -80,6 +81,7 @@ class StyleGuideProvider : RuleSetProvider {
                 EqualsNullCall(config),
                 ForbiddenComment(config),
                 ForbiddenImport(config),
+                ForbiddenMethod(config),
                 FunctionOnlyReturningConstant(config),
                 SpacingBetweenPackageAndImports(config),
                 LoopWithTooManyJumpStatements(config),

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethod.kt
@@ -1,0 +1,61 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
+import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
+
+/**
+ * This rule allows to set a list of forbidden methods. This can be used to discourage the use of unstable, experimental
+ * or deprecated methods, especially for methods imported from external libraries.
+ * Detekt will then report all methods invocation that are forbidden.
+ *
+ * <noncompliant>
+ * import java.lang.System
+ * fun main() {
+ *    System.gc()
+ * }
+ * </noncompliant>
+ *
+ * @configuration methods - Fully qualified method signatures which should not be used (default: `''`)
+ */
+class ForbiddenMethod(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Mark forbidden methods. A forbidden method could be an invocation of an unstable / experimental " +
+                "method and hence you might want to mark it as forbidden in order to get warned about the usage.",
+        Debt.TEN_MINS
+    )
+
+    private val forbiddenMethods = valueOrDefault(METHODS, "").split(",")
+        .map { it.trim() }
+        .filter { it.isNotBlank() }
+        .map { it.split(".") }
+        .map { it.subList(0, it.size - 1).joinToString(".") to it.last() }
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        val callNameExpression = expression.getCallNameExpression()
+        val callNameText = callNameExpression?.text
+        val receiverText = callNameExpression?.getReceiverExpression()?.text ?: ""
+        if (receiverText to callNameText in forbiddenMethods) {
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression), "The method " +
+                            "$callNameText.$receiverText has been forbidden in the Detekt config."
+                )
+            )
+        }
+    }
+
+    companion object {
+        const val METHODS = "methods"
+    }
+}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodSpec.kt
@@ -1,0 +1,102 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class ForbiddenMethodSpec : Spek({
+
+    describe("ForbiddenMethod rule") {
+
+        it("should report nothing by default") {
+            val code = """
+            import java.lang.System
+            fun main() {
+			    System.out.println("hello")
+            }
+		    """
+            val findings = ForbiddenMethod(TestConfig()).compileAndLint(code)
+            assertThat(findings).hasSize(0)
+        }
+
+        it("should report nothing when methods are blank") {
+            val code = """
+            import java.lang.System
+            fun main() {
+			    System.out.println("hello")
+            }
+		    """
+            val findings = ForbiddenMethod(TestConfig(mapOf(ForbiddenMethod.METHODS to "  "))).compileAndLint(code)
+            assertThat(findings).hasSize(0)
+        }
+
+        it("should report nothing when methods do not match") {
+            val code = """
+            import java.lang.System
+            fun main() {
+			    System.out.println("hello")
+            }
+		    """
+            val findings = ForbiddenMethod(
+                TestConfig(mapOf(ForbiddenMethod.METHODS to "System.gc"))
+            ).compileAndLint(code)
+            assertThat(findings).hasSize(0)
+        }
+
+        it("should not report System.out.println when methods is println") {
+            val code = """
+            import java.lang.System
+            fun main() {
+			    System.out.println("hello")
+            }
+		    """
+            val findings = ForbiddenMethod(
+                TestConfig(mapOf(ForbiddenMethod.METHODS to "println"))
+            ).compileAndLint(code)
+            assertThat(findings).isEmpty()
+        }
+
+        it("should report System.out.println when methods is System.out.println") {
+            val code = """
+            import java.lang.System
+            fun main() {
+			    System.out.println("hello")
+            }
+		    """
+            val findings = ForbiddenMethod(
+                TestConfig(mapOf(ForbiddenMethod.METHODS to "System.out.println"))
+            ).compileAndLint(code)
+            assertThat(findings).hasLocationStrings("'println(\"hello\")' at (3,12) in /Test.kt")
+        }
+
+        it("should report println when methods is println") {
+            val code = """
+            fun main() {
+			    println("hello")
+            }
+		    """
+            val findings = ForbiddenMethod(
+                TestConfig(mapOf(ForbiddenMethod.METHODS to "println"))
+            ).compileAndLint(code)
+            assertThat(findings).isNotEmpty()
+        }
+
+        it("should report System.out.println and System.gc when specified in methods") {
+            val code = """
+            import java.lang.System
+            fun main() {
+			    System.out.println("hello")
+                System.gc()
+            }
+		    """
+            val findings = ForbiddenMethod(
+                TestConfig(mapOf(ForbiddenMethod.METHODS to "System.out.println, System.gc"))
+            ).compileAndLint(code)
+            assertThat(findings)
+                .hasSize(2)
+                .hasLocationStrings("'gc()' at (4,17) in /Test.kt", "'println(\"hello\")' at (3,12) in /Test.kt")
+        }
+    }
+})

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -273,6 +273,31 @@ import kotlin.jvm.JvmField
 import kotlin.SinceKotlin
 ```
 
+### ForbiddenMethod
+
+This rule allows to set a list of forbidden methods. This can be used to discourage the use of unstable, experimental
+or deprecated methods, especially for methods imported from external libraries.
+Detekt will then report all methods invocation that are forbidden.
+
+**Severity**: Style
+
+**Debt**: 10min
+
+#### Configuration options:
+
+* `methods` (default: `''`)
+
+   Fully qualified method signatures which should not be used
+
+#### Noncompliant Code:
+
+```kotlin
+import java.lang.System
+fun main() {
+    System.gc()
+}
+```
+
 ### ForbiddenVoid
 
 This rule detects usages of `Void` and reports them as forbidden.


### PR DESCRIPTION
Add a rule to identify call site of forbidden methods
specified by the user in the Detekt config.

This rule is currently not using type and symbol solving, and is just doing a text comparison to check the method invocation. I'm looking for some feedbacks or ideas on how to potentially improve it. Ideally we should use a `org.jetbrains.kotlin.resolve.calls.CallExpressionResolver` but I haven't really managed to let it work.

Fixes #1042