### PR TITLE
Don't checkBuildFailureThreshold if we are creating the baseline

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -22,7 +22,9 @@ class Runner(private val arguments: CliArgs) : Executable {
             val (time, result) = measure { DetektFacade.create(settings).run() }
             result.add(SimpleNotification("detekt finished in $time ms."))
             OutputFacade(arguments, result, settings).run()
-            checkBuildFailureThreshold(result, settings)
+            if (!arguments.createBaseline) {
+                checkBuildFailureThreshold(result, settings)
+            }
         }
     }
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -52,4 +52,21 @@ class RunnerSpec : Spek({
             assertThat(Files.readAllLines(tmpReport)).hasSize(1)
         }
     }
+
+    describe("executes the runner with create baseline") {
+
+        it("should not throw on maxIssues=0") {
+            val tmpReport = Files.createTempFile("RunnerSpec", ".txt")
+            val cliArgs = CliArgs.parse(arrayOf(
+                "--input", inputPath.toString(),
+                "--create-baseline",
+                "--report", "txt:$tmpReport",
+                "--config-resource", "/configs/max-issues-0.yml"
+            ))
+
+            Runner(cliArgs).execute()
+
+            assertThat(Files.readAllLines(tmpReport)).hasSize(1)
+        }
+    }
 })


### PR DESCRIPTION
I'm not sure why create the baseline using `java -jar ...` works but if you do it using the gradle plugin fails. It should fail in both cases, I'm missing something nearly from sure. But at least this quick fix fixes #2033 