### PR TITLE
Use double backtick for the in-line code

### DIFF
--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Markdown.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Markdown.kt
@@ -41,7 +41,7 @@ inline fun MarkdownContent.orderedList(sectionList: () -> List<String>) {
 inline fun MarkdownContent.referenceToHeading(reference: () -> String) =
         "[${reference()}](#${reference().replace(' ', '-').toLowerCase()})"
 
-inline fun MarkdownContent.code(code: () -> String) = "`${code()}`"
+inline fun MarkdownContent.code(code: () -> String) = "``${code()}``"
 inline fun MarkdownContent.codeBlock(code: () -> String) = "```kotlin\n${code()}\n```"
 
 fun MarkdownContent.emptyLine() = append("")

--- a/detekt-generator/src/test/resources/RuleSet.md
+++ b/detekt-generator/src/test/resources/RuleSet.md
@@ -12,7 +12,7 @@ a wildcard import
 
 #### Configuration options:
 
-* `conf1` (default: `foo`)
+* ``conf1`` (default: ``foo``)
 
    a config option
 

--- a/docs/pages/documentation/comments.md
+++ b/docs/pages/documentation/comments.md
@@ -50,7 +50,7 @@ It should end with proper punctuation or with a correct URL.
 
 #### Configuration options:
 
-* `endOfSentenceFormat` (default: `([.?!][ \t\n\r\f<])|([.?!:]$)`)
+* ``endOfSentenceFormat`` (default: ``([.?!][ \t\n\r\f<])|([.?!:]$)``)
 
    regular expression which should match the end of the first sentence in the KDoc
 
@@ -68,19 +68,19 @@ with the configuration options of this rule.
 
 #### Configuration options:
 
-* `searchInNestedClass` (default: `true`)
+* ``searchInNestedClass`` (default: ``true``)
 
    if nested classes should be searched
 
-* `searchInInnerClass` (default: `true`)
+* ``searchInInnerClass`` (default: ``true``)
 
    if inner classes should be searched
 
-* `searchInInnerObject` (default: `true`)
+* ``searchInInnerObject`` (default: ``true``)
 
    if inner objects should be searched
 
-* `searchInInnerInterface` (default: `true`)
+* ``searchInInnerInterface`` (default: ``true``)
 
    if inner interfaces should be searched
 

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -20,7 +20,7 @@ and call those instead.
 
 #### Configuration options:
 
-* `threshold` (default: `4`)
+* ``threshold`` (default: ``4``)
 
    the number of conditions which will trigger the rule
 
@@ -59,11 +59,11 @@ to understand and implement.
 
 #### Configuration options:
 
-* `threshold` (default: `10`)
+* ``threshold`` (default: ``10``)
 
    the amount of definitions in an interface to trigger the rule
 
-* `includeStaticDeclarations` (default: `false`)
+* ``includeStaticDeclarations`` (default: ``false``)
 
    whether static declarations should be included
 
@@ -91,15 +91,15 @@ Each one of them adds one to the complexity count.
 
 #### Configuration options:
 
-* `threshold` (default: `10`)
+* ``threshold`` (default: ``10``)
 
    McCabe's Cyclomatic Complexity (MCC) number for a method
 
-* `ignoreSingleWhenExpression` (default: `false`)
+* ``ignoreSingleWhenExpression`` (default: ``false``)
 
    Ignores a complex method if it only contains a single when expression.
 
-* `ignoreSimpleWhenEntries` (default: `false`)
+* ``ignoreSimpleWhenEntries`` (default: ``false``)
 
    Whether to ignore simple (braceless) when entries.
 
@@ -116,7 +116,7 @@ way to get the instance of an outer class from an inner class in Kotlin.
 
 #### Configuration options:
 
-* `ignoredLabels` (default: `""`)
+* ``ignoredLabels`` (default: ``""``)
 
    allows to provide a list of label names which should be ignored by this rule
 
@@ -172,7 +172,7 @@ things.
 
 #### Configuration options:
 
-* `threshold` (default: `600`)
+* ``threshold`` (default: ``600``)
 
    the size of class required to trigger the rule
 
@@ -189,7 +189,7 @@ Extract parts of the functionality of long methods into separate, smaller method
 
 #### Configuration options:
 
-* `threshold` (default: `60`)
+* ``threshold`` (default: ``60``)
 
    number of lines in a method to trigger the rule
 
@@ -203,11 +203,11 @@ Reports functions which have more parameters than a certain threshold (default: 
 
 #### Configuration options:
 
-* `threshold` (default: `6`)
+* ``threshold`` (default: ``6``)
 
    number of parameters required to trigger the rule
 
-* `ignoreDefaultParameters` (default: `false`)
+* ``ignoreDefaultParameters`` (default: ``false``)
 
    ignore parameters that have a default value
 
@@ -224,7 +224,7 @@ Refactor these methods and try to use optional parameters instead to prevent som
 
 #### Configuration options:
 
-* `threshold` (default: `6`)
+* ``threshold`` (default: ``6``)
 
    number of overloads which will trigger the rule
 
@@ -241,7 +241,7 @@ Prefer extracting the nested code into well-named functions to make it easier to
 
 #### Configuration options:
 
-* `threshold` (default: `4`)
+* ``threshold`` (default: ``4``)
 
    the nested depth required to trigger rule
 
@@ -258,19 +258,19 @@ Instead, prefer extracting the String literal into a property or constant.
 
 #### Configuration options:
 
-* `threshold` (default: `3`)
+* ``threshold`` (default: ``3``)
 
    amount of duplications to trigger rule
 
-* `ignoreAnnotation` (default: `true`)
+* ``ignoreAnnotation`` (default: ``true``)
 
    if values in Annotations should be ignored
 
-* `excludeStringsWithLessThan5Characters` (default: `true`)
+* ``excludeStringsWithLessThan5Characters`` (default: ``true``)
 
    if short strings should be excluded
 
-* `ignoreStringsRegex` (default: `'$^'`)
+* ``ignoreStringsRegex`` (default: ``'$^'``)
 
    RegEx of Strings that should be ignored
 
@@ -312,34 +312,34 @@ which clearly belongs together in separate parts of the code.
 
 #### Configuration options:
 
-* `thresholdInFiles` (default: `11`)
+* ``thresholdInFiles`` (default: ``11``)
 
    threshold in files
 
-* `thresholdInClasses` (default: `11`)
+* ``thresholdInClasses`` (default: ``11``)
 
    threshold in classes
 
-* `thresholdInInterfaces` (default: `11`)
+* ``thresholdInInterfaces`` (default: ``11``)
 
    threshold in interfaces
 
-* `thresholdInObjects` (default: `11`)
+* ``thresholdInObjects`` (default: ``11``)
 
    threshold in objects
 
-* `thresholdInEnums` (default: `11`)
+* ``thresholdInEnums`` (default: ``11``)
 
    threshold in enums
 
-* `ignoreDeprecated` (default: `false`)
+* ``ignoreDeprecated`` (default: ``false``)
 
    ignore deprecated functions
 
-* `ignorePrivate` (default: `false`)
+* ``ignorePrivate`` (default: ``false``)
 
    ignore private functions
 
-* `ignoreOverridden` (default: `false`)
+* ``ignoreOverridden`` (default: ``false``)
 
    ignore overridden functions

--- a/docs/pages/documentation/empty-blocks.md
+++ b/docs/pages/documentation/empty-blocks.md
@@ -19,7 +19,7 @@ Reports empty `catch` blocks. Empty blocks of code serve no purpose and should b
 
 #### Configuration options:
 
-* `allowedExceptionNameRegex` (default: `"^(_|(ignore|expected).*)"`)
+* ``allowedExceptionNameRegex`` (default: ``"^(_|(ignore|expected).*)"``)
 
    ignores exception types which match this regex
 
@@ -86,7 +86,7 @@ functions from the superclass or from an interface (i.e., functions declared wit
 
 #### Configuration options:
 
-* `ignoreOverriddenFunctions` (default: `false`)
+* ``ignoreOverriddenFunctions`` (default: ``false``)
 
    Excludes all the overridden functions
 

--- a/docs/pages/documentation/exceptions.md
+++ b/docs/pages/documentation/exceptions.md
@@ -21,7 +21,7 @@ should not throw any exceptions.
 
 #### Configuration options:
 
-* `methodNames` (default: `'toString,hashCode,equals,finalize'`)
+* ``methodNames`` (default: ``'toString,hashCode,equals,finalize'``)
 
    methods which should not throw exceptions
 
@@ -187,7 +187,7 @@ Using `return` statements in `finally` blocks can discard and hide exceptions th
 
 #### Configuration options:
 
-* `ignoreLabeled` (default: `false`)
+* ``ignoreLabeled`` (default: ``false``)
 
    ignores labeled return statements
 
@@ -214,11 +214,11 @@ passed into a newly thrown exception.
 
 #### Configuration options:
 
-* `ignoredExceptionTypes` (default: `'InterruptedException,NumberFormatException,ParseException,MalformedURLException'`)
+* ``ignoredExceptionTypes`` (default: ``'InterruptedException,NumberFormatException,ParseException,MalformedURLException'``)
 
    exception types which should be ignored by this rule
 
-* `allowedExceptionNameRegex` (default: `"^(_|(ignore|expected).*)"`)
+* ``allowedExceptionNameRegex`` (default: ``"^(_|(ignore|expected).*)"``)
 
    ignores too generic exception types which match this regex
 
@@ -313,7 +313,7 @@ down an underlying issue in a better way.
 
 #### Configuration options:
 
-* `exceptions` (default: `'IllegalArgumentException,IllegalStateException,IOException'`)
+* ``exceptions`` (default: ``'IllegalArgumentException,IllegalStateException,IOException'``)
 
    exceptions which should not be thrown without message or cause
 
@@ -384,18 +384,18 @@ exception is too broad it can lead to unintended exceptions being caught.
 
 #### Configuration options:
 
-* `exceptionNames` (default: `- ArrayIndexOutOfBoundsException
+* ``exceptionNames`` (default: ``- ArrayIndexOutOfBoundsException
     - Error
     - Exception
     - IllegalMonitorStateException
     - NullPointerException
     - IndexOutOfBoundsException
     - RuntimeException
-    - Throwable`)
+    - Throwable``)
 
    exceptions which are too generic and should not be caught
 
-* `allowedExceptionNameRegex` (default: `"^(_|(ignore|expected).*)"`)
+* ``allowedExceptionNameRegex`` (default: ``"^(_|(ignore|expected).*)"``)
 
    ignores too generic exception types which match this regex
 
@@ -430,10 +430,10 @@ exceptions to the case that has currently occurred.
 
 #### Configuration options:
 
-* `exceptionNames` (default: `- Error
+* ``exceptionNames`` (default: ``- Error
     - Exception
     - Throwable
-    - RuntimeException`)
+    - RuntimeException``)
 
    exceptions which are too generic and should not be thrown
 

--- a/docs/pages/documentation/formatting.md
+++ b/docs/pages/documentation/formatting.md
@@ -44,11 +44,11 @@ See <a href="https://ktlint.github.io/#rule-indentation">ktlint-website</a> for 
 
 #### Configuration options:
 
-* `indentSize` (default: `4`)
+* ``indentSize`` (default: ``4``)
 
    indentation size
 
-* `continuationIndentSize` (default: `4`)
+* ``continuationIndentSize`` (default: ``4``)
 
    continuation indentation size
 
@@ -58,7 +58,7 @@ See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
 
 #### Configuration options:
 
-* `maxLineLength` (default: `120`)
+* ``maxLineLength`` (default: ``120``)
 
    maximum line length
 
@@ -124,7 +124,7 @@ See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
 
 #### Configuration options:
 
-* `indentSize` (default: `4`)
+* ``indentSize`` (default: ``4``)
 
    indentation size
 

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -18,7 +18,7 @@ Reports when class or object names which do not follow the specified naming conv
 
 #### Configuration options:
 
-* `classPattern` (default: `'[A-Z$][a-zA-Z0-9$]*'`)
+* ``classPattern`` (default: ``'[A-Z$][a-zA-Z0-9$]*'``)
 
    naming pattern
 
@@ -32,15 +32,15 @@ Reports constructor parameter names which do not follow the specified naming con
 
 #### Configuration options:
 
-* `parameterPattern` (default: `'[a-z][A-Za-z0-9]*'`)
+* ``parameterPattern`` (default: ``'[a-z][A-Za-z0-9]*'``)
 
    naming pattern
 
-* `privateParameterPattern` (default: `'[a-z][A-Za-z0-9]*'`)
+* ``privateParameterPattern`` (default: ``'[a-z][A-Za-z0-9]*'``)
 
    naming pattern
 
-* `excludeClassPattern` (default: `'$^'`)
+* ``excludeClassPattern`` (default: ``'$^'``)
 
    ignores variables in classes which match this regex
 
@@ -54,7 +54,7 @@ Reports when enum names which do not follow the specified naming convention are 
 
 #### Configuration options:
 
-* `enumEntryPattern` (default: `'^[A-Z][_a-zA-Z0-9]*'`)
+* ``enumEntryPattern`` (default: ``'^[A-Z][_a-zA-Z0-9]*'``)
 
    naming pattern
 
@@ -70,7 +70,7 @@ Examples for forbidden names might be too generic class names like `...Manager`.
 
 #### Configuration options:
 
-* `forbiddenName` (default: `''`)
+* ``forbiddenName`` (default: ``''``)
 
    forbidden class names
 
@@ -84,7 +84,7 @@ Reports when very long function names are used.
 
 #### Configuration options:
 
-* `maximumFunctionNameLength` (default: `30`)
+* ``maximumFunctionNameLength`` (default: ``30``)
 
    maximum name length
 
@@ -98,7 +98,7 @@ Reports when very short function names are used.
 
 #### Configuration options:
 
-* `minimumFunctionNameLength` (default: `3`)
+* ``minimumFunctionNameLength`` (default: ``3``)
 
    minimum name length
 
@@ -116,15 +116,15 @@ These factory functions can have the same name as the class being created.
 
 #### Configuration options:
 
-* `functionPattern` (default: `'^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'`)
+* ``functionPattern`` (default: ``'^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'``)
 
    naming pattern
 
-* `excludeClassPattern` (default: `'$^'`)
+* ``excludeClassPattern`` (default: ``'$^'``)
 
    ignores functions in classes which match this regex
 
-* `ignoreOverridden` (default: `true`)
+* ``ignoreOverridden`` (default: ``true``)
 
    ignores functions that have the override modifier
 
@@ -138,15 +138,15 @@ Reports function parameter names which do not follow the specified naming conven
 
 #### Configuration options:
 
-* `parameterPattern` (default: `'[a-z][A-Za-z0-9]*'`)
+* ``parameterPattern`` (default: ``'[a-z][A-Za-z0-9]*'``)
 
    naming pattern
 
-* `excludeClassPattern` (default: `'$^'`)
+* ``excludeClassPattern`` (default: ``'$^'``)
 
    ignores variables in classes which match this regex
 
-* `ignoreOverriddenFunctions` (default: `true`)
+* ``ignoreOverriddenFunctions`` (default: ``true``)
 
    ignores overridden functions with parameters not matching the pattern
 
@@ -160,7 +160,7 @@ Reports when the package declaration is missing or the file location does not ma
 
 #### Configuration options:
 
-* `rootPackage` (default: `''`)
+* ``rootPackage`` (default: ``''``)
 
    if specified this part of the package structure is ignored
 
@@ -213,7 +213,7 @@ Factory functions that create an instance of the class are exempt from this rule
 
 #### Configuration options:
 
-* `ignoreOverriddenFunction` (default: `true`)
+* ``ignoreOverriddenFunction`` (default: ``true``)
 
    if overridden functions should be ignored
 
@@ -255,15 +255,15 @@ Reports when property names inside objects which do not follow the specified nam
 
 #### Configuration options:
 
-* `constantPattern` (default: `'[A-Za-z][_A-Za-z0-9]*'`)
+* ``constantPattern`` (default: ``'[A-Za-z][_A-Za-z0-9]*'``)
 
    naming pattern
 
-* `propertyPattern` (default: `'[A-Za-z][_A-Za-z0-9]*'`)
+* ``propertyPattern`` (default: ``'[A-Za-z][_A-Za-z0-9]*'``)
 
    naming pattern
 
-* `privatePropertyPattern` (default: `'(_)?[A-Za-z][_A-Za-z0-9]*'`)
+* ``privatePropertyPattern`` (default: ``'(_)?[A-Za-z][_A-Za-z0-9]*'``)
 
    naming pattern
 
@@ -277,7 +277,7 @@ Reports when package names which do not follow the specified naming convention a
 
 #### Configuration options:
 
-* `packagePattern` (default: `'^[a-z]+(\.[a-z][A-Za-z0-9]*)*$'`)
+* ``packagePattern`` (default: ``'^[a-z]+(\.[a-z][A-Za-z0-9]*)*$'``)
 
    naming pattern
 
@@ -291,15 +291,15 @@ Reports when top level constant names which do not follow the specified naming c
 
 #### Configuration options:
 
-* `constantPattern` (default: `'[A-Z][_A-Z0-9]*'`)
+* ``constantPattern`` (default: ``'[A-Z][_A-Z0-9]*'``)
 
    naming pattern
 
-* `propertyPattern` (default: `'[A-Za-z][_A-Za-z0-9]*'`)
+* ``propertyPattern`` (default: ``'[A-Za-z][_A-Za-z0-9]*'``)
 
    naming pattern
 
-* `privatePropertyPattern` (default: `'_?[A-Za-z][_A-Za-z0-9]*'`)
+* ``privatePropertyPattern`` (default: ``'_?[A-Za-z][_A-Za-z0-9]*'``)
 
    naming pattern
 
@@ -313,7 +313,7 @@ Reports when very long variable names are used.
 
 #### Configuration options:
 
-* `maximumVariableNameLength` (default: `64`)
+* ``maximumVariableNameLength`` (default: ``64``)
 
    maximum name length
 
@@ -327,7 +327,7 @@ Reports when very short variable names are used.
 
 #### Configuration options:
 
-* `minimumVariableNameLength` (default: `1`)
+* ``minimumVariableNameLength`` (default: ``1``)
 
    maximum name length
 
@@ -341,18 +341,18 @@ Reports when variable names which do not follow the specified naming convention 
 
 #### Configuration options:
 
-* `variablePattern` (default: `'[a-z][A-Za-z0-9]*'`)
+* ``variablePattern`` (default: ``'[a-z][A-Za-z0-9]*'``)
 
    naming pattern
 
-* `privateVariablePattern` (default: `'(_)?[a-z][A-Za-z0-9]*'`)
+* ``privateVariablePattern`` (default: ``'(_)?[a-z][A-Za-z0-9]*'``)
 
    naming pattern
 
-* `excludeClassPattern` (default: `'$^'`)
+* ``excludeClassPattern`` (default: ``'$^'``)
 
    ignores variables in classes which match this regex
 
-* `ignoreOverridden` (default: `true`)
+* ``ignoreOverridden`` (default: ``true``)
 
    ignores member properties that have the override modifier

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -258,12 +258,12 @@ guaranteed. Try using constructor injection or delegation to initialize properti
 
 #### Configuration options:
 
-* `excludeAnnotatedProperties` (default: `""`)
+* ``excludeAnnotatedProperties`` (default: ``""``)
 
    Allows you to provide a list of annotations that disable
 this check.
 
-* `ignoreOnClassesPattern` (default: `""`)
+* ``ignoreOnClassesPattern`` (default: ``""``)
 
    Allows you to disable the rule for a list of classes
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -55,7 +55,7 @@ Data classes will automatically have a generated `equals`, `toString` and `hashC
 
 #### Configuration options:
 
-* `conversionFunctionPrefix` (default: `'to'`)
+* ``conversionFunctionPrefix`` (default: ``'to'``)
 
    allowed conversion function names
 
@@ -197,7 +197,7 @@ cleans up the code.
 
 #### Configuration options:
 
-* `includeLineWrapping` (default: `false`)
+* ``includeLineWrapping`` (default: ``false``)
 
    include return statements with line wraps in it
 
@@ -233,11 +233,11 @@ development. Offending code comments will then be reported.
 
 #### Configuration options:
 
-* `values` (default: `'TODO:,FIXME:,STOPSHIP:'`)
+* ``values`` (default: ``'TODO:,FIXME:,STOPSHIP:'``)
 
    forbidden comment strings
 
-* `allowedPatterns` (default: `""`)
+* ``allowedPatterns`` (default: ``""``)
 
    ignores comments which match the specified regular expression.
 For example `Ticket|Task`.
@@ -260,11 +260,11 @@ or deprecated APIs. Detekt will then report all imports that are forbidden.
 
 #### Configuration options:
 
-* `imports` (default: `''`)
+* ``imports`` (default: ``''``)
 
    imports which should not be used
 
-* `forbiddenPatterns` (default: `""`)
+* ``forbiddenPatterns`` (default: ``""``)
 
    reports imports which match the specified regular expression. For example `net.*R`.
 
@@ -289,11 +289,11 @@ and has only one value - the `Unit` object.
 
 #### Configuration options:
 
-* `ignoreOverridden` (default: `false`)
+* ``ignoreOverridden`` (default: ``false``)
 
    ignores void types in signatures of overridden functions
 
-* `ignoreUsageInGenerics` (default: `false`)
+* ``ignoreUsageInGenerics`` (default: ``false``)
 
    ignore void types as generic arguments
 
@@ -322,15 +322,15 @@ as a `const val`.
 
 #### Configuration options:
 
-* `ignoreOverridableFunction` (default: `true`)
+* ``ignoreOverridableFunction`` (default: ``true``)
 
    if overriden functions should be ignored
 
-* `excludedFunctions` (default: `'describeContents'`)
+* ``excludedFunctions`` (default: ``'describeContents'``)
 
    excluded functions
 
-* `excludeAnnotatedFunction` (default: `"dagger.Provides"`)
+* ``excludeAnnotatedFunction`` (default: ``"dagger.Provides"``)
 
    allows to provide a list of annotations that disable this check
 
@@ -389,7 +389,7 @@ To increase readability they should be refactored into simpler loops.
 
 #### Configuration options:
 
-* `maxJumpCount` (default: `1`)
+* ``maxJumpCount`` (default: ``1``)
 
    maximum allowed jumps in a loop
 
@@ -417,40 +417,40 @@ describing what the magic number means.
 
 #### Configuration options:
 
-* `ignoreNumbers` (default: `'-1,0,1,2'`)
+* ``ignoreNumbers`` (default: ``'-1,0,1,2'``)
 
    numbers which do not count as magic numbers
 
-* `ignoreHashCodeFunction` (default: `true`)
+* ``ignoreHashCodeFunction`` (default: ``true``)
 
    whether magic numbers in hashCode functions should be ignored
 
-* `ignorePropertyDeclaration` (default: `false`)
+* ``ignorePropertyDeclaration`` (default: ``false``)
 
    whether magic numbers in property declarations should be ignored
 
-* `ignoreConstantDeclaration` (default: `true`)
+* ``ignoreConstantDeclaration`` (default: ``true``)
 
    whether magic numbers in property declarations should be ignored
 
-* `ignoreCompanionObjectPropertyDeclaration` (default: `true`)
+* ``ignoreCompanionObjectPropertyDeclaration`` (default: ``true``)
 
    whether magic numbers in companion object
 declarations should be ignored
 
-* `ignoreAnnotation` (default: `false`)
+* ``ignoreAnnotation`` (default: ``false``)
 
    whether magic numbers in annotations should be ignored
 
-* `ignoreNamedArgument` (default: `true`)
+* ``ignoreNamedArgument`` (default: ``true``)
 
    whether magic numbers in named arguments should be ignored
 
-* `ignoreEnums` (default: `false`)
+* ``ignoreEnums`` (default: ``false``)
 
    whether magic numbers in enums should be ignored
 
-* `ignoreRanges` (default: `false`)
+* ``ignoreRanges`` (default: ``false``)
 
    whether magic numbers in ranges should be ignored
 
@@ -522,19 +522,19 @@ in the codebase will help make the code more uniform.
 
 #### Configuration options:
 
-* `maxLineLength` (default: `120`)
+* ``maxLineLength`` (default: ``120``)
 
    maximum line length
 
-* `excludePackageStatements` (default: `true`)
+* ``excludePackageStatements`` (default: ``true``)
 
    if package statements should be ignored
 
-* `excludeImportStatements` (default: `true`)
+* ``excludeImportStatements`` (default: ``true``)
 
    if import statements should be ignored
 
-* `excludeCommentStatements` (default: `false`)
+* ``excludeCommentStatements`` (default: ``false``)
 
    if comment statements should be ignored
 
@@ -827,23 +827,23 @@ code.
 
 #### Configuration options:
 
-* `max` (default: `2`)
+* ``max`` (default: ``2``)
 
    define the maximum number of return statements allowed per function
 
-* `excludedFunctions` (default: `"equals"`)
+* ``excludedFunctions`` (default: ``"equals"``)
 
    define functions to be ignored by this check
 
-* `excludeLabeled` (default: `false`)
+* ``excludeLabeled`` (default: ``false``)
 
    if labeled return statements should be ignored
 
-* `excludeReturnFromLambda` (default: `true`)
+* ``excludeReturnFromLambda`` (default: ``true``)
 
    if labeled return from a lambda should be ignored
 
-* `excludeGuardClauses` (default: `false`)
+* ``excludeGuardClauses`` (default: ``false``)
 
    if true guard clauses at the beginning of a method should be ignored
 
@@ -966,7 +966,7 @@ to confusion. Instead prefer to limit the amount of `throw` statements in a func
 
 #### Configuration options:
 
-* `max` (default: `2`)
+* ``max`` (default: ``2``)
 
    maximum amount of throw statements in a method
 
@@ -1013,7 +1013,7 @@ explicitly ignored. For floats and doubles, anything to the right of the decimal
 
 #### Configuration options:
 
-* `acceptableDecimalLength` (default: `5`)
+* ``acceptableDecimalLength`` (default: ``5``)
 
    Length under which decimal base 10 literals are not required to have
 underscores
@@ -1046,7 +1046,7 @@ refactored into concrete classes.
 
 #### Configuration options:
 
-* `excludeAnnotatedClasses` (default: `"dagger.Module"`)
+* ``excludeAnnotatedClasses`` (default: ``"dagger.Module"``)
 
    Allows you to provide a list of annotations that disable
 this check.
@@ -1235,7 +1235,7 @@ can lead to confusion and potential bugs.
 
 #### Configuration options:
 
-* `allowedNames` (default: `"(_|ignored|expected|serialVersionUID)"`)
+* ``allowedNames`` (default: ``"(_|ignored|expected|serialVersionUID)"``)
 
    unused private member names matching this regex are ignored
 
@@ -1304,11 +1304,11 @@ Read more about `data class`: https://kotlinlang.org/docs/reference/data-classes
 
 #### Configuration options:
 
-* `excludeAnnotatedClasses` (default: `""`)
+* ``excludeAnnotatedClasses`` (default: ``""``)
 
    allows to provide a list of annotations that disable this check
 
-* `allowVars` (default: `false`)
+* ``allowVars`` (default: ``false``)
 
    allows to relax this rule in order to exclude classes that contains one (or more) Vars
 
@@ -1500,7 +1500,7 @@ Therefore if whitelist is needed `NoWildcardImports` rule should be disabled.
 
 #### Configuration options:
 
-* `excludeImports` (default: `'java.util.*,kotlinx.android.synthetic.*'`)
+* ``excludeImports`` (default: ``'java.util.*,kotlinx.android.synthetic.*'``)
 
    Define a whitelist of package names that should be allowed to be imported
 with wildcard imports.


### PR DESCRIPTION
The FunctionNaming regex has the char `` ` `` on it. So [it breaks the documentation formating](https://arturbosch.github.io/detekt/naming.html#functionnaming) and show a different regex: ``.*`` instead of `` `.* ` ``.

Screenshot of the documentation right now:
<img width="523" alt="Captura de pantalla 2019-10-14 a las 14 12 38" src="https://user-images.githubusercontent.com/721244/66750424-b752cd80-ee8c-11e9-9198-494b35f95cea.png">

We can scape the single backtick if we use [double backtick for open and close](https://meta.stackexchange.com/a/82722/191266) the in-line code.