### PR TITLE
Deprecate Location.locationString

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
@@ -27,6 +27,7 @@ interface HasEntity {
     val entity: Entity
     val location: Location
         get() = entity.location
+    @Deprecated("Will be removed in the future. Use queries on 'ktElement' instead.")
     val locationAsString: String
         get() = location.locationString
     val startPosition: SourceLocation

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.psi.psiUtil.startOffset
 data class Location(
     val source: SourceLocation,
     val text: TextLocation,
+    @Deprecated("Will be removed in the future. Use queries on 'ktElement' instead.")
     val locationString: String,
     val file: String
 ) : Compactable {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.TEST_FILENAME
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
@@ -9,8 +8,6 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class EmptyFunctionBlockSpec : Spek({
-
-    val fileName = TEST_FILENAME
 
     val subject by memoized { EmptyFunctionBlock(Config.empty) }
 
@@ -21,7 +18,7 @@ class EmptyFunctionBlockSpec : Spek({
                 class A {
                     protected fun stuff() {}
                 }"""
-            assertThat(subject.compileAndLint(code)).hasExactlyLocationStrings("'{}' at (2,27) in /$fileName")
+            assertThat(subject.compileAndLint(code)).hasSourceLocation(2, 27)
         }
 
         it("should not flag function with open modifier") {
@@ -45,7 +42,7 @@ class EmptyFunctionBlockSpec : Spek({
                 fun a() {
                     fun b() {}
                 }"""
-            assertThat(subject.compileAndLint(code)).hasExactlyLocationStrings("'{}' at (2,13) in /$fileName")
+            assertThat(subject.compileAndLint(code)).hasSourceLocation(2, 13)
         }
 
         context("some overridden functions") {
@@ -79,8 +76,7 @@ class EmptyFunctionBlockSpec : Spek({
 
             it("should not flag overridden functions") {
                 val config = TestConfig(mapOf(EmptyFunctionBlock.IGNORE_OVERRIDDEN_FUNCTIONS to "true"))
-                assertThat(EmptyFunctionBlock(config).compileAndLint(code))
-                    .hasExactlyLocationStrings("'{}' at (1,13) in /$fileName")
+                assertThat(EmptyFunctionBlock(config).compileAndLint(code)).hasSourceLocation(1, 13)
             }
         }
 
@@ -103,8 +99,7 @@ class EmptyFunctionBlockSpec : Spek({
                 }
             """
             it("should not flag overridden functions with commented body") {
-                assertThat(subject.compileAndLint(code))
-                    .hasExactlyLocationStrings("'{\n\n    }' at (12,31) in /$fileName")
+                assertThat(subject.compileAndLint(code)).hasSourceLocation(12, 31)
             }
 
             it("should not flag overridden functions with ignoreOverriddenFunctions") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
-import io.gitlab.arturbosch.detekt.test.TEST_FILENAME
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
@@ -8,8 +7,6 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class FunctionNamingSpec : Spek({
-
-    val fileName = TEST_FILENAME
 
     describe("FunctionNaming rule") {
 
@@ -37,9 +34,7 @@ class FunctionNamingSpec : Spek({
                 fun SHOULD_BE_FLAGGED() { }
             }
         """
-            assertThat(FunctionNaming().lint(code)).hasLocationStrings(
-                    "'fun SHOULD_BE_FLAGGED() { }' at (2,5) in /$fileName"
-            )
+            assertThat(FunctionNaming().lint(code)).hasSourceLocation(2, 5)
         }
 
         it("ignores overridden functions by default") {
@@ -66,9 +61,7 @@ class FunctionNamingSpec : Spek({
                 fun SHOULD_BE_FLAGGED() {}
             }
         """
-            assertThat(FunctionNaming().lint(code)).hasLocationStrings(
-                    "'fun SHOULD_BE_FLAGGED() {}' at (2,5) in /$fileName"
-            )
+            assertThat(FunctionNaming().lint(code)).hasSourceLocation(2, 5)
         }
 
         it("doesn't ignore overridden functions if ignoreOverridden is false") {
@@ -76,9 +69,7 @@ class FunctionNamingSpec : Spek({
             override fun SHOULD_BE_FLAGGED() = TODO()
         """
             val config = TestConfig(mapOf(FunctionNaming.IGNORE_OVERRIDDEN to "false"))
-            assertThat(FunctionNaming(config).lint(code)).hasLocationStrings(
-                    "'override fun SHOULD_BE_FLAGGED() = TODO()' at (1,1) in /$fileName"
-            )
+            assertThat(FunctionNaming(config).lint(code)).hasSourceLocation(1, 1)
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
@@ -93,7 +93,7 @@ internal class MatchingDeclarationNameSpec : Spek({
             it("should not pass for object declaration") {
                 val ktFile = compileContentForTest("object O", filename = "Objects.kt")
                 val findings = MatchingDeclarationName().lint(ktFile)
-                assertThat(findings).hasLocationStrings("'object O' at (1,1) in /Objects.kt")
+                assertThat(findings).hasSourceLocation(1, 1)
             }
 
             it("should not pass for object declaration even with suppress on the object") {
@@ -101,14 +101,13 @@ internal class MatchingDeclarationNameSpec : Spek({
                     """@Suppress("MatchingDeclarationName") object O""",
                     filename = "Objects.kt")
                 val findings = MatchingDeclarationName().lint(ktFile)
-                assertThat(findings).hasLocationStrings(
-                    """'@Suppress("MatchingDeclarationName") object O' at (1,1) in /Objects.kt""")
+                assertThat(findings).hasSourceLocation(1, 1)
             }
 
             it("should not pass for class declaration") {
                 val ktFile = compileContentForTest("class C", filename = "Classes.kt")
                 val findings = MatchingDeclarationName().lint(ktFile)
-                assertThat(findings).hasLocationStrings("'class C' at (1,1) in /Classes.kt")
+                assertThat(findings).hasSourceLocation(1, 1)
             }
 
             it("should not pass for class declaration with utility functions") {
@@ -119,13 +118,13 @@ internal class MatchingDeclarationNameSpec : Spek({
 
             """.trimIndent(), filename = "ClassUtils.kt")
                 val findings = MatchingDeclarationName().lint(ktFile)
-                assertThat(findings).hasLocationStrings("'class C' at (2,1) in /ClassUtils.kt")
+                assertThat(findings).hasSourceLocation(2, 1)
             }
 
             it("should not pass for interface declaration") {
                 val ktFile = compileContentForTest("interface I", filename = "Not_I.kt")
                 val findings = MatchingDeclarationName().lint(ktFile)
-                assertThat(findings).hasLocationStrings("'interface I' at (1,1) in /Not_I.kt")
+                assertThat(findings).hasSourceLocation(1, 1)
             }
 
             it("should not pass for enum declaration") {
@@ -136,10 +135,7 @@ internal class MatchingDeclarationNameSpec : Spek({
 
             """.trimIndent(), filename = "E.kt")
                 val findings = MatchingDeclarationName().lint(ktFile)
-                assertThat(findings).hasLocationStrings("""
-                'enum class NOT_E {
-                    ONE, TWO, THREE
-                }' at (1,1) in /E.kt""", trimIndent = true)
+                assertThat(findings).hasSourceLocation(1, 1)
             }
 
             it("should not pass for a typealias with a different name") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
-import io.gitlab.arturbosch.detekt.test.TEST_FILENAME
+import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
@@ -8,8 +8,6 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class NamingRulesSpec : Spek({
-
-    val fileName = TEST_FILENAME
 
     val subject by memoized { NamingRules() }
 
@@ -26,16 +24,17 @@ class NamingRulesSpec : Spek({
                     fun doStuff(FUN_PARAMETER: String) {}
                 }
             """
-            assertThat(subject.lint(code)).hasLocationStrings(
-                    "'private val _FIELD = 5' at (2,5) in /$fileName",
-                    "'val FIELD get() = _field' at (3,5) in /$fileName",
-                    "'val camel_Case_Property = 5' at (4,5) in /$fileName",
-                    "'const val MY_CONST = 7' at (5,5) in /$fileName",
-                    "'const val MYCONST = 7' at (6,5) in /$fileName",
-                    "'val CONST_PARAMETER: String' at (1,9) in /$fileName",
-                    "'private val PRIVATE_CONST_PARAMETER: Int' at (1,38) in /$fileName",
-                    "'FUN_PARAMETER: String' at (7,17) in /$fileName"
-            )
+            assertThat(subject.lint(code))
+                .hasSourceLocations(
+                    SourceLocation(1, 9),
+                    SourceLocation(1, 38),
+                    SourceLocation(2, 5),
+                    SourceLocation(3, 5),
+                    SourceLocation(4, 5),
+                    SourceLocation(5, 5),
+                    SourceLocation(6, 5),
+                    SourceLocation(7, 17)
+                )
         }
 
         it("checks all negative cases") {
@@ -80,10 +79,11 @@ class NamingRulesSpec : Spek({
                 }
             """
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
-            assertThat(NamingRules(config).lint(code)).hasLocationStrings(
-                    "'override val SHOULD_BE_FLAGGED = \"banana\"' at (2,5) in /$fileName",
-                    "'override val SHOULD_BE_FLAGGED_2 = \"banana\"' at (5,5) in /$fileName"
-            )
+            assertThat(NamingRules(config).lint(code))
+                .hasSourceLocations(
+                    SourceLocation(2, 5),
+                    SourceLocation(5, 5)
+                )
         }
     }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
-import io.gitlab.arturbosch.detekt.test.TEST_FILENAME
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
@@ -9,8 +8,6 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class ObjectPropertyNamingSpec : Spek({
-
-    val fileName = TEST_FILENAME
 
     describe("constants in object declarations") {
 
@@ -58,9 +55,7 @@ class ObjectPropertyNamingSpec : Spek({
                     ${PublicConst.positive}
                 }
             """)
-            assertThat(subject.lint(code)).hasLocationStrings(
-                    "'const val _nAme = \"Artur\"' at (3,21) in /$fileName"
-            )
+            assertThat(subject.lint(code)).hasSourceLocation(3, 21)
         }
     }
 
@@ -120,9 +115,7 @@ class ObjectPropertyNamingSpec : Spek({
                     }
                 }
             """)
-            assertThat(subject.lint(code)).hasLocationStrings(
-                    "'const val _nAme = \"Artur\"' at (4,25) in /$fileName"
-            )
+            assertThat(subject.lint(code)).hasSourceLocation(4, 25)
         }
     }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.test.TEST_FILENAME
+import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assert
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -12,8 +12,6 @@ import org.spekframework.spek2.style.specification.describe
 
 @Suppress("LargeClass")
 class MagicNumberSpec : Spek({
-
-    val fileName = TEST_FILENAME
 
     describe("Magic Number rule") {
 
@@ -27,7 +25,7 @@ class MagicNumberSpec : Spek({
 
             it("should be reported when ignoredNumbers is empty") {
                 val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-                assertThat(findings).hasLocationStrings("'1.0f' at (1,15) in /$fileName")
+                assertThat(findings).hasSourceLocation(1, 15)
             }
         }
 
@@ -55,7 +53,7 @@ class MagicNumberSpec : Spek({
 
             it("should be reported when ignoredNumbers is empty") {
                 val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-                assertThat(findings).hasLocationStrings("'1' at (1,13) in /$fileName")
+                assertThat(findings).hasSourceLocation(1, 13)
             }
         }
 
@@ -83,7 +81,7 @@ class MagicNumberSpec : Spek({
 
             it("should be reported when ignoredNumbers is empty") {
                 val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-                assertThat(findings).hasLocationStrings("'1L' at (1,14) in /$fileName")
+                assertThat(findings).hasSourceLocation(1, 14)
             }
         }
 
@@ -97,7 +95,7 @@ class MagicNumberSpec : Spek({
 
             it("should be reported when ignoredNumbers is empty") {
                 val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-                assertThat(findings).hasLocationStrings("'1L' at (1,15) in /$fileName")
+                assertThat(findings).hasSourceLocation(1, 15)
             }
         }
 
@@ -106,7 +104,7 @@ class MagicNumberSpec : Spek({
 
             it("should be reported by default") {
                 val findings = MagicNumber().lint(ktFile)
-                assertThat(findings).hasLocationStrings("'2L' at (1,15) in /$fileName")
+                assertThat(findings).hasSourceLocation(1, 15)
             }
 
             it("should be ignored when ignoredNumbers contains it verbatim") {
@@ -121,7 +119,7 @@ class MagicNumberSpec : Spek({
 
             it("should not be ignored when ignoredNumbers contains 2 but not -2") {
                 val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to "1,2,3,-1,0"))).lint(ktFile)
-                assertThat(findings).hasLocationStrings("'2L' at (1,15) in /$fileName")
+                assertThat(findings).hasSourceLocation(1, 15)
             }
         }
 
@@ -149,7 +147,7 @@ class MagicNumberSpec : Spek({
 
             it("should be reported when ignoredNumbers is empty") {
                 val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-                assertThat(findings).hasLocationStrings("'1.0' at (1,16) in /$fileName")
+                assertThat(findings).hasSourceLocation(1, 16)
             }
         }
 
@@ -177,7 +175,7 @@ class MagicNumberSpec : Spek({
 
             it("should be reported when ignoredNumbers is empty") {
                 val findings = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NUMBERS to ""))).lint(ktFile)
-                assertThat(findings).hasLocationStrings("'0x1' at (1,13) in /$fileName")
+                assertThat(findings).hasSourceLocation(1, 13)
             }
         }
 
@@ -228,7 +226,7 @@ class MagicNumberSpec : Spek({
 
             it("should be reported by default") {
                 val findings = MagicNumber().lint(ktFile)
-                assertThat(findings).hasLocationStrings("'100_000' at (1,13) in /$fileName")
+                assertThat(findings).hasSourceLocation(1, 13)
             }
 
             it("should not be reported when ignored verbatim") {
@@ -252,12 +250,13 @@ class MagicNumberSpec : Spek({
 
             it("should be reported") {
                 val findings = MagicNumber().lint(ktFile)
-                assertThat(findings).hasLocationStrings(
-                        "'5' at (1,17) in /$fileName",
-                        "'6' at (1,21) in /$fileName",
-                        "'7' at (1,24) in /$fileName",
-                        "'8' at (1,31) in /$fileName"
-                )
+                assertThat(findings)
+                    .hasSourceLocations(
+                        SourceLocation(1, 17),
+                        SourceLocation(1, 21),
+                        SourceLocation(1, 24),
+                        SourceLocation(1, 31)
+                    )
             }
         }
 
@@ -274,13 +273,13 @@ class MagicNumberSpec : Spek({
 
             it("should be reported") {
                 val findings = MagicNumber().lint(ktFile)
-                assertThat(findings).hasLocationStrings(
-                        "'5' at (3,21) in /$fileName",
-                        "'5' at (3,33) in /$fileName",
-                        "'4' at (4,21) in /$fileName",
-                        "'4' at (4,33) in /$fileName",
-                        "'3' at (5,21) in /$fileName",
-                        "'3' at (5,33) in /$fileName"
+                assertThat(findings).hasSourceLocations(
+                    SourceLocation(3, 21),
+                    SourceLocation(3, 33),
+                    SourceLocation(4, 21),
+                    SourceLocation(4, 33),
+                    SourceLocation(5, 21),
+                    SourceLocation(5, 33)
                 )
             }
         }
@@ -325,7 +324,7 @@ class MagicNumberSpec : Spek({
 
             it("should be reported by default") {
                 val findings = MagicNumber().lint(ktFile)
-                assertThat(findings).hasLocationStrings("'0.5f' at (1,12) in /$fileName")
+                assertThat(findings).hasSourceLocation(1, 12)
             }
 
             it("should not be reported when ignoredNumbers contains it") {
@@ -389,14 +388,15 @@ class MagicNumberSpec : Spek({
                 )
 
                 val findings = MagicNumber(config).lint(ktFile)
-                assertThat(findings).hasLocationStrings(
-                        "'69' at (1,29) in /$fileName",
-                        "'42' at (3,36) in /$fileName",
-                        "'93871' at (4,45) in /$fileName",
-                        "'7328672' at (7,38) in /$fileName",
-                        "'43' at (11,47) in /$fileName",
-                        "'93872' at (12,55) in /$fileName"
-                )
+                assertThat(findings)
+                    .hasSourceLocations(
+                        SourceLocation(1, 29),
+                        SourceLocation(3, 36),
+                        SourceLocation(4, 45),
+                        SourceLocation(7, 38),
+                        SourceLocation(11, 47),
+                        SourceLocation(12, 55)
+                    )
             }
 
             it("should not report any issues with all ignore flags") {
@@ -493,7 +493,7 @@ class MagicNumberSpec : Spek({
                 )
 
                 val findings = MagicNumber(config).lint(ktFile)
-                assertThat(findings).hasLocationStrings("'43' at (4,47) in /$fileName")
+                assertThat(findings).hasSourceLocation(4, 47)
             }
 
             it("should report property and constant when not ignoring properties, constants nor companion objects") {
@@ -506,7 +506,11 @@ class MagicNumberSpec : Spek({
                 )
 
                 val findings = MagicNumber(config).lint(ktFile)
-                assertThat(findings).hasLocationStrings("'43' at (4,47) in /$fileName", "'93872' at (5,55) in /$fileName")
+                assertThat(findings)
+                    .hasSourceLocations(
+                        SourceLocation(4, 47),
+                        SourceLocation(5, 55)
+                    )
             }
         }
 
@@ -724,7 +728,7 @@ class MagicNumberSpec : Spek({
                 val code = compileContentForTest("val foo : Int = (127)")
                 assertThat(MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_RANGES to "true"))).lint(code)).hasSize(1)
             }
-            it("reports a finding for an addition if ramges are ignored") {
+            it("reports a finding for an addition if ranges are ignored") {
                 val code = compileContentForTest("val foo : Int = 1 + 27")
                 assertThat(MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_RANGES to "true"))).lint(code)).hasSize(1)
             }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
@@ -1,15 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.TEST_FILENAME
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class UseCheckOrErrorSpec : Spek({
-
-    val fileName = TEST_FILENAME
 
     val subject by memoized { UseCheckOrError(Config.empty) }
 
@@ -21,7 +18,7 @@ class UseCheckOrErrorSpec : Spek({
                     doSomething()
                     if (a < 0) throw IllegalStateException()
                 }"""
-            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw IllegalStateException()' at (3,16) in /$fileName")
+            assertThat(subject.lint(code)).hasSourceLocation(3, 16)
         }
 
         it("reports if a an IllegalStateException is thrown with an error message") {
@@ -30,7 +27,7 @@ class UseCheckOrErrorSpec : Spek({
                     doSomething()
                     if (a < 0) throw IllegalStateException("More details")
                 }"""
-            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw IllegalStateException(\"More details\")' at (3,16) in /$fileName")
+            assertThat(subject.lint(code)).hasSourceLocation(3, 16)
         }
 
         it("reports if a an IllegalStateException is thrown as default case of a when expression") {
@@ -40,7 +37,7 @@ class UseCheckOrErrorSpec : Spek({
                         1 -> doSomething()
                         else -> throw IllegalStateException()
                     }"""
-            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw IllegalStateException()' at (4,17) in /$fileName")
+            assertThat(subject.lint(code)).hasSourceLocation(4, 17)
         }
 
         it("reports if an IllegalStateException is thrown by its fully qualified name") {
@@ -49,7 +46,7 @@ class UseCheckOrErrorSpec : Spek({
                     doSomething()
                     if (a < 0) throw java.lang.IllegalStateException()
                 }"""
-            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw java.lang.IllegalStateException()' at (3,16) in /$fileName")
+            assertThat(subject.lint(code)).hasSourceLocation(3, 16)
         }
 
         it("reports if an IllegalStateException is thrown by its fully qualified name using the kotlin type alias") {
@@ -58,7 +55,7 @@ class UseCheckOrErrorSpec : Spek({
                     doSomething()
                     if (a < 0) throw kotlin.IllegalStateException()
                 }"""
-            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw kotlin.IllegalStateException()' at (3,16) in /$fileName")
+            assertThat(subject.lint(code)).hasSourceLocation(3, 16)
         }
 
         it("does not report if any other kind of exception is thrown") {
@@ -90,12 +87,12 @@ class UseCheckOrErrorSpec : Spek({
 
         it("reports an issue if the exception thrown as the only action in a function") {
             val code = """fun doThrow() = throw IllegalStateException("message")"""
-            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw IllegalStateException(\"message\")' at (1,17) in /$fileName")
+            assertThat(subject.lint(code)).hasSourceLocation(1, 17)
         }
 
         it("reports an issue if the exception thrown as the only action in a function block") {
             val code = """fun doThrow() { throw IllegalStateException("message") }"""
-            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw IllegalStateException(\"message\")' at (1,17) in /$fileName")
+            assertThat(subject.lint(code)).hasSourceLocation(1, 17)
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
@@ -1,15 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.TEST_FILENAME
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class UseRequireSpec : Spek({
-
-    val fileName = TEST_FILENAME
 
     val subject by memoized { UseRequire(Config.empty) }
 
@@ -21,7 +18,7 @@ class UseRequireSpec : Spek({
                     if (a < 0) throw IllegalArgumentException()
                     doSomething()
                 }"""
-            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw IllegalArgumentException()' at (2,16) in /$fileName")
+            assertThat(subject.lint(code)).hasSourceLocation(2, 16)
         }
 
         it("reports if a precondition throws an IllegalArgumentException with more details") {
@@ -30,7 +27,7 @@ class UseRequireSpec : Spek({
                     if (a < 0) throw IllegalArgumentException("More details")
                     doSomething()
                 }"""
-            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw IllegalArgumentException(\"More details\")' at (2,16) in /$fileName")
+            assertThat(subject.lint(code)).hasSourceLocation(2, 16)
         }
 
         it("reports if a precondition throws a fully qualified IllegalArgumentException") {
@@ -39,7 +36,7 @@ class UseRequireSpec : Spek({
                     if (a < 0) throw java.lang.IllegalArgumentException()
                     doSomething()
                 }"""
-            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw java.lang.IllegalArgumentException()' at (2,16) in /$fileName")
+            assertThat(subject.lint(code)).hasSourceLocation(2, 16)
         }
 
         it("reports if a precondition throws a fully qualified IllegalArgumentException using the kotlin type alias") {
@@ -48,7 +45,7 @@ class UseRequireSpec : Spek({
                     if (a < 0) throw kotlin.IllegalArgumentException()
                     doSomething()
                 }"""
-            assertThat(subject.lint(code)).hasExactlyLocationStrings("'throw kotlin.IllegalArgumentException()' at (2,16) in /$fileName")
+            assertThat(subject.lint(code)).hasSourceLocation(2, 16)
         }
 
         it("does not report if a precondition throws a different kind of exception") {

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -24,25 +24,6 @@ class FindingsAssert(actual: List<Finding>) :
     override fun toAssert(value: Finding?, description: String?): FindingAssert =
             FindingAssert(value).`as`(description)
 
-    fun hasLocationStrings(vararg expected: String, trimIndent: Boolean = false) = apply {
-        isNotNull
-        val locationStrings = actual.asSequence().map { it.locationAsString }.sorted()
-        val (actualLocationsList, expectedLocationsList) = if (trimIndent) {
-            locationStrings.map { it.trimIndent() }.toList() to expected.map { it.trimIndent() }.sorted()
-        } else {
-            locationStrings.toList() to expected.toList().sorted()
-        }
-
-        if (!areEqual(actualLocationsList, expectedLocationsList)) {
-            failWithMessage("Expected locations string to be $expectedLocationsList but was $actualLocationsList")
-        }
-    }
-
-    fun hasExactlyLocationStrings(vararg expected: String, trimIndent: Boolean = false) = apply {
-        hasSize(expected.size)
-        hasLocationStrings(*expected, trimIndent = trimIndent)
-    }
-
     fun hasSourceLocations(vararg expected: SourceLocation) = apply {
         isNotNull
 
@@ -56,6 +37,10 @@ class FindingsAssert(actual: List<Finding>) :
         if (!areEqual(actualSources.toList(), expectedSources.toList())) {
             failWithMessage("Expected source locations to be ${expectedSources.toList()} but was ${actualSources.toList()}")
         }
+    }
+
+    fun hasSourceLocation(line: Int, column: Int) = apply {
+        hasSourceLocations(SourceLocation(line, column))
     }
 
     fun hasTextLocations(vararg expected: Pair<Int, Int>) = apply {

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
@@ -83,4 +83,4 @@ class KotlinCoreEnvironmentWrapper(
     }
 }
 
-const val TEST_FILENAME = "Test.kt"
+internal const val TEST_FILENAME = "Test.kt"

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/index.md
@@ -17,7 +17,7 @@ Describes a source code position.
 | [file](file.html) | `open val file: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
 | [inClass](in-class.html) | `open val ~~inClass~~: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
 | [location](location.html) | `open val location: `[`Location`](../-location/index.html) |
-| [locationAsString](location-as-string.html) | `open val locationAsString: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [locationAsString](location-as-string.html) | `open val ~~locationAsString~~: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
 | [name](name.html) | `open val ~~name~~: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
 | [signature](signature.html) | `open val signature: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
 | [startPosition](start-position.html) | `open val startPosition: `[`SourceLocation`](../-source-location/index.html) |

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/location-as-string.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-has-entity/location-as-string.md
@@ -6,4 +6,6 @@ title: HasEntity.locationAsString - detekt-api
 
 # locationAsString
 
-`open val locationAsString: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+`open val ~~locationAsString~~: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+**Deprecated:** Will be removed in the future. Use queries on 'ktElement' instead.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/index.md
@@ -17,7 +17,7 @@ Specifies a position within a source code fragment.
 ### Properties
 
 | [file](file.html) | `val file: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
-| [locationString](location-string.html) | `val locationString: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [locationString](location-string.html) | `val ~~locationString~~: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
 | [source](source.html) | `val source: `[`SourceLocation`](../-source-location/index.html) |
 | [text](text.html) | `val text: `[`TextLocation`](../-text-location/index.html) |
 

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/location-string.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-location/location-string.md
@@ -6,4 +6,6 @@ title: Location.locationString - detekt-api
 
 # locationString
 
-`val locationString: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+`val ~~locationString~~: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)
+**Deprecated:** Will be removed in the future. Use queries on 'ktElement' instead.
+


### PR DESCRIPTION
This PR is a continuation of #2014 

This code is a bit strange: https://github.com/arturbosch/detekt/pull/2083/files#diff-3d9aab0c44e865c3fbae3f5f7a8edc8dR67 for that reason I research a bit about `Location.locationString` and it's not used in the production code. The only uses ar in the test code.

In this PR I refactor the tests to don't use that value and I add the `@Deprecate` annotation to that property.