### PR TITLE
Add snippet code in html report

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReport.kt
@@ -87,14 +87,14 @@ class HtmlOutputReport : OutputReport() {
         }
     }
 
-    private fun FlowContent.renderFinding(it: Finding) {
+    private fun FlowContent.renderFinding(finding: Finding) {
         span("location") {
-            text("${it.file}:${it.location.source.line}:${it.location.source.column}")
+            text("${finding.file}:${finding.location.source.line}:${finding.location.source.column}")
         }
 
-        if (it.message.isNotEmpty()) {
+        if (finding.message.isNotEmpty()) {
             br()
-            span("message") { text(it.message) }
+            span("message") { text(finding.message) }
         }
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReport.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.OutputReport
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
+import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.cli.ClasspathResourceConverter
 import kotlinx.html.CommonAttributeGroupFacadeFlowInteractiveContent
 import kotlinx.html.FlowContent
@@ -96,6 +97,12 @@ class HtmlOutputReport : OutputReport() {
             br()
             span("message") { text(finding.message) }
         }
+
+        val psiFile = finding.entity.ktElement?.containingFile
+        if (psiFile != null) {
+            val lineSequence = psiFile.text.splitToSequence('\n')
+            snippetCode(lineSequence, finding.startPosition, finding.charPosition.length())
+        }
     }
 }
 
@@ -117,3 +124,5 @@ private class SUMMARY(
     false
 ),
     CommonAttributeGroupFacadeFlowInteractiveContent
+
+private fun TextLocation.length(): Int = end - start

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtils.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtils.kt
@@ -1,0 +1,51 @@
+package io.gitlab.arturbosch.detekt.cli.out
+
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import kotlinx.html.FlowContent
+import kotlinx.html.code
+import kotlinx.html.pre
+import kotlinx.html.span
+import kotlin.math.max
+import kotlin.math.min
+
+internal fun FlowContent.snippetCode(lines: Sequence<String>, location: SourceLocation, length: Int) {
+    pre {
+        code {
+            val dropLineCount = max(location.line - 1 - EXTRA_LINES_IN_SNIPPET, 0)
+            val takeLineCount = EXTRA_LINES_IN_SNIPPET + 1 + Math.min(location.line - 1, EXTRA_LINES_IN_SNIPPET)
+            var currentLineNumber = dropLineCount + 1
+            var errorLength = length
+            lines
+                .drop(dropLineCount)
+                .take(takeLineCount)
+                .forEach { line ->
+                    span("lineno") { text("%1$4s ".format(currentLineNumber)) }
+                    if (currentLineNumber >= location.line && errorLength > 0) {
+                        val column = if (currentLineNumber == location.line) location.column - 1 else 0
+                        errorLength -= writeErrorLine(line, column, errorLength) + 1 // we need to consume the \n
+                    } else {
+                        text(line)
+                    }
+                    text("\n")
+                    currentLineNumber++
+                }
+        }
+    }
+}
+
+private fun FlowContent.writeErrorLine(line: String, errorStarts: Int, length: Int): Int {
+    val errorEnds = min(errorStarts + length, line.length)
+    text(line.substring(startIndex = 0, endIndex = errorStarts))
+    span("error") {
+        text(
+            line.substring(
+                startIndex = errorStarts,
+                endIndex = errorEnds
+            )
+        )
+    }
+    text(line.substring(startIndex = errorEnds))
+    return errorEnds - errorStarts
+}
+
+private const val EXTRA_LINES_IN_SNIPPET = 3

--- a/detekt-cli/src/main/resources/default-html-report-template.html
+++ b/detekt-cli/src/main/resources/default-html-report-template.html
@@ -37,6 +37,17 @@ h3 {
   margin-bottom: 8px;
   margin-top: 8px;
 }
+pre {
+  border: 1px solid #e0e0e0;
+  overflow: scroll;
+}
+.lineno {
+  color: #999999;
+  background-color: #f0f0f0;
+}
+.error {
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4AwCFR4T/3uLMgAAADxJREFUCNdNyLERQEAABMCjL4lQwIzcjErpguAL+C9AvgKJDbeD/PRpLdm35Hm+MU+cB+tCKaJW4L4YBy+CAiLJrFs9mgAAAABJRU5ErkJggg==) bottom repeat-x;
+}
 </style>
 </head>
 <body>

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/FakeKtElement.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/FakeKtElement.kt
@@ -1,0 +1,273 @@
+package io.gitlab.arturbosch.detekt.cli.out
+
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.lang.Language
+import org.jetbrains.kotlin.com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.com.intellij.openapi.util.Key
+import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiElementVisitor
+import org.jetbrains.kotlin.com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.com.intellij.psi.PsiManager
+import org.jetbrains.kotlin.com.intellij.psi.PsiReference
+import org.jetbrains.kotlin.com.intellij.psi.ResolveState
+import org.jetbrains.kotlin.com.intellij.psi.scope.PsiScopeProcessor
+import org.jetbrains.kotlin.com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.com.intellij.psi.search.SearchScope
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtVisitor
+import javax.swing.Icon
+
+class FakeKtElement(
+    text: String
+) : KtElement {
+    private val psiFile = FakePsiFile(text)
+
+    override fun <R, D> accept(visitor: KtVisitor<R, D>, data: D): R {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun accept(p0: PsiElementVisitor) {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun <D> acceptChildren(visitor: KtVisitor<Void, D>, data: D) {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun acceptChildren(p0: PsiElementVisitor) {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun add(p0: PsiElement): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun addAfter(p0: PsiElement, p1: PsiElement?): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun addBefore(p0: PsiElement, p1: PsiElement?): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun addRange(p0: PsiElement?, p1: PsiElement?): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun addRangeAfter(p0: PsiElement?, p1: PsiElement?, p2: PsiElement?): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun addRangeBefore(p0: PsiElement, p1: PsiElement, p2: PsiElement?): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun canNavigate(): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun canNavigateToSource(): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun checkAdd(p0: PsiElement) {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun checkDelete() {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun copy(): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun delete() {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun deleteChildRange(p0: PsiElement?, p1: PsiElement?) {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun findElementAt(p0: Int): PsiElement? {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun findReferenceAt(p0: Int): PsiReference? {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getChildren(): Array<PsiElement> {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getContainingFile(): PsiFile = psiFile
+
+    override fun getContainingKtFile(): KtFile {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getContext(): PsiElement? {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun <T : Any?> getCopyableUserData(p0: Key<T>?): T? {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getFirstChild(): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getIcon(p0: Int): Icon {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getLanguage(): Language {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getLastChild(): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getManager(): PsiManager {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getName(): String? {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getNavigationElement(): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getNextSibling(): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getNode(): ASTNode {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getOriginalElement(): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getParent(): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getPrevSibling(): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getProject(): Project {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getPsiOrParent(): KtElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getReference(): PsiReference? {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getReferences(): Array<PsiReference> {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getResolveScope(): GlobalSearchScope {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getStartOffsetInParent(): Int {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getText(): String {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getTextLength(): Int {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getTextOffset(): Int {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getTextRange(): TextRange {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getUseScope(): SearchScope {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun <T : Any?> getUserData(p0: Key<T>): T? {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun isEquivalentTo(p0: PsiElement?): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun isPhysical(): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun isValid(): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun isWritable(): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun navigate(p0: Boolean) {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun processDeclarations(
+        p0: PsiScopeProcessor,
+        p1: ResolveState,
+        p2: PsiElement?,
+        p3: PsiElement
+    ): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun <T : Any?> putCopyableUserData(p0: Key<T>?, p1: T?) {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun <T : Any?> putUserData(p0: Key<T>, p1: T?) {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun replace(p0: PsiElement): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun textContains(p0: Char): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun textMatches(p0: CharSequence): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun textMatches(p0: PsiElement): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun textToCharArray(): CharArray {
+        throw IllegalStateException("not mocked")
+    }
+}

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/FakePsiFile.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/FakePsiFile.kt
@@ -1,0 +1,306 @@
+package io.gitlab.arturbosch.detekt.cli.out
+
+import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
+import org.jetbrains.kotlin.com.intellij.lang.Language
+import org.jetbrains.kotlin.com.intellij.openapi.fileTypes.FileType
+import org.jetbrains.kotlin.com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.com.intellij.openapi.util.Key
+import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
+import org.jetbrains.kotlin.com.intellij.openapi.vfs.VirtualFile
+import org.jetbrains.kotlin.com.intellij.psi.FileViewProvider
+import org.jetbrains.kotlin.com.intellij.psi.PsiDirectory
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiElementVisitor
+import org.jetbrains.kotlin.com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.com.intellij.psi.PsiFileSystemItem
+import org.jetbrains.kotlin.com.intellij.psi.PsiManager
+import org.jetbrains.kotlin.com.intellij.psi.PsiReference
+import org.jetbrains.kotlin.com.intellij.psi.ResolveState
+import org.jetbrains.kotlin.com.intellij.psi.scope.PsiScopeProcessor
+import org.jetbrains.kotlin.com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.com.intellij.psi.search.PsiElementProcessor
+import org.jetbrains.kotlin.com.intellij.psi.search.SearchScope
+import javax.swing.Icon
+
+class FakePsiFile(
+    private val text: String
+) : PsiFile {
+    override fun canNavigate(): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun canNavigateToSource(): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun isEquivalentTo(p0: PsiElement?): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun addBefore(p0: PsiElement, p1: PsiElement?): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun copy(): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getText(): String = text
+
+    override fun getStartOffsetInParent(): Int {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getContainingDirectory(): PsiDirectory {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getPrevSibling(): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun <T : Any?> putUserData(p0: Key<T>, p1: T?) {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun replace(p0: PsiElement): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getContainingFile(): PsiFile {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getViewProvider(): FileViewProvider {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getReferences(): Array<PsiReference> {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun checkAdd(p0: PsiElement) {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getLanguage(): Language {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun addRangeAfter(p0: PsiElement?, p1: PsiElement?, p2: PsiElement?): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getUseScope(): SearchScope {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getResolveScope(): GlobalSearchScope {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getProject(): Project {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun addRange(p0: PsiElement?, p1: PsiElement?): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getContext(): PsiElement? {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun processChildren(p0: PsiElementProcessor<PsiFileSystemItem>?): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun isDirectory(): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun addAfter(p0: PsiElement, p1: PsiElement?): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun processDeclarations(
+        p0: PsiScopeProcessor,
+        p1: ResolveState,
+        p2: PsiElement?,
+        p3: PsiElement
+    ): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun accept(p0: PsiElementVisitor) {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getNextSibling(): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getFirstChild(): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getTextRange(): TextRange {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun <T : Any?> putCopyableUserData(p0: Key<T>?, p1: T?) {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getOriginalElement(): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun checkDelete() {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getNavigationElement(): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getName(): String {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun findElementAt(p0: Int): PsiElement? {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getReference(): PsiReference? {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getTextLength(): Int {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getPsiRoots(): Array<PsiFile> {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun textMatches(p0: CharSequence): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun textMatches(p0: PsiElement): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getTextOffset(): Int {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun textToCharArray(): CharArray {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun add(p0: PsiElement): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun addRangeBefore(p0: PsiElement, p1: PsiElement, p2: PsiElement?): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun isPhysical(): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun findReferenceAt(p0: Int): PsiReference? {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getNode(): FileASTNode {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getManager(): PsiManager {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun isValid(): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun delete() {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getIcon(p0: Int): Icon {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun deleteChildRange(p0: PsiElement?, p1: PsiElement?) {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getParent(): PsiDirectory? {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getModificationStamp(): Long {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getChildren(): Array<PsiElement> {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun acceptChildren(p0: PsiElementVisitor) {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getFileType(): FileType {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun subtreeChanged() {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun isWritable(): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun checkSetName(p0: String?) {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun navigate(p0: Boolean) {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun <T : Any?> getUserData(p0: Key<T>): T? {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getLastChild(): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun setName(p0: String): PsiElement {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getOriginalFile(): PsiFile {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun textContains(p0: Char): Boolean {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun getVirtualFile(): VirtualFile {
+        throw IllegalStateException("not mocked")
+    }
+
+    override fun <T : Any?> getCopyableUserData(p0: Key<T>?): T? {
+        throw IllegalStateException("not mocked")
+    }
+}

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
@@ -9,10 +9,17 @@ import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
+import io.gitlab.arturbosch.detekt.cli.CliArgs
+import io.gitlab.arturbosch.detekt.cli.runners.Runner
 import io.gitlab.arturbosch.detekt.test.TestDetektion
+import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 
 class HtmlOutputFormatTest : Spek({
 
@@ -60,6 +67,19 @@ class HtmlOutputFormatTest : Spek({
             assertThat(result).contains("<span class=\"description\">A1</span>")
             assertThat(result).contains("<span class=\"description\">A2</span>")
             assertThat(result).contains("<span class=\"description\">A3</span>")
+        }
+
+        it("integration") {
+            val result = outputFormat.render(createTestDetektionWithMultipleSmells())
+
+            val tmpReport = Files.createTempFile("HtmlOutputFormatTest", ".html")
+            Files.write(tmpReport, result.toByteArray())
+
+            try {
+                assertThat(tmpReport).hasSameContentAs(Paths.get(resource("/reports/HtmlOutputFormatTest.html")))
+            } finally {
+                Files.delete(tmpReport)
+            }
         }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
@@ -67,7 +67,7 @@ class HtmlOutputFormatTest : Spek({
             assertThat(result).contains("<span class=\"description\">A3</span>")
         }
 
-        it("integration") {
+        it("assert that the html generated is the expected") {
             val result = outputFormat.render(createTestDetektionWithMultipleSmells())
 
             val tmpReport = Files.createTempFile("HtmlOutputFormatTest", ".html")

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
@@ -49,7 +49,6 @@ class HtmlOutputFormatTest : Spek({
             val result = outputFormat.render(createTestDetektionWithMultipleSmells())
 
             assertThat(result).contains("<span class=\"rule\">id_a </span>")
-            assertThat(result).contains("<span class=\"rule\">id_b </span>")
             assertThat(result).contains("<span class=\"rule\">id_c </span>")
         }
 
@@ -58,14 +57,13 @@ class HtmlOutputFormatTest : Spek({
 
             assertThat(result).contains("<span class=\"message\">B1</span>")
             assertThat(result).contains("<span class=\"message\">B2</span>")
-            assertThat(result).contains("<span class=\"message\">B3</span>")
         }
 
         it("testRenderResultContainsDescriptions") {
             val result = outputFormat.render(createTestDetektionWithMultipleSmells())
 
             assertThat(result).contains("<span class=\"description\">A1</span>")
-            assertThat(result).contains("<span class=\"description\">A2</span>")
+            assertThat(result).doesNotContain("<span class=\"description\">A2</span>")
             assertThat(result).contains("<span class=\"description\">A3</span>")
         }
 
@@ -86,8 +84,8 @@ class HtmlOutputFormatTest : Spek({
 
 private fun createTestDetektionWithMultipleSmells(): Detektion {
     val entity1 = Entity("Sample1", "com.sample.Sample1", "",
-            Location(SourceLocation(11, 1), TextLocation(0, 10),
-                    "abcd", "src/main/com/sample/Sample1.kt"))
+            Location(SourceLocation(11, 1), TextLocation(10, 14),
+                    "abcd", "src/main/com/sample/Sample1.kt"), FakeKtElement("\n\n\n\n\n\n\n\n\n\nabcdef\nhi\n"))
     val entity2 = Entity("Sample2", "com.sample.Sample2", "",
             Location(SourceLocation(22, 2), TextLocation(0, 20),
                     "efgh", "src/main/com/sample/Sample2.kt"))
@@ -97,7 +95,7 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
 
     return TestDetektion(
         CodeSmell(Issue("id_a", Severity.CodeSmell, "A1", Debt.TWENTY_MINS), entity1, message = "B1"),
-        CodeSmell(Issue("id_b", Severity.CodeSmell, "A2", Debt.TWENTY_MINS), entity2, message = "B2"),
-        CodeSmell(Issue("id_c", Severity.CodeSmell, "A3", Debt.TWENTY_MINS), entity3, message = "B3")
+        CodeSmell(Issue("id_a", Severity.CodeSmell, "A2", Debt.TWENTY_MINS), entity2, message = "B2"),
+        CodeSmell(Issue("id_c", Severity.CodeSmell, "A3", Debt.TWENTY_MINS), entity3, message = "")
     )
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtilsTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtilsTest.kt
@@ -1,0 +1,169 @@
+package io.gitlab.arturbosch.detekt.cli.out
+
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import kotlinx.html.div
+import kotlinx.html.stream.createHTML
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class HtmlUtilsTest : Spek({
+
+    describe("HTML snippet code") {
+        val code = """
+            package cases
+            // reports 1 - line with just one space
+
+            // reports 1 - a comment with trailing space
+            // A comment
+            // reports 1
+            class TrailingWhitespacePositive {
+                // reports 1 - line with just one tab
+
+                // reports 1
+                fun myFunction() {
+                    // reports 1 - line with 1 trailing tab
+                    println("A message")
+                // reports 1
+                }
+            }
+        """.trimIndent().splitToSequence('\n')
+
+        it("all line") {
+            val snippet = createHTML().div() {
+                snippetCode(code.asSequence(), SourceLocation(7, 1), 34)
+            }
+
+            assertThat(snippet).isEqualTo("""
+                <div>
+                  <pre><code><span class="lineno">   4 </span>// reports 1 - a comment with trailing space
+                <span class="lineno">   5 </span>// A comment
+                <span class="lineno">   6 </span>// reports 1
+                <span class="lineno">   7 </span><span class="error">class TrailingWhitespacePositive {</span>
+                <span class="lineno">   8 </span>    // reports 1 - line with just one tab
+                <span class="lineno">   9 </span>
+                <span class="lineno">  10 </span>    // reports 1
+                </code></pre>
+                </div>
+
+                """.trimIndent()
+            )
+        }
+
+        it("part of line") {
+            val snippet = createHTML().div() {
+                snippetCode(code.asSequence(), SourceLocation(7, 7), 26)
+            }
+
+            assertThat(snippet).isEqualTo("""
+                <div>
+                  <pre><code><span class="lineno">   4 </span>// reports 1 - a comment with trailing space
+                <span class="lineno">   5 </span>// A comment
+                <span class="lineno">   6 </span>// reports 1
+                <span class="lineno">   7 </span>class <span class="error">TrailingWhitespacePositive</span> {
+                <span class="lineno">   8 </span>    // reports 1 - line with just one tab
+                <span class="lineno">   9 </span>
+                <span class="lineno">  10 </span>    // reports 1
+                </code></pre>
+                </div>
+
+                """.trimIndent()
+            )
+        }
+
+        it("more than one line") {
+            val snippet = createHTML().div() {
+                snippetCode(code.asSequence(), SourceLocation(7, 7), 66)
+            }
+
+            assertThat(snippet).isEqualTo("""
+                <div>
+                  <pre><code><span class="lineno">   4 </span>// reports 1 - a comment with trailing space
+                <span class="lineno">   5 </span>// A comment
+                <span class="lineno">   6 </span>// reports 1
+                <span class="lineno">   7 </span>class <span class="error">TrailingWhitespacePositive {</span>
+                <span class="lineno">   8 </span><span class="error">    // reports 1 - line with just one</span> tab
+                <span class="lineno">   9 </span>
+                <span class="lineno">  10 </span>    // reports 1
+                </code></pre>
+                </div>
+
+                """.trimIndent()
+            )
+        }
+
+        it("first line") {
+            val snippet = createHTML().div() {
+                snippetCode(code.asSequence(), SourceLocation(1, 1), 13)
+            }
+
+            assertThat(snippet).isEqualTo("""
+                <div>
+                  <pre><code><span class="lineno">   1 </span><span class="error">package cases</span>
+                <span class="lineno">   2 </span>// reports 1 - line with just one space
+                <span class="lineno">   3 </span>
+                <span class="lineno">   4 </span>// reports 1 - a comment with trailing space
+                </code></pre>
+                </div>
+
+                """.trimIndent()
+            )
+        }
+
+        it("second line") {
+            val snippet = createHTML().div() {
+                snippetCode(code.asSequence(), SourceLocation(2, 1), 39)
+            }
+
+            assertThat(snippet).isEqualTo("""
+                <div>
+                  <pre><code><span class="lineno">   1 </span>package cases
+                <span class="lineno">   2 </span><span class="error">// reports 1 - line with just one space</span>
+                <span class="lineno">   3 </span>
+                <span class="lineno">   4 </span>// reports 1 - a comment with trailing space
+                <span class="lineno">   5 </span>// A comment
+                </code></pre>
+                </div>
+
+                """.trimIndent()
+            )
+        }
+
+        it("penultimate line") {
+            val snippet = createHTML().div() {
+                snippetCode(code.asSequence(), SourceLocation(15, 1), 1)
+            }
+
+            assertThat(snippet).isEqualTo("""
+                <div>
+                  <pre><code><span class="lineno">  12 </span>        // reports 1 - line with 1 trailing tab
+                <span class="lineno">  13 </span>        println(&quot;A message&quot;)
+                <span class="lineno">  14 </span>    // reports 1
+                <span class="lineno">  15 </span><span class="error"> </span>   }
+                <span class="lineno">  16 </span>}
+                </code></pre>
+                </div>
+
+                """.trimIndent()
+            )
+        }
+
+        it("last line") {
+            val snippet = createHTML().div() {
+                snippetCode(code.asSequence(), SourceLocation(16, 1), 1)
+            }
+
+            assertThat(snippet).isEqualTo("""
+                <div>
+                  <pre><code><span class="lineno">  13 </span>        println(&quot;A message&quot;)
+                <span class="lineno">  14 </span>    // reports 1
+                <span class="lineno">  15 </span>    }
+                <span class="lineno">  16 </span><span class="error">}</span>
+                </code></pre>
+                </div>
+
+                """.trimIndent()
+            )
+        }
+    }
+})

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtilsTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtilsTest.kt
@@ -94,39 +94,18 @@ class HtmlUtilsTest : Spek({
 
         it("first line") {
             val snippet = createHTML().div() {
-                snippetCode(code.asSequence(), SourceLocation(1, 1), 13)
+                snippetCode(code.asSequence(), SourceLocation(1, 1), 1)
             }
 
-            assertThat(snippet).isEqualTo("""
-                <div>
-                  <pre><code><span class="lineno">   1 </span><span class="error">package cases</span>
-                <span class="lineno">   2 </span>// reports 1 - line with just one space
-                <span class="lineno">   3 </span>
-                <span class="lineno">   4 </span>// reports 1 - a comment with trailing space
-                </code></pre>
-                </div>
-
-                """.trimIndent()
-            )
+            assertThat(snippet).contains((1..4).map { "  $it " })
         }
 
         it("second line") {
             val snippet = createHTML().div() {
-                snippetCode(code.asSequence(), SourceLocation(2, 1), 39)
+                snippetCode(code.asSequence(), SourceLocation(2, 1), 1)
             }
 
-            assertThat(snippet).isEqualTo("""
-                <div>
-                  <pre><code><span class="lineno">   1 </span>package cases
-                <span class="lineno">   2 </span><span class="error">// reports 1 - line with just one space</span>
-                <span class="lineno">   3 </span>
-                <span class="lineno">   4 </span>// reports 1 - a comment with trailing space
-                <span class="lineno">   5 </span>// A comment
-                </code></pre>
-                </div>
-
-                """.trimIndent()
-            )
+            assertThat(snippet).contains((1..5).map { "  $it " })
         }
 
         it("penultimate line") {
@@ -134,18 +113,7 @@ class HtmlUtilsTest : Spek({
                 snippetCode(code.asSequence(), SourceLocation(15, 1), 1)
             }
 
-            assertThat(snippet).isEqualTo("""
-                <div>
-                  <pre><code><span class="lineno">  12 </span>        // reports 1 - line with 1 trailing tab
-                <span class="lineno">  13 </span>        println(&quot;A message&quot;)
-                <span class="lineno">  14 </span>    // reports 1
-                <span class="lineno">  15 </span><span class="error"> </span>   }
-                <span class="lineno">  16 </span>}
-                </code></pre>
-                </div>
-
-                """.trimIndent()
-            )
+            assertThat(snippet).contains((12..16).map { "  $it " })
         }
 
         it("last line") {
@@ -153,17 +121,7 @@ class HtmlUtilsTest : Spek({
                 snippetCode(code.asSequence(), SourceLocation(16, 1), 1)
             }
 
-            assertThat(snippet).isEqualTo("""
-                <div>
-                  <pre><code><span class="lineno">  13 </span>        println(&quot;A message&quot;)
-                <span class="lineno">  14 </span>    // reports 1
-                <span class="lineno">  15 </span>    }
-                <span class="lineno">  16 </span><span class="error">}</span>
-                </code></pre>
-                </div>
-
-                """.trimIndent()
-            )
+            assertThat(snippet).contains((13..16).map { "  $it " })
         }
     }
 })

--- a/detekt-cli/src/test/resources/reports/HtmlOutputFormatTest.html
+++ b/detekt-cli/src/test/resources/reports/HtmlOutputFormatTest.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>detekt report</title>
+    <style>
+h2 {
+  background-color: #666666;
+  padding: 0.2em;
+  color: #ffffff;
+}
+h3 {
+  background-color:#f8dfdf;
+  padding:0.5em;
+}
+.rule {
+  background-color: #dddddd;
+  padding: 0.3em;
+  font-weight: bold;
+}
+.description {
+  color:#000000;
+  padding:0.3em;
+}
+.location {
+  color: #690505;
+  font-family: monospace;
+}
+.message {
+  font-size: 0.8em;
+  color: #444444;
+}
+.rule-container {
+  border: 0.1em dashed #dddddd;
+  padding: 0.1em;
+  line-height: 1.5em;
+  margin-bottom: 8px;
+  margin-top: 8px;
+}
+pre {
+  border: 1px solid #e0e0e0;
+  overflow: scroll;
+}
+.lineno {
+  color: #999999;
+  background-color: #f0f0f0;
+}
+.error {
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4AwCFR4T/3uLMgAAADxJREFUCNdNyLERQEAABMCjL4lQwIzcjErpguAL+C9AvgKJDbeD/PRpLdm35Hm+MU+cB+tCKaJW4L4YBy+CAiLJrFs9mgAAAABJRU5ErkJggg==) bottom repeat-x;
+}
+</style>
+</head>
+<body>
+
+<h1>detekt report</h1>
+
+<h2>Metrics</h2>
+
+<div>
+  <ul></ul>
+</div>
+
+
+<h2>Findings</h2>
+<div>
+  <h3>id_a</h3>
+  <details id="id_a" open="open">
+    <summary class="rule-container"><span class="rule">id_a </span><span class="description">A1</span></summary>
+    <ul>
+      <li><span class="location">src/main/com/sample/Sample1.kt:11:1</span><br><span class="message">B1</span></li>
+    </ul>
+  </details>
+  <h3>id_b</h3>
+  <details id="id_b" open="open">
+    <summary class="rule-container"><span class="rule">id_b </span><span class="description">A2</span></summary>
+    <ul>
+      <li><span class="location">src/main/com/sample/Sample2.kt:22:2</span><br><span class="message">B2</span></li>
+    </ul>
+  </details>
+  <h3>id_c</h3>
+  <details id="id_c" open="open">
+    <summary class="rule-container"><span class="rule">id_c </span><span class="description">A3</span></summary>
+    <ul>
+      <li><span class="location">src/main/com/sample/Sample3.kt:33:3</span><br><span class="message">B3</span></li>
+    </ul>
+  </details>
+</div>
+
+
+</body>
+</html>

--- a/detekt-cli/src/test/resources/reports/HtmlOutputFormatTest.html
+++ b/detekt-cli/src/test/resources/reports/HtmlOutputFormatTest.html
@@ -67,13 +67,15 @@ pre {
   <details id="id_a" open="open">
     <summary class="rule-container"><span class="rule">id_a </span><span class="description">A1</span></summary>
     <ul>
-      <li><span class="location">src/main/com/sample/Sample1.kt:11:1</span><br><span class="message">B1</span></li>
-    </ul>
-  </details>
-  <h3>id_b</h3>
-  <details id="id_b" open="open">
-    <summary class="rule-container"><span class="rule">id_b </span><span class="description">A2</span></summary>
-    <ul>
+      <li><span class="location">src/main/com/sample/Sample1.kt:11:1</span><br><span class="message">B1</span>
+        <pre><code><span class="lineno">   8 </span>
+<span class="lineno">   9 </span>
+<span class="lineno">  10 </span>
+<span class="lineno">  11 </span><span class="error">abcd</span>ef
+<span class="lineno">  12 </span>hi
+<span class="lineno">  13 </span>
+</code></pre>
+      </li>
       <li><span class="location">src/main/com/sample/Sample2.kt:22:2</span><br><span class="message">B2</span></li>
     </ul>
   </details>
@@ -81,7 +83,7 @@ pre {
   <details id="id_c" open="open">
     <summary class="rule-container"><span class="rule">id_c </span><span class="description">A3</span></summary>
     <ul>
-      <li><span class="location">src/main/com/sample/Sample3.kt:33:3</span><br><span class="message">B3</span></li>
+      <li><span class="location">src/main/com/sample/Sample3.kt:33:3</span></li>
     </ul>
   </details>
 </div>


### PR DESCRIPTION
I'm trying to solve #1779

For get this done I added `kotlinx.html` library, I hope it's ok.

This implemetation is **really** basic. It creates things like this:

<img width="1039" alt="Captura de pantalla 2019-10-03 a las 17 34 13" src="https://user-images.githubusercontent.com/721244/66141508-151d2500-e604-11e9-90cb-7675edba2401.png">

Problems that I see and I want some feedback:
- ~I'm not using any prettify library to give a bit of color to the code~ out of scope
- ~I don't know what to test exactly~
- ~I'm opening the file directly from the path... This have problems, for example for testing because the files doesn't exist. The `if (file.exist())` is a workaround, we should look for a good solution~
- ~If the error is in more than one line I just highlight the first line.~
- For some rules the snippet has no sense at all so we are wasting scroll space. We should have something to decide if we want to show the snippet or not.

On the other hand I copy&pasted some html code from the android linter. I don't know how to point that out in the code.