### PR TITLE
Use config parameter for UseIfInsteadOfWhen rule

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -117,7 +117,7 @@ class StyleGuideProvider : RuleSetProvider {
                 UnderscoresInNumericLiterals(config),
                 UseRequire(config),
                 UseCheckOrError(config),
-                UseIfInsteadOfWhen(),
+                UseIfInsteadOfWhen(config),
                 RedundantExplicitType(config),
                 LibraryCodeMustSpecifyReturnType(config),
                 UseArrayLiteralsInAnnotations(config)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
@@ -24,7 +25,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  * if (x == null) true else false
  * </compliant>
  */
-class UseIfInsteadOfWhen : Rule() {
+class UseIfInsteadOfWhen(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue("UseIfInsteadOfWhen",
             Severity.Style,

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RuleProviderConfigTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RuleProviderConfigTest.kt
@@ -18,7 +18,7 @@ class RuleProviderConfigTest : Spek({
             val providers = reflections.getSubTypesOf(RuleSetProvider::class.java)
 
             providers.forEach {
-                val provider = it.newInstance()
+                val provider = it.getDeclaredConstructor().newInstance()
                 val ruleSet = provider.instance(config)
                 ruleSet.rules.forEach { baseRule ->
                     val rule = baseRule as? Rule

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RuleProviderConfigTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RuleProviderConfigTest.kt
@@ -1,0 +1,34 @@
+package io.gitlab.arturbosch.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.reflections.Reflections
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class RuleProviderConfigTest : Spek({
+
+    describe("RuleProvider config test") {
+
+        it("should test if the config has been passed to all rules") {
+            val config = TestConfig()
+            val reflections = Reflections("io.gitlab.arturbosch.detekt.rules.providers")
+            val providers = reflections.getSubTypesOf(RuleSetProvider::class.java)
+
+            providers.forEach {
+                val provider = it.newInstance()
+                val ruleSet = provider.instance(config)
+                ruleSet.rules.forEach { baseRule ->
+                    val rule = baseRule as? Rule
+                    if (rule != null) {
+                        assertThat(rule.ruleSetConfig)
+                            .withFailMessage("No config was passed to ${rule.javaClass.name}")
+                            .isEqualTo(config)
+                    }
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
Deactivating the UseIfInsteadOfWhen rule had no effect, since the config
parameter was missing for the rule.
Fixes #1986