### PR TITLE
Fix false positive at EmptyIfBlock

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlock.kt
@@ -16,8 +16,7 @@ class EmptyIfBlock(config: Config) : EmptyRule(config) {
 
     override fun visitIfExpression(expression: KtIfExpression) {
         super.visitIfExpression(expression)
-        expression.then?.addFindingIfBlockExprIsEmpty()
-        checkThenBodyForLoneSemicolon(expression)
+        expression.then?.addFindingIfBlockExprIsEmpty() ?: checkThenBodyForLoneSemicolon(expression)
     }
 
     private fun checkThenBodyForLoneSemicolon(expression: KtIfExpression) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlockSpec.kt
@@ -69,6 +69,16 @@ class EmptyIfBlockSpec : Spek({
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
+        it("does not report nonempty if without braces but semicolon") {
+            val code = """
+                fun f() {
+                    var i = 0
+                    if (i == 0) i++;
+                }
+            """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
         it("does not report empty if but nonempty else") {
             val code = """
                 fun f() {


### PR DESCRIPTION
This code was detected as an `EmptyIfBlock`.
```kotlin
fun f() {
    var i = 0
    if (i == 0) i++;
}
```

And it's strange but correct. This PR fix it.