### PR TITLE
Add ImplicitDefaultLocale rule

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -392,6 +392,8 @@ potential-bugs:
     active: true
   HasPlatformType:
     active: false
+  ImplicitDefaultLocale:
+    active: false
   InvalidRange:
     active: false
   IteratorHasNextCallsNextMethod:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
@@ -1,0 +1,60 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.resolve.calls.callUtil.getCalleeExpressionIfAny
+
+/**
+ * Prefer passing [java.util.Locale] explicitly than using implicit default value when formatting
+ * strings.
+ *
+ * The default locale is almost always not appropriate for machine-readable text like HTTP headers.
+ * For example if locale with tag `ar-SA-u-nu-arab` is a current default then `%d` placeholders
+ * will be evaluated to numbers consisting of Eastern-Arabic (non-ASCII) digits.
+ * [java.util.Locale.US] is
+ *
+ * <noncompliant>
+ * String.format("Timestamp: %d", System.currentTimeMillis())
+ * </noncompliant>
+ *
+ * <compliant>
+ * String.format(Locale.US, "Timestamp: %d", System.currentTimeMillis())
+ * </compliant>
+ */
+class ImplicitDefaultLocale(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+            "ImplicitDefaultLocale", Severity.CodeSmell,
+            "Implicit default locale used for string processing. Consider using explicit locale.",
+            Debt.FIVE_MINS
+    )
+
+    override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+        if (expression.receiverExpression.text == "String" &&
+            expression.getCalleeExpressionIfAny()?.text == "format" &&
+            expression.containsStringTemplate()
+        ) {
+            report(CodeSmell(
+                issue, Entity.from(expression),
+                "${expression.text} uses implicitly default locale for string formatting."))
+        }
+        super.visitDotQualifiedExpression(expression)
+    }
+}
+
+private fun KtDotQualifiedExpression.containsStringTemplate(): Boolean {
+    val lastCallExpression = lastChild as? KtCallExpression
+    return lastCallExpression?.valueArgumentList
+        ?.arguments
+        ?.firstOrNull()
+        ?.children
+        ?.firstOrNull() is KtStringTemplateExpression
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getCalleeExpressionIfAny
  * The default locale is almost always not appropriate for machine-readable text like HTTP headers.
  * For example if locale with tag `ar-SA-u-nu-arab` is a current default then `%d` placeholders
  * will be evaluated to numbers consisting of Eastern-Arabic (non-ASCII) digits.
- * [java.util.Locale.US] is
+ * [java.util.Locale.US] is recommended for machine-readable output.
  *
  * <noncompliant>
  * String.format("Timestamp: %d", System.currentTimeMillis())

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
@@ -21,6 +21,7 @@ import io.gitlab.arturbosch.detekt.rules.bugs.UnsafeCallOnNullableType
 import io.gitlab.arturbosch.detekt.rules.bugs.UnsafeCast
 import io.gitlab.arturbosch.detekt.rules.bugs.UselessPostfixExpression
 import io.gitlab.arturbosch.detekt.rules.bugs.WrongEqualsTypeParameter
+import io.gitlab.arturbosch.detekt.rules.bugs.ImplicitDefaultLocale
 
 /**
  * The potential-bugs rule set provides rules that detect potential bugs.
@@ -50,7 +51,8 @@ class PotentialBugProvider : RuleSetProvider {
                 UnconditionalJumpStatementInLoop(config),
                 UnreachableCode(config),
                 UnsafeCallOnNullableType(config),
-                UnsafeCast(config)
+                UnsafeCast(config),
+                ImplicitDefaultLocale(config)
         ))
     }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocaleSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocaleSpec.kt
@@ -16,7 +16,7 @@ class ImplicitDefaultLocaleSpec : Spek({
                 fun x() {
                     String.format("%d", 1)
                 }"""
-            assertThat(subject.compileAndLint(code).size).isEqualTo(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("does not report String.format call with explicit locale") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocaleSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocaleSpec.kt
@@ -1,0 +1,31 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class ImplicitDefaultLocaleSpec : Spek({
+    val subject by memoized { ImplicitDefaultLocale(Config.empty) }
+
+    describe("ImplicitDefault rule") {
+
+        it("reports String.format call with template but without explicit locale") {
+            val code = """
+                fun x() {
+                    String.format("%d", 1)
+                }"""
+            assertThat(subject.compileAndLint(code).size).isEqualTo(1)
+        }
+
+        it("does not report String.format call with explicit locale") {
+            val code = """
+                import java.util.Locale
+                fun x() {
+                    String.format(Locale.US, "%d", 1)
+                }"""
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+    }
+})

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -167,7 +167,7 @@ strings.
 The default locale is almost always not appropriate for machine-readable text like HTTP headers.
 For example if locale with tag `ar-SA-u-nu-arab` is a current default then `%d` placeholders
 will be evaluated to numbers consisting of Eastern-Arabic (non-ASCII) digits.
-[java.util.Locale.US] is
+[java.util.Locale.US] is recommended for machine-readable output.
 
 **Severity**: CodeSmell
 

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -159,6 +159,32 @@ fun apiCall(): String = System.getProperty("propertyName")
 }
 ```
 
+### ImplicitDefaultLocale
+
+Prefer passing [java.util.Locale] explicitly than using implicit default value when formatting
+strings.
+
+The default locale is almost always not appropriate for machine-readable text like HTTP headers.
+For example if locale with tag `ar-SA-u-nu-arab` is a current default then `%d` placeholders
+will be evaluated to numbers consisting of Eastern-Arabic (non-ASCII) digits.
+[java.util.Locale.US] is
+
+**Severity**: CodeSmell
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+String.format("Timestamp: %d", System.currentTimeMillis())
+```
+
+#### Compliant Code:
+
+```kotlin
+String.format(Locale.US, "Timestamp: %d", System.currentTimeMillis())
+```
+
 ### InvalidRange
 
 Reports ranges which are empty.


### PR DESCRIPTION
Analogous to `DefaultLocale` from Android lint.
