### PR TITLE
Dont check WrongEqualsTypeParameter if the function is topLevel

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameter.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameter.kt
@@ -49,7 +49,7 @@ class WrongEqualsTypeParameter(config: Config = Config.empty) : Rule(config) {
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        if (function.name == "equals" && !function.hasCorrectEqualsParameter()) {
+        if (function.name == "equals" && !function.isTopLevel && !function.hasCorrectEqualsParameter()) {
             report(CodeSmell(issue, Entity.from(function), "equals() methods should only take one parameter " +
                     "of type Any?."))
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameterSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameterSpec.kt
@@ -18,7 +18,7 @@ class WrongEqualsTypeParameterSpec : Spek({
                         return super.equals(other)
                     }
                 }"""
-            assertThat(subject.compileAndLint(code).size).isEqualTo(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("reports a String as parameter") {
@@ -28,7 +28,7 @@ class WrongEqualsTypeParameterSpec : Spek({
                         return super.equals(other)
                     }
                 }"""
-            assertThat(subject.compileAndLint(code).size).isEqualTo(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("does not report an interface declaration") {
@@ -36,7 +36,12 @@ class WrongEqualsTypeParameterSpec : Spek({
                 interface I {
                     fun equals(other: String)
                 }"""
-            assertThat(subject.compileAndLint(code).size).isEqualTo(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it("does not report a top level function") {
+            val code = "fun equals(other: String) {}"
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 })


### PR DESCRIPTION
You can have a function named `equals` as a top level function. It's strange but safe.