### PR TITLE
Fix build failure on Travis/JDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
     - os: linux
       dist: xenial
-      jdk: openjdk8
+      jdk: oraclejdk8
     - os: linux
       dist: bionic
       jdk: openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: java
 matrix:
   include:
     - os: linux
-      dist: xenial
+      dist: trusty
       jdk: oraclejdk8
     - os: linux
       dist: bionic


### PR DESCRIPTION
This changes the openjdk to oraclejdk on Travis according to
https://travis-ci.community/t/install-of-oracle-jdk8-is-failing/4365/3
The openjdk seems to be faulty on Travis.
Closes #1925 