### PR TITLE
Report InvalidRange for empty until range

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRange.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRange.kt
@@ -20,14 +20,15 @@ import org.jetbrains.kotlin.psi.KtBinaryExpression
  * for (i in 2..1) {}
  * for (i in 1 downTo 2) {}
  *
- * val range = 2 until 1
+ * val range1 = 2 until 1
+ * val range2 = 2 until 2
  * </noncompliant>
  *
  * <compliant>
  * for (i in 2..2) {}
  * for (i in 2 downTo 2) {}
  *
- * val range =  2 until 2)
+ * val range = 2 until 3
  * </compliant>
  */
 class InvalidRange(config: Config = Config.empty) : Rule(config) {
@@ -66,5 +67,5 @@ class InvalidRange(config: Config = Config.empty) : Rule(config) {
 
     private fun checkDownTo(lower: Int, upper: Int) = lower < upper
 
-    private fun checkUntil(lower: Int, upper: Int) = lower > upper
+    private fun checkUntil(lower: Int, upper: Int) = lower >= upper
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRangeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRangeSpec.kt
@@ -16,7 +16,7 @@ class InvalidRangeSpec : Spek({
                 fun f() {
                     for (i in 2..2) {}
                     for (i in 2 downTo 2) {}
-                    for (i in 2 until 2) {}
+                    for (i in 2 until 3) {}
                     for (i in 2 until 4 step 2) {}
                     for (i in (1+1)..3) { }
                 }"""
@@ -28,7 +28,7 @@ class InvalidRangeSpec : Spek({
                 fun f() {
                     for (i in 2..1) { }
                     for (i in 1 downTo 2) { }
-                    for (i in 2 until 1) { }
+                    for (i in 2 until 2) { }
                     for (i in 2 until 1 step 2) { }
                 }"""
             assertThat(subject.compileAndLint(code)).hasSize(4)

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -201,7 +201,8 @@ This might be due to invalid ranges like (10..9) which will cause the loop to ne
 for (i in 2..1) {}
 for (i in 1 downTo 2) {}
 
-val range = 2 until 1
+val range1 = 2 until 1
+val range2 = 2 until 2
 ```
 
 #### Compliant Code:
@@ -210,7 +211,7 @@ val range = 2 until 1
 for (i in 2..2) {}
 for (i in 2 downTo 2) {}
 
-val range =  2 until 2)
+val range = 2 until 3
 ```
 
 ### IteratorHasNextCallsNextMethod


### PR DESCRIPTION
This commit handles the case where both given values in the until
function are equal. Closes #2044

Docs for Int.until(to: Int): IntRange:
If the [to] value is less than or equal to this value,
then the returned range is empty.
