### PR TITLE
Better handling for the Suppresion of errors

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.internal.searchClass
 import io.gitlab.arturbosch.detekt.api.internal.searchName
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 
 /**
  * Stores information about a specific code fragment.
@@ -27,7 +28,8 @@ data class Entity(
             val name = element.searchName()
             val signature = element.buildFullSignature()
             val clazz = element.searchClass()
-            return Entity(name, clazz, signature, Location.from(element, offset), element as? KtElement)
+            val ktElement = element.getNonStrictParentOfType<KtElement>()!!
+            return Entity(name, clazz, signature, Location.from(element, offset), ktElement)
         }
     }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -28,6 +28,14 @@ class EnumNamingSpec : Spek({
             assertThat(NamingRules().compileAndLint(code)).hasSize(1)
         }
 
+        it("no reports an underscore in enum name because it's suppressed") {
+            val code = """
+                enum class WorkFlow {
+                    @Suppress("EnumNaming") _Default
+                }"""
+            assertThat(NamingRules().compileAndLint(code)).isEmpty()
+        }
+
         it("reports the correct text location in enum name") {
             val code = """
                 enum class WorkFlow {


### PR DESCRIPTION
I added a regresion with #1977. Luckly it was not released yet.

`enumEntry.nameIdentifier` is not a `KtElement` so it's not setted in the `Entity.ktElement`. Right now the only use of that the `KtElement` is to check if there is a `@Suppress` annotation. So if it was null, you can't `@Suppress`. With this PR I fix that.

I'm fixing more than that so, please, check if this is correct. What I'm doing is that, instead of checking if the current element is a `KtElement` I look for the nearest `KtElement` parent. This way, other warnings as `SpacingBetweenPackageAndImports` can use `@Supress` too.

Maybe I'm breaking the API for the plugins. If you think so, I can implement this without any api change.