### PR TITLE
Ignore sealed classes for utility class having public constructor rule

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
@@ -65,9 +65,7 @@ class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(co
             Debt.FIVE_MINS)
 
     override fun visitClass(klass: KtClass) {
-        if (!klass.isInterface() &&
-                !klass.superTypeListEntries.any() &&
-                !klass.isAnnotation()) {
+        if (canBeCheckedForUtilityClass(klass)) {
             val utilityClassConstructor = UtilityClassConstructor(klass)
             val declarations = klass.body?.declarations
             if (hasOnlyUtilityClassMembers(declarations)) {
@@ -82,6 +80,13 @@ class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(co
             }
         }
         super.visitClass(klass)
+    }
+
+    private fun canBeCheckedForUtilityClass(klass: KtClass): Boolean {
+        return !klass.isInterface() &&
+                !klass.superTypeListEntries.any() &&
+                !klass.isAnnotation() &&
+                !klass.isSealed()
     }
 
     private fun hasOnlyUtilityClassMembers(declarations: List<KtDeclaration>?): Boolean {

--- a/detekt-rules/src/test/resources/cases/UtilityClassesPositive.kt
+++ b/detekt-rules/src/test/resources/cases/UtilityClassesPositive.kt
@@ -45,3 +45,18 @@ open class OpenUtilityClass { // violation - utility class should be final
         val C = 0
     }
 }
+
+sealed class SealedParent {
+    companion object {
+        fun create(foo: Int?, bar: String?): SealedParent? =
+            when {
+                foo != null -> FooChild(foo)
+                bar != null -> BarChild(bar)
+                else -> null
+            }
+    }
+}
+
+data class FooChild(val foo: Int) : SealedParent()
+
+data class BarChild(val bar: String) : SealedParent()


### PR DESCRIPTION
Fixes [#2005 ](https://github.com/arturbosch/detekt/issues/2005)

- Skipped sealed classes from utility class check for having public constructor