### PR TITLE
Allow regex configuration support for Forbidden Import rule

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -440,6 +440,7 @@ style:
   ForbiddenImport:
     active: false
     imports: ''
+    forbiddenPatterns: ""
   ForbiddenVoid:
     active: false
     ignoreOverridden: false

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -56,9 +56,8 @@ class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
         }
     }
 
-    private fun containsForbiddenPattern(import: String): Boolean {
-        return forbiddenPatterns.pattern.isNotEmpty() && forbiddenPatterns.containsMatchIn(import)
-    }
+    private fun containsForbiddenPattern(import: String): Boolean =
+        forbiddenPatterns.pattern.isNotEmpty() && forbiddenPatterns.containsMatchIn(import)
 
     companion object {
         const val IMPORTS = "imports"

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -68,5 +68,24 @@ class ForbiddenImportSpec : Spek({
                 ForbiddenImport(TestConfig(mapOf(ForbiddenImport.IMPORTS to "net.example.R.dimen"))).lint(code)
             assertThat(findings).hasSize(1)
         }
+
+        it("should not report import when it does not match any pattern") {
+            val findings =
+                ForbiddenImport(TestConfig(mapOf(ForbiddenImport.FORBIDDEN_PATTERNS to "nets.*R"))).lint(code)
+            assertThat(findings).hasSize(0)
+        }
+
+        it("should report import when it matches any one of the pattern") {
+            val findings =
+                ForbiddenImport(TestConfig(mapOf(ForbiddenImport.FORBIDDEN_PATTERNS to "net.*R|com.*expiremental"))).lint(code)
+            assertThat(findings).hasSize(2)
+        }
+
+        it("should report import when it matches all the patterns") {
+            val findings =
+                ForbiddenImport(TestConfig(mapOf(ForbiddenImport.FORBIDDEN_PATTERNS to "net.*R|example.*dimen"))).lint(code)
+            assertThat(findings).hasSize(2)
+        }
+
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -75,15 +75,9 @@ class ForbiddenImportSpec : Spek({
             assertThat(findings).hasSize(0)
         }
 
-        it("should report import when it matches any one of the pattern") {
+        it("should report import when it matches the forbidden pattern") {
             val findings =
                 ForbiddenImport(TestConfig(mapOf(ForbiddenImport.FORBIDDEN_PATTERNS to "net.*R|com.*expiremental"))).lint(code)
-            assertThat(findings).hasSize(2)
-        }
-
-        it("should report import when it matches all the patterns") {
-            val findings =
-                ForbiddenImport(TestConfig(mapOf(ForbiddenImport.FORBIDDEN_PATTERNS to "net.*R|example.*dimen"))).lint(code)
             assertThat(findings).hasSize(2)
         }
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -264,6 +264,10 @@ or deprecated APIs. Detekt will then report all imports that are forbidden.
 
    imports which should not be used
 
+* `forbiddenPatterns` (default: `""`)
+
+   reports imports which match the specified regular expression. For example `net.*R`.
+
 #### Noncompliant Code:
 
 ```kotlin


### PR DESCRIPTION
Fixes [#1430 ](https://github.com/arturbosch/detekt/issues/1430)

-  Introduce configuration `forbiddenPatterns` to specify forbidden regex for imports.
-  Report imports that match any of the configured patterns even though they are not in imports list