### PR TITLE
Fix EnumNaming textLocation

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
@@ -30,7 +30,7 @@ class EnumNaming(config: Config = Config.empty) : Rule(config) {
         if (!enumEntry.identifierName().matches(enumEntryPattern)) {
             report(CodeSmell(
                     issue,
-                    Entity.from(enumEntry),
+                    Entity.from(enumEntry.nameIdentifier ?: enumEntry),
                     message = "Enum entry names should match the pattern: $enumEntryPattern"))
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -27,5 +27,16 @@ class EnumNamingSpec : Spek({
                 }"""
             assertThat(NamingRules().compileAndLint(code)).hasSize(1)
         }
+
+        it("reports the correct text location in enum name") {
+            val code = """
+                enum class WorkFlow {
+                    _Default,
+                }"""
+            val findings = NamingRules().compileAndLint(code)
+            val source = findings.first().location.text
+            assertThat(source.start).isEqualTo(26)
+            assertThat(source.end).isEqualTo(34)
+        }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ParameterNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ParameterNamingSpec.kt
@@ -33,6 +33,16 @@ class ParameterNamingSpec : Spek({
             """
             assertThat(NamingRules().lint(code)).hasSize(5)
         }
+
+        it("should find a violation in the correct text locaction") {
+            val code = """
+                class C(val PARAM: String)
+            """
+            val findings = NamingRules().lint(code)
+            val source = findings.first().location.text
+            assertThat(source.start).isEqualTo(8)
+            assertThat(source.end).isEqualTo(25)
+        }
     }
 
     describe("parameters in a function of a class") {


### PR DESCRIPTION
I'm finding some problems with the `textLocation` thanks to #1975. This is one of them.

I added two tests becase my first try to fix this bug broke that other part.