### PR TITLE
#1515. Copyright header rule for Kotlin files.

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
@@ -1,0 +1,58 @@
+package io.gitlab.arturbosch.detekt.rules.documentation
+
+import io.gitlab.arturbosch.detekt.api.*
+import org.jetbrains.kotlin.psi.KtFile
+import java.io.File
+
+/**
+ * TODO: write kdoc
+ *
+ * @configuration licenseTemplateFile - path to file with license header template
+ * (default: `config/detekt/license.template`)
+ */
+class AbsentOrWrongFileLicense(config: Config = Config.empty) : Rule(config) {
+
+    private val expectedLicense: String by lazy(LazyThreadSafetyMode.NONE) { loadLicenseFromFile() }
+
+    override val issue = Issue(
+        id = "AbsentOrWrongFileLicense",
+        severity = Severity.Maintainability,
+        description = "License text is absent or incorrect in the file.",
+        debt = Debt.FIVE_MINS
+    )
+
+    override fun visitKtFile(file: KtFile) {
+        if (!file.hasValidLicense) {
+            reportCodeSmell(file)
+        }
+    }
+
+    private val KtFile.hasValidLicense: Boolean
+        get() = text.startsWith(expectedLicense)
+
+    private fun reportCodeSmell(file: KtFile) {
+        report(CodeSmell(
+            issue, Entity.from(file),
+            "Expected license not found or incorrect in the file: ${file.name}."
+        ))
+    }
+
+    // TODO cache this action
+    private fun loadLicenseFromFile(): String {
+        val pathToTemplate = valueOrDefault(PARAM_LICENSE_TEMPLATE_FILE, DEFAULT_LICENSE_TEMPLATE_FILE)
+        val file = File(pathToTemplate)
+
+        if (!file.exists()) {
+            println("==>")
+            return ""
+        }
+
+        require(file.exists()) { "License template file not found at `${file.absolutePath}`." }
+
+        return file.readText()
+    }
+}
+
+private const val PARAM_LICENSE_TEMPLATE_FILE = "licenseTemplateFile"
+
+private const val DEFAULT_LICENSE_TEMPLATE_FILE = "config/detekt/license.template"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CommentSmellProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CommentSmellProvider.kt
@@ -3,11 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.providers
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import io.gitlab.arturbosch.detekt.rules.documentation.CommentOverPrivateFunction
-import io.gitlab.arturbosch.detekt.rules.documentation.CommentOverPrivateProperty
-import io.gitlab.arturbosch.detekt.rules.documentation.KDocStyle
-import io.gitlab.arturbosch.detekt.rules.documentation.UndocumentedPublicClass
-import io.gitlab.arturbosch.detekt.rules.documentation.UndocumentedPublicFunction
+import io.gitlab.arturbosch.detekt.rules.documentation.*
 
 /**
  * This rule set provides rules that address issues in comments and documentation
@@ -25,7 +21,8 @@ class CommentSmellProvider : RuleSetProvider {
                 CommentOverPrivateProperty(config),
                 KDocStyle(config),
                 UndocumentedPublicClass(config),
-                UndocumentedPublicFunction(config)
+                UndocumentedPublicFunction(config),
+                AbsentOrWrongFileLicense(config)
         ))
     }
 }

--- a/docs/pages/documentation/comments.md
+++ b/docs/pages/documentation/comments.md
@@ -9,6 +9,20 @@ folder: documentation
 This rule set provides rules that address issues in comments and documentation
 of the code.
 
+### AbsentOrWrongFileLicense
+
+TODO: description
+
+**Severity**: Maintainability
+
+**Debt**: 5min
+
+#### Configuration options:
+
+* `licenseTemplateFile` (default: `config/detekt/license.template`)
+
+   relative or absolute path to file with license template that should be used in source files.
+
 ### CommentOverPrivateFunction
 
 This rule reports comments and documentation that has been added to private functions. These comments get reported


### PR DESCRIPTION
:construction: _Draft_
