### PR TITLE
Findings assertions

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -42,9 +42,7 @@ class EnumNamingSpec : Spek({
                     _Default,
                 }"""
             val findings = NamingRules().compileAndLint(code)
-            val source = findings.first().location.text
-            assertThat(source.start).isEqualTo(26)
-            assertThat(source.end).isEqualTo(34)
+            assertThat(findings).hasTextLocations(26 to 34)
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ParameterNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ParameterNamingSpec.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -39,9 +39,7 @@ class ParameterNamingSpec : Spek({
                 class C(val PARAM: String)
             """
             val findings = NamingRules().lint(code)
-            val source = findings.first().location.text
-            assertThat(source.start).isEqualTo(8)
-            assertThat(source.end).isEqualTo(25)
+            assertThat(findings).hasTextLocations(8 to 25)
         }
     }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -1,10 +1,11 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.compileForTest
-import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -183,9 +184,7 @@ class MaxLineLengthSpec : Spek({
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(1)
-                val findingSource = rule.findings[0].location.source
-                assertThat(findingSource.line).isEqualTo(6)
-                assertThat(findingSource.column).isEqualTo(17)
+                assertThat(rule.findings).hasSourceLocations(SourceLocation(6, 17))
             }
         }
     }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.test
 
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.api.TextLocation
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.api.AbstractListAssert
 import org.assertj.core.util.Objects.areEqual
@@ -54,6 +55,22 @@ class FindingsAssert(actual: List<Finding>) :
 
         if (!areEqual(actualSources.toList(), expectedSources.toList())) {
             failWithMessage("Expected source locations to be ${expectedSources.toList()} but was ${actualSources.toList()}")
+        }
+    }
+
+    fun hasTextLocations(vararg expected: Pair<Int, Int>) = apply {
+        isNotNull
+
+        val actualSources = actual.asSequence()
+                .map { it.location.text }
+                .sortedWith(compareBy({ it.start }, { it.end }))
+
+        val expectedSources = expected.asSequence()
+                .map { (start, end) -> TextLocation(start, end) }
+                .sortedWith(compareBy({ it.start }, { it.end }))
+
+        if (!areEqual(actualSources.toList(), expectedSources.toList())) {
+            failWithMessage("Expected text locations to be ${expectedSources.toList()} but was ${actualSources.toList()}")
         }
     }
 }


### PR DESCRIPTION
This PR adds the functions `hasTextLocation` to be used in the tests. And refactor other point of the tests to use the assertion (already created) `hasSourceLocations`.