### PR TITLE
Ignore FunctionOnlyReturningConstant for allowed annotations

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -448,6 +448,7 @@ style:
     active: false
     ignoreOverridableFunction: true
     excludedFunctions: 'describeContents'
+    excludeAnnotatedFunction: "dagger.Provides"
   LibraryCodeMustSpecifyReturnType:
     active: false
   LoopWithTooManyJumpStatements:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.AnnotationExcluder
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
@@ -12,6 +13,7 @@ import io.gitlab.arturbosch.detekt.rules.isOpen
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
@@ -31,6 +33,7 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  *
  * @configuration ignoreOverridableFunction - if overriden functions should be ignored (default: `true`)
  * @configuration excludedFunctions - excluded functions (default: `'describeContents'`)
+ * @configuration excludeAnnotatedFunction - allows to provide a list of annotations that disable this check (default: `"dagger.Provides"`)
  */
 class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config) {
 
@@ -41,6 +44,13 @@ class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config
 
     private val ignoreOverridableFunction = valueOrDefault(IGNORE_OVERRIDABLE_FUNCTION, true)
     private val excludedFunctions = SplitPattern(valueOrDefault(EXCLUDED_FUNCTIONS, ""))
+    private val excludeAnnotatedFunctions = SplitPattern(valueOrDefault(EXCLUDE_ANNOTATED_FUNCTION, "dagger.Provides"))
+    private lateinit var annotationExcluder: AnnotationExcluder
+
+    override fun visit(root: KtFile) {
+        annotationExcluder = AnnotationExcluder(root, excludeAnnotatedFunctions)
+        super.visit(root)
+    }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (checkOverridableFunction(function) && isNotExcluded(function) && isReturningAConstant(function)) {
@@ -63,7 +73,7 @@ class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config
     }
 
     private fun isNotExcluded(function: KtNamedFunction) =
-        !excludedFunctions.contains(function.name)
+        !excludedFunctions.contains(function.name) && !annotationExcluder.shouldExclude(function.annotationEntries)
 
     private fun isReturningAConstant(function: KtNamedFunction) =
         isConstantExpression(function.bodyExpression) || returnsConstant(function)
@@ -87,5 +97,6 @@ class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config
     companion object {
         const val IGNORE_OVERRIDABLE_FUNCTION = "ignoreOverridableFunction"
         const val EXCLUDED_FUNCTIONS = "excludedFunctions"
+        const val EXCLUDE_ANNOTATED_FUNCTION = "excludeAnnotatedFunction"
     }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
@@ -31,6 +31,22 @@ class FunctionOnlyReturningConstantSpec : Spek({
             val rule = FunctionOnlyReturningConstant(config)
             assertThat(rule.compileAndLint(code)).hasSize(0)
         }
+
+        it("does not report excluded annotated function which returns a constant") {
+            val code = """
+                import jdk.nashorn.internal.ir.annotations.Ignore
+                class Test {
+                    @Ignore
+                    fun someIgnoredFun(): String {
+                        return "I am a constant"
+                    }
+                }
+            """.trimIndent()
+            val config = TestConfig(mapOf("excludeAnnotatedFunction" to "jdk.nashorn.internal.ir.annotations.Ignore"))
+            val rule = FunctionOnlyReturningConstant(config)
+            assertThat(rule.compileAndLint(code)).hasSize(0)
+
+        }
     }
 
     describe("FunctionOnlyReturningConstant rule - negative cases") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
@@ -34,18 +34,17 @@ class FunctionOnlyReturningConstantSpec : Spek({
 
         it("does not report excluded annotated function which returns a constant") {
             val code = """
-                import jdk.nashorn.internal.ir.annotations.Ignore
+                import kotlin.SinceKotlin
                 class Test {
-                    @Ignore
+                    @SinceKotlin("1.0.0")
                     fun someIgnoredFun(): String {
                         return "I am a constant"
                     }
                 }
             """.trimIndent()
-            val config = TestConfig(mapOf("excludeAnnotatedFunction" to "jdk.nashorn.internal.ir.annotations.Ignore"))
+            val config = TestConfig(mapOf("excludeAnnotatedFunction" to "kotlin.SinceKotlin"))
             val rule = FunctionOnlyReturningConstant(config)
-            assertThat(rule.compileAndLint(code)).hasSize(0)
-
+            assertThat(rule.compileAndLint(code)).isEmpty()
         }
     }
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -326,6 +326,10 @@ as a `const val`.
 
    excluded functions
 
+* `excludeAnnotatedFunction` (default: `"dagger.Provides"`)
+
+   allows to provide a list of annotations that disable this check
+
 #### Noncompliant Code:
 
 ```kotlin


### PR DESCRIPTION
Fixes [#1313](https://github.com/arturbosch/detekt/issues/1313)

- Introduced `excludeAnnotatedFunctions` to provide a list of annotations that can disable `FunctionOnlyReturningConstant` check
- Set default value to `dagger.Provides`