### PR TITLE
Introduce ignoreLabeled config for ReturnFromFinally

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -146,6 +146,7 @@ exceptions:
     active: false
   ReturnFromFinally:
     active: false
+    ignoreLabeled: false
   SwallowedException:
     active: false
     ignoredExceptionTypes: 'InterruptedException,NumberFormatException,ParseException,MalformedURLException'

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
@@ -76,6 +77,30 @@ class ReturnFromFinallySpec : Spek({
                 val findings = subject.compileAndLint(code)
                 assertThat(findings).hasSize(0)
             }
+        }
+
+        context("a finally block with a return as labelled expression") {
+            val code = """
+            fun x() {
+                try {
+                } finally {
+                    label@{
+                     return@label
+                    }
+                }
+            }
+        """
+            it("should report when ignoreLabeled is false") {
+                val findings = subject.compileAndLint(code)
+                assertThat(findings).hasSize(1)
+            }
+
+            it("should not report when ignoreLabeled is true") {
+                val config = TestConfig(mapOf(ReturnFromFinally.IGNORE_LABELED to "true"))
+                val findings = ReturnFromFinally(config).compileAndLint(code)
+                assertThat(findings).isEmpty()
+            }
+
         }
     }
 })

--- a/docs/pages/documentation/exceptions.md
+++ b/docs/pages/documentation/exceptions.md
@@ -185,6 +185,12 @@ Using `return` statements in `finally` blocks can discard and hide exceptions th
 
 **Debt**: 20min
 
+#### Configuration options:
+
+* `ignoreLabeled` (default: `false`)
+
+   ignores labeled return statements
+
 #### Noncompliant Code:
 
 ```kotlin


### PR DESCRIPTION
Fixes #1467

- Introduced ignoreLabeled configuration for ReturnFromFinally rule which is false by default.