### PR TITLE
Clarify threshold pararameter meaning in docs

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
@@ -36,7 +36,7 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
  * fun hasCorrectEnding() = return !str.endsWith("foo") && !str.endsWith("bar") && !str.endsWith("_")
  * </compliant>
  *
- * @configuration threshold - (default: `4`)
+ * @configuration threshold - the number of conditions which will trigger the rule (default: `4`)
  *
  * @active since v1.0.0
  */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.psi.KtProperty
  * Large interfaces should be split into smaller interfaces which have a clear responsibility and are easier
  * to understand and implement.
  *
- * @configuration threshold - the amount of definitions in an interface to trigger a warning (default: `10`)
+ * @configuration threshold - the amount of definitions in an interface to trigger the rule (default: `10`)
  * @configuration includeStaticDeclarations - whether static declarations should be included (default: `false`)
  */
 class ComplexInterface(

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.psi.KtProperty
  * Large interfaces should be split into smaller interfaces which have a clear responsibility and are easier
  * to understand and implement.
  *
- * @configuration threshold - maximum amount of definitions in an interface (default: `10`)
+ * @configuration threshold - the amount of definitions in an interface to trigger a warning (default: `10`)
  * @configuration includeStaticDeclarations - whether static declarations should be included (default: `false`)
  */
 class ComplexInterface(

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -21,7 +21,7 @@ import java.util.IdentityHashMap
  * split up large classes into smaller classes. These smaller classes are then easier to understand and handle less
  * things.
  *
- * @configuration threshold - maximum size of a class (default: `600`)
+ * @configuration threshold - the size of class required to trigger the rule (default: `600`)
  *
  * @active since v1.0.0
  */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -21,7 +21,7 @@ import java.util.IdentityHashMap
  *
  * Extract parts of the functionality of long methods into separate, smaller methods.
  *
- * @configuration threshold - maximum lines in a method (default: `60`)
+ * @configuration threshold - number of lines in a method to trigger the rule (default: `60`)
  *
  * @active since v1.0.0
  */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtParameterList
 /**
  * Reports functions which have more parameters than a certain threshold (default: 6).
  *
- * @configuration threshold - maximum number of parameters (default: `6`)
+ * @configuration threshold - number of parameters required to trigger the rule (default: `6`)
  * @configuration ignoreDefaultParameters - ignore parameters that have a default value (default: `false`)
  *
  * @active since v1.0.0

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
  *
  * Refactor these methods and try to use optional parameters instead to prevent some of the overloading.
  *
- * @configuration threshold - (default: `6`)
+ * @configuration threshold - number of overloads which will trigger the rule (default: `6`)
  */
 class MethodOverloading(
     config: Config = Config.empty,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  *
  * Prefer extracting the nested code into well-named functions to make it easier to understand.
  *
- * @configuration threshold - maximum nesting depth (default: `4`)
+ * @configuration threshold - the nested depth required to trigger rule (default: `4`)
  *
  * @active since v1.0.0
  */

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -22,7 +22,8 @@ and call those instead.
 
 * `threshold` (default: `4`)
 
-   
+  the number of conditions which will trigger the rule
+
 
 #### Noncompliant Code:
 
@@ -61,7 +62,7 @@ to understand and implement.
 
 * `threshold` (default: `10`)
 
-   maximum amount of definitions in an interface
+   the number of definitions in an interface that will trigger the rule
 
 * `includeStaticDeclarations` (default: `false`)
 
@@ -174,7 +175,7 @@ things.
 
 * `threshold` (default: `600`)
 
-   maximum size of a class
+   size of class required to trigger the rule
 
 ### LongMethod
 
@@ -191,7 +192,7 @@ Extract parts of the functionality of long methods into separate, smaller method
 
 * `threshold` (default: `60`)
 
-   maximum lines in a method
+   number of lines in a method to trigger the rule
 
 ### LongParameterList
 
@@ -205,7 +206,7 @@ Reports functions which have more parameters than a certain threshold (default: 
 
 * `threshold` (default: `6`)
 
-   maximum number of parameters
+   number of parameters required to trigger the rule
 
 * `ignoreDefaultParameters` (default: `false`)
 
@@ -226,6 +227,7 @@ Refactor these methods and try to use optional parameters instead to prevent som
 
 * `threshold` (default: `6`)
 
+  number of overloads which will trigger the rule
    
 
 ### NestedBlockDepth
@@ -243,7 +245,7 @@ Prefer extracting the nested code into well-named functions to make it easier to
 
 * `threshold` (default: `4`)
 
-   maximum nesting depth
+   the nested depth required to trigger rule
 
 ### StringLiteralDuplication
 

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -22,7 +22,7 @@ and call those instead.
 
 * `threshold` (default: `4`)
 
-  the number of conditions which will trigger the rule
+   the number of conditions which will trigger the rule
 
 #### Noncompliant Code:
 
@@ -61,7 +61,7 @@ to understand and implement.
 
 * `threshold` (default: `10`)
 
-   the number of definitions in an interface that will trigger the rule
+   the amount of definitions in an interface to trigger the rule
 
 * `includeStaticDeclarations` (default: `false`)
 
@@ -174,7 +174,7 @@ things.
 
 * `threshold` (default: `600`)
 
-   size of class required to trigger the rule
+   the size of class required to trigger the rule
 
 ### LongMethod
 
@@ -226,8 +226,7 @@ Refactor these methods and try to use optional parameters instead to prevent som
 
 * `threshold` (default: `6`)
 
-  number of overloads which will trigger the rule
-   
+   number of overloads which will trigger the rule
 
 ### NestedBlockDepth
 

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -24,7 +24,6 @@ and call those instead.
 
   the number of conditions which will trigger the rule
 
-
 #### Noncompliant Code:
 
 ```kotlin


### PR DESCRIPTION
In most cases the `threshold` parameter is documented as the maximum number of instances possible before the rule triggers, but it's actually the number required to trigger a rule, as all the conditions are of the form `>= threshold`. Hopefully this will make the documenation clearer.