### PR TITLE
Don't allow to use underscores and lowercases at the same time in names

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -300,7 +300,7 @@ naming:
   EnumNaming:
     active: true
     excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
-    enumEntryPattern: '^[A-Z][_a-zA-Z0-9]*'
+    enumEntryPattern: '[A-Z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'
   ForbiddenClassName:
     active: false
     excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
@@ -336,9 +336,9 @@ naming:
   ObjectPropertyNaming:
     active: true
     excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
-    constantPattern: '[A-Za-z][_A-Za-z0-9]*'
-    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
-    privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
+    constantPattern: '[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'
+    propertyPattern: '[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'
+    privatePropertyPattern: '_?[a-z][A-Za-z0-9]*|_?[A-Z][_A-Z0-9]*'
   PackageNaming:
     active: true
     excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
@@ -347,8 +347,8 @@ naming:
     active: true
     excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
     constantPattern: '[A-Z][_A-Z0-9]*'
-    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
-    privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
+    propertyPattern: '[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'
+    privatePropertyPattern: '_?[a-z][A-Za-z0-9]*|_?[A-Z][_A-Z0-9]*'
   VariableMaxLength:
     active: false
     excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
 /**
  * Reports when enum names which do not follow the specified naming convention are used.
  *
- * @configuration enumEntryPattern - naming pattern (default: `'^[A-Z][_a-zA-Z0-9]*'`)
+ * @configuration enumEntryPattern - naming pattern (default: `'[A-Z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'`)
  * @active since v1.0.0
  */
 class EnumNaming(config: Config = Config.empty) : Rule(config) {
@@ -24,7 +24,7 @@ class EnumNaming(config: Config = Config.empty) : Rule(config) {
             "Enum names should follow the naming convention set in the projects configuration.",
             debt = Debt.FIVE_MINS)
 
-    private val enumEntryPattern by LazyRegex(ENUM_PATTERN, "^[A-Z][_a-zA-Z0-9]*")
+    private val enumEntryPattern by LazyRegex(ENUM_PATTERN, "[A-Z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*")
 
     override fun visitEnumEntry(enumEntry: KtEnumEntry) {
         if (!enumEntry.identifierName().matches(enumEntryPattern)) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
@@ -16,9 +16,9 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 /**
  * Reports when property names inside objects which do not follow the specified naming convention are used.
  *
- * @configuration constantPattern - naming pattern (default: `'[A-Za-z][_A-Za-z0-9]*'`)
- * @configuration propertyPattern - naming pattern (default: `'[A-Za-z][_A-Za-z0-9]*'`)
- * @configuration privatePropertyPattern - naming pattern (default: `'(_)?[A-Za-z][_A-Za-z0-9]*'`)
+ * @configuration constantPattern - naming pattern (default: `'[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'`)
+ * @configuration propertyPattern - naming pattern (default: `'[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'`)
+ * @configuration privatePropertyPattern - naming pattern (default: `'_?[a-z][A-Za-z0-9]*|_?[A-Z][_A-Z0-9]*'`)
  * @active since v1.0.0
  */
 class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
@@ -28,9 +28,9 @@ class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
             "Property names inside objects should follow the naming convention set in the projects configuration.",
             debt = Debt.FIVE_MINS)
 
-    private val constantPattern by LazyRegex(CONSTANT_PATTERN, "[A-Za-z][_A-Za-z0-9]*")
-    private val propertyPattern by LazyRegex(PROPERTY_PATTERN, "[A-Za-z][_A-Za-z0-9]*")
-    private val privatePropertyPattern by LazyRegex(PRIVATE_PROPERTY_PATTERN, "(_)?[A-Za-z][_A-Za-z0-9]*")
+    private val constantPattern by LazyRegex(CONSTANT_PATTERN, "[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*")
+    private val propertyPattern by LazyRegex(PROPERTY_PATTERN, "[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*")
+    private val privatePropertyPattern by LazyRegex(PRIVATE_PROPERTY_PATTERN, "_?[a-z][A-Za-z0-9]*|_?[A-Z][_A-Z0-9]*")
 
     override fun visitProperty(property: KtProperty) {
         if (property.isLocal) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
@@ -17,8 +17,8 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  * Reports when top level constant names which do not follow the specified naming convention are used.
  *
  * @configuration constantPattern - naming pattern (default: `'[A-Z][_A-Z0-9]*'`)
- * @configuration propertyPattern - naming pattern (default: `'[A-Za-z][_A-Za-z0-9]*'`)
- * @configuration privatePropertyPattern - naming pattern (default: `'_?[A-Za-z][_A-Za-z0-9]*'`)
+ * @configuration propertyPattern - naming pattern (default: `'[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'`)
+ * @configuration privatePropertyPattern - naming pattern (default: `'_?[a-z][A-Za-z0-9]*|_?[A-Z][_A-Z0-9]*'`)
  *
  * @active since v1.0.0
  */
@@ -30,8 +30,8 @@ class TopLevelPropertyNaming(config: Config = Config.empty) : Rule(config) {
             debt = Debt.FIVE_MINS)
 
     private val constantPattern by LazyRegex(CONSTANT_PATTERN, "[A-Z][_A-Z0-9]*")
-    private val propertyPattern by LazyRegex(PROPERTY_PATTERN, "[A-Za-z][_A-Za-z0-9]*")
-    private val privatePropertyPattern by LazyRegex(PRIVATE_PROPERTY_PATTERN, "_?[A-Za-z][_A-Za-z0-9]*")
+    private val propertyPattern by LazyRegex(PROPERTY_PATTERN, "[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*")
+    private val privatePropertyPattern by LazyRegex(PRIVATE_PROPERTY_PATTERN, "_?[a-z][A-Za-z0-9]*|_?[A-Z][_A-Z0-9]*")
 
     override fun visitProperty(property: KtProperty) {
         if (property.isConstant()) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -20,6 +20,14 @@ class EnumNamingSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
+        it("enum name that uses lowercases and undescores") {
+            val code = """
+                enum class WorkFlow {
+                    Def_AULT
+                }"""
+            assertThat(NamingRules().compileAndLint(code)).hasSize(1)
+        }
+
         it("enum name that start with lowercase") {
             val code = """
                 enum class WorkFlow {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -20,6 +20,14 @@ class EnumNamingSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
+        it("enum name that start with lowercase") {
+            val code = """
+                enum class WorkFlow {
+                    default
+                }"""
+            assertThat(NamingRules().compileAndLint(code)).hasSize(1)
+        }
+
         it("reports an underscore in enum name") {
             val code = """
                 enum class WorkFlow {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -130,7 +130,7 @@ class ObjectPropertyNamingSpec : Spek({
 
         val subject by memoized { ObjectPropertyNaming() }
 
-        it("should not detect public constants complying to the naming rules") {
+        it("should not detect public variables complying to the naming rules") {
             val code = compileContentForTest("""
                 object O {
                     ${PublicVal.negative}
@@ -139,7 +139,7 @@ class ObjectPropertyNamingSpec : Spek({
             assertThat(subject.lint(code)).isEmpty()
         }
 
-        it("should detect public constants not complying to the naming rules") {
+        it("should detect public variables not complying to the naming rules") {
             val code = compileContentForTest("""
                 object O {
                     ${PublicVal.positive}
@@ -148,7 +148,7 @@ class ObjectPropertyNamingSpec : Spek({
             assertThat(subject.lint(code)).hasSize(1)
         }
 
-        it("should not detect private constants complying to the naming rules") {
+        it("should not detect private variables complying to the naming rules") {
             val code = compileContentForTest("""
                 object O {
                     ${PrivateVal.negative}
@@ -157,7 +157,7 @@ class ObjectPropertyNamingSpec : Spek({
             assertThat(subject.lint(code)).isEmpty()
         }
 
-        it("should detect private constants not complying to the naming rules") {
+        it("should detect private variables not complying to the naming rules") {
             val code = compileContentForTest("""
                 object O {
                     private val __NAME = "Artur"

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -157,13 +157,26 @@ class ObjectPropertyNamingSpec : Spek({
             assertThat(subject.lint(code)).isEmpty()
         }
 
+        it("should detect variables not complying to the naming rules") {
+            val code = compileContentForTest("""
+                object O {
+                    val MyNAME = "Artur"
+                    val n_a_m_e = "Artur"
+                }
+            """)
+            assertThat(subject.lint(code)).hasSize(2)
+        }
+
         it("should detect private variables not complying to the naming rules") {
             val code = compileContentForTest("""
                 object O {
                     private val __NAME = "Artur"
+                    private val MyNAME = "Artur"
+                    private val n_a_m_e = "Artur"
+                    private val _MY_NAME = "Artur"
                 }
             """)
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(3)
         }
     }
 
@@ -221,7 +234,6 @@ abstract class NamingSnippet(private val isPrivate: Boolean, private val isConst
     val negative = """
                     ${visibility()}${const()}val MY_NAME_8 = "Artur"
                     ${visibility()}${const()}val MYNAME = "Artur"
-                    ${visibility()}${const()}val MyNAME = "Artur"
                     ${visibility()}${const()}val name = "Artur"
                     ${visibility()}${const()}val nAme = "Artur"
                     ${visibility()}${const()}val serialVersionUID = 42L"""

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -42,10 +42,9 @@ class TopLevelPropertyNamingSpec : Spek({
                 val serialVersionUID = 42L
                 val MY_NAME = "Artur"
                 val MYNAME = "Artur"
-                val MyNAME = "Artur"
                 private val NAME = "Artur"
-                val s_d_d_1 = listOf("")
                 private val INTERNAL_VERSION = "1.0.0"
+                private val _INTERNAL_VERSION = "1.0.0"
             """)
             assertThat(subject.lint(code)).hasSize(0)
         }
@@ -61,7 +60,35 @@ class TopLevelPropertyNamingSpec : Spek({
             val code = compileContentForTest("""
                 private val __NAME = "Artur"
             """)
-            io.gitlab.arturbosch.detekt.test.assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
+        }
+
+        it("should report top level property using lowercases and underscores") {
+            val code = compileContentForTest("""
+                val s_d_d_1 = listOf("")
+            """)
+            assertThat(subject.lint(code)).hasSize(1)
+        }
+
+        it("should report private top level property using lowercases and underscores") {
+            val code = compileContentForTest("""
+                private val s_d_d_1 = listOf("")
+            """)
+            assertThat(subject.lint(code)).hasSize(1)
+        }
+
+        it("should report top level property starting with upercase and then using lowercases") {
+            val code = compileContentForTest("""
+                val MyNAME = "Artur"
+            """)
+            assertThat(subject.lint(code)).hasSize(1)
+        }
+
+        it("should report private top level property starting with upercase and then using lowercases") {
+            val code = compileContentForTest("""
+                private val MyNAME = "Artur"
+            """)
+            assertThat(subject.lint(code)).hasSize(1)
         }
     }
 })

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -54,7 +54,7 @@ Reports when enum names which do not follow the specified naming convention are 
 
 #### Configuration options:
 
-* `enumEntryPattern` (default: `'^[A-Z][_a-zA-Z0-9]*'`)
+* `enumEntryPattern` (default: `'[A-Z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'`)
 
    naming pattern
 
@@ -255,15 +255,15 @@ Reports when property names inside objects which do not follow the specified nam
 
 #### Configuration options:
 
-* `constantPattern` (default: `'[A-Za-z][_A-Za-z0-9]*'`)
+* `constantPattern` (default: `'[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'`)
 
    naming pattern
 
-* `propertyPattern` (default: `'[A-Za-z][_A-Za-z0-9]*'`)
+* `propertyPattern` (default: `'[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'`)
 
    naming pattern
 
-* `privatePropertyPattern` (default: `'(_)?[A-Za-z][_A-Za-z0-9]*'`)
+* `privatePropertyPattern` (default: `'_?[a-z][A-Za-z0-9]*|_?[A-Z][_A-Z0-9]*'`)
 
    naming pattern
 
@@ -295,11 +295,11 @@ Reports when top level constant names which do not follow the specified naming c
 
    naming pattern
 
-* `propertyPattern` (default: `'[A-Za-z][_A-Za-z0-9]*'`)
+* `propertyPattern` (default: `'[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'`)
 
    naming pattern
 
-* `privatePropertyPattern` (default: `'_?[A-Za-z][_A-Za-z0-9]*'`)
+* `privatePropertyPattern` (default: `'_?[a-z][A-Za-z0-9]*|_?[A-Z][_A-Z0-9]*'`)
 
    naming pattern
 


### PR DESCRIPTION
There are places where we allow to use: `thisFormat` or `THIS_FORMAT` but we should never allow to use `This_Format`. This PR fix this issue in the 3 places where we allow the use of `_` in the naming: enums, object properties and top level properties.