### PR TITLE
Convert tabs in multiline strings to 4 spaces

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -41,7 +41,7 @@ abstract class Rule(
      * When overriding this property make sure to meet following structure for detekt-generator to pick
      * it up and generate documentation for aliases:
      *
-     * 		override val defaultRuleIdAliases = setOf("Name1", "Name2")
+     *      override val defaultRuleIdAliases = setOf("Name1", "Name2")
      */
     open val defaultRuleIdAliases: Set<String> = emptySet()
 

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
@@ -15,10 +15,10 @@ class AnnotationExcluderSpec : Spek({
         val sinceKotlinAnnotation = psiFactory.createAnnotationEntry("@SinceKotlin")
 
         val file = compileContentForTest("""
-			package foo
+            package foo
 
-			import kotlin.jvm.JvmField
-		""".trimIndent())
+            import kotlin.jvm.JvmField
+        """.trimIndent())
 
         it("should exclude when the annotation was found") {
             val excluder = AnnotationExcluder(file, SplitPattern("JvmField"))

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SuppressibleSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SuppressibleSpec.kt
@@ -91,9 +91,9 @@ internal class SuppressibleSpec : Spek({
 
 private fun checkSuppression(annotation: String, argument: String): Boolean {
     val annotated = """
-			@$annotation("$argument")
-			class Test {}
-			 """
+            @$annotation("$argument")
+            class Test {}
+             """
     val file = compileContentForTest(annotated)
     val annotatedClass = file.children.first { it is KtClass } as KtAnnotated
     return annotatedClass.isSuppressedBy("Test", setOf("alias"))

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SuppressionSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SuppressionSpec.kt
@@ -37,14 +37,14 @@ internal class SuppressionSpec : Spek({
 
         it("rule should be suppressed by detekt prefix in uppercase with dot separator") {
             val ktFile = compileContentForTest("""
-			@file:Suppress("Detekt.ALL")
-			object SuppressedWithDetektPrefix {
+            @file:Suppress("Detekt.ALL")
+            object SuppressedWithDetektPrefix {
 
-				fun stuff() {
-					println("FAILED TEST")
-				}
-			}
-			""")
+                fun stuff() {
+                    println("FAILED TEST")
+                }
+            }
+            """)
             val rule = TestRule()
             rule.visitFile(ktFile)
             assertThat(rule.expected).isNotNull()
@@ -52,14 +52,14 @@ internal class SuppressionSpec : Spek({
 
         it("rule should be suppressed by detekt prefix in lowercase with colon separator") {
             val ktFile = compileContentForTest("""
-			@file:Suppress("detekt:ALL")
-			object SuppressedWithDetektPrefix {
+            @file:Suppress("detekt:ALL")
+            object SuppressedWithDetektPrefix {
 
-				fun stuff() {
-					println("FAILED TEST")
-				}
-			}
-			""")
+                fun stuff() {
+                    println("FAILED TEST")
+                }
+            }
+            """)
             val rule = TestRule()
             rule.visitFile(ktFile)
             assertThat(rule.expected).isNotNull()
@@ -67,14 +67,14 @@ internal class SuppressionSpec : Spek({
 
         it("rule should be suppressed by detekt prefix in all caps with colon separator") {
             val ktFile = compileContentForTest("""
-			@file:Suppress("DETEKT:ALL")
-			object SuppressedWithDetektPrefix {
+            @file:Suppress("DETEKT:ALL")
+            object SuppressedWithDetektPrefix {
 
-				fun stuff() {
-					println("FAILED TEST")
-				}
-			}
-			""")
+                fun stuff() {
+                    println("FAILED TEST")
+                }
+            }
+            """)
             val rule = TestRule()
             rule.visitFile(ktFile)
             assertThat(rule.expected).isNotNull()
@@ -85,14 +85,14 @@ internal class SuppressionSpec : Spek({
 
         it("allows to declare") {
             val ktFile = compileContentForTest("""
-			@file:Suppress("detekt:MyTest")
-			object SuppressedWithDetektPrefixAndCustomConfigBasedPrefix {
+            @file:Suppress("detekt:MyTest")
+            object SuppressedWithDetektPrefixAndCustomConfigBasedPrefix {
 
-				fun stuff() {
-					println("FAILED TEST")
-				}
-			}
-			""")
+                fun stuff() {
+                    println("FAILED TEST")
+                }
+            }
+            """)
             val rule = TestRule(TestConfig(mutableMapOf("aliases" to "[MyTest]")))
             rule.visitFile(ktFile)
             assertThat(rule.expected).isNotNull()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/McCabeVisitorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/McCabeVisitorSpec.kt
@@ -13,14 +13,14 @@ class McCabeVisitorSpec : Spek({
 
         it("counts simple when branches as 1") {
             val code = """
-				fun test() {
-					when (System.currentTimeMillis()) {
-						0 -> println("Epoch!")
-						1 -> println("1 past epoch.")
-						else -> println("Meh")
-					}
-				}
-			"""
+                fun test() {
+                    when (System.currentTimeMillis()) {
+                        0 -> println("Epoch!")
+                        1 -> println("1 past epoch.")
+                        else -> println("Meh")
+                    }
+                }
+            """
             val subject = McCabeVisitor(ignoreSimpleWhenEntries = false)
 
             subject.visitFile(code.compile())
@@ -30,16 +30,16 @@ class McCabeVisitorSpec : Spek({
 
         it("counts block when branches as 1") {
             val code = """
-				fun test() {
-					when (System.currentTimeMillis()) {
-						0 -> {
-							println("Epoch!")
-						}
-						1 -> println("1 past epoch.")
-						else -> println("Meh")
-					}
-				}
-			"""
+                fun test() {
+                    when (System.currentTimeMillis()) {
+                        0 -> {
+                            println("Epoch!")
+                        }
+                        1 -> println("1 past epoch.")
+                        else -> println("Meh")
+                    }
+                }
+            """
             val subject = McCabeVisitor(ignoreSimpleWhenEntries = false)
 
             subject.visitFile(code.compile())
@@ -52,14 +52,14 @@ class McCabeVisitorSpec : Spek({
 
         it("counts a when with only simple branches as 1") {
             val code = """
-				fun test() {
-					when (System.currentTimeMillis()) {
-						0 -> println("Epoch!")
-						1 -> println("1 past epoch.")
-						else -> println("Meh")
-					}
-				}
-			"""
+                fun test() {
+                    when (System.currentTimeMillis()) {
+                        0 -> println("Epoch!")
+                        1 -> println("1 past epoch.")
+                        else -> println("Meh")
+                    }
+                }
+            """
             val subject = McCabeVisitor(ignoreSimpleWhenEntries = true)
 
             subject.visitFile(code.compile())
@@ -69,19 +69,19 @@ class McCabeVisitorSpec : Spek({
 
         it("does not count simple when branches") {
             val code = """
-				fun test() {
-					when (System.currentTimeMillis()) {
-						0 -> {
-							println("Epoch!")
-							println("yay")
-						}
-						1 -> {
-							println("1 past epoch!")
-						}
-						else -> println("Meh")
-					}
-				}
-			"""
+                fun test() {
+                    when (System.currentTimeMillis()) {
+                        0 -> {
+                            println("Epoch!")
+                            println("yay")
+                        }
+                        1 -> {
+                            println("1 past epoch!")
+                        }
+                        else -> println("Meh")
+                    }
+                }
+            """
             val subject = McCabeVisitor(ignoreSimpleWhenEntries = true)
 
             subject.visitFile(code.compile())
@@ -92,21 +92,21 @@ class McCabeVisitorSpec : Spek({
         it("counts block when branches as 1") {
             val subject = McCabeVisitor(ignoreSimpleWhenEntries = true)
             val code = """
-				fun test() {
-					when (System.currentTimeMillis()) {
-						0 -> {
-							println("Epoch!")
-							println("yay!")
-						}
-						1 -> {
-							println("1 past epoch.")
-							println("yay?")
-						}
-						2 -> println("shrug")
-						else -> println("Meh")
-					}
-				}
-			"""
+                fun test() {
+                    when (System.currentTimeMillis()) {
+                        0 -> {
+                            println("Epoch!")
+                            println("yay!")
+                        }
+                        1 -> {
+                            println("1 past epoch.")
+                            println("yay?")
+                        }
+                        2 -> println("shrug")
+                        else -> println("Meh")
+                    }
+                }
+            """
 
             subject.visitFile(code.compile())
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CustomRuleSetProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CustomRuleSetProviderSpec.kt
@@ -11,10 +11,10 @@ import java.nio.file.Paths
  * When any breaking change in 'detekt-api' is done, this test will break.
  *
  * The procedure to repair this test is:
- * 	1. 'gradle build -x test publishToMavenLocal'
- * 	2. 'gradle build' again to let the 'sample' project pick up the new api changes.
- * 	3. 'cp detekt-sample-extensions/build/libs/detekt-sample-extensions-<version>.jar detekt-core/src/test/resources/sample-rule-set.jar'
- * 	4. Now 'gradle build' should be green again.
+ *  1. 'gradle build -x test publishToMavenLocal'
+ *  2. 'gradle build' again to let the 'sample' project pick up the new api changes.
+ *  3. 'cp detekt-sample-extensions/build/libs/detekt-sample-extensions-<version>.jar detekt-core/src/test/resources/sample-rule-set.jar'
+ *  4. Now 'gradle build' should be green again.
  */
 class CustomRuleSetProviderSpec : Spek({
 

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/DetektPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/DetektPrinter.kt
@@ -24,14 +24,14 @@ class DetektPrinter(private val arguments: GeneratorArgs) {
     private fun jekyllHeader(ruleSet: String): String {
         check(ruleSet.length > 1) { "Rule set name must be not empty or less than two symbols." }
         return """
-			|---
-			|title: ${ruleSet[0].toUpperCase()}${ruleSet.substring(1)} Rule Set
-			|sidebar: home_sidebar
-			|keywords: rules, $ruleSet
-			|permalink: $ruleSet.html
-			|toc: true
-			|folder: documentation
-			|---
-		""".trimMargin()
+            |---
+            |title: ${ruleSet[0].toUpperCase()}${ruleSet.substring(1)} Rule Set
+            |sidebar: home_sidebar
+            |keywords: rules, $ruleSet
+            |permalink: $ruleSet.html
+            |toc: true
+            |folder: documentation
+            |---
+        """.trimMargin()
     }
 }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollectorSpec.kt
@@ -15,22 +15,22 @@ class MultiRuleCollectorSpec : Spek({
 
         it("collects no multirule when no class is extended") {
             val code = """
-				package foo
+                package foo
 
-				class SomeRandomClass {
-				}
-			"""
+                class SomeRandomClass {
+                }
+            """
             val items = subject.run(code)
             assertThat(items).isEmpty()
         }
 
         it("collects no rules when no multirule class is extended") {
             val code = """
-				package foo
+                package foo
 
-				class SomeRandomClass: SomeOtherClass {
-				}
-			"""
+                class SomeRandomClass: SomeOtherClass {
+                }
+            """
             val items = subject.run(code)
             assertThat(items).isEmpty()
         }
@@ -38,11 +38,11 @@ class MultiRuleCollectorSpec : Spek({
         it("throws when no rules are added") {
             val name = "SomeRandomClass"
             val code = """
-				package foo
+                package foo
 
-				class $name: MultiRule {
-				}
-			"""
+                class $name: MultiRule {
+                }
+            """
             assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy {
                 subject.run(code)
             }
@@ -51,20 +51,20 @@ class MultiRuleCollectorSpec : Spek({
         it("collects all rules in fields and in the rule property") {
             val name = "SomeRandomClass"
             val code = """
-				package foo
+                package foo
 
-				class $name: MultiRule {
-					val propertyRuleOne = RuleOne()
-					val propertyRuleTwo = RuleTwo()
+                class $name: MultiRule {
+                    val propertyRuleOne = RuleOne()
+                    val propertyRuleTwo = RuleTwo()
 
-					override val rules: List<Rule> = listOf(
-								FirstRule(),
-								SecondRule(),
-								propertyRuleOne,
-								propertyRuleTwo
-						)
-				}
-			"""
+                    override val rules: List<Rule> = listOf(
+                                FirstRule(),
+                                SecondRule(),
+                                propertyRuleOne,
+                                propertyRuleTwo
+                        )
+                }
+            """
             val items = subject.run(code)
             assertThat(items[0].rules).hasSize(4)
             assertThat(items[0].rules).contains("FirstRule", "SecondRule", "RuleOne", "RuleTwo")

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -39,11 +39,11 @@ class RuleCollectorSpec : Spek({
         it("collects the rule name") {
             val name = "SomeRandomClass"
             val code = """
-				/**
-				 * description
-				 */
-				class $name : Rule
-			"""
+                /**
+                 * description
+                 */
+                class $name : Rule
+            """
             val items = subject.run(code)
             assertThat(items[0].name).isEqualTo(name)
         }
@@ -51,11 +51,11 @@ class RuleCollectorSpec : Spek({
         it("collects the rule description") {
             val description = "description"
             val code = """
-				/**
-				 * $description
-				 */
-				class SomeRandomClass : Rule
-			"""
+                /**
+                 * $description
+                 */
+                class SomeRandomClass : Rule
+            """
             val items = subject.run(code)
             assertThat(items[0].description).isEqualTo(description)
         }
@@ -63,13 +63,13 @@ class RuleCollectorSpec : Spek({
         it("has a multi paragraph description") {
             val description = "description"
             val code = """
-				/**
-				 * $description
-				 *
-				 * more...
-				 */
-				class SomeRandomClass : Rule
-			"""
+                /**
+                 * $description
+                 *
+                 * more...
+                 */
+                class SomeRandomClass : Rule
+            """
             val items = subject.run(code)
             assertThat(items[0].description).startsWith(description)
             assertThat(items[0].description).contains("more...")
@@ -77,61 +77,61 @@ class RuleCollectorSpec : Spek({
 
         it("is not active") {
             val code = """
-				/**
-				 * description
-				 */
-				class SomeRandomClass : Rule
-			"""
+                /**
+                 * description
+                 */
+                class SomeRandomClass : Rule
+            """
             val items = subject.run(code)
             assertThat(items[0].active).isFalse()
         }
 
         it("is active tag present") {
             val code = """
-				/**
-				 * description
-				 * @active
-				 */
-				class SomeRandomClass : Rule
-			"""
+                /**
+                 * description
+                 * @active
+                 */
+                class SomeRandomClass : Rule
+            """
             val items = subject.run(code)
             assertThat(items[0].active).isTrue()
         }
 
         it("is auto-correctable tag is present") {
             val code = """
-				/**
-				 * description
-				 * @autoCorrect
-				 */
-				class SomeRandomClass : Rule
-			"""
+                /**
+                 * description
+                 * @autoCorrect
+                 */
+                class SomeRandomClass : Rule
+            """
             val items = subject.run(code)
             assertThat(items[0].autoCorrect).isTrue()
         }
 
         it("is active if the tag is there and has a description") {
             val code = """
-				/**
-				 * description
-				 * @active description about the active tag
-				 */
-				class SomeRandomClass : Rule
-			"""
+                /**
+                 * description
+                 * @active description about the active tag
+                 */
+                class SomeRandomClass : Rule
+            """
             val items = subject.run(code)
             assertThat(items[0].active).isTrue()
         }
 
         it("collects the issue property") {
             val code = """
-				/**
-				 * description
-				 */
-				class SomeRandomClass : Rule {
-					override val defaultRuleIdAliases = setOf("RULE", "RULE2")
+                /**
+                 * description
+                 */
+                class SomeRandomClass : Rule {
+                    override val defaultRuleIdAliases = setOf("RULE", "RULE2")
                     override val issue = Issue(javaClass.simpleName, Severity.Style, "", Debt.TEN_MINS)
-				}
-			"""
+                }
+            """
             val items = subject.run(code)
             assertThat(items[0].severity).isEqualTo("Style")
             assertThat(items[0].debt).isEqualTo("10min")
@@ -140,23 +140,23 @@ class RuleCollectorSpec : Spek({
 
         it("contains no configuration options by default") {
             val code = """
-				/**
-				 * description
-				 */
-				class SomeRandomClass : Rule
-			"""
+                /**
+                 * description
+                 */
+                class SomeRandomClass : Rule
+            """
             val items = subject.run(code)
             assertThat(items[0].configuration).isEmpty()
         }
 
         it("contains one configuration option with correct formatting") {
             val code = """
-				/**
-				 * description
-				 * @configuration config - description (default: `'[A-Z$]'`)
-				 */
-				class SomeRandomClass : Rule
-			"""
+                /**
+                 * description
+                 * @configuration config - description (default: `'[A-Z$]'`)
+                 */
+                class SomeRandomClass : Rule
+            """
             val items = subject.run(code)
             assertThat(items[0].configuration).hasSize(1)
             assertThat(items[0].configuration[0].name).isEqualTo("config")
@@ -166,76 +166,76 @@ class RuleCollectorSpec : Spek({
 
         it("contains multiple configuration options") {
             val code = """
-				/**
-				 * description
-				 * @configuration config - description (default: `""`)
-				 * @configuration config2 - description2 (default: `""`)
-				 */
-				class SomeRandomClass: Rule
-			"""
+                /**
+                 * description
+                 * @configuration config - description (default: `""`)
+                 * @configuration config2 - description2 (default: `""`)
+                 */
+                class SomeRandomClass: Rule
+            """
             val items = subject.run(code)
             assertThat(items[0].configuration).hasSize(2)
         }
 
         it("config option doesn't have a default value") {
             val code = """
-				/**
-				 * description
-				 * @configuration config - description
-				 */
-				class SomeRandomClass : Rule
-			"""
+                /**
+                 * description
+                 * @configuration config - description
+                 */
+                class SomeRandomClass : Rule
+            """
             assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
         }
 
         it("has a blank default value") {
             val code = """
-				/**
-				 * description
-				 * @configuration config - description (default: ``)
-				 */
-				class SomeRandomClass : Rule
-			"""
+                /**
+                 * description
+                 * @configuration config - description (default: ``)
+                 */
+                class SomeRandomClass : Rule
+            """
             assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
         }
 
         it("has an incorrectly delimited default value") {
             val code = """
-				/**
-				 * description
-				 * @configuration config - description (default: true)
-				 */
-				class SomeRandomClass : Rule
-			"""
+                /**
+                 * description
+                 * @configuration config - description (default: true)
+                 */
+                class SomeRandomClass : Rule
+            """
             assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
         }
 
         it("contains a misconfigured configuration option") {
             val code = """
-				/**
-				 * description
-				 * @configuration something: description
-				 */
-				class SomeRandomClass : Rule
-			"""
+                /**
+                 * description
+                 * @configuration something: description
+                 */
+                class SomeRandomClass : Rule
+            """
             assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
         }
 
         it("contains compliant and noncompliant code examples") {
             val code = """
-				/**
-				 * description
-				 *
-				 * <noncompliant>
-				 * val one = 2
-				 * </noncompliant>
-				 *
-				 * <compliant>
-				 * val one = 1
-				 * </compliant>
-				 */
-				class RandomClass : Rule
-			"""
+                /**
+                 * description
+                 *
+                 * <noncompliant>
+                 * val one = 2
+                 * </noncompliant>
+                 *
+                 * <compliant>
+                 * val one = 1
+                 * </compliant>
+                 */
+                class RandomClass : Rule
+            """
             val items = subject.run(code)
             assertThat(items[0].nonCompliantCodeExample).isEqualTo("val one = 2")
             assertThat(items[0].compliantCodeExample).isEqualTo("val one = 1")
@@ -243,80 +243,80 @@ class RuleCollectorSpec : Spek({
 
         it("has wrong noncompliant code example declaration") {
             val code = """
-				/**
-				 * description
-				 *
-				 * <noncompliant>
-				 */
-				class RandomClass : Rule
-			"""
+                /**
+                 * description
+                 *
+                 * <noncompliant>
+                 */
+                class RandomClass : Rule
+            """
             assertThatExceptionOfType(InvalidCodeExampleDocumentationException::class.java)
                 .isThrownBy { subject.run(code) }
         }
 
         it("has wrong compliant code example declaration") {
             val code = """
-				/**
-				 * description
-				 *
-				 * <noncompliant>
-				 * val one = 2
-				 * </noncompliant>
-				 * <compliant>
-				 */
-				class RandomClass : Rule
-			"""
+                /**
+                 * description
+                 *
+                 * <noncompliant>
+                 * val one = 2
+                 * </noncompliant>
+                 * <compliant>
+                 */
+                class RandomClass : Rule
+            """
             assertThatExceptionOfType(InvalidCodeExampleDocumentationException::class.java)
                 .isThrownBy { subject.run(code) }
         }
 
         it("has wrong compliant without noncompliant code example declaration") {
             val code = """
-				/**
-				 * description
-				 *
-				 * <compliant>
-				 * val one = 1
-				 * </compliant>
-				 */
-				class RandomClass : Rule
-			"""
+                /**
+                 * description
+                 *
+                 * <compliant>
+                 * val one = 1
+                 * </compliant>
+                 */
+                class RandomClass : Rule
+            """
             assertThatExceptionOfType(InvalidCodeExampleDocumentationException::class.java)
                 .isThrownBy { subject.run(code) }
         }
 
         it("has wrong issue style property") {
             val code = """
-				/**
-				 * description
-				 */
-				class SomeRandomClass : Rule {
+                /**
+                 * description
+                 */
+                class SomeRandomClass : Rule {
 
-					val style = Severity.Style
-					override val issue = Issue(javaClass.simpleName,
-							style,
-							"",
-							debt = Debt.TEN_MINS)
-				}
-			"""
+                    val style = Severity.Style
+                    override val issue = Issue(javaClass.simpleName,
+                            style,
+                            "",
+                            debt = Debt.TEN_MINS)
+                }
+            """
             assertThatExceptionOfType(InvalidIssueDeclaration::class.java).isThrownBy { subject.run(code) }
         }
 
         it("has wrong aliases property structure") {
             val code = """
-				/**
-				 * description
-				 */
-				class SomeRandomClass : Rule {
+                /**
+                 * description
+                 */
+                class SomeRandomClass : Rule {
 
-					val a = setOf("UNUSED_VARIABLE")
-					override val defaultRuleIdAliases = a
-					override val issue = Issue(javaClass.simpleName,
-							Severity.Style,
-							"",
-							debt = Debt.TEN_MINS)
-				}
-			"""
+                    val a = setOf("UNUSED_VARIABLE")
+                    override val defaultRuleIdAliases = a
+                    override val issue = Issue(javaClass.simpleName,
+                            Severity.Style,
+                            "",
+                            debt = Debt.TEN_MINS)
+                }
+            """
             assertThatExceptionOfType(InvalidAliasesDeclaration::class.java).isThrownBy { subject.run(code) }
         }
 

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
@@ -14,14 +14,14 @@ class RuleSetProviderCollectorSpec : Spek({
     describe("RuleSetProviderCollector rule") {
         context("a non-RuleSetProvider class extending nothing") {
             val code = """
-			package foo
+            package foo
 
-			class SomeRandomClass {
-				fun logSomething(message: String) {
-					println(message)
-				}
-			}
-		"""
+            class SomeRandomClass {
+                fun logSomething(message: String) {
+                    println(message)
+                }
+            }
+        """
             it("collects no rulesets") {
                 val items = subject.run(code)
                 assertThat(items).isEmpty()
@@ -30,14 +30,14 @@ class RuleSetProviderCollectorSpec : Spek({
 
         context("a non-RuleSetProvider class extending a class that is not related to rules") {
             val code = """
-			package foo
+            package foo
 
-			class SomeRandomClass: SomeOtherClass {
-				fun logSomething(message: String) {
-					println(message)
-				}
-			}
-		"""
+            class SomeRandomClass: SomeOtherClass {
+                fun logSomething(message: String) {
+                    println(message)
+                }
+            }
+        """
             it("collects no rulesets") {
                 val items = subject.run(code)
                 assertThat(items).isEmpty()
@@ -46,14 +46,14 @@ class RuleSetProviderCollectorSpec : Spek({
 
         context("a RuleSetProvider without documentation") {
             val code = """
-			package foo
+            package foo
 
-			class TestProvider: RuleSetProvider {
-				fun logSomething(message: String) {
-					println(message)
-				}
-			}
-		"""
+            class TestProvider: RuleSetProvider {
+                fun logSomething(message: String) {
+                    println(message)
+                }
+            }
+        """
             it("throws an exception") {
                 assertThatExceptionOfType(InvalidDocumentationException::class.java)
                         .isThrownBy { subject.run(code) }
@@ -62,14 +62,14 @@ class RuleSetProviderCollectorSpec : Spek({
 
         context("a correct RuleSetProvider class extending RuleSetProvider but missing parameters") {
             val code = """
-			package foo
+            package foo
 
-			class TestProvider: RuleSetProvider {
-				fun logSomething(message: String) {
-					println(message)
-				}
-			}
-		"""
+            class TestProvider: RuleSetProvider {
+                fun logSomething(message: String) {
+                    println(message)
+                }
+            }
+        """
 
             it("throws an exception") {
                 assertThatExceptionOfType(InvalidDocumentationException::class.java)
@@ -82,23 +82,23 @@ class RuleSetProviderCollectorSpec : Spek({
             val ruleSetId = "test"
             val ruleName = "TestRule"
             val code = """
-			package foo
+            package foo
 
-			/**
-			 * $description
-			 *
-			 * @active since v1.0.0
-			 */
-			class TestProvider: RuleSetProvider {
-				override val ruleSetId: String = "$ruleSetId"
+            /**
+             * $description
+             *
+             * @active since v1.0.0
+             */
+            class TestProvider: RuleSetProvider {
+                override val ruleSetId: String = "$ruleSetId"
 
-				override fun instance(config: Config): RuleSet {
-					return RuleSet(ruleSetId, listOf(
-							$ruleName(config)
-					))
-				}
-			}
-		"""
+                override fun instance(config: Config): RuleSet {
+                    return RuleSet(ruleSetId, listOf(
+                            $ruleName(config)
+                    ))
+                }
+            }
+        """
 
             it("collects a RuleSetProvider") {
                 val items = subject.run(code)
@@ -136,21 +136,21 @@ class RuleSetProviderCollectorSpec : Spek({
             val ruleSetId = "test"
             val ruleName = "TestRule"
             val code = """
-			package foo
+            package foo
 
-			/**
-			 * $description
-			 */
-			class TestProvider: RuleSetProvider {
-				override val ruleSetId: String = "$ruleSetId"
+            /**
+             * $description
+             */
+            class TestProvider: RuleSetProvider {
+                override val ruleSetId: String = "$ruleSetId"
 
-				override fun instance(config: Config): RuleSet {
-					return RuleSet(ruleSetId, listOf(
-							$ruleName(config)
-					))
-				}
-			}
-		"""
+                override fun instance(config: Config): RuleSet {
+                    return RuleSet(ruleSetId, listOf(
+                            $ruleName(config)
+                    ))
+                }
+            }
+        """
 
             it("is not active") {
                 val items = subject.run(code)
@@ -163,19 +163,19 @@ class RuleSetProviderCollectorSpec : Spek({
             val description = "This is a description"
             val ruleName = "TestRule"
             val code = """
-			package foo
+            package foo
 
-			/**
-			 * $description
-			 */
-			class TestProvider: RuleSetProvider {
-				override fun instance(config: Config): RuleSet {
-					return RuleSet(ruleSetId, listOf(
-							$ruleName(config)
-					))
-				}
-			}
-		"""
+            /**
+             * $description
+             */
+            class TestProvider: RuleSetProvider {
+                override fun instance(config: Config): RuleSet {
+                    return RuleSet(ruleSetId, listOf(
+                            $ruleName(config)
+                    ))
+                }
+            }
+        """
 
             it("throws an exception") {
                 assertThatExceptionOfType(InvalidDocumentationException::class.java)
@@ -187,18 +187,18 @@ class RuleSetProviderCollectorSpec : Spek({
             val ruleSetId = "test"
             val ruleName = "TestRule"
             val code = """
-			package foo
+            package foo
 
-			class TestProvider: RuleSetProvider {
-				override val ruleSetId: String = "$ruleSetId"
+            class TestProvider: RuleSetProvider {
+                override val ruleSetId: String = "$ruleSetId"
 
-				override fun instance(config: Config): RuleSet {
-					return RuleSet(ruleSetId, listOf(
-							$ruleName(config)
-					))
-				}
-			}
-		"""
+                override fun instance(config: Config): RuleSet {
+                    return RuleSet(ruleSetId, listOf(
+                            $ruleName(config)
+                    ))
+                }
+            }
+        """
 
             it("throws an exception") {
                 assertThatExceptionOfType(InvalidDocumentationException::class.java)
@@ -209,16 +209,16 @@ class RuleSetProviderCollectorSpec : Spek({
         context("a RuleSetProvider with no rules") {
             val ruleSetId = "test"
             val code = """
-			package foo
+            package foo
 
-			class TestProvider: RuleSetProvider {
-				override val ruleSetId: String = "$ruleSetId"
+            class TestProvider: RuleSetProvider {
+                override val ruleSetId: String = "$ruleSetId"
 
-				override fun instance(config: Config): RuleSet {
-					return RuleSet(ruleSetId, emptyListOf())
-				}
-			}
-		"""
+                override fun instance(config: Config): RuleSet {
+                    return RuleSet(ruleSetId, emptyListOf())
+                }
+            }
+        """
 
             it("throws an exception") {
                 assertThatExceptionOfType(InvalidDocumentationException::class.java)
@@ -232,24 +232,24 @@ class RuleSetProviderCollectorSpec : Spek({
             val ruleName = "TestRule"
             val secondRuleName = "SecondRule"
             val code = """
-			package foo
+            package foo
 
-			/**
-			 * $description
-			 *
-			 * @active since v1.0.0
-			 */
-			class TestProvider: RuleSetProvider {
-				override val ruleSetId: String = "$ruleSetId"
+            /**
+             * $description
+             *
+             * @active since v1.0.0
+             */
+            class TestProvider: RuleSetProvider {
+                override val ruleSetId: String = "$ruleSetId"
 
-				override fun instance(config: Config): RuleSet {
-					return RuleSet(ruleSetId, listOf(
-							$ruleName(config),
-							$secondRuleName(config)
-					))
-				}
-			}
-		"""
+                override fun instance(config: Config): RuleSet {
+                    return RuleSet(ruleSetId, listOf(
+                            $ruleName(config),
+                            $secondRuleName(config)
+                    ))
+                }
+            }
+        """
 
             it("collects multiple rules") {
                 val items = subject.run(code)

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
@@ -19,36 +19,36 @@ class DslGradleRunner(
     private val randomString = UUID.randomUUID().toString()
 
     private val settingsContent = """
-    	|rootProject.name = "rootDir-project"
-		|include(${projectLayout.submodules.map { "\"${it.name}\"" }.joinToString(",")})
-		|
-		""".trimMargin()
+        |rootProject.name = "rootDir-project"
+        |include(${projectLayout.submodules.map { "\"${it.name}\"" }.joinToString(",")})
+        |
+        """.trimMargin()
 
     private val baselineContent = """
-		|<some>
-		|	<xml/>
-		|</some>
-		""".trimMargin()
+        |<some>
+        |   <xml/>
+        |</some>
+        """.trimMargin()
 
     private val configFileContent = """
-		|build:
-		|  maxIssues: 5
-		|style:
-		|  MagicNumber:
-		|    active: true
-		""".trimMargin()
+        |build:
+        |  maxIssues: 5
+        |style:
+        |  MagicNumber:
+        |    active: true
+        """.trimMargin()
 
     /**
      * Each generated file is different so the artifacts are not cached in between test runs
      */
     private fun ktFileContent(className: String, withCodeSmell: Boolean = false) = """
-	|internal class $className(
-	|	val randomDefaultValue: String = "$randomString"
-	|) {
-	|	val smellyConstant: Int = ${if (withCodeSmell) "11" else "0"}
-	|}
-	|
-	""".trimMargin()
+    |internal class $className(
+    |   val randomDefaultValue: String = "$randomString"
+    |) {
+    |   val smellyConstant: Int = ${if (withCodeSmell) "11" else "0"}
+    |}
+    |
+    """.trimMargin()
 
     fun setupProject() {
         writeProjectFile(buildFileName, mainBuildFileContent)

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/TooManyFunctionsSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/TooManyFunctionsSpec.kt
@@ -21,71 +21,71 @@ class TooManyFunctionsSpec : Spek({
 
 const val code: String =
     """
-			class TooManyFunctions : Rule("TooManyFunctions") {
+            class TooManyFunctions : Rule("TooManyFunctions") {
 
-				override fun visitUserType(type: KtUserType) {
-					super.visitUserType(type)
-				}
+                override fun visitUserType(type: KtUserType) {
+                    super.visitUserType(type)
+                }
 
-				override fun visitReferenceExpression(expression: KtReferenceExpression) {
-					super.visitReferenceExpression(expression)
-				}
+                override fun visitReferenceExpression(expression: KtReferenceExpression) {
+                    super.visitReferenceExpression(expression)
+                }
 
-				override fun visitCallExpression(expression: KtCallExpression) {
-					super.visitCallExpression(expression)
-				}
+                override fun visitCallExpression(expression: KtCallExpression) {
+                    super.visitCallExpression(expression)
+                }
 
-				override fun visitBlockStringTemplateEntry(entry: KtBlockStringTemplateEntry) {
-					super.visitBlockStringTemplateEntry(entry)
-				}
+                override fun visitBlockStringTemplateEntry(entry: KtBlockStringTemplateEntry) {
+                    super.visitBlockStringTemplateEntry(entry)
+                }
 
-				override fun visitUnaryExpression(expression: KtUnaryExpression) {
-					super.visitUnaryExpression(expression)
-				}
+                override fun visitUnaryExpression(expression: KtUnaryExpression) {
+                    super.visitUnaryExpression(expression)
+                }
 
-				override fun visitDynamicType(type: KtDynamicType) {
-					super.visitDynamicType(type)
-				}
+                override fun visitDynamicType(type: KtDynamicType) {
+                    super.visitDynamicType(type)
+                }
 
-				override fun visitDynamicType(type: KtDynamicType, data: Void?): Void {
-					return super.visitDynamicType(type, data)
-				}
+                override fun visitDynamicType(type: KtDynamicType, data: Void?): Void {
+                    return super.visitDynamicType(type, data)
+                }
 
-				override fun visitSuperTypeCallEntry(call: KtSuperTypeCallEntry) {
-					super.visitSuperTypeCallEntry(call)
-				}
+                override fun visitSuperTypeCallEntry(call: KtSuperTypeCallEntry) {
+                    super.visitSuperTypeCallEntry(call)
+                }
 
-				override fun visitParenthesizedExpression(expression: KtParenthesizedExpression) {
-					super.visitParenthesizedExpression(expression)
-				}
+                override fun visitParenthesizedExpression(expression: KtParenthesizedExpression) {
+                    super.visitParenthesizedExpression(expression)
+                }
 
-				override fun visitFinallySection(finallySection: KtFinallySection) {
-					super.visitFinallySection(finallySection)
-				}
+                override fun visitFinallySection(finallySection: KtFinallySection) {
+                    super.visitFinallySection(finallySection)
+                }
 
-				override fun visitStringTemplateExpression(expression: KtStringTemplateExpression) {
-					super.visitStringTemplateExpression(expression)
-				}
+                override fun visitStringTemplateExpression(expression: KtStringTemplateExpression) {
+                    super.visitStringTemplateExpression(expression)
+                }
 
-				override fun visitDeclaration(dcl: KtDeclaration) {
-					super.visitDeclaration(dcl)
-				}
+                override fun visitDeclaration(dcl: KtDeclaration) {
+                    super.visitDeclaration(dcl)
+                }
 
-				override fun visitLabeledExpression(expression: KtLabeledExpression) {
-					super.visitLabeledExpression(expression)
-				}
+                override fun visitLabeledExpression(expression: KtLabeledExpression) {
+                    super.visitLabeledExpression(expression)
+                }
 
-				override fun visitEscapeStringTemplateEntry(entry: KtEscapeStringTemplateEntry) {
-					super.visitEscapeStringTemplateEntry(entry)
-				}
+                override fun visitEscapeStringTemplateEntry(entry: KtEscapeStringTemplateEntry) {
+                    super.visitEscapeStringTemplateEntry(entry)
+                }
 
-				override fun visitScript(script: KtScript) {
-					super.visitScript(script)
-				}
+                override fun visitScript(script: KtScript) {
+                    super.visitScript(script)
+                }
 
-				override fun visitTypeConstraintList(list: KtTypeConstraintList) {
-					super.visitTypeConstraintList(list)
-				}
+                override fun visitTypeConstraintList(list: KtTypeConstraintList) {
+                    super.visitTypeConstraintList(list)
+                }
 
-			}
-		"""
+            }
+        """

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessorSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessorSpec.kt
@@ -12,14 +12,14 @@ class NumberOfLoopsProcessorSpec : Spek({
 
         it("should expect two loops") {
             val code = """
-			fun main() {
-				for (i in 0..10) {
-					while (i < 5) {
-						println(i)
-					}
-				}
-			}
-		"""
+            fun main() {
+                for (i in 0..10) {
+                    while (i < 5) {
+                        println(i)
+                    }
+                }
+            }
+        """
 
             val ktFile = compileContentForTest(code)
             ktFile.accept(DetektVisitor())

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorTest.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorTest.kt
@@ -54,9 +54,9 @@ private val result = object : Detektion {
 }
 
 const val code = """
-	package io.gitlab.arturbosch.detekt.sample
+    package io.gitlab.arturbosch.detekt.sample
 
-	class Foo {}
-	object Bar {}
-	interface Bla {}
+    class Foo {}
+    object Bar {}
+    interface Bla {}
 """


### PR DESCRIPTION
In the past this repo used tabs instead of 4 spaces for .kt files.
Ktlint doesn't convert tabs in multiline strings to spaces.
Please take a look at the following issue.
pinterest/ktlint#575

Therefore, the following command has been used for conversion.

find ./ -iname '*.kt' -type f -exec bash -c 'expand -t 4 "$0" | sponge "$0"' {} \;

* ./ is recursively searching the given directory
* -iname is a case insensitive match .kt files
* type -f finds only regular files (no directories, binaries or symlinks)
* -exec bash -c executes the following commands in a subshell for each file
* expand -t 4 expands all tabs to 4 spaces
* sponge soaks up standard input (from expand) and writes it to the same file

Source:
https://stackoverflow.com/a/43523362