### PR TITLE
Convert tabs in multiline strings to 4 spaces (rules)

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -112,10 +112,10 @@ private class UnusedFunctionVisitor(allowedNames: Regex) : UnusedMemberVisitor(a
     }
 
     /*
-	 * We need to collect all private function declarations and references to these functions
-	 * for the whole file as Kotlin allows to access private and internal object declarations
-	 * from everywhere in the file.
-	 */
+     * We need to collect all private function declarations and references to these functions
+     * for the whole file as Kotlin allows to access private and internal object declarations
+     * from everywhere in the file.
+     */
 
     override fun visitReferenceExpression(expression: KtReferenceExpression) {
         super.visitReferenceExpression(expression)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpressionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpressionSpec.kt
@@ -13,24 +13,24 @@ class DuplicateCaseInWhenExpressionSpec : Spek({
 
         it("reports duplicated label in when") {
             val code = """
-				fun f() {
-					when (1) {
-						1 -> println()
-						1 -> println()
-						else -> println()
-					}
-				}"""
+                fun f() {
+                    when (1) {
+                        1 -> println()
+                        1 -> println()
+                        else -> println()
+                    }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("does not report duplicated label in when") {
             val code = """
-				fun f() {
-					when (1) {
-						1 -> println()
-						else -> println()
-					}
-				}"""
+                fun f() {
+                    when (1) {
+                        1 -> println()
+                        else -> println()
+                    }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
@@ -15,35 +15,35 @@ class EqualsWithHashCodeExistSpec : Spek({
 
             it("reports hashCode() without equals() function") {
                 val code = """
-				class A {
-					override fun hashCode(): Int { return super.hashCode() }
-				}"""
+                class A {
+                    override fun hashCode(): Int { return super.hashCode() }
+                }"""
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
             it("reports equals() without hashCode() function") {
                 val code = """
-				class A {
-					override fun equals(other: Any?): Boolean { return super.equals(other) }
-				}"""
+                class A {
+                    override fun equals(other: Any?): Boolean { return super.equals(other) }
+                }"""
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
             it("does not report equals() with hashCode() function") {
                 val code = """
-				class A {
-					override fun equals(other: Any?): Boolean { return super.equals(other) }
-					override fun hashCode(): Int { return super.hashCode() }
-				}"""
+                class A {
+                    override fun equals(other: Any?): Boolean { return super.equals(other) }
+                    override fun hashCode(): Int { return super.hashCode() }
+                }"""
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
 
             it("does not report when using kotlin.Any?") {
                 val code = """
-				class A {
-					override fun equals(other: kotlin.Any?): Boolean { return super.equals(other) }
-					override fun hashCode(): Int { return super.hashCode() }
-				}"""
+                class A {
+                    override fun equals(other: kotlin.Any?): Boolean { return super.equals(other) }
+                    override fun hashCode(): Int { return super.hashCode() }
+                }"""
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }
@@ -52,11 +52,11 @@ class EqualsWithHashCodeExistSpec : Spek({
 
             it("does not report equals() or hashcode() violation on data class") {
                 val code = """
-				data class EqualsData(val i: Int) {
-					override fun equals(other: Any?): Boolean {
-						return super.equals(other)
-					}
-				}"""
+                data class EqualsData(val i: Int) {
+                    override fun equals(other: Any?): Boolean {
+                        return super.equals(other)
+                    }
+                }"""
                 assertThat(subject.compileAndLint(code)).hasSize(0)
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCallSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCallSpec.kt
@@ -13,11 +13,11 @@ class ExplicitGarbageCollectionCallSpec : Spek({
 
         it("reports garbage collector calls") {
             val code = """
-				fun f() {
-					System.gc()
-					Runtime.getRuntime().gc()
-					System.runFinalization()
-				}"""
+                fun f() {
+                    System.gc()
+                    Runtime.getRuntime().gc()
+                    System.runFinalization()
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(3)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRangeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRangeSpec.kt
@@ -13,34 +13,34 @@ class InvalidRangeSpec : Spek({
 
         it("does not report correct bounds in for loop conditions") {
             val code = """
-				fun f() {
-					for (i in 2..2) {}
-					for (i in 2 downTo 2) {}
-					for (i in 2 until 2) {}
-					for (i in 2 until 4 step 2) {}
-					for (i in (1+1)..3) { }
-				}"""
+                fun f() {
+                    for (i in 2..2) {}
+                    for (i in 2 downTo 2) {}
+                    for (i in 2 until 2) {}
+                    for (i in 2 until 4 step 2) {}
+                    for (i in (1+1)..3) { }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
 
         it("reports incorrect bounds in for loop conditions") {
             val code = """
-				fun f() {
-					for (i in 2..1) { }
-					for (i in 1 downTo 2) { }
-					for (i in 2 until 1) { }
-					for (i in 2 until 1 step 2) { }
-				}"""
+                fun f() {
+                    for (i in 2..1) { }
+                    for (i in 1 downTo 2) { }
+                    for (i in 2 until 1) { }
+                    for (i in 2 until 1 step 2) { }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(4)
         }
 
         it("reports nested loops with incorrect bounds in for loop conditions") {
             val code = """
-				fun f() {
-					for (i in 2..2) {
-						for (i in 2..1) { }
-					}
-				}"""
+                fun f() {
+                    for (i in 2..2) {
+                        for (i in 2..1) { }
+                    }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
@@ -12,13 +12,13 @@ class LateinitUsageSpec : Spek({
 
     describe("LateinitUsage rule") {
         val code = """
-			import kotlin.SinceKotlin
+            import kotlin.SinceKotlin
 
-			class SomeRandomTest {
-				lateinit var v1: String
-				@SinceKotlin("1.0.0") lateinit var v2: String
-			}
-		"""
+            class SomeRandomTest {
+                lateinit var v1: String
+                @SinceKotlin("1.0.0") lateinit var v2: String
+            }
+        """
 
         it("should report lateinit usages") {
             val findings = LateinitUsage().compileAndLint(code)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
@@ -34,17 +34,17 @@ class UnsafeCastSpec : Spek({
 
         it("does not report cast that might succeed") {
             val code = """
-				fun test(s: Any) {
-					println(s as Int)
-				}"""
+                fun test(s: Any) {
+                    println(s as Int)
+                }"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
         }
 
         it("does not report 'safe' cast that might succeed") {
             val code = """
-				fun test(s: Any) {
-					println((s as? Int) ?: 0)
-				}"""
+                fun test(s: Any) {
+                    println((s as? Int) ?: 0)
+                }"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
@@ -12,77 +12,77 @@ class UselessPostfixExpressionSpec : Spek({
 
         it("overrides the incremented integer") {
             val code = """
-				fun f() {
-					var i = 0
-					i = i-- // invalid
-					i = 1 + i++ // invalid
-					i = i++ + 1 // invalid
-				}"""
+                fun f() {
+                    var i = 0
+                    i = i-- // invalid
+                    i = 1 + i++ // invalid
+                    i = i++ + 1 // invalid
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(3)
         }
 
         it("does not override the incremented integer") {
             val code = """
-				fun f() {
+                fun f() {
                     var i = 0
-					var j = 0
-					j = i++
-				}"""
+                    var j = 0
+                    j = i++
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
 
         it("returns no incremented value") {
             val code = """
-				fun f(): Int {
-					var i = 0
+                fun f(): Int {
+                    var i = 0
                     var j = 0
-					if (i == 0) return 1 + j++
-					return i++
-				}"""
+                    if (i == 0) return 1 + j++
+                    return i++
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
         it("should not report field increments") {
             val code = """
-				class Test {
-					private var runningId: Long = 0
+                class Test {
+                    private var runningId: Long = 0
 
-					fun increment() {
-						runningId++
-					}
+                    fun increment() {
+                        runningId++
+                    }
 
-					fun getId(): Long {
-						return runningId++
-					}
-				}
+                    fun getId(): Long {
+                        return runningId++
+                    }
+                }
 
-				class Foo(var i: Int = 0) {
-					fun getIdAndIncrement(): Int {
-						return i++
-					}
-				}
-				"""
+                class Foo(var i: Int = 0) {
+                    fun getIdAndIncrement(): Int {
+                        return i++
+                    }
+                }
+                """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("should detect properties shadowing fields that are incremented") {
             val code = """
-				class Test {
-					private var runningId: Long = 0
+                class Test {
+                    private var runningId: Long = 0
 
-					fun getId(): Long {
-						var runningId: Long = 0
-						return runningId++
-					}
-				}
+                    fun getId(): Long {
+                        var runningId: Long = 0
+                        return runningId++
+                    }
+                }
 
-				class Foo(var i: Int = 0) {
-					fun foo(): Int {
-						var i = 0
-						return i++
-					}
-				}
-				"""
+                class Foo(var i: Int = 0) {
+                    fun foo(): Int {
+                        var i = 0
+                        return i++
+                    }
+                }
+                """
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
     }
@@ -93,14 +93,14 @@ class UselessPostfixExpressionSpec : Spek({
             val code = """
                 val str: String? = ""
 
-				fun f1(): String {
-					return str!!
-				}
+                fun f1(): String {
+                    return str!!
+                }
 
-				fun f2(): Int {
-					return str!!.count()
-				}
-				"""
+                fun f2(): Int {
+                    return str!!.count()
+                }
+                """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameterSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameterSpec.kt
@@ -13,29 +13,29 @@ class WrongEqualsTypeParameterSpec : Spek({
 
         it("does not report Any? as parameter") {
             val code = """
-				class A {
-					override fun equals(other: Any?): Boolean {
-						return super.equals(other)
-					}
-				}"""
+                class A {
+                    override fun equals(other: Any?): Boolean {
+                        return super.equals(other)
+                    }
+                }"""
             assertThat(subject.compileAndLint(code).size).isEqualTo(0)
         }
 
         it("reports a String as parameter") {
             val code = """
-				class A {
-					fun equals(other: String): Boolean {
-						return super.equals(other)
-					}
-				}"""
+                class A {
+                    fun equals(other: String): Boolean {
+                        return super.equals(other)
+                    }
+                }"""
             assertThat(subject.compileAndLint(code).size).isEqualTo(1)
         }
 
         it("does not report an interface declaration") {
             val code = """
-				interface I {
-					fun equals(other: String)
-				}"""
+                interface I {
+                    fun equals(other: String)
+                }"""
             assertThat(subject.compileAndLint(code).size).isEqualTo(0)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexConditionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexConditionSpec.kt
@@ -10,13 +10,13 @@ class ComplexConditionSpec : Spek({
     describe("ComplexCondition rule") {
 
         val code = """
-			val a = if (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5)) { 42 } else { 24 }
+            val a = if (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5)) { 42 } else { 24 }
 
-			fun complexConditions() {
-				while (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5)) {}
-				do { } while (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5))
-			}
-		"""
+            fun complexConditions() {
+                while (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5)) {}
+                do { } while (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5))
+            }
+        """
 
         it("reports some complex conditions") {
             assertThat(ComplexCondition().compileAndLint(code)).hasSize(3)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
@@ -58,7 +58,7 @@ class ComplexMethodSpec : Spek({
                 val config = TestConfig(mapOf(ComplexMethod.IGNORE_SIMPLE_WHEN_ENTRIES to "true"))
                 val subject = ComplexMethod(config)
                 val code = """
-			    	 fun f() {
+                     fun f() {
                         val map = HashMap<Any, String>()
                         for ((key, value) in map) {
                             when (key) {
@@ -74,7 +74,7 @@ class ComplexMethodSpec : Spek({
                             }
                         }
                     }
-			    """
+                """
 
                 val findings = subject.compileAndLint(code)
                 assertThat(findings).isEmpty()
@@ -84,52 +84,52 @@ class ComplexMethodSpec : Spek({
         context("function containing object literal with many overridden functions") {
 
             val code = """
-			fun f(): List<Any> {
-				return object : List<Any> {
-					override val size: Int get() = TODO("not implemented")
+            fun f(): List<Any> {
+                return object : List<Any> {
+                    override val size: Int get() = TODO("not implemented")
 
-					override fun contains(element: Any): Boolean {
-						TODO("not implemented")
-					}
+                    override fun contains(element: Any): Boolean {
+                        TODO("not implemented")
+                    }
 
-					override fun containsAll(elements: Collection<Any>): Boolean {
-						TODO("not implemented")
-					}
+                    override fun containsAll(elements: Collection<Any>): Boolean {
+                        TODO("not implemented")
+                    }
 
-					override fun get(index: Int): Any {
-						TODO("not implemented")
-					}
+                    override fun get(index: Int): Any {
+                        TODO("not implemented")
+                    }
 
-					override fun indexOf(element: Any): Int {
-						TODO("not implemented")
-					}
+                    override fun indexOf(element: Any): Int {
+                        TODO("not implemented")
+                    }
 
-					override fun isEmpty(): Boolean {
-						TODO("not implemented")
-					}
+                    override fun isEmpty(): Boolean {
+                        TODO("not implemented")
+                    }
 
-					override fun iterator(): Iterator<Any> {
-						TODO("not implemented")
-					}
+                    override fun iterator(): Iterator<Any> {
+                        TODO("not implemented")
+                    }
 
-					override fun lastIndexOf(element: Any): Int {
-						TODO("not implemented")
-					}
+                    override fun lastIndexOf(element: Any): Int {
+                        TODO("not implemented")
+                    }
 
-					override fun listIterator(): ListIterator<Any> {
-						TODO("not implemented")
-					}
+                    override fun listIterator(): ListIterator<Any> {
+                        TODO("not implemented")
+                    }
 
-					override fun listIterator(index: Int): ListIterator<Any> {
-						TODO("not implemented")
-					}
+                    override fun listIterator(index: Int): ListIterator<Any> {
+                        TODO("not implemented")
+                    }
 
-					override fun subList(fromIndex: Int, toIndex: Int): List<Any> {
-						TODO("not implemented")
-					}
-				}
-			}
-			"""
+                    override fun subList(fromIndex: Int, toIndex: Int): List<Any> {
+                        TODO("not implemented")
+                    }
+                }
+            }
+            """
 
             it("should not count these overridden functions to base functions complexity") {
                 assertThat(ComplexMethod().compileAndLint(code)).isEmpty()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpressionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpressionSpec.kt
@@ -26,9 +26,9 @@ class LabeledExpressionSpec : Spek({
 
         it("does not report excluded label") {
             val code = """fun f() {
-    			loop@ for (i in 1..5) {}
+                loop@ for (i in 1..5) {}
             }
-    		"""
+            """
             val config = TestConfig(mapOf(LabeledExpression.IGNORED_LABELS to "loop"))
             val findings = LabeledExpression(config).compileAndLint(code)
             assertThat(findings).isEmpty()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
@@ -28,10 +28,10 @@ class MethodOverloadingSpec : Spek({
 
             it("does not report overloaded methods which do not exceed the threshold") {
                 subject.compileAndLint("""
-				class Test {
-					fun x() { }
-					fun x(i: Int) { }
-				}""")
+                class Test {
+                    fun x() { }
+                    fun x(i: Int) { }
+                }""")
                 assertThat(subject.findings.size).isZero()
             }
         }
@@ -40,17 +40,17 @@ class MethodOverloadingSpec : Spek({
 
             it("does not report extension methods with a different receiver") {
                 subject.compileAndLint("""
-				fun Boolean.foo() {}
-				fun Int.foo() {}
-				fun Long.foo() {}""")
+                fun Boolean.foo() {}
+                fun Int.foo() {}
+                fun Long.foo() {}""")
                 assertThat(subject.findings.size).isZero()
             }
 
             it("reports extension methods with the same receiver") {
                 subject.compileAndLint("""
-				fun Int.foo() {}
-				fun Int.foo(i: Int) {}
-				fun Int.foo(i: String) {}""")
+                fun Int.foo() {}
+                fun Int.foo(i: Int) {}
+                fun Int.foo(i: String) {}""")
                 assertThat(subject.findings.size).isEqualTo(1)
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
@@ -21,29 +21,29 @@ class NestedBlockDepthSpec : Spek({
 
         it("should detect too nested block depth") {
             val code = """
-				fun f() {
-					if (true) {
-						if (true) {
-							if (true) {
-								if (true) {
-								}
-							}
-						}
-					}
-				}"""
+                fun f() {
+                    if (true) {
+                        if (true) {
+                            if (true) {
+                                if (true) {
+                                }
+                            }
+                        }
+                    }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("should not detect valid nested block depth") {
             val code = """
-				fun f() {
-					if (true) {
-						if (true) {
-							if (true) {
-							}
-						}
-					}
-				}"""
+                fun f() {
+                    if (true) {
+                        if (true) {
+                            if (true) {
+                            }
+                        }
+                    }
+                }"""
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -55,20 +55,20 @@ class NestedBlockDepthSpec : Spek({
 })
 
 const val nestedBlockCode = """
-	override fun procedure(node: ASTNode) {
-		val psi = node.psi
-		if (psi.isNotPartOfEnum() && psi.isNotPartOfString()) {
-			if (psi.isDoubleSemicolon()) {
-				addFindings(CodeSmell(id, Entity.from(psi)))
-				withAutoCorrect {
-					deleteOneOrTwoSemicolons(node as LeafPsiElement)
-				}
-			} else if (psi.isSemicolon()) {
-				val nextLeaf = psi.nextLeaf()
-				if (nextLeaf.isSemicolonOrEOF() || nextTokenHasSpaces(nextLeaf)) {
-					addFindings(CodeSmell(id, Entity.from(psi)))
-					withAutoCorrect { psi.delete() }
-				}
-			}
-		}
-	}"""
+    override fun procedure(node: ASTNode) {
+        val psi = node.psi
+        if (psi.isNotPartOfEnum() && psi.isNotPartOfString()) {
+            if (psi.isDoubleSemicolon()) {
+                addFindings(CodeSmell(id, Entity.from(psi)))
+                withAutoCorrect {
+                    deleteOneOrTwoSemicolons(node as LeafPsiElement)
+                }
+            } else if (psi.isSemicolon()) {
+                val nextLeaf = psi.nextLeaf()
+                if (nextLeaf.isSemicolonOrEOF() || nextTokenHasSpaces(nextLeaf)) {
+                    addFindings(CodeSmell(id, Entity.from(psi)))
+                    withAutoCorrect { psi.delete() }
+                }
+            }
+        }
+    }"""

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
@@ -18,12 +18,12 @@ class StringLiteralDuplicationSpec : Spek({
 
             it("reports 3 equal hardcoded strings") {
                 val code = """
-				class Duplication {
-					var s1 = "lorem"
-					fun f(s: String = "lorem") {
-						s1.equals("lorem")
-					}
-				}"""
+                class Duplication {
+                    var s1 = "lorem"
+                    fun f(s: String = "lorem") {
+                        s1.equals("lorem")
+                    }
+                }"""
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
@@ -36,12 +36,12 @@ class StringLiteralDuplicationSpec : Spek({
         context("strings in annotations") {
 
             val code = """
-		        @Suppress("unused")
-		        class A
-		        @Suppress("unused")
-		        class B
-		        @Suppress("unused")
-		        class C
+                @Suppress("unused")
+                class A
+                @Suppress("unused")
+                class B
+                @Suppress("unused")
+                class C
             """
 
             it("does not report strings in annotations") {
@@ -71,15 +71,15 @@ class StringLiteralDuplicationSpec : Spek({
         context("strings with values to match for the regex") {
 
             val regexTestingCode = """
-				val str1 = "lorem" + "lorem" + "lorem"
-				val str2 = "ipsum" + "ipsum" + "ipsum"
-			"""
+                val str1 = "lorem" + "lorem" + "lorem"
+                val str2 = "ipsum" + "ipsum" + "ipsum"
+            """
 
             it("does not report lorem or ipsum according to config in regex") {
                 val code = """
-			    	val str1 = "lorem" + "lorem" + "lorem"
-			    	val str2 = "ipsum" + "ipsum" + "ipsum"
-			    """
+                    val str1 = "lorem" + "lorem" + "lorem"
+                    val str2 = "ipsum" + "ipsum" + "ipsum"
+                """
                 val config = TestConfig(mapOf(StringLiteralDuplication.IGNORE_STRINGS_REGEX to "(lorem|ipsum)"))
                 assertFindingWithConfig(code, config, 0)
             }
@@ -105,12 +105,12 @@ class StringLiteralDuplicationSpec : Spek({
 
             it("reports 3 locations for 'lorem'") {
                 val code = """
-				class Duplication {
-					var s1 = "lorem"
-					fun f(s: String = "lorem") {
-						s1.equals("lorem")
-					}
-				}"""
+                class Duplication {
+                    var s1 = "lorem"
+                    fun f(s: String = "lorem") {
+                        s1.equals("lorem")
+                    }
+                }"""
                 val finding = subject.compileAndLint(code)[0]
                 val locations = finding.references.map { it.location } + finding.entity.location
                 assertThat(locations).hasSize(3)
@@ -123,10 +123,10 @@ class StringLiteralDuplicationSpec : Spek({
                 val code = """
                     // does not report because it treats the multiline string parts as one string
                     val str = ""${'"'}
-	                    |
                         |
                         |
-	                    ""${'"'}
+                        |
+                        ""${'"'}
                 """
                 assertThat(subject.compileAndLint(code)).hasSize(0)
             }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
@@ -35,41 +35,41 @@ class TooManyFunctionsSpec : Spek({
 
         it("finds one function in class") {
             val code = """
-				class A {
-					fun a() = Unit
-				}
-			"""
+                class A {
+                    fun a() = Unit
+                }
+            """
 
             assertThat(rule.compileAndLint(code)).hasSize(1)
         }
 
         it("finds one function in object") {
             val code = """
-				object O {
-					fun o() = Unit
-				}
-			"""
+                object O {
+                    fun o() = Unit
+                }
+            """
 
             assertThat(rule.compileAndLint(code)).hasSize(1)
         }
 
         it("finds one function in interface") {
             val code = """
-				interface I {
-					fun i()
-				}
-			"""
+                interface I {
+                    fun i()
+                }
+            """
 
             assertThat(rule.compileAndLint(code)).hasSize(1)
         }
 
         it("finds one function in enum") {
             val code = """
-				enum class E {
+                enum class E {
                     A;
-					fun e() {}
-				}
-			"""
+                    fun e() {}
+                }
+            """
 
             assertThat(rule.compileAndLint(code)).hasSize(1)
         }
@@ -82,42 +82,42 @@ class TooManyFunctionsSpec : Spek({
 
         it("finds one function in file ignoring other declarations") {
             val code = """
-				fun f1() = Unit
-				class C
-				object O
-				fun f2() = Unit
-				interface I
-				enum class E
-				fun f3() = Unit
-			"""
+                fun f1() = Unit
+                class C
+                object O
+                fun f2() = Unit
+                interface I
+                enum class E
+                fun f3() = Unit
+            """
 
             assertThat(rule.compileAndLint(code)).hasSize(1)
         }
 
         it("finds one function in nested class") {
             val code = """
-				class A {
-					class B {
-						fun a() = Unit
-					}
-				}
-			"""
+                class A {
+                    class B {
+                        fun a() = Unit
+                    }
+                }
+            """
 
             assertThat(rule.compileAndLint(code)).hasSize(1)
         }
 
         describe("different deprecated functions") {
             val code = """
-				@Deprecated("")
-				fun f() {
-				}
+                @Deprecated("")
+                fun f() {
+                }
 
-				class A {
-					@Deprecated("")
-					fun f() {
-					}
-				}
-				"""
+                class A {
+                    @Deprecated("")
+                    fun f() {
+                    }
+                }
+                """
             it("finds all deprecated functions per default") {
 
                 assertThat(rule.compileAndLint(code)).hasSize(2)
@@ -136,10 +136,10 @@ class TooManyFunctionsSpec : Spek({
         describe("different private functions") {
 
             val code = """
-				class A {
-					private fun f() {}
-				}
-				"""
+                class A {
+                    private fun f() {}
+                }
+                """
 
             it("finds the private function per default") {
                 assertThat(rule.compileAndLint(code)).hasSize(1)
@@ -175,7 +175,7 @@ class TooManyFunctionsSpec : Spek({
                         override fun a() = Unit
                         override fun b() = Unit
                     }
-				"""
+                """
                 val configuredRule = TooManyFunctions(TestConfig(mapOf(
                         TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
                         TooManyFunctions.THRESHOLD_IN_FILES to "1",

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethodSpec.kt
@@ -12,32 +12,32 @@ class CommentOverPrivateMethodSpec : Spek({
 
         it("reports private method with a comment") {
             val code = """
-    			class Test {
-					/**
-					 * asdf
-					 */
-					private fun f() {}
-				}"""
+                class Test {
+                    /**
+                     * asdf
+                     */
+                    private fun f() {}
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("does not report public method with a comment") {
             val code = """
-				/**
-				 * asdf
-				 */
-				fun f() {}"""
+                /**
+                 * asdf
+                 */
+                fun f() {}"""
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
 
         it("does not report public method in a class with a comment") {
             val code = """
-    			class Test {
-					/**
-					 * asdf
-					 */
-					fun f() {}
-				}"""
+                class Test {
+                    /**
+                     * asdf
+                     */
+                    fun f() {}
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivatePropertiesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivatePropertiesSpec.kt
@@ -12,41 +12,41 @@ class CommentOverPrivatePropertiesSpec : Spek({
 
         it("reports private property with a comment") {
             val code = """
-				/**
-				 * asdf
-				 */
-				private val v = 1"""
+                /**
+                 * asdf
+                 */
+                private val v = 1"""
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("does not report public property with a comment") {
             val code = """
-				/**
-				 * asdf
-				 */
-				val v = 1"""
+                /**
+                 * asdf
+                 */
+                val v = 1"""
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
 
         it("reports private property in class with a comment") {
             val code = """
-					class Test {
-					/**
-					 * asdf
-					 */
-					private val v = 1
-				}"""
+                    class Test {
+                    /**
+                     * asdf
+                     */
+                    private val v = 1
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("does not report public property with a comment") {
             val code = """
-				class Test {
-					/**
-					 * asdf
-					 */
-					val v = 1
-				}"""
+                class Test {
+                    /**
+                     * asdf
+                     */
+                    val v = 1
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
@@ -12,181 +12,181 @@ class EndOfSentenceFormatSpec : Spek({
 
         it("reports invalid KDoc endings on classes") {
             val code = """
-			/** Some doc */
-			class Test {
-			}
-			"""
+            /** Some doc */
+            class Test {
+            }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("reports invalid KDoc endings on objects") {
             val code = """
-			/** Some doc */
-			object Test {
-			}
-			"""
+            /** Some doc */
+            object Test {
+            }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("reports invalid KDoc endings on properties") {
             val code = """
-			class Test {
-			 	/** Some doc */
-				val test = 3
-			}
-			"""
+            class Test {
+                /** Some doc */
+                val test = 3
+            }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("reports invalid KDoc endings on top-level functions") {
             val code = """
-			/** Some doc */
-			fun test() = 3
-			"""
+            /** Some doc */
+            fun test() = 3
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("reports invalid KDoc endings on functions") {
             val code = """
-			class Test {
-			 	/** Some doc */
-				fun test() = 3
-			}
-			"""
+            class Test {
+                /** Some doc */
+                fun test() = 3
+            }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("reports invalid KDoc endings") {
             val code = """
-			class Test {
-			 	/** Some doc-- */
-				fun test() = 3
-			}
-			"""
+            class Test {
+                /** Some doc-- */
+                fun test() = 3
+            }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("reports invalid KDoc endings in block") {
             val code = """
-			/**
-			 * Something off abc@@
-			 */
-			class Test {
-			}
-			"""
+            /**
+             * Something off abc@@
+             */
+            class Test {
+            }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("does not validate first sentence KDoc endings in a multi sentence comment") {
             val code = """
-			/**
-			 * This sentence is correct.
-			 *
-			 * This sentence doesn't matter
-			 */
-			class Test {
-			}
-			"""
+            /**
+             * This sentence is correct.
+             *
+             * This sentence doesn't matter
+             */
+            class Test {
+            }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report KDoc which doesn't contain any real sentence") {
             val code = """
-			/**
-			 */
-			class Test {
-			}
-			"""
+            /**
+             */
+            class Test {
+            }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report KDoc which doesn't contain any real sentence but many tags") {
             val code = """
-			/**
-			 * @configuration this - just an example (default: `150`)
-			 *
-			 * @active since v1.0.0
-			 */
-			class Test {
-			}
-			"""
+            /**
+             * @configuration this - just an example (default: `150`)
+             *
+             * @active since v1.0.0
+             */
+            class Test {
+            }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report KDoc which doesn't contain any real sentence but html tags") {
             val code = """
-			/**
-			 *
-			 * <noncompliant>
-			 * fun foo(): Unit { }
-			 * </noncompliant>
-			 *
-			 * <compliant>
-			 * fun foo() { }
-			 * </compliant>
-			 *
-			 */
-			class Test {
-			}
-			"""
+            /**
+             *
+             * <noncompliant>
+             * fun foo(): Unit { }
+             * </noncompliant>
+             *
+             * <compliant>
+             * fun foo() { }
+             * </compliant>
+             *
+             */
+            class Test {
+            }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report KDoc ending with periods") {
             val code = """
-			/**
-			 * Something correct.
-			 */
-			class Test {
-			}
-			"""
+            /**
+             * Something correct.
+             */
+            class Test {
+            }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report KDoc ending with questionmarks") {
             val code = """
-			/**
-			 * Something correct?
-			 */
-			class Test {
-			}
-			"""
+            /**
+             * Something correct?
+             */
+            class Test {
+            }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report KDoc ending with exclamation marks") {
             val code = """
-			/**
-			 * Something correct!
-			 */
-			class Test {
-			}
-			"""
+            /**
+             * Something correct!
+             */
+            class Test {
+            }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report KDoc ending with colon") {
             val code = """
-			/**
-			 * Something correct:
-			 */
-			class Test {
-			}
-			"""
+            /**
+             * Something correct:
+             */
+            class Test {
+            }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report URLs in comments") {
             val code = """
-			/** http://www.google.com */
-			class Test1 {
-			}
+            /** http://www.google.com */
+            class Test1 {
+            }
 
-			/** Look here
-			http://google.com */
-			class Test2 {
-			}
-			"""
+            /** Look here
+            http://google.com */
+            class Test2 {
+            }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -10,42 +10,42 @@ class UndocumentedPublicClassSpec : Spek({
     val subject by memoized { UndocumentedPublicClass() }
 
     val inner = """
-			/** Some doc */
-			class TestInner {
-				inner class Inner
-			}"""
+            /** Some doc */
+            class TestInner {
+                inner class Inner
+            }"""
 
     val innerObject = """
-			/** Some doc */
-			class TestInner {
-				object Inner
-			}"""
+            /** Some doc */
+            class TestInner {
+                object Inner
+            }"""
 
     val innerInterface = """
-			/** Some doc */
-			class TestInner {
-				interface Something
-			}"""
+            /** Some doc */
+            class TestInner {
+                interface Something
+            }"""
 
     val nested = """
-			/** Some doc */
-			class TestNested {
-				class Nested
-			}"""
+            /** Some doc */
+            class TestNested {
+                class Nested
+            }"""
 
     val nestedPublic = """
-    		/** Some doc */
-			class TestNested {
-				public class Nested
-			}
-			"""
+            /** Some doc */
+            class TestNested {
+                public class Nested
+            }
+            """
 
     val nestedPrivate = """
-    		/** Some doc */
-			class TestNested {
-				private class Nested
-			}
-			"""
+            /** Some doc */
+            class TestNested {
+                private class Nested
+            }
+            """
 
     val privateClass = "private class TestNested {}"
     val internalClass = "internal class TestNested {}"
@@ -110,53 +110,53 @@ class UndocumentedPublicClassSpec : Spek({
 
         it("should not report for documented public object") {
             val code = """
-			/**
-			 * Class docs not being recognized.
-			 */
-			object Main {
-				/**
-				 * The entry point for the application.
-				 *
-				 * @param args The list of process arguments.
-				 */
-				@JvmStatic
-				fun main(args: Array<String>) {
-				}
-			}
-		"""
+            /**
+             * Class docs not being recognized.
+             */
+            object Main {
+                /**
+                 * The entry point for the application.
+                 *
+                 * @param args The list of process arguments.
+                 */
+                @JvmStatic
+                fun main(args: Array<String>) {
+                }
+            }
+        """
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("should not report for anonymous objects") {
             val code = """
-			fun main(args: Array<String>) {
-				val value = object : Iterator<Int> {
-        		    override fun hasNext() = true
-        		    override fun next() = 1
-        		}
-			}
-		"""
+            fun main(args: Array<String>) {
+                val value = object : Iterator<Int> {
+                    override fun hasNext() = true
+                    override fun next() = 1
+                }
+            }
+        """
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("should report for enum classes") {
             val code = """
-		    enum class Enum {
-				CONSTANT
-			}
-		"""
+            enum class Enum {
+                CONSTANT
+            }
+        """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("should not report for enum constants") {
             val code = """
-			/** Some doc */
-			enum class Enum {
-				CONSTANT
-			}
-		"""
+            /** Some doc */
+            enum class Enum {
+                CONSTANT
+            }
+        """
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
@@ -12,97 +12,97 @@ class UndocumentedPublicFunctionSpec : Spek({
 
         it("reports undocumented public functions") {
             val code = """
-    			fun noComment1() {}
-			"""
+                fun noComment1() {}
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("reports undocumented public functions in companion object") {
             val code = """
-    			class Test {
-    				companion object {
-    					fun noComment1() {}
-    					public fun noComment2() {}
-    				}
-    			}
-			"""
+                class Test {
+                    companion object {
+                        fun noComment1() {}
+                        public fun noComment2() {}
+                    }
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
         it("does not report documented public function") {
             val code = """
-    			/**
-			     * Comment
-				 */
-				fun commented1() {}
-			"""
+                /**
+                 * Comment
+                 */
+                fun commented1() {}
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report documented public function in class") {
             val code = """
-				class Test {
-					/**
-					*
-					*/
-					fun commented1() {}
+                class Test {
+                    /**
+                    *
+                    */
+                    fun commented1() {}
 
-					/**
-					*
-					*/
-					fun commented2() {}
-				}
-			"""
+                    /**
+                    *
+                    */
+                    fun commented2() {}
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report udocumented internal and private function") {
             val code = """
-    			class Test {
-    				internal fun no1(){}
-    				private fun no2(){}
-    			}
-			"""
+                class Test {
+                    internal fun no1(){}
+                    private fun no2(){}
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report undocumented nested function") {
             val code = """
-    			/**
-			     * Comment
-				 */
-				fun commented() {
-					fun iDontNeedDoc() {}
-				}
-			"""
+                /**
+                 * Comment
+                 */
+                fun commented() {
+                    fun iDontNeedDoc() {}
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report public functions in internal class") {
             val code = """
-    			internal class NoComments {
+                internal class NoComments {
 
-					fun nope0() {}
-					public fun nope1() {}
-					internal fun nope2() {}
-					protected fun nope3() {}
-					private fun nope4() {}
-				}
-			"""
+                    fun nope0() {}
+                    public fun nope1() {}
+                    internal fun nope2() {}
+                    protected fun nope3() {}
+                    private fun nope4() {}
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report public functions in private class") {
             val code = """
-    			private class NoComments {
+                private class NoComments {
 
-					fun nope0() {}
-					public fun nope1() {}
-					internal fun nope2() {}
-					protected fun nope3() {}
-					private fun nope4() {}
-				}
-			"""
+                    fun nope0() {}
+                    public fun nope1() {}
+                    internal fun nope2() {}
+                    protected fun nope3() {}
+                    private fun nope4() {}
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
@@ -16,11 +16,11 @@ import java.util.regex.PatternSyntaxException
 class EmptyCodeSpec : Spek({
 
     val regexTestingCode = """
-			fun f() {
-				try {
-				} catch (foo: Exception) {
-				}
-			}"""
+            fun f() {
+                try {
+                } catch (foo: Exception) {
+                }
+            }"""
 
     describe("EmptyCatchBlock rule") {
 
@@ -30,35 +30,35 @@ class EmptyCodeSpec : Spek({
 
         it("findsEmptyNestedCatch") {
             val code = """
-			fun f() {
-				try {
+            fun f() {
+                try {
                 } catch (ignore: Exception) {
-					try {
-					} catch (e: Exception) {
-					}
-				}
-			}"""
+                    try {
+                    } catch (e: Exception) {
+                    }
+                }
+            }"""
             assertThat(EmptyCatchBlock(Config.empty).compileAndLint(code)).hasSize(1)
         }
 
         it("doesNotReportIgnoredOrExpectedException") {
             val code = """
-			fun f() {
-				try {
+            fun f() {
+                try {
                 } catch (ignore: IllegalArgumentException) {
-				} catch (expected: Exception) {
-				}
-			}"""
+                } catch (expected: Exception) {
+                }
+            }"""
             assertThat(EmptyCatchBlock(Config.empty).compileAndLint(code)).isEmpty()
         }
 
         it("doesNotReportEmptyCatchWithConfig") {
             val code = """
-			fun f() {
-				try {
-				} catch (foo: Exception) {
-				}
-			}"""
+            fun f() {
+                try {
+                } catch (foo: Exception) {
+                }
+            }"""
             val config = TestConfig(mapOf(EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "foo"))
             assertThat(EmptyCatchBlock(config).compileAndLint(code)).isEmpty()
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyConstructorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyConstructorSpec.kt
@@ -13,12 +13,12 @@ class EmptyConstructorSpec : Spek({
 
         it("should not report empty constructors for annotation classes with expect or actual keyword - #1362") {
             val code = """
-			expect annotation class NeedsConstructor()
-			actual annotation class NeedsConstructor actual constructor()
+            expect annotation class NeedsConstructor()
+            actual annotation class NeedsConstructor actual constructor()
 
-			@NeedsConstructor
-			fun annotatedFunction() = Unit
-		"""
+            @NeedsConstructor
+            fun annotatedFunction() = Unit
+        """
 
             val findings = EmptyDefaultConstructor(Config.empty).lint(code)
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
@@ -34,10 +34,10 @@ class EmptyFunctionBlockSpec : Spek({
 
         it("should flag the nested empty function") {
             val code = """
-				fun a() {
-					fun b() {}
-				}"""
-            assertThat(subject.compileAndLint(code)).hasExactlyLocationStrings("'{}' at (2,10) in /$fileName")
+                fun a() {
+                    fun b() {}
+                }"""
+            assertThat(subject.compileAndLint(code)).hasExactlyLocationStrings("'{}' at (2,13) in /$fileName")
         }
 
         context("some overridden functions") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
@@ -30,9 +30,9 @@ class ExceptionRaisedInUnexpectedLocationSpec : Spek({
         it("reports the configured method") {
             val config = TestConfig(mapOf(ExceptionRaisedInUnexpectedLocation.METHOD_NAMES to "toDo,todo2"))
             val findings = ExceptionRaisedInUnexpectedLocation(config).compileAndLint("""
-			fun toDo() {
-				throw IllegalStateException()
-			}""")
+            fun toDo() {
+                throw IllegalStateException()
+            }""")
             assertThat(findings).hasSize(1)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
@@ -13,45 +13,45 @@ class InstanceOfCheckForExceptionSpec : Spek({
         it("has is and as checks") {
 
             val code = """
-				fun x() {
-					try {
+                fun x() {
+                    try {
                     } catch(e: Exception) {
                         if (e is IllegalArgumentException || (e as IllegalArgumentException) != null) {
                             return
                         }
                     }
-				}
-				"""
+                }
+                """
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
         it("has nested is and as checks") {
             val code = """
-				fun x() {
-					try {
-					} catch(e: Exception) {
-						if (1 == 1) {
-							val b = e !is IllegalArgumentException || (e as IllegalArgumentException) != null
-						}
-					}
-				}
-				"""
+                fun x() {
+                    try {
+                    } catch(e: Exception) {
+                        if (1 == 1) {
+                            val b = e !is IllegalArgumentException || (e as IllegalArgumentException) != null
+                        }
+                    }
+                }
+                """
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
         it("has no instance of check") {
             val code = """
-				fun x() {
-					try {
-					} catch(e: Exception) {
-						val s = ""
-						if (s is String || (s as String) != null) {
+                fun x() {
+                    try {
+                    } catch(e: Exception) {
+                        val s = ""
+                        if (s is String || (s as String) != null) {
                             val other: Exception? = null
-							val b = other !is IllegalArgumentException || (other as IllegalArgumentException) != null
-						}
-					}
-				}
-				"""
+                            val b = other !is IllegalArgumentException || (other as IllegalArgumentException) != null
+                        }
+                    }
+                }
+                """
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclarationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclarationSpec.kt
@@ -12,27 +12,27 @@ class NotImplementedDeclarationSpec : Spek({
 
         it("reports NotImplementedErrors") {
             val code = """
-			fun f() {
-				if (1 == 1) throw NotImplementedError()
-				throw NotImplementedError()
-			}"""
+            fun f() {
+                if (1 == 1) throw NotImplementedError()
+                throw NotImplementedError()
+            }"""
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
         it("reports TODO method calls") {
             val code = """
-			fun f() {
-				TODO("not implemented")
-				TODO()
-			}"""
+            fun f() {
+                TODO("not implemented")
+                TODO()
+            }"""
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
         it("does not report TODO comments") {
             val code = """
-			fun f() {
-				// TODO
-			}"""
+            fun f() {
+                // TODO
+            }"""
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTraceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTraceSpec.kt
@@ -14,26 +14,26 @@ class PrintStackTraceSpec : Spek({
 
             it("prints a stacktrace") {
                 val code = """
-				fun x() {
-					try {
-					} catch (e: Exception) {
-						e.printStackTrace()
-					}
-				}"""
+                fun x() {
+                    try {
+                    } catch (e: Exception) {
+                        e.printStackTrace()
+                    }
+                }"""
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
             it("does not print a stacktrace") {
                 val code = """
-				fun x() {
-					try {
-					} catch (e: Exception) {
-						e.fillInStackTrace()
-						val msg = e.message
+                fun x() {
+                    try {
+                    } catch (e: Exception) {
+                        e.fillInStackTrace()
+                        val msg = e.message
                         fun printStackTrace() {}
-						printStackTrace()
-					}
-				}
+                        printStackTrace()
+                    }
+                }
                 """
                 assertThat(subject.compileAndLint(code)).hasSize(0)
             }
@@ -43,12 +43,12 @@ class PrintStackTraceSpec : Spek({
 
             it("prints one") {
                 val code = """
-				fun x() {
-					Thread.dumpStack()
+                fun x() {
+                    Thread.dumpStack()
 
                     fun dumpStack() {}
                     dumpStack()
-				}"""
+                }"""
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
@@ -12,13 +12,13 @@ class ReturnFromFinallySpec : Spek({
 
         context("a finally block with a return statement") {
             val code = """
-			fun x() {
-				try {
-				} finally {
-					return
-				}
-			}
-		"""
+            fun x() {
+                try {
+                } finally {
+                    return
+                }
+            }
+        """
 
             it("should report") {
                 val findings = subject.compileAndLint(code)
@@ -28,12 +28,12 @@ class ReturnFromFinallySpec : Spek({
 
         context("a finally block with no return statement") {
             val code = """
-			fun x() {
-				try {
-				} finally {
-				}
-			}
-		"""
+            fun x() {
+                try {
+                } finally {
+                }
+            }
+        """
 
             it("should not report") {
                 val findings = subject.compileAndLint(code)
@@ -43,15 +43,15 @@ class ReturnFromFinallySpec : Spek({
 
         context("a finally block with a nested return statement") {
             val code = """
-			fun x() {
-				try {
-				} finally {
-					if (1 == 1) {
-						return
-					}
-				}
-			}
-		"""
+            fun x() {
+                try {
+                } finally {
+                    if (1 == 1) {
+                        return
+                    }
+                }
+            }
+        """
 
             it("should report") {
                 val findings = subject.compileAndLint(code)
@@ -61,16 +61,16 @@ class ReturnFromFinallySpec : Spek({
 
         context("a finally block with a return in an inner function") {
             val code = """
-			fun x() {
-				try {
-				} finally {
-					fun y() {
-						return
-					}
-					y()
-				}
-			}
-		"""
+            fun x() {
+                try {
+                } finally {
+                    fun y() {
+                        return
+                    }
+                    y()
+                }
+            }
+        """
 
             it("should not report") {
                 val findings = subject.compileAndLint(code)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinallySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinallySpec.kt
@@ -12,36 +12,36 @@ class ThrowingExceptionFromFinallySpec : Spek({
 
         it("should report a throw expression") {
             val code = """
-				fun x() {
-					try {
-					} finally {
-						if (1 == 1) {
-							throw IllegalArgumentException()
-						}
-					}
-				}"""
+                fun x() {
+                    try {
+                    } finally {
+                        if (1 == 1) {
+                            throw IllegalArgumentException()
+                        }
+                    }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("should report a nested throw expression") {
             val code = """
-				fun x() {
-					try {
-					} finally {
-						throw IllegalArgumentException()
-					}
-				}"""
+                fun x() {
+                    try {
+                    } finally {
+                        throw IllegalArgumentException()
+                    }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("should not report a finally expression without a throw expression") {
             val code = """
-				fun x() {
-					try {
-					} finally {
-						println()
-					}
-				}"""
+                fun x() {
+                    try {
+                    } finally {
+                        println()
+                    }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
@@ -18,11 +18,11 @@ class ThrowingExceptionsWithoutMessageOrCauseSpec : Spek({
         context("several exception calls") {
 
             val code = """
-				fun x() {
-					IllegalArgumentException(IllegalArgumentException())
-					IllegalArgumentException("foo")
-					throw IllegalArgumentException()
-				}"""
+                fun x() {
+                    IllegalArgumentException(IllegalArgumentException())
+                    IllegalArgumentException("foo")
+                    throw IllegalArgumentException()
+                }"""
 
             it("reports calls to the default constructor") {
                 assertThat(subject.compileAndLint(code)).hasSize(2)
@@ -39,10 +39,10 @@ class ThrowingExceptionsWithoutMessageOrCauseSpec : Spek({
 
             it("does not report a call to this exception") {
                 val code = """
-				fun test() {
-					org.assertj.core.api.Assertions.assertThatIllegalArgumentException().isThrownBy { println() }
-				}
-			"""
+                fun test() {
+                    org.assertj.core.api.Assertions.assertThatIllegalArgumentException().isThrownBy { println() }
+                }
+            """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
@@ -12,13 +12,13 @@ class ThrowingNewInstanceOfSameExceptionSpec : Spek({
 
         context("a catch block which rethrows a new instance of the caught exception") {
             val code = """
-			fun x() {
-				try {
-				} catch (e: IllegalStateException) {
-					throw IllegalStateException(e)
-				}
-			}
-		"""
+            fun x() {
+                try {
+                } catch (e: IllegalStateException) {
+                    throw IllegalStateException(e)
+                }
+            }
+        """
 
             it("should report") {
                 val findings = subject.compileAndLint(code)
@@ -28,13 +28,13 @@ class ThrowingNewInstanceOfSameExceptionSpec : Spek({
 
         context("a catch block which rethrows a new instance of another exception") {
             val code = """
-			fun x() {
-				try {
-				} catch (e: IllegalStateException) {
-					throw IllegalArgumentException(e)
-				}
-			}
-		"""
+            fun x() {
+                try {
+                } catch (e: IllegalStateException) {
+                    throw IllegalArgumentException(e)
+                }
+            }
+        """
 
             it("should not report") {
                 val findings = subject.compileAndLint(code)
@@ -44,13 +44,13 @@ class ThrowingNewInstanceOfSameExceptionSpec : Spek({
 
         context("a catch block which throws a new instance of the same exception type without wrapping the caught exception") {
             val code = """
-			fun x() {
-				try {
-				} catch (e: IllegalStateException) {
-					throw IllegalStateException()
-				}
-			}
-		"""
+            fun x() {
+                try {
+                } catch (e: IllegalStateException) {
+                    throw IllegalStateException()
+                }
+            }
+        """
 
             it("should not report") {
                 val findings = subject.compileAndLint(code)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
@@ -12,27 +12,27 @@ class ClassNamingSpec : Spek({
         it("should detect no violations") {
             val findings = NamingRules().compileAndLint(
                     """
-					class MyClassWithNumbers5
+                    class MyClassWithNumbers5
 
-					class NamingConventions {
+                    class NamingConventions {
 
-						private val _classVariable = 5
-						val classVariable = 5
+                        private val _classVariable = 5
+                        val classVariable = 5
 
-						fun classMethod() {}
+                        fun classMethod() {}
 
-						fun underscoreTestMethod() {
-							val (_, status) = Pair(1, 2) // valid: _
-						}
+                        fun underscoreTestMethod() {
+                            val (_, status) = Pair(1, 2) // valid: _
+                        }
 
-						companion object {
-							const val stUff = "stuff"
-							val SSS = "stuff"
-							val ooo = Any()
-							val OOO = Any()
-						}
-					}
-				"""
+                        companion object {
+                            const val stUff = "stuff"
+                            val SSS = "stuff"
+                            val ooo = Any()
+                            val OOO = Any()
+                        }
+                    }
+                """
             )
             assertThat(findings).isEmpty()
         }
@@ -40,20 +40,20 @@ class ClassNamingSpec : Spek({
         it("should find seven violations") {
             val findings = NamingRules().compileAndLint(
                     """
-					class _NamingConventions {
+                    class _NamingConventions {
 
-						val C_lassVariable = 5
-						val CLASSVARIABLE = 5
+                        val C_lassVariable = 5
+                        val CLASSVARIABLE = 5
 
-						fun _classmethod() {}
-						fun Classmethod() {}
+                        fun _classmethod() {}
+                        fun Classmethod() {}
 
-						companion object {
-							val __bla = Any()
-						}
-					}
-					class namingConventions {}
-				"""
+                        companion object {
+                            val __bla = Any()
+                        }
+                    }
+                    class namingConventions {}
+                """
             )
             assertThat(findings).hasSize(7)
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -12,19 +12,19 @@ class EnumNamingSpec : Spek({
         it("should detect no violation") {
             val findings = NamingRules().compileAndLint(
                     """
-				enum class WorkFlow {
-					ACTIVE, NOT_ACTIVE, Unknown, Number1
-				}
-				"""
+                enum class WorkFlow {
+                    ACTIVE, NOT_ACTIVE, Unknown, Number1
+                }
+                """
             )
             assertThat(findings).isEmpty()
         }
 
         it("reports an underscore in enum name") {
             val code = """
-				enum class WorkFlow {
-					_Default
-				}"""
+                enum class WorkFlow {
+                    _Default
+                }"""
             assertThat(NamingRules().compileAndLint(code)).hasSize(1)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenNameSpec.kt
@@ -12,9 +12,9 @@ class ForbiddenNameSpec : Spek({
 
         it("should report classes with forbidden names") {
             val code = """
-				class TestManager {} // violation
-				class TestProvider {} // violation
-				class TestHolder"""
+                class TestManager {} // violation
+                class TestProvider {} // violation
+                class TestHolder"""
             assertThat(NamingRules(TestConfig(mapOf(ForbiddenClassName.FORBIDDEN_NAME to "Manager, Provider")))
                     .compileAndLint(code))
                     .hasSize(2)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -15,37 +15,37 @@ class FunctionNamingSpec : Spek({
 
         it("allows FunctionName as alias for suppressing") {
             val code = """
-			@Suppress("FunctionName")
-			fun MY_FUN() = TODO()
-		"""
+            @Suppress("FunctionName")
+            fun MY_FUN() = TODO()
+        """
             assertThat(FunctionNaming().lint(code)).isEmpty()
         }
 
         it("ignores functions in classes matching excludeClassPattern") {
             val code = """
-			class WhateverTest {
-				fun SHOULD_NOT_BE_FLAGGED() = TODO()
-			}
-		"""
+            class WhateverTest {
+                fun SHOULD_NOT_BE_FLAGGED() = TODO()
+            }
+        """
             val config = TestConfig(mapOf("excludeClassPattern" to ".*Test$"))
             assertThat(FunctionNaming(config).lint(code)).isEmpty()
         }
 
         it("flags functions inside functions") {
             val code = """
-			override fun shouldNotBeFlagged() {
-				fun SHOULD_BE_FLAGGED() { }
-			}
-		"""
+            override fun shouldNotBeFlagged() {
+                fun SHOULD_BE_FLAGGED() { }
+            }
+        """
             assertThat(FunctionNaming().lint(code)).hasLocationStrings(
-                    "'fun SHOULD_BE_FLAGGED() { }' at (2,2) in /$fileName"
+                    "'fun SHOULD_BE_FLAGGED() { }' at (2,5) in /$fileName"
             )
         }
 
         it("ignores overridden functions by default") {
             val code = """
-			override fun SHOULD_NOT_BE_FLAGGED() = TODO()
-		"""
+            override fun SHOULD_NOT_BE_FLAGGED() = TODO()
+        """
             assertThat(FunctionNaming().lint(code)).isEmpty()
         }
 
@@ -54,27 +54,27 @@ class FunctionNamingSpec : Spek({
             interface Foo
             private class FooImpl : Foo
 
-			fun Foo(): Foo = FooImpl()
-		"""
+            fun Foo(): Foo = FooImpl()
+        """
             val config = TestConfig(mapOf("ignoreOverridden" to "false"))
             assertThat(FunctionNaming(config).lint(code))
         }
 
         it("flags functions with bad names inside overridden functions by default") {
             val code = """
-			override fun SHOULD_NOT_BE_FLAGGED() {
-				fun SHOULD_BE_FLAGGED() {}
-			}
-		"""
+            override fun SHOULD_NOT_BE_FLAGGED() {
+                fun SHOULD_BE_FLAGGED() {}
+            }
+        """
             assertThat(FunctionNaming().lint(code)).hasLocationStrings(
-                    "'fun SHOULD_BE_FLAGGED() {}' at (2,2) in /$fileName"
+                    "'fun SHOULD_BE_FLAGGED() {}' at (2,5) in /$fileName"
             )
         }
 
         it("doesn't ignore overridden functions if ignoreOverridden is false") {
             val code = """
-			override fun SHOULD_BE_FLAGGED() = TODO()
-		"""
+            override fun SHOULD_BE_FLAGGED() = TODO()
+        """
             val config = TestConfig(mapOf("ignoreOverridden" to "false"))
             assertThat(FunctionNaming(config).lint(code)).hasLocationStrings(
                     "'override fun SHOULD_BE_FLAGGED() = TODO()' at (1,1) in /$fileName"

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
@@ -35,10 +35,10 @@ internal class MatchingDeclarationNameSpec : Spek({
 
             it("should pass for enum declaration") {
                 val ktFile = compileContentForTest("""
-				enum class E {
-					ONE, TWO, THREE
-				}
-			""")
+                enum class E {
+                    ONE, TWO, THREE
+                }
+            """)
                 ktFile.name = "E.kt"
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
@@ -46,10 +46,10 @@ internal class MatchingDeclarationNameSpec : Spek({
 
             it("should pass for multiple declaration") {
                 val ktFile = compileContentForTest("""
-				class C
-				object O
-				fun a() = 5
-			""")
+                class C
+                object O
+                fun a() = 5
+            """)
                 ktFile.name = "MultiDeclarations.kt"
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
@@ -57,10 +57,10 @@ internal class MatchingDeclarationNameSpec : Spek({
 
             it("should pass for class declaration with utility functions") {
                 val ktFile = compileContentForTest("""
-				class C
-				fun a() = 5
-				fun C.b() = 5
-			""")
+                class C
+                fun a() = 5
+                fun C.b() = 5
+            """)
                 ktFile.name = "C.kt"
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
@@ -68,9 +68,9 @@ internal class MatchingDeclarationNameSpec : Spek({
 
             it("should pass for private class declaration") {
                 val ktFile = compileContentForTest("""
-				private class C
-				fun a() = 5
-			""")
+                private class C
+                fun a() = 5
+            """)
                 ktFile.name = "b.kt"
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
@@ -78,9 +78,9 @@ internal class MatchingDeclarationNameSpec : Spek({
 
             it("should pass for a class with a typealias") {
                 val code = """
-				typealias Foo = FooImpl
+                typealias Foo = FooImpl
 
-				class FooImpl {}"""
+                class FooImpl {}"""
                 val ktFile = compileContentForTest(code)
                 ktFile.name = "Foo.kt"
                 val findings = MatchingDeclarationName().lint(ktFile)
@@ -106,17 +106,17 @@ internal class MatchingDeclarationNameSpec : Spek({
 
             it("should not pass for class declaration with utility functions") {
                 val ktFile = compileContentForTest("""
-				class C
-				fun a() = 5
-				fun C.b() = 5
-			""")
+                class C
+                fun a() = 5
+                fun C.b() = 5
+            """)
                 ktFile.name = "ClassUtils.kt"
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).hasLocationStrings("""'
-				class C
-				fun a() = 5
-				fun C.b() = 5
-			' at (1,1) in /ClassUtils.kt""", trimIndent = true)
+                class C
+                fun a() = 5
+                fun C.b() = 5
+            ' at (1,1) in /ClassUtils.kt""", trimIndent = true)
             }
 
             it("should not pass for interface declaration") {
@@ -128,24 +128,24 @@ internal class MatchingDeclarationNameSpec : Spek({
 
             it("should not pass for enum declaration") {
                 val ktFile = compileContentForTest("""
-				enum class NOT_E {
-					ONE, TWO, THREE
-				}
-			""")
+                enum class NOT_E {
+                    ONE, TWO, THREE
+                }
+            """)
                 ktFile.name = "E.kt"
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).hasLocationStrings("""'
-				enum class NOT_E {
-					ONE, TWO, THREE
-				}
-			' at (1,1) in /E.kt""", trimIndent = true)
+                enum class NOT_E {
+                    ONE, TWO, THREE
+                }
+            ' at (1,1) in /E.kt""", trimIndent = true)
             }
 
             it("should not pass for a typealias with a different name") {
                 val code = """
-				typealias Bar = FooImpl
+                typealias Bar = FooImpl
 
-				class FooImpl {}"""
+                class FooImpl {}"""
                 val ktFile = compileContentForTest(code)
                 ktFile.name = "Foo.kt"
                 val findings = MatchingDeclarationName().lint(ktFile)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternTest.kt
@@ -44,22 +44,22 @@ class NamingConventionCustomPatternTest : Spek({
     }
 
     val excludeClassPatternVariableRegexCode = """
-			class Bar {
-				val MYVar = 3
-			}
+            class Bar {
+                val MYVar = 3
+            }
 
-			object Foo {
-				val MYVar = 3
-			}"""
+            object Foo {
+                val MYVar = 3
+            }"""
 
     val excludeClassPatternFunctionRegexCode = """
-			class Bar {
-				fun MYFun() {}
-			}
+            class Bar {
+                fun MYFun() {}
+            }
 
-			object Foo {
-				fun MYFun() {}
-			}"""
+            object Foo {
+                fun MYFun() {}
+            }"""
 
     describe("NamingRules rule") {
 
@@ -107,13 +107,13 @@ class NamingConventionCustomPatternTest : Spek({
 
         it("shouldExcludeClassesFromVariableNaming") {
             val code = """
-			class Bar {
-				val MYVar = 3
-			}
+            class Bar {
+                val MYVar = 3
+            }
 
-			object Foo {
-				val MYVar = 3
-			}"""
+            object Foo {
+                val MYVar = 3
+            }"""
             val config = TestConfig(mapOf(VariableNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar"))
             assertThat(VariableNaming(config).compileAndLint(code)).isEmpty()
         }
@@ -136,13 +136,13 @@ class NamingConventionCustomPatternTest : Spek({
 
         it("shouldExcludeClassesFromFunctionNaming") {
             val code = """
-			class Bar {
-				fun MYFun() {}
-			}
+            class Bar {
+                fun MYFun() {}
+            }
 
-			object Foo {
-				fun MYFun() {}
-			}"""
+            object Foo {
+                fun MYFun() {}
+            }"""
             val config = TestConfig(mapOf(FunctionNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar"))
             assertThat(FunctionNaming(config).compileAndLint(code)).isEmpty()
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
@@ -35,9 +35,9 @@ class NamingConventionLengthSpec : Spek({
 
             it("does not report a variable with only a single underscore") {
                 val code = """
-			class C {
-				val prop: (Int) -> Unit = { _ -> Unit }
-			}"""
+            class C {
+                val prop: (Int) -> Unit = { _ -> Unit }
+            }"""
                 assertThat(variableMinLength.lint(code)).hasSize(0)
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
@@ -17,72 +17,72 @@ class NamingRulesSpec : Spek({
 
         it("should detect all positive cases") {
             val code = """
-				class C(val CONST_PARAMETER: String, private val PRIVATE_CONST_PARAMETER: Int) {
-					private val _FIELD = 5
-					val FIELD get() = _field
-					val camel_Case_Property = 5
-					const val MY_CONST = 7
-					const val MYCONST = 7
-					fun doStuff(FUN_PARAMETER: String) {}
-				}
-			"""
+                class C(val CONST_PARAMETER: String, private val PRIVATE_CONST_PARAMETER: Int) {
+                    private val _FIELD = 5
+                    val FIELD get() = _field
+                    val camel_Case_Property = 5
+                    const val MY_CONST = 7
+                    const val MYCONST = 7
+                    fun doStuff(FUN_PARAMETER: String) {}
+                }
+            """
             assertThat(subject.lint(code)).hasLocationStrings(
-                    "'private val _FIELD = 5' at (2,2) in /$fileName",
-                    "'val FIELD get() = _field' at (3,2) in /$fileName",
-                    "'val camel_Case_Property = 5' at (4,2) in /$fileName",
-                    "'const val MY_CONST = 7' at (5,2) in /$fileName",
-                    "'const val MYCONST = 7' at (6,2) in /$fileName",
+                    "'private val _FIELD = 5' at (2,5) in /$fileName",
+                    "'val FIELD get() = _field' at (3,5) in /$fileName",
+                    "'val camel_Case_Property = 5' at (4,5) in /$fileName",
+                    "'const val MY_CONST = 7' at (5,5) in /$fileName",
+                    "'const val MYCONST = 7' at (6,5) in /$fileName",
                     "'val CONST_PARAMETER: String' at (1,9) in /$fileName",
                     "'private val PRIVATE_CONST_PARAMETER: Int' at (1,38) in /$fileName",
-                    "'FUN_PARAMETER: String' at (7,14) in /$fileName"
+                    "'FUN_PARAMETER: String' at (7,17) in /$fileName"
             )
         }
 
         it("checks all negative cases") {
             val code = """
-				class C(val constParameter: String, private val privateConstParameter: Int) {
-					private val _field = 5
-					val field get() = _field
-					val camelCaseProperty = 5
-					const val myConst = 7
+                class C(val constParameter: String, private val privateConstParameter: Int) {
+                    private val _field = 5
+                    val field get() = _field
+                    val camelCaseProperty = 5
+                    const val myConst = 7
 
-					data class D(val i: Int, val j: Int)
-					fun doStuff() {
-						val (_, holyGrail) = D(5, 4)
-						emptyMap<String, String>().forEach { _, v -> println(v) }
-					}
-					val doable: (Int) -> Unit = { _ -> Unit }
-					fun doStuff(funParameter: String) {}
-				}
-			"""
+                    data class D(val i: Int, val j: Int)
+                    fun doStuff() {
+                        val (_, holyGrail) = D(5, 4)
+                        emptyMap<String, String>().forEach { _, v -> println(v) }
+                    }
+                    val doable: (Int) -> Unit = { _ -> Unit }
+                    fun doStuff(funParameter: String) {}
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should not flag overridden member properties by default") {
             val code = """
-				class C {
-					override val SHOULD_NOT_BE_FLAGGED = "banana"
-				}
-				interface I {
-					override val SHOULD_NOT_BE_FLAGGED_2 = "banana"
-				}
-			"""
+                class C {
+                    override val SHOULD_NOT_BE_FLAGGED = "banana"
+                }
+                interface I {
+                    override val SHOULD_NOT_BE_FLAGGED_2 = "banana"
+                }
+            """
             assertThat(NamingRules().lint(code)).isEmpty()
         }
 
         it("doesn't ignore overridden member properties if ignoreOverridden is false") {
             val code = """
-				class C {
-					override val SHOULD_BE_FLAGGED = "banana"
-				}
-				interface I {
-					override val SHOULD_BE_FLAGGED_2 = "banana"
-				}
-			"""
+                class C {
+                    override val SHOULD_BE_FLAGGED = "banana"
+                }
+                interface I {
+                    override val SHOULD_BE_FLAGGED_2 = "banana"
+                }
+            """
             val config = TestConfig(mapOf("ignoreOverridden" to "false"))
             assertThat(NamingRules(config).lint(code)).hasLocationStrings(
-                    "'override val SHOULD_BE_FLAGGED = \"banana\"' at (2,2) in /$fileName",
-                    "'override val SHOULD_BE_FLAGGED_2 = \"banana\"' at (5,2) in /$fileName"
+                    "'override val SHOULD_BE_FLAGGED = \"banana\"' at (2,5) in /$fileName",
+                    "'override val SHOULD_BE_FLAGGED_2 = \"banana\"' at (5,5) in /$fileName"
             )
         }
     }
@@ -90,12 +90,12 @@ class NamingRulesSpec : Spek({
     describe("naming like in constants is allowed for destructuring and lambdas") {
         it("should not detect any") {
             val code = """
-				data class D(val i: Int, val j: Int)
-				fun doStuff() {
-					val (_, HOLY_GRAIL) = D(5, 4)
-					emptyMap<String, String>().forEach { _, V -> println(v) }
-				}
-			"""
+                data class D(val i: Int, val j: Int)
+                fun doStuff() {
+                    val (_, HOLY_GRAIL) = D(5, 4)
+                    emptyMap<String, String>().forEach { _, V -> println(v) }
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -18,48 +18,48 @@ class ObjectPropertyNamingSpec : Spek({
 
         it("should not detect public constants complying to the naming rules") {
             val code = compileContentForTest("""
-				object O {
-					${PublicConst.negative}
-				}
-			""")
+                object O {
+                    ${PublicConst.negative}
+                }
+            """)
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should detect public constants not complying to the naming rules") {
             val code = compileContentForTest("""
-				object O {
-					${PublicConst.positive}
-				}
-			""")
+                object O {
+                    ${PublicConst.positive}
+                }
+            """)
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("should not detect private constants complying to the naming rules") {
             val code = compileContentForTest("""
-				object O {
-					${PrivateConst.negative}
-				}
-			""")
+                object O {
+                    ${PrivateConst.negative}
+                }
+            """)
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should detect private constants not complying to the naming rules") {
             val code = compileContentForTest("""
-				object O {
-					${PrivateConst.positive}
-				}
-			""")
+                object O {
+                    ${PrivateConst.positive}
+                }
+            """)
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("should report constants not complying to the naming rules at the right position") {
             val code = compileContentForTest("""
-				object O {
-					${PublicConst.positive}
-				}
-			""")
+                object O {
+                    ${PublicConst.positive}
+                }
+            """)
             assertThat(subject.lint(code)).hasLocationStrings(
-                    "'const val _nAme = \"Artur\"' at (3,6) in /$fileName"
+                    "'const val _nAme = \"Artur\"' at (3,21) in /$fileName"
             )
         }
     }
@@ -70,58 +70,58 @@ class ObjectPropertyNamingSpec : Spek({
 
         it("should not detect public constants complying to the naming rules") {
             val code = compileContentForTest("""
-				class C {
-					companion object {
-						${PublicConst.negative}
-					}
-				}
-			""")
+                class C {
+                    companion object {
+                        ${PublicConst.negative}
+                    }
+                }
+            """)
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should detect public constants not complying to the naming rules") {
             val code = compileContentForTest("""
-				class C {
-					companion object {
-						${PublicConst.positive}
-					}
-				}
-			""")
+                class C {
+                    companion object {
+                        ${PublicConst.positive}
+                    }
+                }
+            """)
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("should not detect private constants complying to the naming rules") {
             val code = compileContentForTest("""
-				class C {
-					companion object {
-						${PrivateConst.negative}
-					}
-				}
-			""")
+                class C {
+                    companion object {
+                        ${PrivateConst.negative}
+                    }
+                }
+            """)
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should detect private constants not complying to the naming rules") {
             val code = compileContentForTest("""
-				class C {
-					companion object {
-						${PrivateConst.positive}
-					}
-				}
-			""")
+                class C {
+                    companion object {
+                        ${PrivateConst.positive}
+                    }
+                }
+            """)
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("should report constants not complying to the naming rules at the right position") {
             val code = compileContentForTest("""
-				class C {
-					companion object {
-						${PublicConst.positive}
-					}
-				}
-			""")
+                class C {
+                    companion object {
+                        ${PublicConst.positive}
+                    }
+                }
+            """)
             assertThat(subject.lint(code)).hasLocationStrings(
-                    "'const val _nAme = \"Artur\"' at (4,7) in /$fileName"
+                    "'const val _nAme = \"Artur\"' at (4,25) in /$fileName"
             )
         }
     }
@@ -132,37 +132,37 @@ class ObjectPropertyNamingSpec : Spek({
 
         it("should not detect public constants complying to the naming rules") {
             val code = compileContentForTest("""
-				object O {
-					${PublicVal.negative}
-				}
-			""")
+                object O {
+                    ${PublicVal.negative}
+                }
+            """)
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should detect public constants not complying to the naming rules") {
             val code = compileContentForTest("""
-				object O {
-					${PublicVal.positive}
-				}
-			""")
+                object O {
+                    ${PublicVal.positive}
+                }
+            """)
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("should not detect private constants complying to the naming rules") {
             val code = compileContentForTest("""
-				object O {
-					${PrivateVal.negative}
-				}
-			""")
+                object O {
+                    ${PrivateVal.negative}
+                }
+            """)
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should detect private constants not complying to the naming rules") {
             val code = compileContentForTest("""
-				object O {
-					private val __NAME = "Artur"
-				}
-			""")
+                object O {
+                    private val __NAME = "Artur"
+                }
+            """)
             assertThat(subject.lint(code)).hasSize(1)
         }
     }
@@ -177,21 +177,21 @@ class ObjectPropertyNamingSpec : Spek({
 
         it("should not detect constants in object with underscores") {
             val code = compileContentForTest("""
-				object O {
-					const val _NAME = "Artur"
-					const val _name = "Artur"
-				}
-			""")
+                object O {
+                    const val _NAME = "Artur"
+                    const val _name = "Artur"
+                }
+            """)
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should not detect private properties in object") {
             val code = compileContentForTest("""
-				object O {
-					private val __NAME = "Artur"
-					private val _1234 = "Artur"
-				}
-			""")
+                object O {
+                    private val __NAME = "Artur"
+                    private val _1234 = "Artur"
+                }
+            """)
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -219,12 +219,12 @@ class ObjectPropertyNamingSpec : Spek({
 abstract class NamingSnippet(private val isPrivate: Boolean, private val isConst: Boolean) {
 
     val negative = """
-					${visibility()}${const()}val MY_NAME_8 = "Artur"
-					${visibility()}${const()}val MYNAME = "Artur"
-					${visibility()}${const()}val MyNAME = "Artur"
-					${visibility()}${const()}val name = "Artur"
-					${visibility()}${const()}val nAme = "Artur"
-					${visibility()}${const()}val serialVersionUID = 42L"""
+                    ${visibility()}${const()}val MY_NAME_8 = "Artur"
+                    ${visibility()}${const()}val MYNAME = "Artur"
+                    ${visibility()}${const()}val MyNAME = "Artur"
+                    ${visibility()}${const()}val name = "Artur"
+                    ${visibility()}${const()}val nAme = "Artur"
+                    ${visibility()}${const()}val serialVersionUID = 42L"""
     val positive = """${visibility()}${const()}val _nAme = "Artur""""
 
     private fun visibility() = if (isPrivate) "private " else ""

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ParameterNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ParameterNamingSpec.kt
@@ -12,25 +12,25 @@ class ParameterNamingSpec : Spek({
 
         it("should detect no violations") {
             val code = """
-				class C(val param: String, private val privateParam: String)
+                class C(val param: String, private val privateParam: String)
 
-				class C {
-					construct(val param: String) {}
-					construct(val param: String, private val privateParam: String) {}
-				}
-			"""
+                class C {
+                    construct(val param: String) {}
+                    construct(val param: String, private val privateParam: String) {}
+                }
+            """
             assertThat(ConstructorParameterNaming().lint(code)).isEmpty()
         }
 
         it("should find some violations") {
             val code = """
-				class C(val PARAM: String, private val PRIVATE_PARAM: String)
+                class C(val PARAM: String, private val PRIVATE_PARAM: String)
 
-				class C {
-					construct(val PARAM: String) {}
-					construct(val PARAM: String, private val PRIVATE_PARAM: String) {}
-				}
-			"""
+                class C {
+                    construct(val PARAM: String) {}
+                    construct(val PARAM: String, private val PRIVATE_PARAM: String) {}
+                }
+            """
             assertThat(NamingRules().lint(code)).hasSize(5)
         }
     }
@@ -39,38 +39,38 @@ class ParameterNamingSpec : Spek({
 
         it("should detect no violations") {
             val code = """
-				class C {
-					fun someStuff(param: String) {}
-				}
-			"""
+                class C {
+                    fun someStuff(param: String) {}
+                }
+            """
             assertThat(ConstructorParameterNaming().lint(code)).isEmpty()
         }
 
         it("should not detect violations in overridden function by default") {
             val code = """
-				class C {
-					override fun someStuff(`object`: String) {}
-				}
-			"""
+                class C {
+                    override fun someStuff(`object`: String) {}
+                }
+            """
             assertThat(FunctionParameterNaming().lint(code)).isEmpty()
         }
 
         it("should detect violations in overridden function if ignoreOverriddenFunctions is false") {
             val code = """
-				class C {
-					override fun someStuff(`object`: String) {}
-				}
-			"""
+                class C {
+                    override fun someStuff(`object`: String) {}
+                }
+            """
             val config = TestConfig(mapOf("ignoreOverriddenFunctions" to "false"))
             assertThat(FunctionParameterNaming(config).lint(code)).hasSize(1)
         }
 
         it("should find some violations") {
             val code = """
-				class C {
-					fun someStuff(PARAM: String) {}
-				}
-			"""
+                class C {
+                    fun someStuff(PARAM: String) {}
+                }
+            """
             assertThat(NamingRules().lint(code)).hasSize(1)
         }
     }
@@ -81,10 +81,10 @@ class ParameterNamingSpec : Spek({
 
         it("should not detect function parameter") {
             val code = """
-				class Excluded {
-					fun f(PARAM: Int)
-				}
-			"""
+                class Excluded {
+                    fun f(PARAM: Int)
+                }
+            """
             assertThat(FunctionParameterNaming(config).lint(code)).isEmpty()
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
@@ -11,21 +11,21 @@ class ForEachOnRangeSpec : Spek({
 
         context("a kt file with using a forEach on a range") {
             val code = """
-			fun test() {
-				(1..10).forEach {
-					println(it)
-				}
-				(1 until 10).forEach {
-					println(it)
-				}
-				(10 downTo 1).forEach {
-					println(it)
-				}
-				(10 downTo 1 step 2).forEach {
-					println(it)
-				}
-			}
-		"""
+            fun test() {
+                (1..10).forEach {
+                    println(it)
+                }
+                (1 until 10).forEach {
+                    println(it)
+                }
+                (10 downTo 1).forEach {
+                    println(it)
+                }
+                (10 downTo 1 step 2).forEach {
+                    println(it)
+                }
+            }
+        """
 
             it("should report the forEach usage") {
                 val findings = ForEachOnRange().compileAndLint(code)
@@ -35,10 +35,10 @@ class ForEachOnRangeSpec : Spek({
 
         context("a kt file with using any other method on a range") {
             val code = """
-			fun test() {
-				(1..10).isEmpty()
-			}
-		"""
+            fun test() {
+                (1..10).isEmpty()
+            }
+        """
 
             it("should report not report any issues") {
                 val findings = ForEachOnRange().compileAndLint(code)
@@ -48,12 +48,12 @@ class ForEachOnRangeSpec : Spek({
 
         context("a kt file with using a forEach on a list") {
             val code = """
-			fun test() {
-				listOf(1, 2, 3).forEach {
-					println(it)
-				}
-			}
-		"""
+            fun test() {
+                listOf(1, 2, 3).forEach {
+                    println(it)
+                }
+            }
+        """
 
             it("should report not report any issues") {
                 val findings = ForEachOnRange().compileAndLint(code)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
@@ -71,26 +71,26 @@ class SpreadOperatorSpec : Spek({
 
             it("doesn't report when function doesn't take a vararg parameter") {
                 val code = """
-				fun test0(strs: Array<String>) {
-					test(strs)
-				}
+                fun test0(strs: Array<String>) {
+                    test(strs)
+                }
 
-				fun test(strs: Array<String>) {
-					strs.forEach { println(it) }
-				}
+                fun test(strs: Array<String>) {
+                    strs.forEach { println(it) }
+                }
                 """
                 assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
             }
 
             it("doesn't report with expression inside params") {
                 val code = """
-				fun test0(strs: Array<String>) {
-					test(2*2)
-				}
+                fun test0(strs: Array<String>) {
+                    test(2*2)
+                }
 
-				fun test(test : Int) {
-					println(test)
-				}
+                fun test(test : Int) {
+                    println(test)
+                }
                 """
                 assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
             }
@@ -151,26 +151,26 @@ class SpreadOperatorSpec : Spek({
 
             it("doesn't report when function doesn't take a vararg parameter") {
                 val code = """
-				fun test0(strs: Array<String>) {
-					test(strs)
-				}
+                fun test0(strs: Array<String>) {
+                    test(strs)
+                }
 
-				fun test(strs: Array<String>) {
-					strs.forEach { println(it) }
-				}
+                fun test(strs: Array<String>) {
+                    strs.forEach { println(it) }
+                }
                 """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
 
             it("doesn't report with expression inside params") {
                 val code = """
-				fun test0(strs: Array<String>) {
-					test(2*2)
-				}
+                fun test0(strs: Array<String>) {
+                    test(2*2)
+                }
 
-				fun test(test : Int) {
-					println(test)
-				}
+                fun test(test : Int) {
+                    println(test)
+                }
                 """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCallSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCallSpec.kt
@@ -13,25 +13,25 @@ class EqualsNullCallSpec : Spek({
 
         it("reports equals call with null as parameter") {
             val code = """
-				fun x(a: String) {
-					a.equals(null)
-				}"""
+                fun x(a: String) {
+                    a.equals(null)
+                }"""
             assertThat(subject.compileAndLint(code).size).isEqualTo(1)
         }
 
         it("reports nested equals call with null as parameter") {
             val code = """
-				fun x(a: String, b: String) {
-					a.equals(b.equals(null))
-				}"""
+                fun x(a: String, b: String) {
+                    a.equals(b.equals(null))
+                }"""
             assertThat(subject.compileAndLint(code).size).isEqualTo(1)
         }
 
         it("does not report equals call with parameter of type string") {
             val code = """
-				fun x(a: String, b: String) {
-					a.equals(b)
-				}"""
+                fun x(a: String, b: String) {
+                    a.equals(b)
+                }"""
             assertThat(subject.compileAndLint(code).size).isEqualTo(0)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLineSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLineSpec.kt
@@ -14,19 +14,19 @@ class EqualsOnSignatureLineSpec : Spek({
         context("with expression syntax and without a return type") {
             it("reports when the equals is on a new line") {
                 val findings = subject.compileAndLint("""
-				    fun foo()
-				    	= 1
-				""")
+                    fun foo()
+                        = 1
+                """)
                 assertThat(findings).hasSize(1)
             }
 
             it("does not report when the equals is on the same line") {
                 val findings = subject.compileAndLint("""
-				fun foo() = 1
+                fun foo() = 1
 
-				fun bar() =
-					2
-				""")
+                fun bar() =
+                    2
+                """)
                 assertThat(findings).isEmpty()
             }
         }
@@ -34,53 +34,53 @@ class EqualsOnSignatureLineSpec : Spek({
         context("with expression syntax and with a return type") {
             it("reports when the equals is on a new line") {
                 val findings = subject.compileAndLint("""
-				fun one(): Int
-					= 1
+                fun one(): Int
+                    = 1
 
-				fun two(
-					foo: String
-				)
-					= 2
+                fun two(
+                    foo: String
+                )
+                    = 2
 
-				fun three(
-					foo: String
-				): Int
-					= 3
-				""")
+                fun three(
+                    foo: String
+                ): Int
+                    = 3
+                """)
                 assertThat(findings).hasSize(3)
             }
 
             it("does not report when the equals is on the same line") {
                 val findings = subject.compileAndLint("""
-				fun one(): Int =
-					1
+                fun one(): Int =
+                    1
 
-				fun two()
-					: Int =
-					2
+                fun two()
+                    : Int =
+                    2
 
-				fun three():
-					Int =
-					3
+                fun three():
+                    Int =
+                    3
 
-				fun four(
-					foo: String
-				): Int =
-					4
+                fun four(
+                    foo: String
+                ): Int =
+                    4
 
-				fun five(
-					foo: String
-				)
-				: Int =
-					5
+                fun five(
+                    foo: String
+                )
+                : Int =
+                    5
 
-				fun six(
-					foo: String
-				)
-				:
-				Int =
-					6
-				""")
+                fun six(
+                    foo: String
+                )
+                :
+                Int =
+                    6
+                """)
                 assertThat(findings).isEmpty()
             }
         }
@@ -88,52 +88,52 @@ class EqualsOnSignatureLineSpec : Spek({
         context("with expression syntax and with a where clause") {
             it("reports when the equals is on a new line") {
                 val findings = subject.compileAndLint("""
-				fun <V> one(): Int where V : Number
-					= 1
+                fun <V> one(): Int where V : Number
+                    = 1
 
-				fun <V> two(
-					foo: String
-				) where V : Number
-					= 2
+                fun <V> two(
+                    foo: String
+                ) where V : Number
+                    = 2
 
-				fun <V> three(
-					foo: String
-				): Int
-					where V : Number
-					= 3
-				""")
+                fun <V> three(
+                    foo: String
+                ): Int
+                    where V : Number
+                    = 3
+                """)
                 assertThat(findings).hasSize(3)
             }
 
             it("does not report when the equals is on the same line") {
                 val findings = subject.compileAndLint("""
-				fun <V> one(): Int where V : Number =
-					1
+                fun <V> one(): Int where V : Number =
+                    1
 
-				fun <V> two() : Int
-					where V : Number =
-					2
+                fun <V> two() : Int
+                    where V : Number =
+                    2
 
-				""")
+                """)
                 assertThat(findings).isEmpty()
             }
         }
 
         it("does not report non-expression functions") {
             val findings = subject.compileAndLint("""
-			fun foo() {
-			}
+            fun foo() {
+            }
 
-			fun bar()
-			{
-			}
+            fun bar()
+            {
+            }
 
-			fun baz()
-			:
-			Unit
-			{
-			}
-			""")
+            fun baz()
+            :
+            Unit
+            {
+            }
+            """)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
@@ -13,27 +13,27 @@ class ExplicitItLambdaParameterSpec : Spek({
         context("single parameter lambda with name `it` declared explicitly") {
             it("reports when parameter type is not declared") {
                 val findings = subject.compileAndLint("""
-				fun f() {
-					val digits = 1234.let { it -> listOf(it) }
-				}""")
+                fun f() {
+                    val digits = 1234.let { it -> listOf(it) }
+                }""")
                 assertThat(findings).hasSize(1)
             }
             it("reports when parameter type is declared explicitly") {
                 val findings = subject.compileAndLint("""
-				fun f() {
-					val lambda = { it: Int -> it.toString() }
-				}""")
+                fun f() {
+                    val lambda = { it: Int -> it.toString() }
+                }""")
                 assertThat(findings).hasSize(1)
             }
         }
         context("no parameter declared explicitly") {
             it("does not report implicit `it` parameter usage") {
                 val findings = subject.compileAndLint("""
-				fun f() {
-					val lambda = { i: Int -> i.toString() }
-					val digits = 1234.let { lambda(it) }.toList()
-					val flat = listOf(listOf(1), listOf(2)).flatMap { it }
-				}""")
+                fun f() {
+                    val lambda = { i: Int -> i.toString() }
+                    val digits = 1234.let { lambda(it) }.toList()
+                    val flat = listOf(listOf(1), listOf(2)).flatMap { it }
+                }""")
                 assertThat(findings).isEmpty()
             }
         }
@@ -41,16 +41,16 @@ class ExplicitItLambdaParameterSpec : Spek({
         context("multiple parameters one of which with name `it` declared explicitly") {
             it("reports when parameter types are not declared") {
                 val findings = subject.compileAndLint("""
-				fun f() {
-					val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it -> it + index }
-				}""")
+                fun f() {
+                    val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it -> it + index }
+                }""")
                 assertThat(findings).hasSize(1)
             }
             it("reports when parameter types are declared explicitly") {
                 val findings = subject.compileAndLint("""
-				fun f() {
-					val lambda = { it: Int, that: String -> it.toString() + that }
-				}""")
+                fun f() {
+                    val lambda = { it: Int, that: String -> it.toString() + that }
+                }""")
                 assertThat(findings).hasSize(1)
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
@@ -16,40 +16,40 @@ class ExpressionBodySyntaxSpec : Spek({
 
             it("reports constant return") {
                 assertThat(subject.compileAndLint("""
-			    	fun stuff(): Int {
-			    		return 5
-			    	}
-			    """
+                    fun stuff(): Int {
+                        return 5
+                    }
+                """
                 )).hasSize(1)
             }
 
             it("reports return statement with method chain") {
                 assertThat(subject.compileAndLint("""
-			    	fun stuff(): String {
-			    		return StringBuilder().append(0).toString()
-			    	}
-			    """
+                    fun stuff(): String {
+                        return StringBuilder().append(0).toString()
+                    }
+                """
                 )).hasSize(1)
             }
 
             it("reports return statements with conditionals") {
                 assertThat(subject.compileAndLint("""
-			    	fun stuff(): Int {
-			    		return if (true) return 5 else return 3
-			    	}
-			    	fun stuff(): Int {
-			    		return try { return 5 } catch (e: Exception) { return 3 }
-			    	}
-			    """)).hasSize(2)
+                    fun stuff(): Int {
+                        return if (true) return 5 else return 3
+                    }
+                    fun stuff(): Int {
+                        return try { return 5 } catch (e: Exception) { return 3 }
+                    }
+                """)).hasSize(2)
             }
 
             it("does not report multiple if statements") {
                 assertThat(subject.compileAndLint("""
-			    	fun stuff(): Boolean {
-			    		if (true) return true
-			    		return false
-			    	}
-			    """)).isEmpty()
+                    fun stuff(): Boolean {
+                        if (true) return true
+                        return false
+                    }
+                """)).isEmpty()
             }
 
             it("does not report when using shortcut return") {
@@ -66,11 +66,11 @@ class ExpressionBodySyntaxSpec : Spek({
         context("several return statements with multiline method chain") {
 
             val code = """
-			    fun stuff(): String {
-			    	return StringBuilder()
-			    		.append(1)
-			    		.toString()
-			    }"""
+                fun stuff(): String {
+                    return StringBuilder()
+                        .append(1)
+                        .toString()
+                }"""
 
             it("does not report with the default configuration") {
                 assertThat(subject.compileAndLint(code)).isEmpty()
@@ -85,12 +85,12 @@ class ExpressionBodySyntaxSpec : Spek({
         context("several return statements with multiline when expression") {
 
             val code = """
-			    fun stuff(arg: Int): Int {
-			    	return when(arg) {
-			    		0 -> 0
-			    		else -> 1
-			    	}
-			    }"""
+                fun stuff(arg: Int): Int {
+                    return when(arg) {
+                        0 -> 0
+                        else -> 1
+                    }
+                }"""
 
             it("does not report with the default configuration") {
                 assertThat(subject.compileAndLint(code)).isEmpty()
@@ -105,10 +105,10 @@ class ExpressionBodySyntaxSpec : Spek({
         context("several return statements with multiline if expression") {
 
             val code = """
-			    fun stuff(arg: Int): Int {
-			    	return if (arg == 0) 0
-			    	else 1
-			    }
+                fun stuff(arg: Int): Int {
+                    return if (arg == 0) 0
+                    else 1
+                }
             """
 
             it("does not report with the default configuration") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -9,15 +9,15 @@ import org.spekframework.spek2.style.specification.describe
 class ForbiddenImportSpec : Spek({
     describe("ForbiddenImport rule") {
         val code = """
-			package foo
+            package foo
 
-			import kotlin.jvm.JvmField
-			import kotlin.SinceKotlin
+            import kotlin.jvm.JvmField
+            import kotlin.SinceKotlin
 
-			import com.example.R.string
-			import net.example.R.dimen
-			import net.example.R.dimension
-		"""
+            import com.example.R.string
+            import net.example.R.dimen
+            import net.example.R.dimension
+        """
 
         it("should report nothing by default") {
             val findings = ForbiddenImport().lint(code)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
@@ -42,7 +42,7 @@ class ForbiddenVoidSpec : Spek({
 
         it("does not report when functions or classes are called 'Void'") {
             val code = """
-				class Void {
+                class Void {
                     fun void() {}
                     val void = "string"
                 }
@@ -53,7 +53,7 @@ class ForbiddenVoidSpec : Spek({
                     fun myFun2(): E = E.Void
                     abstract fun myFun(): Void
                 }
-			"""
+            """
 
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -263,34 +263,34 @@ class MagicNumberSpec : Spek({
 
         context("a when statement with magic numbers") {
             val ktFile = compileContentForTest("""
-			fun test(x: Int) {
-				when (x) {
-					5 -> return 5
-					4 -> return 4
-					3 -> return 3
-				}
-			}
-		""".trimMargin())
+            fun test(x: Int) {
+                when (x) {
+                    5 -> return 5
+                    4 -> return 4
+                    3 -> return 3
+                }
+            }
+        """.trimMargin())
 
             it("should be reported") {
                 val findings = MagicNumber().lint(ktFile)
                 assertThat(findings).hasLocationStrings(
-                        "'5' at (3,6) in /$fileName",
-                        "'5' at (3,18) in /$fileName",
-                        "'4' at (4,6) in /$fileName",
-                        "'4' at (4,18) in /$fileName",
-                        "'3' at (5,6) in /$fileName",
-                        "'3' at (5,18) in /$fileName"
+                        "'5' at (3,21) in /$fileName",
+                        "'5' at (3,33) in /$fileName",
+                        "'4' at (4,21) in /$fileName",
+                        "'4' at (4,33) in /$fileName",
+                        "'3' at (5,21) in /$fileName",
+                        "'3' at (5,33) in /$fileName"
                 )
             }
         }
 
         context("a method containing variables with magic numbers") {
             val ktFile = compileContentForTest("""
-			fun test(x: Int) {
-				val i = 5
-			}
-		""")
+            fun test(x: Int) {
+                val i = 5
+            }
+        """)
 
             it("should be reported") {
                 val findings = MagicNumber().lint(ktFile)
@@ -300,10 +300,10 @@ class MagicNumberSpec : Spek({
 
         context("a boolean value") {
             val ktFile = compileContentForTest("""
-			fun test() : Boolean {
-				return true;
-			}
-		""")
+            fun test() : Boolean {
+                return true;
+            }
+        """)
 
             it("should not be reported") {
                 val findings = MagicNumber().lint(ktFile)
@@ -361,21 +361,21 @@ class MagicNumberSpec : Spek({
 
         context("ignoring properties") {
             val ktFile = compileContentForTest("""
-			@Magic(number = 69)
-			class A {
-				val boringNumber = 42
-				const val BORING_CONSTANT = 93871
+            @Magic(number = 69)
+            class A {
+                val boringNumber = 42
+                const val BORING_CONSTANT = 93871
 
-				override fun hashCode(): Int {
-					val iAmSoMagic = 7328672
-				}
+                override fun hashCode(): Int {
+                    val iAmSoMagic = 7328672
+                }
 
-				companion object {
-				    val anotherBoringNumber = 43
-					const val anotherBoringConstant = 93872
-				}
-			}
-		""".trimMargin())
+                companion object {
+                    val anotherBoringNumber = 43
+                    const val anotherBoringConstant = 93872
+                }
+            }
+        """.trimMargin())
 
             it("should report all without ignore flags") {
                 val config = TestConfig(
@@ -390,12 +390,12 @@ class MagicNumberSpec : Spek({
 
                 val findings = MagicNumber(config).lint(ktFile)
                 assertThat(findings).hasLocationStrings(
-                        "'69' at (1,20) in /$fileName",
-                        "'42' at (3,24) in /$fileName",
-                        "'93871' at (4,33) in /$fileName",
-                        "'7328672' at (7,23) in /$fileName",
-                        "'43' at (11,35) in /$fileName",
-                        "'93872' at (12,40) in /$fileName"
+                        "'69' at (1,29) in /$fileName",
+                        "'42' at (3,36) in /$fileName",
+                        "'93871' at (4,45) in /$fileName",
+                        "'7328672' at (7,38) in /$fileName",
+                        "'43' at (11,47) in /$fileName",
+                        "'93872' at (12,55) in /$fileName"
                 )
             }
 
@@ -417,14 +417,14 @@ class MagicNumberSpec : Spek({
 
         context("magic numbers in companion object property assignments") {
             val ktFile = compileContentForTest("""
-			class A {
+            class A {
 
-				companion object {
-				    val anotherBoringNumber = 43
-					const val anotherBoringConstant = 93872
-				}
-			}
-		""".trimMargin())
+                companion object {
+                    val anotherBoringNumber = 43
+                    const val anotherBoringConstant = 93872
+                }
+            }
+        """.trimMargin())
 
             it("should not report any issues by default") {
                 val findings = MagicNumber().lint(ktFile)
@@ -493,7 +493,7 @@ class MagicNumberSpec : Spek({
                 )
 
                 val findings = MagicNumber(config).lint(ktFile)
-                assertThat(findings).hasLocationStrings("'43' at (4,35) in /$fileName")
+                assertThat(findings).hasLocationStrings("'43' at (4,47) in /$fileName")
             }
 
             it("should report property and constant when not ignoring properties, constants nor companion objects") {
@@ -506,7 +506,7 @@ class MagicNumberSpec : Spek({
                 )
 
                 val findings = MagicNumber(config).lint(ktFile)
-                assertThat(findings).hasLocationStrings("'43' at (4,35) in /$fileName", "'93872' at (5,40) in /$fileName")
+                assertThat(findings).hasLocationStrings("'43' at (4,47) in /$fileName", "'93872' at (5,55) in /$fileName")
             }
         }
 
@@ -522,13 +522,13 @@ class MagicNumberSpec : Spek({
         context("ignoring named arguments") {
             context("in constructor invocation") {
                 fun code(numberString: String) = compileContentForTest("""
-				data class Model(
-						val someVal: Int,
-						val other: String = "default"
-				)
+                data class Model(
+                        val someVal: Int,
+                        val other: String = "default"
+                )
 
-				var model = Model(someVal = $numberString)
-			""")
+                var model = Model(someVal = $numberString)
+            """)
 
                 it("should not ignore int by default") {
                     assertThat(MagicNumber().lint(code("53"))).hasSize(1)
@@ -553,10 +553,10 @@ class MagicNumberSpec : Spek({
 
                 it("should ignore named arguments in inheritance - #992") {
                     val code = """
-					abstract class A(n: Int)
+                    abstract class A(n: Int)
 
-					object B : A(n = 5)
-				"""
+                    object B : A(n = 5)
+                """
                     val rule = MagicNumber(TestConfig(mapOf("ignoreNamedArgument" to "true")))
                     assertThat(rule.lint(code)).isEmpty()
                 }
@@ -574,13 +574,13 @@ class MagicNumberSpec : Spek({
             context("Issue#659 - false-negative reporting on unnamed argument when ignore is true") {
 
                 fun code(numberString: String) = compileContentForTest("""
-				data class Model(
-						val someVal: Int,
-						val other: String = "default"
-				)
+                data class Model(
+                        val someVal: Int,
+                        val other: String = "default"
+                )
 
-				var model = Model($numberString)
-			""")
+                var model = Model($numberString)
+            """)
 
                 it("should detect the argument") {
                     val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NAMED_ARGUMENT to "true")))
@@ -590,10 +590,10 @@ class MagicNumberSpec : Spek({
 
             context("in function invocation") {
                 fun code(number: Number) = compileContentForTest("""
-				fun tested(someVal: Int, other: String = "default")
+                fun tested(someVal: Int, other: String = "default")
 
-				tested(someVal = $number)
-			""")
+                tested(someVal = $number)
+            """)
                 it("should ignore int by default") {
                     assertThat(MagicNumber().lint(code(53))).isEmpty()
                 }
@@ -612,11 +612,11 @@ class MagicNumberSpec : Spek({
             }
             context("in enum constructor argument") {
                 val ktFile = compileContentForTest("""
-				enum class Bag(id: Int) {
-					SMALL(1),
-					EXTRA_LARGE(5)
-				}
-			""")
+                enum class Bag(id: Int) {
+                    SMALL(1),
+                    EXTRA_LARGE(5)
+                }
+            """)
                 it("should be reported by default") {
                     assertThat(MagicNumber().lint(ktFile)).hasSize(1)
                 }
@@ -627,11 +627,11 @@ class MagicNumberSpec : Spek({
             }
             context("in enum constructor as named argument") {
                 val ktFile = compileContentForTest("""
-				enum class Bag(id: Int) {
-					SMALL(id = 1),
-					EXTRA_LARGE(id = 5)
-				}
-			""")
+                enum class Bag(id: Int) {
+                    SMALL(id = 1),
+                    EXTRA_LARGE(id = 5)
+                }
+            """)
                 it("should be reported by default") {
                     assertThat(MagicNumber().lint(ktFile)).hasSize(1)
                 }
@@ -646,15 +646,15 @@ class MagicNumberSpec : Spek({
 
             it("does not report functions that always returns a constant value") {
                 val code = """
-				fun x() = 9
-				fun y() { return 9 }"""
+                fun x() = 9
+                fun y() { return 9 }"""
                 assertThat(MagicNumber().lint(code)).isEmpty()
             }
 
             it("reports functions that does not return a constant value") {
                 val code = """
-				fun x() = 9 + 1
-				fun y(): Int { return 9 + 1 }"""
+                fun x() = 9 + 1
+                fun y(): Int { return 9 + 1 }"""
                 assertThat(MagicNumber().lint(code)).hasSize(2)
             }
         }
@@ -676,9 +676,9 @@ class MagicNumberSpec : Spek({
 
             it("reports no finding") {
                 val code = compileContentForTest("""
-				class SomeClassWithDefault {
-					constructor(val defaultValue: Int = 10) { }
-				}""")
+                class SomeClassWithDefault {
+                    constructor(val defaultValue: Int = 10) { }
+                }""")
                 assertThat(MagicNumber().lint(code)).isEmpty()
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -47,13 +47,13 @@ class MaxLineLengthSpec : Spek({
 
         context("a kt file with a long package name and long import statements") {
             val code = """
-			package anIncrediblyLongAndComplexPackageNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
+            package anIncrediblyLongAndComplexPackageNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
 
-			import anIncrediblyLongAndComplexImportNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
+            import anIncrediblyLongAndComplexImportNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
 
-			class Test {
-			}
-		"""
+            class Test {
+            }
+        """
 
             val file = compileContentForTest(code)
             val lines = file.text.splitToSequence("\n")
@@ -130,14 +130,14 @@ class MaxLineLengthSpec : Spek({
 
         context("a kt file with a long package name, long import statements and a long line") {
             val code = """
-			package anIncrediblyLongAndComplexPackageNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
+            package anIncrediblyLongAndComplexPackageNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
 
-			import anIncrediblyLongAndComplexImportNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
+            import anIncrediblyLongAndComplexImportNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
 
-			class Test {
-				fun anIncrediblyLongAndComplexMethodNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot() {}
-			}
-		""".trim()
+            class Test {
+                fun anIncrediblyLongAndComplexMethodNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot() {}
+            }
+        """.trim()
 
             val file = compileContentForTest(code)
             val lines = file.text.splitToSequence("\n")
@@ -185,7 +185,7 @@ class MaxLineLengthSpec : Spek({
                 assertThat(rule.findings).hasSize(1)
                 val findingSource = rule.findings[0].location.source
                 assertThat(findingSource.line).isEqualTo(6)
-                assertThat(findingSource.column).isEqualTo(5)
+                assertThat(findingSource.column).isEqualTo(17)
             }
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
@@ -21,47 +21,47 @@ class MayBeConstSpec : Spek({
 
             it("is const vals in object") {
                 val code = """
-				object Test {
-					const val TEST = "Test"
-				}
-				"""
+                object Test {
+                    const val TEST = "Test"
+                }
+                """
                 subject.lint(code)
                 assertThat(subject.findings).isEmpty()
             }
 
             it("isconst vals in companion objects") {
                 val code = """
-				class Test {
-					companion object {
-						const val B = 1
-					}
-				}
-				"""
+                class Test {
+                    companion object {
+                        const val B = 1
+                    }
+                }
+                """
                 subject.lint(code)
                 assertThat(subject.findings).isEmpty()
             }
 
             it("does not report const vals that use other const vals") {
                 val code = """
-				const val a = 0
+                const val a = 0
 
-				class Test {
-					companion object {
-						@JvmField
-						const val B = a + 1
-					}
-				}
-				"""
+                class Test {
+                    companion object {
+                        @JvmField
+                        const val B = a + 1
+                    }
+                }
+                """
                 subject.lint(code)
                 assertThat(subject.findings).isEmpty()
             }
 
             it("does not report none const val candidates") {
                 val code = """
-				const val a = 0
-				val p = Pair(a, a + a)
-				val p2 = emptyList<Int>().plus(a)
-				"""
+                const val a = 0
+                val p = Pair(a, a + a)
+                val p2 = emptyList<Int>().plus(a)
+                """
                 subject.lint(code)
                 assertThat(subject.findings).isEmpty()
             }
@@ -70,38 +70,38 @@ class MayBeConstSpec : Spek({
         context("some vals that could be constants") {
             it("is a simple val") {
                 val code = """
-				val x = 1
-				"""
+                val x = 1
+                """
                 subject.lint(code)
                 assertThat(subject.findings).hasSize(1)
             }
 
             it("is a simple JvmField val") {
                 val code = """
-				@JvmField val x = 1
-				"""
+                @JvmField val x = 1
+                """
                 subject.lint(code)
                 assertThat(subject.findings).hasSize(1)
             }
 
             it("is a field in an object") {
                 val code = """
-				object Test {
-    				@JvmField val test = "Test"
-				}
-				"""
+                object Test {
+                    @JvmField val test = "Test"
+                }
+                """
                 subject.lint(code)
                 assertThat(subject.findings).hasSize(1)
             }
 
             it("reports vals in companion objects") {
                 val code = """
-				class Test {
-					companion object {
-						val b = 1
-					}
-				}
-				"""
+                class Test {
+                    companion object {
+                        val b = 1
+                    }
+                }
+                """
                 subject.lint(code)
                 assertThat(subject.findings).hasSize(1)
             }
@@ -110,64 +110,64 @@ class MayBeConstSpec : Spek({
         context("vals that can be constants but detekt doesn't handle yet") {
             it("is a constant binary expression") {
                 val code = """
-				const val one = 1
-				val two = one * 2
-				"""
+                const val one = 1
+                val two = one * 2
+                """
                 subject.lint(code)
                 assertThat(subject.findings).hasSize(1)
             }
 
             it("is a constant binary expression in a companion object") {
                 val code = """
-				class Test {
-					companion object {
-						const val one = 1
-						val two = one * 2
-					}
-				}
-				"""
+                class Test {
+                    companion object {
+                        const val one = 1
+                        val two = one * 2
+                    }
+                }
+                """
                 subject.lint(code)
                 assertThat(subject.findings).hasSize(1)
             }
 
             it("is a nested constant binary expression") {
                 val code = """
-				const val one = 1
-				val two = one * 2 + 1
-				"""
+                const val one = 1
+                val two = one * 2 + 1
+                """
                 subject.lint(code)
                 assertThat(subject.findings).hasSize(1)
             }
 
             it("is a nested constant parenthesised expression") {
                 val code = """
-				const val one = 1
-				val two = one * (2 + 1)
-				"""
+                const val one = 1
+                val two = one * (2 + 1)
+                """
                 subject.lint(code)
                 assertThat(subject.findings).hasSize(1)
             }
 
             it("reports vals that use other const vals") {
                 val code = """
-				const val a = 0
+                const val a = 0
 
-				class Test {
-					companion object {
-						@JvmField
-						val b = a + 1
-					}
-				}
-				"""
+                class Test {
+                    companion object {
+                        @JvmField
+                        val b = a + 1
+                    }
+                }
+                """
                 subject.lint(code)
                 assertThat(subject.findings).hasSize(1)
             }
 
             it("reports concatenated string vals") {
                 val code = """
-				private const val A = "a"
-				private val B = A + "b"
-				"""
+                private const val A = "a"
+                private val B = A + "b"
+                """
                 subject.lint(code)
                 assertThat(subject.findings).hasSize(1)
             }
@@ -200,34 +200,34 @@ class MayBeConstSpec : Spek({
 
             it("is a JvmField in a class") {
                 val code = """
-				class Test {
-					@JvmField val a = 3
-				}
-			"""
+                class Test {
+                    @JvmField val a = 3
+                }
+            """
                 subject.lint(code)
                 assertThat(subject.findings).isEmpty()
             }
 
             it("has some annotation") {
                 val code = """
-				annotation class A
+                annotation class A
 
-				@A val a = 55
-			"""
+                @A val a = 55
+            """
                 subject.lint(code)
                 assertThat(subject.findings).isEmpty()
             }
 
             it("overrides something") {
                 val code = """
-				interface Base {
-					val property: Int
-				}
+                interface Base {
+                    val property: Int
+                }
 
-				object Derived : Base {
-					override val property = 1
-				}
-			"""
+                object Derived : Base {
+                    override val property = 1
+                }
+            """
                 subject.lint(code)
                 assertThat(subject.findings).isEmpty()
             }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
@@ -69,9 +69,9 @@ class ModifierOrderSpec : Spek({
                     abstract class A {
                         abstract fun test()
                     }
-				    abstract class Test : A() {
-				    	override fun test() {}
-				    }"""
+                    abstract class Test : A() {
+                        override fun test() {}
+                    }"""
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeywordSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeywordSpec.kt
@@ -27,11 +27,11 @@ class OptionalAbstractKeywordSpec : Spek({
 
         it("reports nested abstract interface") {
             val code = """
-				class A {
-					abstract interface B {
-						abstract fun x()
-					}
-				}"""
+                class A {
+                    abstract interface B {
+                        abstract fun x()
+                    }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
@@ -44,9 +44,9 @@ class OptionalAbstractKeywordSpec : Spek({
             val code = """
                 interface I {
                     abstract class A {
-						abstract fun dependency()
-				    }
-				}"""
+                        abstract fun dependency()
+                    }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBracesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBracesSpec.kt
@@ -12,30 +12,30 @@ class OptionalWhenBracesSpec : Spek({
 
         it("does not report necessary braces") {
             val code = """
-				fun x() {
-					when (1) {
-						1 -> print(1)
-						2 -> {
-							print(2)
-							print(2)
-						}
-						else -> {
-							// a comment
-							println()
-						}
-					}
-				}"""
+                fun x() {
+                    when (1) {
+                        1 -> print(1)
+                        2 -> {
+                            print(2)
+                            print(2)
+                        }
+                        else -> {
+                            // a comment
+                            println()
+                        }
+                    }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
 
         it("reports unnecessary braces") {
             val code = """
-				fun x() {
-					when (1) {
-						1 -> { print(1) }
-						else -> println()
-					}
-				}"""
+                fun x() {
+                    when (1) {
+                        1 -> { print(1) }
+                        else -> println()
+                    }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
@@ -11,120 +11,120 @@ class RedundantVisibilityModifierRuleSpec : Spek({
     describe("RedundantVisibilityModifier rule") {
         it("does not report overridden function of abstract class w/ public modifier") {
             val code = """
-				abstract class A {
-					abstract protected fun A()
-				}
+                abstract class A {
+                    abstract protected fun A()
+                }
 
-				class Test : A() {
-					override public fun A() {}
-				}
-			"""
+                class Test : A() {
+                    override public fun A() {}
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
 
         it("does not report overridden function of abstract class w/o public modifier") {
             val code = """
-				abstract class A {
-					abstract protected fun A()
-				}
+                abstract class A {
+                    abstract protected fun A()
+                }
 
-				class Test : A() {
-					override fun A() {}
-				}
-			"""
+                class Test : A() {
+                    override fun A() {}
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
 
         it("does not report overridden function of interface") {
             val code = """
-				interface A {
-					fun A()
-				}
+                interface A {
+                    fun A()
+                }
 
-				class Test : A {
-					override public fun A() {}
-				}
-			"""
+                class Test : A {
+                    override public fun A() {}
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
 
         it("reports public function in class") {
             val code = """
-				class Test{
-					public fun A() {}
-				}
-			"""
+                class Test{
+                    public fun A() {}
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("does not report function in class w/o modifier") {
             val code = """
-				class Test{
-					fun A() {}
-				}
-			"""
+                class Test{
+                    fun A() {}
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
 
         it("reports public class") {
             val code = """
-				public class Test(){
-					fun test(){}
-				}
-			"""
+                public class Test(){
+                    fun test(){}
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("reports interface w/ public modifier") {
             val code = """
-				public interface Test{
-					public fun test()
-				}
-			"""
+                public interface Test{
+                    public fun test()
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
         it("reports field w/ public modifier") {
             val code = """
-				class Test{
-					public val str : String = "test"
-				}
-			"""
+                class Test{
+                    public val str : String = "test"
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("does not report field w/o public modifier") {
             val code = """
-				class Test{
-					val str : String = "test"
-				}
-			"""
+                class Test{
+                    val str : String = "test"
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
 
         it("does not report overridden field w/o public modifier") {
             val code = """
-				abstract class A {
-					abstract val test: String
-				}
+                abstract class A {
+                    abstract val test: String
+                }
 
-				class B : A() {
-					override val test: String = "valid"
-				}
-			"""
+                class B : A() {
+                    override val test: String = "valid"
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
 
         it("does not report overridden field w/ public modifier") {
             val code = """
-				abstract class A {
-					abstract val test: String
-				}
+                abstract class A {
+                    abstract val test: String
+                }
 
-				class B : A() {
-					override public val test: String = "valid"
-				}
-			"""
+                class B : A() {
+                    override public val test: String = "valid"
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -12,14 +12,14 @@ class ReturnCountSpec : Spek({
 
         context("a file with an if condition guard clause and 2 returns") {
             val code = """
-			fun test(x: Int): Int {
-				if (x < 4) return 0
-				when (x) {
-					5 -> return 5
-					4 -> return 4
-				}
-			}
-		"""
+            fun test(x: Int): Int {
+                if (x < 4) return 0
+                when (x) {
+                    5 -> return 5
+                    4 -> return 4
+                }
+            }
+        """
 
             it("should not get flagged for if condition guard clauses") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
@@ -30,14 +30,14 @@ class ReturnCountSpec : Spek({
 
         context("a file with an ELVIS operator guard clause and 2 returns") {
             val code = """
-			fun test(x: Int): Int {
-				val y = x ?: return 0
-				when (x) {
-					5 -> return 5
-					4 -> return 4
-				}
-			}
-		"""
+            fun test(x: Int): Int {
+                val y = x ?: return 0
+                when (x) {
+                    5 -> return 5
+                    4 -> return 4
+                }
+            }
+        """
 
             it("should not get flagged for ELVIS operator guard clauses") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
@@ -48,14 +48,14 @@ class ReturnCountSpec : Spek({
 
         context("a file with 2 returns and an if condition guard clause which is not the first statement") {
             val code = """
-			fun test(x: Int): Int {
-				when (x) {
-					5 -> return 5
-					4 -> return 4
-				}
-				if (x < 4) return 0
-			}
-		"""
+            fun test(x: Int): Int {
+                when (x) {
+                    5 -> return 5
+                    4 -> return 4
+                }
+                if (x < 4) return 0
+            }
+        """
 
             it("should get flagged for an if condition guard clause which is not the first statement") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
@@ -66,14 +66,14 @@ class ReturnCountSpec : Spek({
 
         context("a file with 2 returns and an ELVIS guard clause which is not the first statement") {
             val code = """
-			fun test(x: Int): Int {
-				when (x) {
-					5 -> return 5
-					4 -> return 4
-				}
-				val y = x ?: return 0
-			}
-		"""
+            fun test(x: Int): Int {
+                when (x) {
+                    5 -> return 5
+                    4 -> return 4
+                }
+                val y = x ?: return 0
+            }
+        """
 
             it("should get flagged for an ELVIS guard clause which is not the first statement") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
@@ -84,14 +84,14 @@ class ReturnCountSpec : Spek({
 
         context("a file with 3 returns") {
             val code = """
-			fun test(x: Int): Int {
-				when (x) {
-					5 -> return 5
-					4 -> return 4
-					3 -> return 3
-				}
-			}
-		"""
+            fun test(x: Int): Int {
+                when (x) {
+                    5 -> return 5
+                    4 -> return 4
+                    3 -> return 3
+                }
+            }
+        """
 
             it("should get flagged by default") {
                 val findings = ReturnCount().lint(code)
@@ -111,13 +111,13 @@ class ReturnCountSpec : Spek({
 
         context("a file with 2 returns") {
             val code = """
-			fun test(x: Int): Int {
-				when (x) {
-					5 -> return 5
-					4 -> return 4
-				}
-			}
-		"""
+            fun test(x: Int): Int {
+                when (x) {
+                    5 -> return 5
+                    4 -> return 4
+                }
+            }
+        """
 
             it("should not get flagged by default") {
                 val findings = ReturnCount().lint(code)
@@ -137,14 +137,14 @@ class ReturnCountSpec : Spek({
 
         context("a function is ignored") {
             val code = """
-    		fun test(x: Int): Int {
-				when (x) {
-					5 -> return 5
-					4 -> return 4
-					3 -> return 3
-				}
-			}
-		"""
+            fun test(x: Int): Int {
+                when (x) {
+                    5 -> return 5
+                    4 -> return 4
+                    3 -> return 3
+                }
+            }
+        """
 
             it("should not get flagged") {
                 val findings = ReturnCount(TestConfig(mapOf(
@@ -157,30 +157,30 @@ class ReturnCountSpec : Spek({
 
         context("a subset of functions are ignored") {
             val code = """
-    		fun test1(x: Int): Int {
-				when (x) {
-					5 -> return 5
-					4 -> return 4
-					3 -> return 3
-				}
-			}
+            fun test1(x: Int): Int {
+                when (x) {
+                    5 -> return 5
+                    4 -> return 4
+                    3 -> return 3
+                }
+            }
 
-			fun test2(x: Int): Int {
-				when (x) {
-					5 -> return 5
-					4 -> return 4
-					3 -> return 3
-				}
-			}
+            fun test2(x: Int): Int {
+                when (x) {
+                    5 -> return 5
+                    4 -> return 4
+                    3 -> return 3
+                }
+            }
 
-			fun test3(x: Int): Int {
-				when (x) {
-					5 -> return 5
-					4 -> return 4
-					3 -> return 3
-				}
-			}
-		"""
+            fun test3(x: Int): Int {
+                when (x) {
+                    5 -> return 5
+                    4 -> return 4
+                    3 -> return 3
+                }
+            }
+        """
 
             it("should flag none of the ignored functions") {
                 val findings = ReturnCount(TestConfig(mapOf(
@@ -193,21 +193,21 @@ class ReturnCountSpec : Spek({
 
         context("a function with inner object") {
             val code = """
-			fun test(x: Int): Int {
-				val a = object {
-					fun test2(x: Int): Int {
-						when (x) {
-							5 -> return 5
-							else -> return 0
-						}
-					}
-				}
-				when (x) {
-					5 -> return 5
-					else -> return 0
-				}
-			}
-    	"""
+            fun test(x: Int): Int {
+                val a = object {
+                    fun test2(x: Int): Int {
+                        when (x) {
+                            5 -> return 5
+                            else -> return 0
+                        }
+                    }
+                }
+                when (x) {
+                    5 -> return 5
+                    else -> return 0
+                }
+            }
+        """
 
             it("should not get flag when returns is in inner object") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
@@ -217,29 +217,29 @@ class ReturnCountSpec : Spek({
 
         context("a function with 2 inner object") {
             val code = """
-			fun test(x: Int): Int {
-				val a = object {
-					fun test2(x: Int): Int {
-						val b = object {
-							fun test3(x: Int): Int {
-								when (x) {
-									5 -> return 5
-									else -> return 0
-								}
-							}
-						}
-						when (x) {
-							5 -> return 5
-							else -> return 0
-						}
-					}
-				}
-				when (x) {
-					5 -> return 5
-					else -> return 0
-				}
-			}
-    	"""
+            fun test(x: Int): Int {
+                val a = object {
+                    fun test2(x: Int): Int {
+                        val b = object {
+                            fun test3(x: Int): Int {
+                                when (x) {
+                                    5 -> return 5
+                                    else -> return 0
+                                }
+                            }
+                        }
+                        when (x) {
+                            5 -> return 5
+                            else -> return 0
+                        }
+                    }
+                }
+                when (x) {
+                    5 -> return 5
+                    else -> return 0
+                }
+            }
+        """
 
             it("should not get flag when returns is in inner object") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
@@ -249,31 +249,31 @@ class ReturnCountSpec : Spek({
 
         context("a function with 2 inner object and exceeded max") {
             val code = """
-			fun test(x: Int): Int {
-				val a = object {
-					fun test2(x: Int): Int {
-						val b = object {
-							fun test3(x: Int): Int {
-								when (x) {
-									5 -> return 5
-									else -> return 0
-								}
-							}
-						}
-						when (x) {
-							5 -> return 5
-							else -> return 0
-						}
-					}
-				}
-				when (x) {
-					5 -> return 5
-					4 -> return 4
-					3 -> return 3
-					else -> return 0
-				}
-			}
-    	"""
+            fun test(x: Int): Int {
+                val a = object {
+                    fun test2(x: Int): Int {
+                        val b = object {
+                            fun test3(x: Int): Int {
+                                when (x) {
+                                    5 -> return 5
+                                    else -> return 0
+                                }
+                            }
+                        }
+                        when (x) {
+                            5 -> return 5
+                            else -> return 0
+                        }
+                    }
+                }
+                when (x) {
+                    5 -> return 5
+                    4 -> return 4
+                    3 -> return 3
+                    else -> return 0
+                }
+            }
+        """
 
             it("should get flagged when returns is in inner object") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
@@ -284,14 +284,14 @@ class ReturnCountSpec : Spek({
         context("function with multiple labeled return statements") {
 
             val code = """
-			fun readUsers(name: String): Flowable<User> {
-			return userDao.read(name)
-				.flatMap {
-					if (it.isEmpty()) return@flatMap Flowable.empty<User>()
-					return@flatMap Flowable.just(it[0])
-				}
-    		}
-		"""
+            fun readUsers(name: String): Flowable<User> {
+            return userDao.read(name)
+                .flatMap {
+                    if (it.isEmpty()) return@flatMap Flowable.empty<User>()
+                    return@flatMap Flowable.just(it[0])
+                }
+            }
+        """
 
             it("should not count labeled returns from lambda by default") {
                 val findings = ReturnCount().lint(code)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCastSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCastSpec.kt
@@ -12,50 +12,50 @@ class SafeCastSpec : Spek({
 
         it("reports negated expression") {
             val code = """
-				fun test(element: Int) {
-					val cast = if (element !is Number) {
-						null
-					} else {
-						element
-					}
-				}"""
+                fun test(element: Int) {
+                    val cast = if (element !is Number) {
+                        null
+                    } else {
+                        element
+                    }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("reports expression") {
             val code = """
-				fun test(element: Int) {
-					val cast = if (element is Number) {
-						element
-					} else {
-						null
-					}
-				}"""
+                fun test(element: Int) {
+                    val cast = if (element is Number) {
+                        element
+                    } else {
+                        null
+                    }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("does not report wrong condition") {
             val code = """
-				fun test(element: Int) {
+                fun test(element: Int) {
                     val other = 3
-					val cast = if (element == other) {
-						element
-					} else {
-						null
-					}
-				}"""
+                    val cast = if (element == other) {
+                        element
+                    } else {
+                        null
+                    }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
 
         it("does not report wrong else clause") {
             val code = """
-				fun test(element: Int) {
-					val cast = if (element is Number) {
-						element
-					} else {
-						String()
-					}
-				}"""
+                fun test(element: Int) {
+                    val cast = if (element is Number) {
+                        element
+                    } else {
+                        String()
+                    }
+                }"""
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
@@ -75,23 +75,23 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
 
         it("has multiple imports in file") {
             val code = """
-				package com.my
+                package com.my
 
-				import kotlin.collections.List
-				import kotlin.collections.Set
+                import kotlin.collections.List
+                import kotlin.collections.Set
 
-				class A { }
-				"""
+                class A { }
+                """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("has no class") {
             val code = """
-				package com.my
+                package com.my
 
-				import kotlin.collections.List
-				import kotlin.collections.Set
-				"""
+                import kotlin.collections.List
+                import kotlin.collections.Set
+                """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
@@ -12,29 +12,29 @@ class ThrowsCountSpec : Spek({
     describe("ThrowsCount rule") {
 
         val code = """
-			fun f1(x: Int) {
-				when (x) {
-					1 -> throw IOException()
-					2 -> throw IOException()
-					3 -> throw IOException()
-				}
-			}
+            fun f1(x: Int) {
+                when (x) {
+                    1 -> throw IOException()
+                    2 -> throw IOException()
+                    3 -> throw IOException()
+                }
+            }
 
-			fun f2(x: Int) {
-				when (x) {
-					1 -> throw IOException()
-					2 -> throw IOException()
-				}
-			}
+            fun f2(x: Int) {
+                when (x) {
+                    1 -> throw IOException()
+                    2 -> throw IOException()
+                }
+            }
 
-			override fun f3(x: Int) { // does not report overridden function
-				when (x) {
-					1 -> throw IOException()
-					2 -> throw IOException()
-					3 -> throw IOException()
-				}
-			}
-		"""
+            override fun f3(x: Int) { // does not report overridden function
+                when (x) {
+                    1 -> throw IOException()
+                    2 -> throw IOException()
+                    3 -> throw IOException()
+                }
+            }
+        """
 
         context("default config") {
             val subject = ThrowsCount(Config.empty)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
@@ -13,8 +13,8 @@ class UnnecessaryInheritanceSpec : Spek({
 
         it("has unnecessary super type declarations") {
             val findings = subject.lint("""
-				class A : Any()
-				class B : Object()""")
+                class A : Any()
+                class B : Object()""")
             assertThat(findings).hasSize(2)
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -12,53 +12,53 @@ class UnnecessaryLetSpec : Spek({
     describe("UnnecessaryLet rule") {
         it("reports unnecessary lets that can be changed to ordinary method call") {
             val findings = subject.lint("""
-				fun f() {
-					val a : Int? = null
-					a.let { it.plus(1) }
-					a?.let { it.plus(1) }
-					a.let { that -> that.plus(1) }
-					a?.let { that -> that.plus(1) }
-					a?.let { that -> that.plus(1) }?.let { it.plus(1) }
-				}""")
+                fun f() {
+                    val a : Int? = null
+                    a.let { it.plus(1) }
+                    a?.let { it.plus(1) }
+                    a.let { that -> that.plus(1) }
+                    a?.let { that -> that.plus(1) }
+                    a?.let { that -> that.plus(1) }?.let { it.plus(1) }
+                }""")
             assertThat(findings).hasSize(6)
         }
         it("does not report lets used for function calls") {
             val findings = subject.lint("""
-				fun f() {
-					val a : Int? = null
-					a.let { print(it) }
-					a?.let { print(it) }
-					a.let { that -> print(that) }
-					a?.let { that -> 1.plus(that) }
-					a?.let { that -> 1.plus(that) }?.let { print(it) }
-				}""")
+                fun f() {
+                    val a : Int? = null
+                    a.let { print(it) }
+                    a?.let { print(it) }
+                    a.let { that -> print(that) }
+                    a?.let { that -> 1.plus(that) }
+                    a?.let { that -> 1.plus(that) }?.let { print(it) }
+                }""")
             assertThat(findings).hasSize(0)
         }
         it("does not report lets with lambda body containing more than one statement") {
             val findings = subject.lint("""
-				fun f() {
-					val a : Int? = null
-					a.let { it.plus(1)
+                fun f() {
+                    val a : Int? = null
+                    a.let { it.plus(1)
                             it.plus(2) }
-					a?.let { it.plus(1)
+                    a?.let { it.plus(1)
                              it.plus(2) }
-					a.let { that -> that.plus(1)
+                    a.let { that -> that.plus(1)
                                     that.plus(2)  }
-					a?.let { that -> that.plus(1)
+                    a?.let { that -> that.plus(1)
                                      that.plus(2)  }
-					a?.let { that -> 1.plus(that) }
+                    a?.let { that -> 1.plus(that) }
                      ?.let { it.plus(1)
                              it.plus(2) }
-				}""")
+                }""")
             assertThat(findings).hasSize(0)
         }
         it("does not report lets where it is used multiple times") {
             val findings = subject.lint("""
-				fun f() {
-					val a : Int? = null
-					a?.let { it.plus(it) }
-					a?.let { foo -> foo.plus(foo) }
-				}""")
+                fun f() {
+                    val a : Int? = null
+                    a?.let { it.plus(it) }
+                    a?.let { foo -> foo.plus(foo) }
+                }""")
             assertThat(findings).hasSize(0)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -28,11 +28,11 @@ class UnnecessaryParenthesesSpec : Spek({
 
         it("unnecessary parentheses in other parentheses") {
             val code = """
-				fun x(a: String, b: String) {
-					if ((a equals b)) {
-					 	println("Test")
-					}
-				}"""
+                fun x(a: String, b: String) {
+                    if ((a equals b)) {
+                        println("Test")
+                    }
+                }"""
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -51,115 +51,115 @@ class UnnecessaryParenthesesSpec : Spek({
 
         it("doesn't report function calls containing lambdas and other parameters") {
             val code = """
-				fun function (integer: Int, a: (input: String) -> Unit) {
-					a.invoke("TEST")
-				}
+                fun function (integer: Int, a: (input: String) -> Unit) {
+                    a.invoke("TEST")
+                }
 
-				fun test() {
-					function(1, { input -> println(input) })
-				}
-				"""
+                fun test() {
+                    function(1, { input -> println(input) })
+                }
+                """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report unnecessary parentheses when assigning a lambda to a val") {
             val code = """
-				fun f() {
-					instance.copy(value = { false })
-				}"""
+                fun f() {
+                    instance.copy(value = { false })
+                }"""
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report well behaved parentheses") {
             val code = """
-				fun x(a: String, b: String) {
-					if (a equals b) {
-					 	println("Test")
-					}
-				}"""
+                fun x(a: String, b: String) {
+                    if (a equals b) {
+                        println("Test")
+                    }
+                }"""
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report well behaved parentheses in super constructors") {
             val code = """
-				class TestSpek : SubjectSpek({
-					describe("a simple test") {
-						it("should do something") {
-						}
-					}
-				})
-				"""
+                class TestSpek : SubjectSpek({
+                    describe("a simple test") {
+                        it("should do something") {
+                        }
+                    }
+                })
+                """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report well behaved parentheses in constructors") {
             val code = """
-				class TestSpek({
-					describe("a simple test") {
-						it("should do something") {
-						}
-					}
-				})
-				"""
+                class TestSpek({
+                    describe("a simple test") {
+                        it("should do something") {
+                        }
+                    }
+                })
+                """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should not report lambdas within super constructor calls") {
             val code = """
-				class Clazz(
-					private val func: (X, Y) -> Z
-				) {
-					constructor() : this({ first, second -> true })
-				}
-			"""
+                class Clazz(
+                    private val func: (X, Y) -> Z
+                ) {
+                    constructor() : this({ first, second -> true })
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should not report call to function with two lambda parameters with one as block body") {
             val code = """
-				class Clazz {
-					fun test(first: (Int) -> Unit, second: (Int) -> Unit) {
-						first(1)
-						second(2)
-					}
+                class Clazz {
+                    fun test(first: (Int) -> Unit, second: (Int) -> Unit) {
+                        first(1)
+                        second(2)
+                    }
 
-					fun call() {
-						test({ println(it) }) { println(it) }
-					}
-				}
-			"""
+                    fun call() {
+                        test({ println(it) }) { println(it) }
+                    }
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should not report call to function with two lambda parameters") {
             val code = """
-				class Clazz {
-					fun test(first: (Int) -> Unit, second: (Int) -> Unit) {
-						first(1)
-						second(2)
-					}
+                class Clazz {
+                    fun test(first: (Int) -> Unit, second: (Int) -> Unit) {
+                        first(1)
+                        second(2)
+                    }
 
-					fun call() {
-						test({ println(it) }, { println(it) })
-					}
-				}
-			"""
+                    fun call() {
+                        test({ println(it) }, { println(it) })
+                    }
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should not report call to function with multiple lambdas as parameters but also other parameters") {
             val code = """
-				class Clazz {
-					fun test(text: String, first: () -> Unit, second: () -> Unit) {
-						first()
-						second()
-					}
+                class Clazz {
+                    fun test(text: String, first: () -> Unit, second: () -> Unit) {
+                        first()
+                        second()
+                    }
 
-					fun call() {
-						test("hello", { println(it) }) { println(it) }
-					}
-				}
-			"""
+                    fun call() {
+                        test("hello", { println(it) }) { println(it) }
+                    }
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UntilInsteadOfRangeToSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UntilInsteadOfRangeToSpec.kt
@@ -13,35 +13,35 @@ class UntilInsteadOfRangeToSpec : Spek({
 
         it("reports for '..'") {
             val code = """
-				fun f() {
-					for (i in 0 .. 10 - 1) {}
-				}"""
+                fun f() {
+                    for (i in 0 .. 10 - 1) {}
+                }"""
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("does not report if rangeTo not used") {
             val code = """
-				fun f() {
-					for (i in 0 until 10 - 1) {}
-					for (i in 10 downTo 2 - 1) {}
-				}"""
+                fun f() {
+                    for (i in 0 until 10 - 1) {}
+                    for (i in 10 downTo 2 - 1) {}
+                }"""
             assertThat(subject.lint(code)).hasSize(0)
         }
 
         it("does not report if upper value isn't a binary expression") {
             val code = """
-				fun f() {
-					for (i in 0 .. 10) {}
-				}"""
+                fun f() {
+                    for (i in 0 .. 10) {}
+                }"""
             assertThat(subject.lint(code)).hasSize(0)
         }
 
         it("does not report if not minus one") {
             val code = """
-				fun f() {
-					for (i in 0 .. 10 + 1) {}
-					for (i in 0 .. 10 - 2) {}
-				}"""
+                fun f() {
+                    for (i in 0 .. 10 + 1) {}
+                    for (i in 0 .. 10 - 2) {}
+                }"""
             assertThat(subject.lint(code)).hasSize(0)
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
@@ -13,51 +13,51 @@ class UnusedImportsSpec : Spek({
 
         it("does not report infix operators") {
             assertThat(subject.lint("""
-            	import tasks.success
+                import tasks.success
 
-            	fun main() {
-					task {
-					} success {
-					}
-            	}"""
+                fun main() {
+                    task {
+                    } success {
+                    }
+                }"""
             )).isEmpty()
         }
 
         it("does not report imports in documentation") {
             assertThat(subject.lint("""
-           		import tasks.success
-           		import tasks.failure
-           		import tasks.undefined
+                import tasks.success
+                import tasks.failure
+                import tasks.undefined
 
-           		/**
-           		*  Reference to [failure]
-           		*/
-           		class Test{
-           		  /** Reference to [undefined]*/
-           		  fun main() {
-           		    task {
-           		    } success {
-           		    }
-           		  }
-           		}
-           		"""
+                /**
+                *  Reference to [failure]
+                */
+                class Test{
+                  /** Reference to [undefined]*/
+                  fun main() {
+                    task {
+                    } success {
+                    }
+                  }
+                }
+                """
             )).isEmpty()
         }
 
         it("should ignore import for link") {
             val lint = subject.lint("""
-				import tasks.success
-				import tasks.failure
-				import tasks.undefined
+                import tasks.success
+                import tasks.failure
+                import tasks.undefined
 
-				/**
-				* Reference [undefined][failure]
-				*/
-				fun main() {
-				task {
-				} success {
-				}
-				}
+                /**
+                * Reference [undefined][failure]
+                */
+                fun main() {
+                task {
+                } success {
+                }
+                }
             """
             )
             with(lint) {
@@ -68,11 +68,11 @@ class UnusedImportsSpec : Spek({
 
         it("reports imports from the current package") {
             val lint = subject.lint("""
-				package test
-				import test.SomeClass
+                package test
+                import test.SomeClass
 
-				val a: SomeClass? = null
-			"""
+                val a: SomeClass? = null
+            """
             )
             with(lint) {
                 assertThat(this).hasSize(1)
@@ -82,39 +82,39 @@ class UnusedImportsSpec : Spek({
 
         it("does not report KDoc references with method calls") {
             val code = """
-				package com.example
+                package com.example
 
-				import android.text.TextWatcher
+                import android.text.TextWatcher
 
-				class Test {
-					/**
-					 * [TextWatcher.beforeTextChanged]
-					 */
-					fun test() {
-						TODO()
-					}
-				}"""
+                class Test {
+                    /**
+                     * [TextWatcher.beforeTextChanged]
+                     */
+                    fun test() {
+                        TODO()
+                    }
+                }"""
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("reports imports with different cases") {
             val lint = subject.lint("""
-            	import p.a
-            	import p.B6 // positive
-            	import p.B as B12 // positive
-            	import p2.B as B2
-            	import p.C
-            	import escaped.`when`
-            	import escaped.`foo` // positive
-            	import p.D
+                import p.a
+                import p.B6 // positive
+                import p.B as B12 // positive
+                import p2.B as B2
+                import p.C
+                import escaped.`when`
+                import escaped.`foo` // positive
+                import p.D
 
-            	/** reference to [D] */
-            	fun main() {
-            	    println(a())
-            	    C.call()
-            	    fn(B2.NAME)
-            	    `when`()
-            	}"""
+                /** reference to [D] */
+                fun main() {
+                    println(a())
+                    C.call()
+                    fn(B2.NAME)
+                    `when`()
+                }"""
             )
             with(lint) {
                 assertThat(this).hasSize(3)
@@ -126,13 +126,13 @@ class UnusedImportsSpec : Spek({
 
         it("does not report imports in same package when inner") {
             val lint = subject.lint("""
-            	package test
+                package test
 
-				import test.Outer.Inner
+                import test.Outer.Inner
 
-				class Outer : Something<Inner>() {
-					class Inner { }
-				}"""
+                class Outer : Something<Inner>() {
+                    class Inner { }
+                }"""
             )
             with(lint) {
                 assertThat(this).isEmpty()
@@ -141,90 +141,90 @@ class UnusedImportsSpec : Spek({
 
         it("does not report KDoc @see annotation linking to class") {
             val code = """
-				import tasks.success
+                import tasks.success
 
-				/**
-				 * Do something.
-				 * @see success
-				 */
-				fun doSomething()"""
+                /**
+                 * Do something.
+                 * @see success
+                 */
+                fun doSomething()"""
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report KDoc @see annotation linking to class with description") {
             val code = """
-				import tasks.success
+                import tasks.success
 
-				/**
-				 * Do something.
-				 * @see success something
-				 */
-				fun doSomething()"""
+                /**
+                 * Do something.
+                 * @see success something
+                 */
+                fun doSomething()"""
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("reports KDoc @see annotation that does not link to class") {
             val code = """
-				import tasks.success
+                import tasks.success
 
-				/**
-				 * Do something.
-				 * @see something
-				 */
-				fun doSomething()"""
+                /**
+                 * Do something.
+                 * @see something
+                 */
+                fun doSomething()"""
 
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("reports KDoc @see annotation that links after description") {
             val code = """
-				import tasks.success
+                import tasks.success
 
-				/**
-				 * Do something.
-				 * @see something success
-				 */
-				fun doSomething()"""
+                /**
+                 * Do something.
+                 * @see something success
+                 */
+                fun doSomething()"""
 
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("does not report imports in KDoc") {
             val code = """
-				import tasks.success   // here
-				import tasks.undefined // and here
+                import tasks.success   // here
+                import tasks.undefined // and here
 
-				/**
-				 * Do something.
-				 * @throws [success] when ...
-				 * @see [undefined]
-				 */
-				fun doSomething()"""
+                /**
+                 * Do something.
+                 * @throws [success] when ...
+                 * @see [undefined]
+                 */
+                fun doSomething()"""
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should not report import alias as unused when the alias is used") {
             val code = """
-				import test.forEach as foreach
-				fun foo() = listOf().iterator().foreach {}
-			"""
+                import test.forEach as foreach
+                fun foo() = listOf().iterator().foreach {}
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should not report used alias even when import is from same package") {
             val code = """
-				package com.example
+                package com.example
 
-				import com.example.foo as myFoo // from same package but with alias, check alias usage
-				import com.example.other.foo as otherFoo // not from package with used alias
+                import com.example.foo as myFoo // from same package but with alias, check alias usage
+                import com.example.other.foo as otherFoo // not from package with used alias
 
-				fun f() : Boolean {
-					return myFoo() == otherFoo()
-				}
-			"""
+                fun f() : Boolean {
+                    return myFoo() == otherFoo()
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
@@ -12,9 +12,9 @@ class UnusedPrivateClassSpec : Spek({
     describe("top level interfaces") {
         it("should report them if not used") {
             val code = """
-				private interface Foo
-				class Bar
-				"""
+                private interface Foo
+                class Bar
+                """
 
             val lint = subject.lint(code)
 
@@ -28,9 +28,9 @@ class UnusedPrivateClassSpec : Spek({
 
             it("should report them if not used") {
                 val code = """
-				private class Foo
-				class Bar
-				"""
+                private class Foo
+                class Bar
+                """
 
                 val lint = subject.lint(code)
 
@@ -42,9 +42,9 @@ class UnusedPrivateClassSpec : Spek({
 
             it("should not report them if used as parent") {
                 val code = """
-				private class Foo
-				private class Bar : Foo
-				"""
+                private class Foo
+                private class Bar : Foo
+                """
 
                 val lint = subject.lint(code)
 
@@ -56,14 +56,14 @@ class UnusedPrivateClassSpec : Spek({
 
             it("should not report them used as generic parent type") {
                 val code = """
-				private class Foo<in Bar> {
-					operator fun invoke(b: Bar): Unit
-				}
+                private class Foo<in Bar> {
+                    operator fun invoke(b: Bar): Unit
+                }
 
-				data class FooOne(val b: Bar2) : Foo<Bar2> {
-					override fun invoke(b: Bar2): Unit = Unit
-				}
-				"""
+                data class FooOne(val b: Bar2) : Foo<Bar2> {
+                    override fun invoke(b: Bar2): Unit = Unit
+                }
+                """
 
                 val lint = subject.lint(code)
 
@@ -73,11 +73,11 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used inside a function") {
             val code = """
-				private class Foo
-				fun something() {
-					val foo: Foo = Foo()
-				}
-				"""
+                private class Foo
+                fun something() {
+                    val foo: Foo = Foo()
+                }
+                """
 
             val lint = subject.lint(code)
 
@@ -86,9 +86,9 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used as function parameter") {
             val code = """
-				private class Foo
-				fun bar(foo: Foo) = Unit
-				"""
+                private class Foo
+                fun bar(foo: Foo) = Unit
+                """
 
             val lint = subject.lint(code)
 
@@ -97,9 +97,9 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used as nullable variable type") {
             val code = """
-				private class Foo
-				val a: Foo? = null
-				"""
+                private class Foo
+                val a: Foo? = null
+                """
 
             val lint = subject.lint(code)
 
@@ -108,9 +108,9 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used as variable type") {
             val code = """
-				private class Foo
-				lateinit var a: Foo
-				"""
+                private class Foo
+                lateinit var a: Foo
+                """
 
             val lint = subject.lint(code)
 
@@ -119,9 +119,9 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used as generic type") {
             val code = """
-				private class Foo
-				lateinit var foos: List<Foo>
-				"""
+                private class Foo
+                lateinit var foos: List<Foo>
+                """
 
             val lint = subject.lint(code)
 
@@ -130,9 +130,9 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used as nested generic type") {
             val code = """
-				private class Foo
-				lateinit var foos: List<List<Foo>>
-				"""
+                private class Foo
+                lateinit var foos: List<List<Foo>>
+                """
 
             val lint = subject.lint(code)
 
@@ -141,9 +141,9 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used as type with generics") {
             val code = """
-				private class Foo<T>
-				lateinit var foos: Foo<String>
-				"""
+                private class Foo<T>
+                lateinit var foos: Foo<String>
+                """
 
             val lint = subject.lint(code)
 
@@ -152,9 +152,9 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used as nullable type with generics") {
             val code = """
-				private class Foo<T>
-				lateinit var foos: Foo<String>?
-				"""
+                private class Foo<T>
+                lateinit var foos: Foo<String>?
+                """
 
             val lint = subject.lint(code)
 
@@ -163,9 +163,9 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used as non-argument constructor") {
             val code = """
-				private class Foo
-				val a = Foo()
-				"""
+                private class Foo
+                val a = Foo()
+                """
 
             val lint = subject.lint(code)
 
@@ -174,9 +174,9 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used as constructor with arguments") {
             val code = """
-				private class Foo(val a: String)
-				val a = Foo("test")
-				"""
+                private class Foo(val a: String)
+                val a = Foo("test")
+                """
 
             val lint = subject.lint(code)
 
@@ -185,9 +185,9 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used as function return type") {
             val code = """
-				private class Foo(val a: String)
-				fun foo(): Foo? = null
-				"""
+                private class Foo(val a: String)
+                fun foo(): Foo? = null
+                """
 
             val lint = subject.lint(code)
 
@@ -196,9 +196,9 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used as lambda declaration parameter") {
             val code = """
-				private class Foo
-				val lambda: ((Foo) -> Unit)? = null
-				"""
+                private class Foo
+                val lambda: ((Foo) -> Unit)? = null
+                """
 
             val lint = subject.lint(code)
 
@@ -207,9 +207,9 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used as lambda declaration return type") {
             val code = """
-				private class Foo
-				val lambda: (() -> Foo)? = null
-				"""
+                private class Foo
+                val lambda: (() -> Foo)? = null
+                """
 
             val lint = subject.lint(code)
 
@@ -218,9 +218,9 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used as lambda declaration generic type") {
             val code = """
-				private class Foo
-				val lambda: (() -> List<Foo>)? = null
-				"""
+                private class Foo
+                val lambda: (() -> List<Foo>)? = null
+                """
 
             val lint = subject.lint(code)
 
@@ -229,14 +229,14 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used as inline object type") {
             val code = """
-				private abstract class Foo {
-					abstract fun bar()
-				}
+                private abstract class Foo {
+                    abstract fun bar()
+                }
 
-				private fun foo() = object : Foo() {
-					override fun bar() = Unit
-				}
-				"""
+                private fun foo() = object : Foo() {
+                    override fun bar() = Unit
+                }
+                """
 
             val lint = subject.lint(code)
 
@@ -248,9 +248,9 @@ class UnusedPrivateClassSpec : Spek({
 
         it("does not crash when using wildcasts in generics - #1345") {
             val code = """
-				private class Foo
-				fun bar(clazz: KClass<*>) = Unit
-			"""
+                private class Foo
+                fun bar(clazz: KClass<*>) = Unit
+            """
 
             val findings = UnusedPrivateClass().lint(code)
 
@@ -259,18 +259,18 @@ class UnusedPrivateClassSpec : Spek({
 
         it("does not report (companion-)object/named-dot references - #1347") {
             val code = """
-					package com.example
+                    package com.example
 
-					class Test {
-						val items = Item.values().map { it.text }.toList()
-					}
+                    class Test {
+                        val items = Item.values().map { it.text }.toList()
+                    }
 
-					private enum class Item(val text: String) {
-						A("A"),
-						B("B"),
-						C("C")
-					}
-				"""
+                    private enum class Item(val text: String) {
+                        A("A"),
+                        B("B"),
+                        C("C")
+                    }
+                """
 
             val findings = UnusedPrivateClass().lint(code)
 
@@ -279,22 +279,22 @@ class UnusedPrivateClassSpec : Spek({
 
         it("does not report classes that are used with ::class - #1390") {
             val code = """
-					class UnusedPrivateClassTest {
+                    class UnusedPrivateClassTest {
 
-						private data class SomeClass(val name: String)
+                        private data class SomeClass(val name: String)
 
-						private data class AnotherClass(val id: Long)
+                        private data class AnotherClass(val id: Long)
 
-						@Test
-						fun `verify class is used`() {
-							val instance = SomeClass(name = "test")
-							assertNotEquals(AnotherClass::class.java.simpleName, instance::class.java.simpleName)
-						}
+                        @Test
+                        fun `verify class is used`() {
+                            val instance = SomeClass(name = "test")
+                            assertNotEquals(AnotherClass::class.java.simpleName, instance::class.java.simpleName)
+                        }
 
                         fun getSomeObject(): ((String) -> Any) = ::InternalClass
                         private class InternalClass(val param: String)
-					}
-				"""
+                    }
+                """
 
             val findings = UnusedPrivateClass().lint(code)
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -14,15 +14,15 @@ class UnusedPrivateMemberSpec : Spek({
     val subject by memoized { UnusedPrivateMember() }
 
     val regexTestingCode = """
-				class Test {
-					private val used = "This is used"
-					private val unused = "This is not used"
+                class Test {
+                    private val used = "This is used"
+                    private val unused = "This is not used"
 
-					fun use() {
-						println(used)
-					}
-				}
-				"""
+                    fun use() {
+                        println(used)
+                    }
+                }
+                """
 
     describe("cases file with different findings") {
 
@@ -39,11 +39,11 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("should not report parameters in interface functions") {
             val code = """
-				interface UserPlugin {
-					fun plug(application: Application)
-					fun unplug()
-				}
-			"""
+                interface UserPlugin {
+                    fun plug(application: Application)
+                    fun unplug()
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -60,14 +60,14 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("should not report parameters in not private functions") {
             val code = """
-				override fun funA() {
-					objectA.resolve(valA, object : MyCallback {
-						override fun onResolveFailed(throwable: Throwable) {
-							errorMessage.visibility = View.VISIBLE
-						}
-					})
-				}
-			"""
+                override fun funA() {
+                    objectA.resolve(valA, object : MyCallback {
+                        override fun onResolveFailed(throwable: Throwable) {
+                            errorMessage.visibility = View.VISIBLE
+                        }
+                    })
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -76,17 +76,17 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("should not report used constants") {
             val code = """
-				class A {
-					companion object {
-						private const val MY_CONST = 42
-					}
+                class A {
+                    companion object {
+                        private const val MY_CONST = 42
+                    }
 
-					fun a() {
-						Completable.timer(MY_CONST.toLong(), TimeUnit.MILLISECONDS)
-								.subscribe()
-					}
-				}
-			"""
+                    fun a() {
+                        Completable.timer(MY_CONST.toLong(), TimeUnit.MILLISECONDS)
+                                .subscribe()
+                    }
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -95,54 +95,54 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("reports an unused member") {
             val code = """
-				class Test {
-					private val unused = "This is not used"
+                class Test {
+                    private val unused = "This is not used"
 
-					fun use() {
-						println("This is not using a property")
-					}
-				}
-				"""
+                    fun use() {
+                        println("This is not using a property")
+                    }
+                }
+                """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("does not report unused public members") {
             val code = """
-				class Test {
-					val unused = "This is not used"
+                class Test {
+                    val unused = "This is not used"
 
-					fun use() {
-						println("This is not using a property")
-					}
-				}
-				"""
+                    fun use() {
+                        println("This is not using a property")
+                    }
+                }
+                """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report used members") {
             val code = """
-				class Test {
-					private val used = "This is used"
+                class Test {
+                    private val used = "This is used"
 
-					fun use() {
-						println(used)
-					}
-				}
-				"""
+                    fun use() {
+                        println(used)
+                    }
+                }
+                """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report used members but reports unused members") {
             val code = """
-				class Test {
-					private val used = "This is used"
-					private val unused = "This is not used"
+                class Test {
+                    private val used = "This is used"
+                    private val unused = "This is not used"
 
-					fun use() {
-						println(used)
-					}
-				}
-				"""
+                    fun use() {
+                        println(used)
+                    }
+                }
+                """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -167,43 +167,43 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("reports an unused member") {
             val code = """
-				class Test {
-					private val unused = "This is not used"
+                class Test {
+                    private val unused = "This is not used"
 
-					fun use() {
-						val used = "This is used"
-						println(used)
-					}
-				}
-				"""
+                    fun use() {
+                        val used = "This is used"
+                        println(used)
+                    }
+                }
+                """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("does not report used members") {
             val code = """
-				class Test {
-					private val used = "This is used"
+                class Test {
+                    private val used = "This is used"
 
-					fun use() {
-						val text = used
-						println(text)
-					}
-				}
-				"""
+                    fun use() {
+                        val text = used
+                        println(text)
+                    }
+                }
+                """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("reports unused local properties") {
             val code = """
-				class Test {
-					private val used = "This is used"
+                class Test {
+                    private val used = "This is used"
 
-					fun use() {
-						val unused = used
-						println(used)
-					}
-				}
-				"""
+                    fun use() {
+                        val unused = used
+                        println(used)
+                    }
+                }
+                """
             assertThat(subject.lint(code)).hasSize(1)
         }
     }
@@ -212,78 +212,78 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("should not depend on evaluation order of functions or properties") {
             val code = """
-				fun RuleSetProvider.provided() = ruleSetId in defaultRuleSetIds
+                fun RuleSetProvider.provided() = ruleSetId in defaultRuleSetIds
 
-				val defaultRuleSetIds = listOf("comments", "complexity", "empty-blocks",
-						"exceptions", "potential-bugs", "performance", "style")
-			"""
+                val defaultRuleSetIds = listOf("comments", "complexity", "empty-blocks",
+                        "exceptions", "potential-bugs", "performance", "style")
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("doesn't report loop properties") {
             val code = """
-				class Test {
-					fun use() {
-						for (i in 0 until 10) {
-							println(i)
-						}
-					}
-				}
-				"""
+                class Test {
+                    fun use() {
+                        for (i in 0 until 10) {
+                            println(i)
+                        }
+                    }
+                }
+                """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("reports unused loop property") {
             val code = """
-				class Test {
-					fun use() {
-						for (i in 0 until 10) {
-						}
-					}
-				}
-				"""
+                class Test {
+                    fun use() {
+                        for (i in 0 until 10) {
+                        }
+                    }
+                }
+                """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("reports unused loop property in indexed array") {
             val code = """
-				class Test {
-					fun use() {
-						val array = intArrayOf(1, 2, 3)
-						for ((index, value) in array.withIndex()) {
-							println(index)
-						}
-					}
-				}
-				"""
+                class Test {
+                    fun use() {
+                        val array = intArrayOf(1, 2, 3)
+                        for ((index, value) in array.withIndex()) {
+                            println(index)
+                        }
+                    }
+                }
+                """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("reports all unused loop properties in indexed array") {
             val code = """
-				class Test {
-					fun use() {
-						val array = intArrayOf(1, 2, 3)
-						for ((index, value) in array.withIndex()) {
-						}
-					}
-				}
-				"""
+                class Test {
+                    fun use() {
+                        val array = intArrayOf(1, 2, 3)
+                        for ((index, value) in array.withIndex()) {
+                        }
+                    }
+                }
+                """
             assertThat(subject.lint(code)).hasSize(2)
         }
 
         it("does not report used loop properties in indexed array") {
             val code = """
-				class Test {
-					fun use() {
-						val array = intArrayOf(1, 2, 3)
-						for ((index, value) in array.withIndex()) {
-							println(index)
-							println(value)
-						}
-					}
-				}
-				"""
+                class Test {
+                    fun use() {
+                        val array = intArrayOf(1, 2, 3)
+                        for ((index, value) in array.withIndex()) {
+                            println(index)
+                            println(value)
+                        }
+                    }
+                }
+                """
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -292,28 +292,28 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("does not report properties used by other properties") {
             val code = """
-				class Test {
-					private val used = "This is used"
-					private val text = used
+                class Test {
+                    private val used = "This is used"
+                    private val text = used
 
-					fun use() {
-						println(text)
-					}
-				}
-				"""
+                    fun use() {
+                        println(text)
+                    }
+                }
+                """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report properties used by inner classes") {
             val code = """
-				class Test {
-					private val unused = "This is not used"
+                class Test {
+                    private val unused = "This is not used"
 
-					inner class Something {
-						val test = unused
-					}
-				}
-				"""
+                    inner class Something {
+                        val test = unused
+                    }
+                }
+                """
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -321,70 +321,70 @@ class UnusedPrivateMemberSpec : Spek({
     describe("function parameters") {
         it("reports single parameters if they are unused") {
             val code = """
-			class Test {
-				val value = usedMethod(1)
+            class Test {
+                val value = usedMethod(1)
 
-				private fun usedMethod(unusedParameter: Int): Int {
-					return 5
-				}
-			}
-			"""
+                private fun usedMethod(unusedParameter: Int): Int {
+                    return 5
+                }
+            }
+            """
 
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("does not report single parameters if they used in return statement") {
             val code = """
-			class Test {
-				val value = usedMethod(1)
+            class Test {
+                val value = usedMethod(1)
 
-				private fun usedMethod(used: Int): Int {
-					return used
-				}
-			}
-			"""
+                private fun usedMethod(used: Int): Int {
+                    return used
+                }
+            }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report single parameters if they used in function") {
             val code = """
-			class Test {
-				val value = usedMethod(1)
+            class Test {
+                val value = usedMethod(1)
 
-				private fun usedMethod(used: Int) {
-					println(used)
-				}
-			}
-			"""
+                private fun usedMethod(used: Int) {
+                    println(used)
+                }
+            }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("reports parameters that are unused in return statement") {
             val code = """
-			class Test {
-				val value = usedMethod(1, 2)
+            class Test {
+                val value = usedMethod(1, 2)
 
-				private fun usedMethod(unusedParameter: Int, usedParameter: Int): Int {
-					return usedParameter
-				}
-			}
-			"""
+                private fun usedMethod(unusedParameter: Int, usedParameter: Int): Int {
+                    return usedParameter
+                }
+            }
+            """
 
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("reports parameters that are unused in function") {
             val code = """
-			class Test {
-				val value = usedMethod(1, 2)
+            class Test {
+                val value = usedMethod(1, 2)
 
-				private fun usedMethod(unusedParameter: Int, usedParameter: Int) {
-					println(usedParameter)
-				}
-			}
-			"""
+                private fun usedMethod(unusedParameter: Int, usedParameter: Int) {
+                    println(usedParameter)
+                }
+            }
+            """
 
             assertThat(subject.lint(code)).hasSize(1)
         }
@@ -393,50 +393,50 @@ class UnusedPrivateMemberSpec : Spek({
     describe("top level function parameters") {
         it("reports single parameters if they are unused") {
             val code = """
-			fun function(unusedParameter: Int): Int {
-				return 5
-			}
-			"""
+            fun function(unusedParameter: Int): Int {
+                return 5
+            }
+            """
 
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("does not report single parameters if they used in return statement") {
             val code = """
-			fun function(used: Int): Int {
-				return used
-			}
-			"""
+            fun function(used: Int): Int {
+                return used
+            }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report single parameters if they used in function") {
             val code = """
-			fun function(used: Int) {
-				println(used)
-			}
-			"""
+            fun function(used: Int) {
+                println(used)
+            }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("reports parameters that are unused in return statement") {
             val code = """
-			fun function(unusedParameter: Int, usedParameter: Int): Int {
-				return usedParameter
-			}
-			"""
+            fun function(unusedParameter: Int, usedParameter: Int): Int {
+                return usedParameter
+            }
+            """
 
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("reports parameters that are unused in function") {
             val code = """
-			fun function(unusedParameter: Int, usedParameter: Int) {
-				println(usedParameter)
-			}
-			"""
+            fun function(unusedParameter: Int, usedParameter: Int) {
+                println(usedParameter)
+            }
+            """
 
             assertThat(subject.lint(code)).hasSize(1)
         }
@@ -445,26 +445,26 @@ class UnusedPrivateMemberSpec : Spek({
     describe("unused private functions") {
         it("does not report used private functions") {
             val code = """
-			class Test {
-				val value = usedMethod()
+            class Test {
+                val value = usedMethod()
 
-				private fun usedMethod(): Int {
-					return 5
-				}
-			}
-			"""
+                private fun usedMethod(): Int {
+                    return 5
+                }
+            }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("reports unused private functions") {
             val code = """
-			class Test {
-				private fun unusedFunction(): Int {
-					return 5
-				}
-			}
-			"""
+            class Test {
+                private fun unusedFunction(): Int {
+                    return 5
+                }
+            }
+            """
 
             assertThat(subject.lint(code)).hasSize(1)
         }
@@ -487,16 +487,16 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("reports the non called private function") {
             val code = """
-			class Test {
-				private fun unusedFunction(): Int {
-					return someOtherUnusedFunction()
-				}
+            class Test {
+                private fun unusedFunction(): Int {
+                    return someOtherUnusedFunction()
+                }
 
-				private fun someOtherUnusedFunction() {
-					println("Never used")
-				}
-			}
-			"""
+                private fun someOtherUnusedFunction() {
+                    println("Never used")
+                }
+            }
+            """
 
             assertThat(subject.lint(code)).hasSize(1)
         }
@@ -506,17 +506,17 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("does not report the unused private property") {
             val code = """
-				class Test {
-					private val ignored = ""
-				}"""
+                class Test {
+                    private val ignored = ""
+                }"""
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report the unused private function and parameter") {
             val code = """
-				class Test {
-					private fun ignored(ignored: Int) {}
-				}"""
+                class Test {
+                    private fun ignored(ignored: Int) {}
+                }"""
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -525,22 +525,22 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("reports unused nested private property") {
             val code = """
-				class Test {
-					class Inner {
-						private val unused = 1
-					}
-				}"""
+                class Test {
+                    class Inner {
+                        private val unused = 1
+                    }
+                }"""
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("does not report used nested private property") {
             val code = """
-				class Test {
-					class Inner {
-						private val used = 1
-						fun someFunction() = used
-					}
-				}"""
+                class Test {
+                    class Inner {
+                        private val used = 1
+                        fun someFunction() = used
+                    }
+                }"""
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -548,70 +548,70 @@ class UnusedPrivateMemberSpec : Spek({
     describe("parameters in primary constructors") {
         it("reports unused private property") {
             val code = """
-				class Test(private val unused: Any)
-				"""
+                class Test(private val unused: Any)
+                """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("reports unused parameter") {
             val code = """
-				class Test(unused: Any)
-				"""
+                class Test(unused: Any)
+                """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("does not report used parameter for calling super") {
             val code = """
-    			class Parent(val ignored: Any)
-				class Test(used: Any) : Parent(used)
-				"""
+                class Parent(val ignored: Any)
+                class Test(used: Any) : Parent(used)
+                """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report used parameter in init block") {
             val code = """
-				class Test(used: Any) {
-					init {
-						used.toString()
-					}
-				}
-				"""
+                class Test(used: Any) {
+                    init {
+                        used.toString()
+                    }
+                }
+                """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report used parameter to initialize property") {
             val code = """
-				class Test(used: Any) {
-					val usedString = used.toString()
-				}
-				"""
+                class Test(used: Any) {
+                    val usedString = used.toString()
+                }
+                """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report public property") {
             val code = """
-				class Test(val unused: Any)
-				"""
+                class Test(val unused: Any)
+                """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report private property used in init block") {
             val code = """
-				class Test(private val used: Any) {
-					init { used.toString() }
-				}
-				"""
+                class Test(private val used: Any) {
+                    init { used.toString() }
+                }
+                """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report private property used in function") {
             val code = """
-				class Test(private val used: Any) {
-					fun something() {
-						used.toString()
-					}
-				}
-				"""
+                class Test(private val used: Any) {
+                    fun something() {
+                        used.toString()
+                    }
+                }
+                """
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -619,8 +619,8 @@ class UnusedPrivateMemberSpec : Spek({
     describe("error messages") {
         it("are specific for function parameters") {
             val code = """
-				fun foo(unused: Int){}
-			"""
+                fun foo(unused: Int){}
+            """
 
             val lint = subject.lint(code)
 
@@ -629,8 +629,8 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("are specific for local variables") {
             val code = """
-				fun foo(){ val unused = 1 }
-			"""
+                fun foo(){ val unused = 1 }
+            """
 
             val lint = subject.lint(code)
 
@@ -639,12 +639,12 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("are specific for private functions") {
             val code = """
-			class Test {
-				private fun unusedFunction(): Int {
-					return 5
-				}
-			}
-			"""
+            class Test {
+                private fun unusedFunction(): Int {
+                    return 5
+                }
+            }
+            """
 
             val lint = subject.lint(code)
 
@@ -655,16 +655,16 @@ class UnusedPrivateMemberSpec : Spek({
     describe("suppress unused parameter warning annotations") {
         it("does not report annotated parameters") {
             val code = """
-				fun foo(@Suppress("UNUSED_PARAMETER") unused: String){}
-			"""
+                fun foo(@Suppress("UNUSED_PARAMETER") unused: String){}
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("reports parameters without annotation") {
             val code = """
-				fun foo(@Suppress("UNUSED_PARAMETER") unused: String, unusedWithoutAnnotation: String){}
-			"""
+                fun foo(@Suppress("UNUSED_PARAMETER") unused: String, unusedWithoutAnnotation: String){}
+            """
 
             val lint = subject.lint(code)
 
@@ -674,63 +674,63 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("does not report parameters in annotated function") {
             val code = """
-        		@Suppress("UNUSED_PARAMETER")
-				fun foo(unused: String, otherUnused: String){}
-			"""
+                @Suppress("UNUSED_PARAMETER")
+                fun foo(unused: String, otherUnused: String){}
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report parameters in annotated class") {
             val code = """
-        		@Suppress("UNUSED_PARAMETER")
-        		class Test {
-					fun foo(unused: String, otherUnused: String){}
-					fun bar(unused: String){}
-				}
-			"""
+                @Suppress("UNUSED_PARAMETER")
+                class Test {
+                    fun foo(unused: String, otherUnused: String){}
+                    fun bar(unused: String){}
+                }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report parameters in annotated object") {
             val code = """
-				@Suppress("UNUSED_PARAMETER")
-				object Test {
-					fun foo(unused: String){}
-				}
-			"""
+                @Suppress("UNUSED_PARAMETER")
+                object Test {
+                    fun foo(unused: String){}
+                }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report parameters in class with annotated outer class") {
             val code = """
-        		@Suppress("UNUSED_PARAMETER")
-				class Test {
-					fun foo(unused: String){}
+                @Suppress("UNUSED_PARAMETER")
+                class Test {
+                    fun foo(unused: String){}
 
-					class InnerTest {
-						fun bar(unused: String){}
-					}
-				}
-			"""
+                    class InnerTest {
+                        fun bar(unused: String){}
+                    }
+                }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report parameters in annotated file") {
             val code = """
-				@file:Suppress("UNUSED_PARAMETER")
+                @file:Suppress("UNUSED_PARAMETER")
 
-				class Test {
-					fun foo(unused: String){}
+                class Test {
+                    fun foo(unused: String){}
 
-					class InnerTest {
-						fun bar(unused: String){}
-					}
-				}
-			"""
+                    class InnerTest {
+                        fun bar(unused: String){}
+                    }
+                }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -739,19 +739,19 @@ class UnusedPrivateMemberSpec : Spek({
     describe("suppress unused property warning annotations") {
         it("does not report annotated private constructor properties") {
             val code = """
-				class Test(@Suppress("unused") private val foo: String) {}
-			"""
+                class Test(@Suppress("unused") private val foo: String) {}
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("reports private constructor properties without annotation") {
             val code = """
-				class Test(
-					@Suppress("unused") private val foo: String,
-					private val bar: String
-				) {}
-			"""
+                class Test(
+                    @Suppress("unused") private val foo: String,
+                    private val bar: String
+                ) {}
+            """
 
             val lint = subject.lint(code)
 
@@ -761,66 +761,66 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("does not report private constructor properties in annotated class") {
             val code = """
-        		@Suppress("unused")
-				class Test(
-					private val foo: String,
-					private val bar: String
-				) {}
-			"""
+                @Suppress("unused")
+                class Test(
+                    private val foo: String,
+                    private val bar: String
+                ) {}
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report private constructor properties in class with annotated outer class") {
             val code = """
-        		@Suppress("unused")
-				class Test(
-					private val foo: String,
-					private val bar: String
-				) {
-					class InnerTest(
-						private val baz: String
-					) {}
-				}
-			"""
+                @Suppress("unused")
+                class Test(
+                    private val foo: String,
+                    private val bar: String
+                ) {
+                    class InnerTest(
+                        private val baz: String
+                    ) {}
+                }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report private constructor properties in annotated file") {
             val code = """
-				@file:Suppress("unused")
+                @file:Suppress("unused")
 
-				class Test(
-					private val foo: String,
-					private val bar: String
-				) {
-					class InnerTest(
-						private val baz: String
-					) {}
-				}
-			"""
+                class Test(
+                    private val foo: String,
+                    private val bar: String
+                ) {
+                    class InnerTest(
+                        private val baz: String
+                    ) {}
+                }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report annotated private properties") {
             val code = """
-				class Test {
-					@Suppress("unused") private val foo: String
-				}
-			"""
+                class Test {
+                    @Suppress("unused") private val foo: String
+                }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("reports private properties without annotation") {
             val code = """
-				class Test {
-					@Suppress("unused") private val foo: String
-					private val bar: String
-				}
-			"""
+                class Test {
+                    @Suppress("unused") private val foo: String
+                    private val bar: String
+                }
+            """
 
             val lint = subject.lint(code)
 
@@ -830,45 +830,45 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("does not report private properties in annotated class") {
             val code = """
-        		@Suppress("unused")
-				class Test {
-					private val foo: String
-					private val bar: String
-				}
-			"""
+                @Suppress("unused")
+                class Test {
+                    private val foo: String
+                    private val bar: String
+                }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report private properties in class with annotated outer class") {
             val code = """
-        		@Suppress("unused")
-				class Test {
-					private val foo: String
-					private val bar: String
+                @Suppress("unused")
+                class Test {
+                    private val foo: String
+                    private val bar: String
 
-					class InnerTest {
-						private val baz: String
-					}
-				}
-			"""
+                    class InnerTest {
+                        private val baz: String
+                    }
+                }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report private properties in annotated file") {
             val code = """
-				@file:Suppress("unused")
+                @file:Suppress("unused")
 
-				class Test {
-					private val foo: String
-					private val bar: String
+                class Test {
+                    private val foo: String
+                    private val bar: String
 
-					class InnerTest {
-						private val baz: String
-					}
-				}
-			"""
+                    class InnerTest {
+                        private val baz: String
+                    }
+                }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -877,17 +877,17 @@ class UnusedPrivateMemberSpec : Spek({
     describe("suppress unused function warning annotations") {
         it("does not report annotated private functions") {
             val code = """
-				@Suppress("unused")
-				private fun foo(): String = ""
-			"""
+                @Suppress("unused")
+                private fun foo(): String = ""
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("reports private functions without annotation") {
             val code = """
-				private fun foo(): String = ""
-			"""
+                private fun foo(): String = ""
+            """
 
             val lint = subject.lint(code)
 
@@ -897,43 +897,43 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("does not report private functions in annotated class") {
             val code = """
-        		@Suppress("unused")
-				class Test {
-					private fun foo(): String = ""
-				}
-			"""
+                @Suppress("unused")
+                class Test {
+                    private fun foo(): String = ""
+                }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report private functions in class with annotated outer class") {
             val code = """
-        		@Suppress("unused")
-				class Test {
-					private fun foo(): String = ""
-					private fun bar(): String = ""
+                @Suppress("unused")
+                class Test {
+                    private fun foo(): String = ""
+                    private fun bar(): String = ""
 
-					class InnerTest {
-						private fun baz(): String = ""
-					}
-				}
-			"""
+                    class InnerTest {
+                        private fun baz(): String = ""
+                    }
+                }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report private functions in annotated file") {
             val code = """
-				@file:Suppress("unused")
-				class Test {
-					private fun foo(): String = ""
-					private fun bar(): String = ""
+                @file:Suppress("unused")
+                class Test {
+                    private fun foo(): String = ""
+                    private fun bar(): String = ""
 
-					class InnerTest {
-						private fun baz(): String = ""
-					}
-				}
-			"""
+                    class InnerTest {
+                        private fun baz(): String = ""
+                    }
+                }
+            """
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -943,23 +943,23 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("does not report the args parameter of the main function inside an object") {
             val code = """
-				object O {
+                object O {
 
-					@JvmStatic
-					fun main(args: Array<String>) {
-						println("b")
-					}
-				}
-			"""
+                    @JvmStatic
+                    fun main(args: Array<String>) {
+                        println("b")
+                    }
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report the args parameter of the main function as top level function") {
             val code = """
-				fun main(args: Array<String>) {
-					println("b")
-				}
-			"""
+                fun main(args: Array<String>) {
+                    println("b")
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -968,14 +968,14 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("does not report used plus operator - #1354") {
             val code = """
-				import java.util.Date
-				class Foo {
-					val bla: Date = Date(System.currentTimeMillis()) + 300L
-					companion object {
-						private operator fun Date.plus(diff: Long): Date = Date(this.time + diff)
-					}
-				}
-			"""
+                import java.util.Date
+                class Foo {
+                    val bla: Date = Date(System.currentTimeMillis()) + 300L
+                    companion object {
+                        private operator fun Date.plus(diff: Long): Date = Date(this.time + diff)
+                    }
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -182,11 +182,11 @@ class UseDataClassSpec : Spek({
 
         it("does not report a class which has an ignored annotation") {
             val code = """
-				import kotlin.SinceKotlin
+                import kotlin.SinceKotlin
 
-				@SinceKotlin("1.0.0")
-				class AnnotatedClass(val i: Int) {}
-				"""
+                @SinceKotlin("1.0.0")
+                class AnnotatedClass(val i: Int) {}
+                """
             val config = TestConfig(mapOf(UseDataClass.EXCLUDE_ANNOTATED_CLASSES to "kotlin.*"))
             assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructorSpec.kt
@@ -38,18 +38,18 @@ class UtilityClassWithPublicConstructorSpec : Spek({
 
             it("should not get triggered for utility class") {
                 val code = """
-				@Retention(AnnotationRetention.SOURCE)
-				@StringDef(
-					Gender.MALE,
-					Gender.FEMALE
-				)
-				annotation class Gender {
-					companion object {
-						const val MALE = "male"
-						const val FEMALE = "female"
-					}
-				}
-			"""
+                @Retention(AnnotationRetention.SOURCE)
+                @StringDef(
+                    Gender.MALE,
+                    Gender.FEMALE
+                )
+                annotation class Gender {
+                    companion object {
+                        const val MALE = "male"
+                        const val FEMALE = "female"
+                    }
+                }
+            """
                 assertThat(subject.lint(code)).isEmpty()
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -13,63 +13,63 @@ class VarCouldBeValSpec : Spek({
 
         it("does not report variables that are re-assigned") {
             val code = """
-    		fun test() {
-				var a = 1
-				a = 2
-			}
-			"""
+            fun test() {
+                var a = 1
+                a = 2
+            }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report variables that are re-assigned with assignment operator") {
             val code = """
-			fun test() {
-				var a = 1
-				a += 2
-			}
-			"""
+            fun test() {
+                var a = 1
+                a += 2
+            }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report variables that are re-assigned with postfix operators") {
             val code = """
-			fun test() {
-				var a = 1
-				a++
-			}
-			"""
+            fun test() {
+                var a = 1
+                a++
+            }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report variables that are re-assigned with infix operators") {
             val code = """
-			fun test() {
-				var a = 1
-				--a
-			}
-			"""
+            fun test() {
+                var a = 1
+                --a
+            }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report variables that are re-assigned inside scope functions") {
             val code = """
-			fun test() {
-				var a = 1
-				a.also {
-					a = 2
-				}
-			}
-			"""
+            fun test() {
+                var a = 1
+                a.also {
+                    a = 2
+                }
+            }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("reports variables that are not re-assigned, but used in expressions") {
             val code = """
-			fun test() {
-				var a = 1
-				val b = a + 2
-			}
-			"""
+            fun test() {
+                var a = 1
+                val b = a + 2
+            }
+            """
             val lint = subject.lint(code)
 
             assertThat(lint).hasSize(1)
@@ -80,11 +80,11 @@ class VarCouldBeValSpec : Spek({
 
         it("reports variables that are not re-assigned, but used in function calls") {
             val code = """
-			fun test() {
-				var a = 1
-				something(a)
-			}
-			"""
+            fun test() {
+                var a = 1
+                something(a)
+            }
+            """
             val lint = subject.lint(code)
 
             assertThat(lint).hasSize(1)
@@ -95,14 +95,14 @@ class VarCouldBeValSpec : Spek({
 
         it("reports variables that are not re-assigned, but shadowed by one that is") {
             val code = """
-			fun test() {
-				var shadowed = 1
-				fun nestedFunction() {
-					var shadowed = 2
-					shadowed = 3
-				}
-			}
-			"""
+            fun test() {
+                var shadowed = 1
+                fun nestedFunction() {
+                    var shadowed = 2
+                    shadowed = 3
+                }
+            }
+            """
             val lint = subject.lint(code)
 
             assertThat(lint).hasSize(1)
@@ -116,38 +116,38 @@ class VarCouldBeValSpec : Spek({
 
         it("finds unused field and local") {
             val code = """
-				fun createObject() = object {
-					private var myVar: String? = null
-					fun assign(value: String?) {
-						var myVar = value
-					}
-				}
-			"""
+                fun createObject() = object {
+                    private var myVar: String? = null
+                    fun assign(value: String?) {
+                        var myVar = value
+                    }
+                }
+            """
             assertThat(subject.lint(code)).hasSize(2)
         }
 
         it("should not report this-prefixed property") {
             val code = """
-				fun createObject() = object {
-					private var myVar: String? = null
-					fun assign(value: String?) {
-						this.myVar = value
-					}
-				}
-			"""
+                fun createObject() = object {
+                    private var myVar: String? = null
+                    fun assign(value: String?) {
+                        this.myVar = value
+                    }
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should report unused local variable") {
             val code = """
-				fun createObject() = object {
-					private var myVar: String? = null
-					fun assign(value: String?) {
-						var myVar = value
-						this.myVar = value
-					}
-				}
-			"""
+                fun createObject() = object {
+                    private var myVar: String? = null
+                    fun assign(value: String?) {
+                        var myVar = value
+                        this.myVar = value
+                    }
+                }
+            """
             with(subject.lint(code)[0]) {
                 // we accept wrong entity reporting here due to no symbol solving
                 // false reporting with shadowed vars vs false positives

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -62,13 +62,13 @@ class WildcardImportSpec : Spek({
 
         context("a kt file with no wildcard imports") {
             val code = """
-			package test
+            package test
 
-			import test.Test
+            import test.Test
 
-			class Test {
-			}
-		"""
+            class Test {
+            }
+        """
 
             it("should not report any issues") {
                 val findings = WildcardImport().lint(code)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -14,15 +14,15 @@ class OptionalUnitSpec : Spek({
         context("several functions which return Unit") {
 
             val code = """
-				fun returnsUnit1(): Unit {
-					fun returnsUnitNested(): Unit {
-						return Unit
-					}
-					return Unit
-				}
+                fun returnsUnit1(): Unit {
+                    fun returnsUnitNested(): Unit {
+                        return Unit
+                    }
+                    return Unit
+                }
 
-				fun returnsUnit2() = Unit
-			"""
+                fun returnsUnit2() = Unit
+            """
             val findings = subject.compileAndLint(code)
 
             it("should report functions returning Unit") {
@@ -56,20 +56,20 @@ class OptionalUnitSpec : Spek({
         context("several lone Unit statements") {
 
             val code = """
-				fun returnsNothing() {
-					Unit
-					val i: (Int) -> Unit = { _ -> Unit }
-					if (true) {
-						Unit
-					}
-				}
+                fun returnsNothing() {
+                    Unit
+                    val i: (Int) -> Unit = { _ -> Unit }
+                    if (true) {
+                        Unit
+                    }
+                }
 
-				class A {
-					init {
-						Unit
-					}
-				}
-			"""
+                class A {
+                    init {
+                        Unit
+                    }
+                }
+            """
             val findings = subject.compileAndLint(code)
 
             it("should report lone Unit statement") {
@@ -87,14 +87,14 @@ class OptionalUnitSpec : Spek({
 
             it("should not report Unit reference") {
                 val findings = subject.compileAndLint("""
-			    	fun returnsNothing(u: Unit, us: () -> String) {
-			    		val u1 = u is Unit
-			    		val u2: Unit = Unit
-			    		val Unit = 1
-			    		Unit.equals(null)
-			    		val i: (Int) -> Unit = { _ -> }
-			    	}
-			    """)
+                    fun returnsNothing(u: Unit, us: () -> String) {
+                        val u1 = u is Unit
+                        val u2: Unit = Unit
+                        val Unit = 1
+                        Unit.equals(null)
+                        val i: (Int) -> Unit = { _ -> }
+                    }
+                """)
                 assertThat(findings).isEmpty()
             }
         }


### PR DESCRIPTION
In the past this repo used tabs instead of 4 spaces for .kt files.
Ktlint doesn't convert tabs in multiline strings to spaces.
Please take a look at the following issue.
pinterest/ktlint#575

Therefore, the following command has been used for conversion.

find ./ -iname '*.kt' -type f -exec bash -c 'expand -t 4 "$0" | sponge "$0"' {} \;

* ./ is recursively searching the given directory
* -iname is a case insensitive match .kt files
* type -f finds only regular files (no directories, binaries or symlinks)
* -exec bash -c executes the following commands in a subshell for each file
* expand -t 4 expands all tabs to 4 spaces
* sponge soaks up standard input (from expand) and writes it to the same file

Source:
https://stackoverflow.com/a/43523362
