### PR TITLE
ForbiddenMethod Rule

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -459,6 +459,9 @@ style:
     active: false
     imports: ''
     forbiddenPatterns: ""
+  ForbiddenMethodCall:
+    active: false
+    methods: ''
   ForbiddenPublicDataClass:
     active: false
     ignorePackages: '*.internal,*.internal.*'

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -14,6 +14,7 @@ import io.gitlab.arturbosch.detekt.rules.style.FileParsingRule
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenComment
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenImport
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenPublicDataClass
+import io.gitlab.arturbosch.detekt.rules.style.ForbiddenMethodCall
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenVoid
 import io.gitlab.arturbosch.detekt.rules.style.FunctionOnlyReturningConstant
 import io.gitlab.arturbosch.detekt.rules.style.LibraryCodeMustSpecifyReturnType
@@ -83,6 +84,7 @@ class StyleGuideProvider : RuleSetProvider {
                 EqualsNullCall(config),
                 ForbiddenComment(config),
                 ForbiddenImport(config),
+                ForbiddenMethodCall(config),
                 ForbiddenPublicDataClass(config),
                 FunctionOnlyReturningConstant(config),
                 SpacingBetweenPackageAndImports(config),

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -1,0 +1,61 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.commaSeparatedPattern
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
+
+/**
+ * This rule allows to set a list of forbidden methods. This can be used to discourage the use of unstable, experimental
+ * or deprecated methods, especially for methods imported from external libraries.
+ * Detekt will then report all methods invocation that are forbidden.
+ *
+ * <noncompliant>
+ * import java.lang.System
+ * fun main() {
+ *    System.gc()
+ * }
+ * </noncompliant>
+ *
+ * @configuration methods - Comma separated list of fully qualified method signatures which are forbidden (default: `''`)
+ */
+class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Mark forbidden methods. A forbidden method could be an invocation of an unstable / experimental " +
+                "method and hence you might want to mark it as forbidden in order to get warned about the usage.",
+        Debt.TEN_MINS
+    )
+
+    private val forbiddenMethods = valueOrDefault(METHODS, "").commaSeparatedPattern()
+
+    override fun visitQualifiedExpression(expression: KtQualifiedExpression) {
+        super.visitQualifiedExpression(expression)
+        if (bindingContext == BindingContext.EMPTY) return
+
+        val resolvedCall = expression.getResolvedCall(bindingContext) ?: return
+        val fqName = resolvedCall.resultingDescriptor.fqNameOrNull()?.asString()
+
+        if (fqName != null && fqName in forbiddenMethods) {
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression), "The method $fqName has been forbidden in the Detekt config."
+                )
+            )
+        }
+    }
+
+    companion object {
+        const val METHODS = "methods"
+    }
+}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -1,0 +1,100 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class ForbiddenMethodCallSpec : Spek({
+
+    val wrapper by memoized(
+        factory = { KtTestCompiler.createEnvironment() },
+        destructor = { it.dispose() }
+    )
+
+    describe("ForbiddenMethodCall rule") {
+
+        it("should report nothing by default") {
+            val code = """
+            import java.lang.System
+            fun main() {
+            System.out.println("hello")
+            }
+            """
+            val findings = ForbiddenMethodCall(TestConfig()).compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        it("should report nothing when methods are blank") {
+            val code = """
+            import java.lang.System
+            fun main() {
+            System.out.println("hello")
+            }
+            """
+            val findings =
+                ForbiddenMethodCall(TestConfig(mapOf(ForbiddenMethodCall.METHODS to "  "))).compileAndLintWithContext(
+                    wrapper.env,
+                    code
+                )
+            assertThat(findings).isEmpty()
+        }
+
+        it("should report nothing when methods do not match") {
+            val code = """
+            import java.lang.System
+            fun main() {
+            System.out.println("hello")
+            }
+            """
+            val findings = ForbiddenMethodCall(
+                TestConfig(mapOf(ForbiddenMethodCall.METHODS to "java.lang.System.gc"))
+            ).compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        it("should report method call when using the fully qualified name") {
+            val code = """
+            fun main() {
+            java.lang.System.out.println("hello")
+            }
+            """
+            val findings = ForbiddenMethodCall(
+                TestConfig(mapOf(ForbiddenMethodCall.METHODS to "java.io.PrintStream.println"))
+            ).compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasTextLocations(13 to 50)
+        }
+
+        it("should report method call when not using the fully qualified name") {
+            val code = """
+            import java.lang.System.out
+            fun main() {
+            out.println("hello")
+            }
+            """
+            val findings = ForbiddenMethodCall(
+                TestConfig(mapOf(ForbiddenMethodCall.METHODS to "java.io.PrintStream.println"))
+            ).compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasTextLocations(41 to 61)
+        }
+
+        it("should report multiple different methods") {
+            val code = """
+            import java.lang.System
+            fun main() {
+            System.out.println("hello")
+                System.gc()
+            }
+            """
+            val findings = ForbiddenMethodCall(
+                TestConfig(mapOf(ForbiddenMethodCall.METHODS to "java.io.PrintStream.println, java.lang.System.gc"))
+            ).compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(2)
+            assertThat(findings).hasTextLocations(37 to 64, 69 to 80)
+        }
+    }
+})

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -277,6 +277,31 @@ import kotlin.jvm.JvmField
 import kotlin.SinceKotlin
 ```
 
+### ForbiddenMethodCall
+
+This rule allows to set a list of forbidden methods. This can be used to discourage the use of unstable, experimental
+or deprecated methods, especially for methods imported from external libraries.
+Detekt will then report all methods invocation that are forbidden.
+
+**Severity**: Style
+
+**Debt**: 10min
+
+#### Configuration options:
+
+* ``methods`` (default: ``''``)
+
+   Comma separated list of fully qualified method signatures which are forbidden
+
+#### Noncompliant Code:
+
+```kotlin
+import java.lang.System
+fun main() {
+    System.gc()
+}
+```
+
 ### ForbiddenPublicDataClass
 
 The data classes are bad for the binary compatibility in public APIs. Avoid to use it.


### PR DESCRIPTION
Add a rule to identify call site of forbidden methods
specified by the user in the Detekt config.

This rule is currently not using type and symbol solving, and is just doing a text comparison to check the method invocation. I'm looking for some feedbacks or ideas on how to potentially improve it. Ideally we should use a `org.jetbrains.kotlin.resolve.calls.CallExpressionResolver` but I haven't really managed to let it work.

Fixes #1072