### PR TITLE
Improve text location: InvalidPackageDeclaration

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclaration.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclaration.kt
@@ -29,17 +29,18 @@ class InvalidPackageDeclaration(config: Config = Config.empty) : Rule(config) {
 
     private val rootPackage: String = valueOrDefault(ROOT_PACKAGE, "")
 
-    private var normalizedPathFromPackageDeclaration: String = ""
+    private var packageDeclaration: KtPackageDirective? = null
 
     override fun visitPackageDirective(directive: KtPackageDirective) {
         super.visitPackageDirective(directive)
-        normalizedPathFromPackageDeclaration = directive.packageNames.map(KtElement::getText).toNormalizedForm()
+        packageDeclaration = directive
     }
 
     override fun postVisit(root: KtFile) {
         super.postVisit(root)
-        val declaredPath = normalizedPathFromPackageDeclaration
-        if (declaredPath.isBlank()) {
+        val packageDeclaration = packageDeclaration
+        val declaredPath = packageDeclaration?.packageNames?.map(KtElement::getText)?.toNormalizedForm()
+        if (declaredPath.isNullOrBlank()) {
             root.reportInvalidPackageDeclaration("The file does not contain a package declaration.")
         } else {
             val normalizedFilePath = Paths.get(root.absolutePath()).parent.toNormalizedForm()
@@ -53,12 +54,12 @@ class InvalidPackageDeclaration(config: Config = Config.empty) : Rule(config) {
 
             val isInRootPackage = expectedPath.isBlank()
             if (!isInRootPackage && !normalizedFilePath.endsWith(expectedPath)) {
-                root.reportInvalidPackageDeclaration("The package declaration does not match the actual file location.")
+                packageDeclaration.reportInvalidPackageDeclaration("The package declaration does not match the actual file location.")
             }
         }
     }
 
-    private fun KtFile.reportInvalidPackageDeclaration(message: String) {
+    private fun KtElement.reportInvalidPackageDeclaration(message: String) {
         report(CodeSmell(issue, Entity.from(this), message))
     }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
@@ -42,11 +42,12 @@ internal class InvalidPackageDeclarationSpec : Spek({
                 package foo
                 
                 class C
-                """
+                """.trimIndent()
             val ktFile = compileContentForTest(source)
             ktFile.setAbsolutePath("project/src/bar/File.kt")
             val findings = InvalidPackageDeclaration().lint(ktFile)
             assertThat(findings).hasSize(1)
+            assertThat(findings).hasTextLocations(0 to 11)
         }
 
         describe("with root package specified") {
@@ -117,5 +118,5 @@ private fun KtFile.setAbsolutePath(universalPath: String) {
     val pathSegments = universalPath.split('/')
     val aRootPath = FileSystems.getDefault().rootDirectories.first()
     val path = Paths.get(aRootPath.toString(), *pathSegments.toTypedArray())
-    putUserData(ABSOLUTE_PATH, path?.toString())
+    putUserData(ABSOLUTE_PATH, path.toString())
 }


### PR DESCRIPTION
This is an easy one. If the file has a package and it doesn't match with the directories the error should be only the package line.

Little offtopic: I have 8 branches like this one ready to review. I didn't send them because I don't want to be spammy.

What do you prefer? One PR for each rule or a PR with all those changes?

I prefer one PR per rules because I think that all those PRs can have it's own discussions and in this way we can merge the easy ones and talk more about the others. But as I said, I didn't create all the PRs yet because I don't want to be spammy.