### PR TITLE
Update LongParameterList rule to match documentation

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -39,7 +39,7 @@ class LongParameterList(
         val parameterList = function.valueParameterList
         val parameters = parameterList?.parameterCount()
 
-        if (parameters != null && parameters >= threshold) {
+        if (parameters != null && parameters > threshold) {
             report(ThresholdedCodeSmell(issue,
                     Entity.from(parameterList),
                     Metric("SIZE", parameters, threshold),

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -13,24 +13,24 @@ class LongParameterListSpec : Spek({
     describe("LongParameterList rule") {
 
         it("reports too long parameter list") {
-            val code = "fun long(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) {}"
+            val code = "fun long(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) {}"
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
-        it("does not reports short parameter list") {
+        it("does not report short parameter list") {
             val code = "fun long(a: Int, b: Int, c: Int, d: Int, e: Int) {}"
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("reports too long parameter list event for parameters with defaults") {
-            val code = "fun long(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int = 1) {}"
+            val code = "fun long(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int = 1) {}"
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("does not report long parameter list if parameters with defaults should be ignored") {
             val config = TestConfig(mapOf(LongParameterList.IGNORE_DEFAULT_PARAMETERS to "true"))
             val rule = LongParameterList(config)
-            val code = "fun long(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int = 1, g: Int = 2) {}"
+            val code = "fun long(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int = 1, h: Int = 2) {}"
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -18,7 +18,7 @@ class LongParameterListSpec : Spek({
         }
 
         it("does not report short parameter list") {
-            val code = "fun long(a: Int, b: Int, c: Int, d: Int, e: Int) {}"
+            val code = "fun long(a: Int, b: Int, c: Int, d: Int, e: Int, f:Int) {}"
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 


### PR DESCRIPTION
The documentation for the `LongParameterList` rule (in https://github.com/arturbosch/detekt/blob/master/docs/pages/documentation/complexity.md) states:

"Reports functions which have more parameters than a certain threshold (default: 6)."

But it currently also reports functions which have exactly that amount of parameters.

This PR modifies the LongParameterList rule so that it follows the description in the documentation (obviously an alternative is to change the documentation to match the implementation but this seems more natural considering the description of the parameter).
