### PR TITLE
Replace spek test hasSize(0) with isEmpty()

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
@@ -24,7 +24,7 @@ class SuppressingSpec : Spek({
             findings.forEach {
                 println(it.compact())
             }
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
 
         it("all findings are suppressed on file levels") {
@@ -34,7 +34,7 @@ class SuppressingSpec : Spek({
             findings.forEach {
                 println(it.compact())
             }
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
 
         it("all findings are suppressed on class levels") {
@@ -44,7 +44,7 @@ class SuppressingSpec : Spek({
             findings.forEach {
                 println(it.compact())
             }
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
 
         it("should suppress TooManyFunctionsRule on class level") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
@@ -17,7 +17,7 @@ class EqualsAlwaysReturnsTrueOrFalseSpec : Spek({
         }
 
         it("does not report equals() methods") {
-            assertThat(subject.lint(Case.EqualsAlwaysReturnsTrueOrFalseNegative.path())).hasSize(0)
+            assertThat(subject.lint(Case.EqualsAlwaysReturnsTrueOrFalseNegative.path())).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
@@ -57,7 +57,7 @@ class EqualsWithHashCodeExistSpec : Spek({
                         return super.equals(other)
                     }
                 }"""
-                assertThat(subject.compileAndLint(code)).hasSize(0)
+                assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRangeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRangeSpec.kt
@@ -20,7 +20,7 @@ class InvalidRangeSpec : Spek({
                     for (i in 2 until 4 step 2) {}
                     for (i in (1+1)..3) { }
                 }"""
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("reports incorrect bounds in for loop conditions") {
@@ -54,7 +54,7 @@ class InvalidRangeSpec : Spek({
 
         it("does not report binary expressions without an invalid range") {
             val code = "val sum = 1 + 2"
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethodSpec.kt
@@ -18,7 +18,7 @@ class IteratorHasNextCallsNextMethodSpec : Spek({
 
         it("does not report correct iterator implementations") {
             val path = Case.IteratorImplNegative.path()
-            assertThat(subject.lint(path)).hasSize(0)
+            assertThat(subject.lint(path)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementExceptionSpec.kt
@@ -18,7 +18,7 @@ class IteratorNotThrowingNoSuchElementExceptionSpec : Spek({
 
         it("does not report correct next() implemenations") {
             val path = Case.IteratorImplNegative.path()
-            assertThat(subject.lint(path)).hasSize(0)
+            assertThat(subject.lint(path)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
@@ -18,7 +18,7 @@ class UnconditionalJumpStatementInLoopSpec : Spek({
 
         it("does not report conditional jumps") {
             val path = Case.UnconditionalJumpStatementInLoopNegative.path()
-            assertThat(subject.lint(path)).hasSize(0)
+            assertThat(subject.lint(path)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
@@ -28,7 +28,7 @@ class UselessPostfixExpressionSpec : Spek({
                     var j = 0
                     j = i++
                 }"""
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("returns no incremented value") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
@@ -29,7 +29,7 @@ class StringLiteralDuplicationSpec : Spek({
 
             it("does not report 2 equal hardcoded strings") {
                 val code = """val str = "lorem" + "lorem" + "ipsum""""
-                assertThat(subject.compileAndLint(code)).hasSize(0)
+                assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }
 
@@ -45,7 +45,7 @@ class StringLiteralDuplicationSpec : Spek({
             """
 
             it("does not report strings in annotations") {
-                assertThat(subject.compileAndLint(code)).hasSize(0)
+                assertThat(subject.compileAndLint(code)).isEmpty()
             }
 
             it("reports strings in annotations according to config") {
@@ -59,7 +59,7 @@ class StringLiteralDuplicationSpec : Spek({
             val code = """val str = "amet" + "amet" + "amet""""
 
             it("does not report strings with 4 characters") {
-                assertThat(subject.compileAndLint(code)).hasSize(0)
+                assertThat(subject.compileAndLint(code)).isEmpty()
             }
 
             it("reports string with 4 characters") {
@@ -128,7 +128,7 @@ class StringLiteralDuplicationSpec : Spek({
                         |
                         ""${'"'}
                 """
-                assertThat(subject.compileAndLint(code)).hasSize(0)
+                assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethodSpec.kt
@@ -27,7 +27,7 @@ class CommentOverPrivateMethodSpec : Spek({
                  * asdf
                  */
                 fun f() {}"""
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report public method in a class with a comment") {
@@ -38,7 +38,7 @@ class CommentOverPrivateMethodSpec : Spek({
                      */
                     fun f() {}
                 }"""
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivatePropertiesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivatePropertiesSpec.kt
@@ -25,7 +25,7 @@ class CommentOverPrivatePropertiesSpec : Spek({
                  * asdf
                  */
                 val v = 1"""
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("reports private property in class with a comment") {
@@ -47,7 +47,7 @@ class CommentOverPrivatePropertiesSpec : Spek({
                      */
                     val v = 1
                 }"""
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -73,15 +73,15 @@ class UndocumentedPublicClassSpec : Spek({
         }
 
         it("should not report internal classes") {
-            assertThat(subject.compileAndLint(internalClass)).hasSize(0)
+            assertThat(subject.compileAndLint(internalClass)).isEmpty()
         }
 
         it("should not report private classes") {
-            assertThat(subject.compileAndLint(privateClass)).hasSize(0)
+            assertThat(subject.compileAndLint(privateClass)).isEmpty()
         }
 
         it("should not report nested private classes") {
-            assertThat(subject.compileAndLint(nestedPrivate)).hasSize(0)
+            assertThat(subject.compileAndLint(nestedPrivate)).isEmpty()
         }
 
         it("should not report inner classes when turned off") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocksMultiRuleSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocksMultiRuleSpec.kt
@@ -31,7 +31,7 @@ class EmptyBlocksMultiRuleSpec : Spek({
 
             val findings = ruleSet?.accept(file)
 
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
 
         it("reports an empty kt file") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
@@ -24,7 +24,7 @@ class ExceptionRaisedInUnexpectedLocationSpec : Spek({
 
         it("does not report methods raising no exception") {
             val path = Case.ExceptionRaisedInMethodsNegative.path()
-            assertThat(subject.lint(path)).hasSize(0)
+            assertThat(subject.lint(path)).isEmpty()
         }
 
         it("reports the configured method") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
@@ -52,7 +52,7 @@ class InstanceOfCheckForExceptionSpec : Spek({
                     }
                 }
                 """
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclarationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclarationSpec.kt
@@ -33,7 +33,7 @@ class NotImplementedDeclarationSpec : Spek({
             fun f() {
                 // TODO
             }"""
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTraceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTraceSpec.kt
@@ -35,7 +35,7 @@ class PrintStackTraceSpec : Spek({
                     }
                 }
                 """
-                assertThat(subject.compileAndLint(code)).hasSize(0)
+                assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
@@ -38,7 +38,7 @@ class ReturnFromFinallySpec : Spek({
 
             it("should not report") {
                 val findings = subject.compileAndLint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
         }
 
@@ -75,7 +75,7 @@ class ReturnFromFinallySpec : Spek({
 
             it("should not report") {
                 val findings = subject.compileAndLint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinallySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinallySpec.kt
@@ -42,7 +42,7 @@ class ThrowingExceptionFromFinallySpec : Spek({
                         println()
                     }
                 }"""
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
@@ -25,7 +25,7 @@ class ThrowingExceptionInMainSpec : Spek({
                     fun mai() { }
                     fun main(args: String) { }"""
             )
-            assertThat(subject.lint(file)).hasSize(0)
+            assertThat(subject.lint(file)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
@@ -31,7 +31,7 @@ class ThrowingExceptionsWithoutMessageOrCauseSpec : Spek({
             it("does not report calls to the default constructor with empty configuration") {
                 val config = TestConfig(mapOf(ThrowingExceptionsWithoutMessageOrCause.EXCEPTIONS to ""))
                 val findings = ThrowingExceptionsWithoutMessageOrCause(config).compileAndLint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
@@ -38,7 +38,7 @@ class ThrowingNewInstanceOfSameExceptionSpec : Spek({
 
             it("should not report") {
                 val findings = subject.compileAndLint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
         }
 
@@ -54,7 +54,7 @@ class ThrowingNewInstanceOfSameExceptionSpec : Spek({
 
             it("should not report") {
                 val findings = subject.compileAndLint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionSpec.kt
@@ -20,7 +20,7 @@ class TooGenericExceptionSpec : Spek({
 
             val findings = ruleSet?.accept(file)
 
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
@@ -18,7 +18,7 @@ class MemberNameEqualsClassNameSpec : Spek({
 
             it("reports methods which are not named after the class") {
                 val path = Case.MemberNameEqualsClassNameNegative.path()
-                assertThat(subject.lint(path)).hasSize(0)
+                assertThat(subject.lint(path)).isEmpty()
             }
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
@@ -21,7 +21,7 @@ class NamingConventionLengthSpec : Spek({
         it("should not report a variable with single letter name") {
             val code = "private val a = 3"
             subject.lint(code)
-            assertThat(subject.findings).hasSize(0)
+            assertThat(subject.findings).isEmpty()
         }
 
         context("VariableMinLength rule with a custom minimum length") {
@@ -38,14 +38,14 @@ class NamingConventionLengthSpec : Spek({
             class C {
                 val prop: (Int) -> Unit = { _ -> Unit }
             }"""
-                assertThat(variableMinLength.lint(code)).hasSize(0)
+                assertThat(variableMinLength.lint(code)).isEmpty()
             }
         }
 
         it("should not report a variable with 64 letters") {
             val code = "private val varThatIsExactly64LettersLongWhichYouMightNotWantToBelieveInLolz = 3"
             subject.lint(code)
-            assertThat(subject.findings).hasSize(0)
+            assertThat(subject.findings).isEmpty()
         }
 
         it("should report a variable name that is too long") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
@@ -17,7 +17,7 @@ class TopLevelPropertyNamingSpec : Spek({
                 const val MY_NAME_8 = "Artur"
                 const val MYNAME = "Artur"
             """)
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should detect five constants not complying to the naming rules") {
@@ -47,7 +47,7 @@ class TopLevelPropertyNamingSpec : Spek({
                 val s_d_d_1 = listOf("")
                 private val INTERNAL_VERSION = "1.0.0"
             """)
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should report non private top level property using underscore") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatementsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatementsSpec.kt
@@ -19,7 +19,7 @@ class CollapsibleIfStatementsSpec : Spek({
 
         it("does not report if statements which can't be merged") {
             val path = Case.CollapsibleIfsNegative.path()
-            assertThat(subject.lint(path)).hasSize(0)
+            assertThat(subject.lint(path)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -28,7 +28,7 @@ class ForbiddenCommentSpec : Spek({
 
             it("should not report TODO usages") {
                 val findings = ForbiddenComment().compileAndLint(todo)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
 
             it("should report FIXME: usages") {
@@ -38,7 +38,7 @@ class ForbiddenCommentSpec : Spek({
 
             it("should not report FIXME usages") {
                 val findings = ForbiddenComment().compileAndLint(fixme)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
 
             it("should report STOPSHIP: usages") {
@@ -48,7 +48,7 @@ class ForbiddenCommentSpec : Spek({
 
             it("should not report STOPSHIP usages") {
                 val findings = ForbiddenComment().compileAndLint(stopShip)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
 
             it("should report violation in multiline comment") {
@@ -79,17 +79,17 @@ class ForbiddenCommentSpec : Spek({
 
             it("should not report TODO: usages") {
                 val findings = ForbiddenComment(config).compileAndLint(todoColon)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
 
             it("should not report FIXME: usages") {
                 val findings = ForbiddenComment(config).compileAndLint(fixmeColon)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
 
             it("should not report STOPME: usages") {
                 val findings = ForbiddenComment(config).compileAndLint(stopShipColon)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
 
             it("should report Banana usages") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -21,17 +21,17 @@ class ForbiddenImportSpec : Spek({
 
         it("should report nothing by default") {
             val findings = ForbiddenImport().lint(code)
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
 
         it("should report nothing when imports are blank") {
             val findings = ForbiddenImport(TestConfig(mapOf(ForbiddenImport.IMPORTS to "  "))).lint(code)
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
 
         it("should report nothing when imports do not match") {
             val findings = ForbiddenImport(TestConfig(mapOf(ForbiddenImport.IMPORTS to "org.*"))).lint(code)
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
 
         it("should report kotlin.* when imports are kotlin.*") {
@@ -72,7 +72,7 @@ class ForbiddenImportSpec : Spek({
         it("should not report import when it does not match any pattern") {
             val findings =
                 ForbiddenImport(TestConfig(mapOf(ForbiddenImport.FORBIDDEN_PATTERNS to "nets.*R"))).lint(code)
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
 
         it("should report import when it matches the forbidden pattern") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
@@ -29,7 +29,7 @@ class FunctionOnlyReturningConstantSpec : Spek({
             val code = "fun f() = 1"
             val config = TestConfig(mapOf("excludedFunctions" to "f"))
             val rule = FunctionOnlyReturningConstant(config)
-            assertThat(rule.compileAndLint(code)).hasSize(0)
+            assertThat(rule.compileAndLint(code)).isEmpty()
         }
 
         it("does not report excluded annotated function which returns a constant") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
@@ -21,12 +21,12 @@ class LoopWithTooManyJumpStatementsSpec : Spek({
         it("does not report when max count configuration is set to 2") {
             val config = TestConfig(mapOf(LoopWithTooManyJumpStatements.MAX_JUMP_COUNT to "2"))
             val findings = LoopWithTooManyJumpStatements(config).lint(path)
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
 
         it("does not report loop with less than 1 break or continue statement") {
             val findings = subject.lint(Case.LoopWithTooManyJumpStatementsNegative.path())
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
@@ -13,7 +13,7 @@ class NewLineAtEndOfFileSpec : Spek({
     describe("NewLineAtEndOfFile rule") {
 
         it("should not flag a kt file containing new space at end") {
-            assertThat(subject.lint(Case.NewLineAtEndOfFile.path())).hasSize(0)
+            assertThat(subject.lint(Case.NewLineAtEndOfFile.path())).isEmpty()
         }
 
         it("should flag a kt file not containing new space at end") {
@@ -21,7 +21,7 @@ class NewLineAtEndOfFileSpec : Spek({
         }
 
         it("should not flag an empty kt file") {
-            assertThat(subject.lint(Case.EmptyKtFile.path())).hasSize(0)
+            assertThat(subject.lint(Case.EmptyKtFile.path())).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabsSpec.kt
@@ -21,7 +21,7 @@ class NoTabsSpec : Spek({
         it("should not flag a line that does not contain a tab") {
             val file = compileForTest(Case.NoTabsNegative.path())
             subject.findTabs(file)
-            assertThat(subject.findings).hasSize(0)
+            assertThat(subject.findings).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeywordSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeywordSpec.kt
@@ -12,7 +12,7 @@ class OptionalAbstractKeywordSpec : Spek({
 
         it("does not report abstract keywords on an interface") {
             val code = "interface A {}"
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("reports abstract interface with abstract property") {
@@ -37,7 +37,7 @@ class OptionalAbstractKeywordSpec : Spek({
 
         it("does not report an abstract class") {
             val code = "abstract class A { abstract fun x() }"
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report a nested abstract class function") {
@@ -47,7 +47,7 @@ class OptionalAbstractKeywordSpec : Spek({
                         abstract fun dependency()
                     }
                 }"""
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBracesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBracesSpec.kt
@@ -25,7 +25,7 @@ class OptionalWhenBracesSpec : Spek({
                         }
                     }
                 }"""
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("reports unnecessary braces") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
@@ -19,7 +19,7 @@ class ProtectedMemberInFinalClassSpec : Spek({
 
         it("does not report protected visibility") {
             val path = Case.FinalClassNegative.path()
-            assertThat(subject.lint(path)).hasSize(0)
+            assertThat(subject.lint(path)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
@@ -19,7 +19,7 @@ class RedundantVisibilityModifierRuleSpec : Spek({
                     override public fun A() {}
                 }
             """
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report overridden function of abstract class w/o public modifier") {
@@ -32,7 +32,7 @@ class RedundantVisibilityModifierRuleSpec : Spek({
                     override fun A() {}
                 }
             """
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report overridden function of interface") {
@@ -45,7 +45,7 @@ class RedundantVisibilityModifierRuleSpec : Spek({
                     override public fun A() {}
                 }
             """
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("reports public function in class") {
@@ -63,7 +63,7 @@ class RedundantVisibilityModifierRuleSpec : Spek({
                     fun A() {}
                 }
             """
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("reports public class") {
@@ -99,7 +99,7 @@ class RedundantVisibilityModifierRuleSpec : Spek({
                     val str : String = "test"
                 }
             """
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report overridden field w/o public modifier") {
@@ -112,7 +112,7 @@ class RedundantVisibilityModifierRuleSpec : Spek({
                     override val test: String = "valid"
                 }
             """
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report overridden field w/ public modifier") {
@@ -125,7 +125,7 @@ class RedundantVisibilityModifierRuleSpec : Spek({
                     override public val test: String = "valid"
                 }
             """
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -24,7 +24,7 @@ class ReturnCountSpec : Spek({
             it("should not get flagged for if condition guard clauses") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
                     .lint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
         }
 
@@ -42,7 +42,7 @@ class ReturnCountSpec : Spek({
             it("should not get flagged for ELVIS operator guard clauses") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
                     .lint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
         }
 
@@ -100,7 +100,7 @@ class ReturnCountSpec : Spek({
 
             it("should not get flagged when max value is 3") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "3"))).lint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
 
             it("should get flagged when max value is 1") {
@@ -121,12 +121,12 @@ class ReturnCountSpec : Spek({
 
             it("should not get flagged by default") {
                 val findings = ReturnCount().lint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
 
             it("should not get flagged when max value is 2") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
 
             it("should get flagged when max value is 1") {
@@ -211,7 +211,7 @@ class ReturnCountSpec : Spek({
 
             it("should not get flag when returns is in inner object") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
         }
 
@@ -243,7 +243,7 @@ class ReturnCountSpec : Spek({
 
             it("should not get flag when returns is in inner object") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCastSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCastSpec.kt
@@ -44,7 +44,7 @@ class SafeCastSpec : Spek({
                         null
                     }
                 }"""
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report wrong else clause") {
@@ -56,7 +56,7 @@ class SafeCastSpec : Spek({
                         String()
                     }
                 }"""
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
@@ -49,7 +49,7 @@ class ThrowsCountSpec : Spek({
             val subject = ThrowsCount(config)
 
             it("does not report for configuration max parameter") {
-                assertThat(subject.lint(code)).hasSize(0)
+                assertThat(subject.lint(code)).isEmpty()
             }
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
@@ -32,7 +32,7 @@ class TrailingWhitespaceSpec : Spek({
             it("should not flag it") {
                 val rule = TrailingWhitespace()
                 rule.visit(Case.TrailingWhitespaceNegative.getKtFileContent())
-                assertThat(rule.findings).hasSize(0)
+                assertThat(rule.findings).isEmpty()
             }
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
@@ -20,7 +20,7 @@ class UnnecessaryInheritanceSpec : Spek({
 
         it("has no unnecessary super type declarations") {
             val findings = subject.lint("class C : An()")
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -32,7 +32,7 @@ class UnnecessaryLetSpec : Spek({
                     a?.let { that -> 1.plus(that) }
                     a?.let { that -> 1.plus(that) }?.let { print(it) }
                 }""")
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
         it("does not report lets with lambda body containing more than one statement") {
             val findings = subject.lint("""
@@ -50,7 +50,7 @@ class UnnecessaryLetSpec : Spek({
                      ?.let { it.plus(1)
                              it.plus(2) }
                 }""")
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
         it("does not report lets where it is used multiple times") {
             val findings = subject.lint("""
@@ -59,7 +59,7 @@ class UnnecessaryLetSpec : Spek({
                     a?.let { it.plus(it) }
                     a?.let { foo -> foo.plus(foo) }
                 }""")
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UntilInsteadOfRangeToSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UntilInsteadOfRangeToSpec.kt
@@ -25,7 +25,7 @@ class UntilInsteadOfRangeToSpec : Spek({
                     for (i in 0 until 10 - 1) {}
                     for (i in 10 downTo 2 - 1) {}
                 }"""
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report if upper value isn't a binary expression") {
@@ -33,7 +33,7 @@ class UntilInsteadOfRangeToSpec : Spek({
                 fun f() {
                     for (i in 0 .. 10) {}
                 }"""
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report if not minus one") {
@@ -42,7 +42,7 @@ class UntilInsteadOfRangeToSpec : Spek({
                     for (i in 0 .. 10 + 1) {}
                     for (i in 0 .. 10 - 2) {}
                 }"""
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("reports for '..'") {
@@ -52,7 +52,7 @@ class UntilInsteadOfRangeToSpec : Spek({
 
         it("does not report binary expressions without a range operator") {
             val code = "val sum = 1 + 2"
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
@@ -19,7 +19,7 @@ class MandatoryBracesIfStatementsSpec : Spek({
 
         it("reports non multi-line if statements should have braces") {
             val path = Case.MandatoryBracesIfStatementsNegative.path()
-            assertThat(subject.lint(path)).hasSize(0)
+            assertThat(subject.lint(path)).isEmpty()
         }
     }
 })


### PR DESCRIPTION
Since it came up in recent PRs, a bash cmd automatically replaced that.

find . -type f -name '*.kt' -exec sed -i '' -e 's/hasSize(0)/isNotEmpty()/g' {} +
