### PR TITLE
Use compileAndLint instead of lint

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -22,12 +23,14 @@ class EqualsAlwaysReturnsTrueOrFalseSpec : Spek({
 
         it("detects and doesn't crash when return expression is annotated - #2021") {
             val code = """
-            override fun equals(other: Any?): Boolean {
-                @Suppress("UnsafeCallOnNullableType")
-                return true
+            class C {
+                override fun equals(other: Any?): Boolean {
+                    @Suppress("UnsafeCallOnNullableType")
+                    return true
+                }
             }
             """
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -31,7 +31,7 @@ class FunctionNamingSpec : Spek({
 
         it("flags functions inside functions") {
             val code = """
-            class C : I{
+            class C : I {
                 override fun shouldNotBeFlagged() {
                     fun SHOULD_BE_FLAGGED() { }
                 }
@@ -46,9 +46,9 @@ class FunctionNamingSpec : Spek({
             class C : I {
                 override fun SHOULD_NOT_BE_FLAGGED() {}
             }
-            interface I { fun SHOULD_NOT_BE_FLAGGED() }
+            interface I { @Suppress("FunctionNaming") fun SHOULD_NOT_BE_FLAGGED() }
         """
-            assertThat(FunctionNaming().compileAndLint(code)).hasSize(1) // Only reports the interface
+            assertThat(FunctionNaming().compileAndLint(code)).isEmpty()
         }
 
         it("does not report when the function name is identical to the type of the result") {
@@ -65,16 +65,13 @@ class FunctionNamingSpec : Spek({
         it("flags functions with bad names inside overridden functions by default") {
             val code = """
             class C : I {
-                override fun SHOULD_NOT_BE_FLAGGED() {
+                override fun SHOULD_BE_FLAGGED() {
                     fun SHOULD_BE_FLAGGED() {}
                 }
             }
-            interface I { fun SHOULD_NOT_BE_FLAGGED() }
+            interface I { @Suppress("FunctionNaming") fun SHOULD_BE_FLAGGED() }
         """
-            assertThat(FunctionNaming().compileAndLint(code)).hasSourceLocations(
-                SourceLocation(3, 9),
-                SourceLocation(6, 15)
-            )
+            assertThat(FunctionNaming().compileAndLint(code)).hasSourceLocation(3, 9)
         }
 
         it("doesn't ignore overridden functions if ignoreOverridden is false") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -13,14 +13,19 @@ class NamingConventionLengthSpec : Spek({
     describe("NamingRules rule") {
 
         it("should not report underscore variable names") {
-            val code = "val (_, status) = getResult()"
-            subject.lint(code)
+            val code = """
+                fun getResult(): Pair<String, String> = TODO()
+                fun function() {
+                    val (_, status) = getResult()
+                }
+            """
+            subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
 
         it("should not report a variable with single letter name") {
             val code = "private val a = 3"
-            subject.lint(code)
+            subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
 
@@ -30,7 +35,7 @@ class NamingConventionLengthSpec : Spek({
 
             it("reports a very short variable name") {
                 val code = "private val a = 3"
-                assertThat(variableMinLength.lint(code)).hasSize(1)
+                assertThat(variableMinLength.compileAndLint(code)).hasSize(1)
             }
 
             it("does not report a variable with only a single underscore") {
@@ -38,49 +43,49 @@ class NamingConventionLengthSpec : Spek({
             class C {
                 val prop: (Int) -> Unit = { _ -> Unit }
             }"""
-                assertThat(variableMinLength.lint(code)).isEmpty()
+                assertThat(variableMinLength.compileAndLint(code)).isEmpty()
             }
         }
 
         it("should not report a variable with 64 letters") {
             val code = "private val varThatIsExactly64LettersLongWhichYouMightNotWantToBelieveInLolz = 3"
-            subject.lint(code)
+            subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
 
         it("should report a variable name that is too long") {
             val code = "private val thisVariableIsDefinitelyWayTooLongLongerThanEverythingAndShouldBeMuchShorter = 3"
-            subject.lint(code)
+            subject.compileAndLint(code)
             assertThat(subject.findings).hasSize(1)
         }
 
         it("should not report a variable name that is okay") {
             val code = "private val thisOneIsCool = 3"
-            subject.lint(code)
+            subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
 
         it("should report a function name that is too short") {
-            val code = "private fun a = 3"
-            subject.lint(code)
+            val code = "fun a() = 3"
+            subject.compileAndLint(code)
             assertThat(subject.findings).hasSize(1)
         }
 
         it("should report a function name that is too long") {
-            val code = "private fun thisFunctionIsDefinitelyWayTooLongAndShouldBeMuchShorter = 3"
-            subject.lint(code)
+            val code = "fun thisFunctionIsDefinitelyWayTooLongAndShouldBeMuchShorter() = 3"
+            subject.compileAndLint(code)
             assertThat(subject.findings).hasSize(1)
         }
 
         it("should not report a function name that is okay") {
-            val code = "private fun three = 3"
-            subject.lint(code)
+            val code = "fun three() = 3"
+            subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
 
         it("should not report a function name that begins with a backtick, capitals, and spaces") {
-            val code = "private fun `Hi bye` = 3"
-            subject.lint(code)
+            val code = "fun `Hi bye`() = 3"
+            subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
@@ -67,30 +67,29 @@ class NamingRulesSpec : Spek({
                     override val SHOULD_NOT_BE_FLAGGED: String
                 }
                 interface I2 {
-                    val SHOULD_NOT_BE_FLAGGED: String
+                    @Suppress("VariableNaming") val SHOULD_NOT_BE_FLAGGED: String
                 }
             """
-            assertThat(NamingRules().compileAndLint(code)).hasSize(1) // Only reports the interface
+            assertThat(NamingRules().compileAndLint(code)).isEmpty()
         }
 
         it("doesn't ignore overridden member properties if ignoreOverridden is false") {
             val code = """
                 class C : I {
-                    override val SHOULD_NOT_BE_FLAGGED = "banana"
+                    override val SHOULD_BE_FLAGGED = "banana"
                 }
                 interface I : I2 {
-                    override val SHOULD_NOT_BE_FLAGGED: String
+                    override val SHOULD_BE_FLAGGED: String
                 }
                 interface I2 {
-                    val SHOULD_NOT_BE_FLAGGED: String
+                    @Suppress("VariableNaming") val SHOULD_BE_FLAGGED: String
                 }
             """
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
             assertThat(NamingRules(config).compileAndLint(code))
                 .hasSourceLocations(
                     SourceLocation(2, 5),
-                    SourceLocation(5, 5),
-                    SourceLocation(8, 5)
+                    SourceLocation(5, 5)
                 )
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -204,7 +205,7 @@ class ObjectPropertyNamingSpec : Spek({
                 }
             """
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ParameterNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ParameterNamingSpec.kt
@@ -59,9 +59,9 @@ class ParameterNamingSpec : Spek({
                 class C : I {
                     override fun someStuff(`object`: String) {}
                 }
-                interface I { fun someStuff(`object`: String) }
+                interface I { fun someStuff(@Suppress("FunctionParameterNaming") `object`: String) }
             """
-            assertThat(FunctionParameterNaming().compileAndLint(code)).hasSize(1) // Only reports the interface
+            assertThat(FunctionParameterNaming().compileAndLint(code)).isEmpty()
         }
 
         it("should detect violations in overridden function if ignoreOverriddenFunctions is false") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ParameterNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ParameterNamingSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -14,12 +14,12 @@ class ParameterNamingSpec : Spek({
             val code = """
                 class C(val param: String, private val privateParam: String)
 
-                class C {
-                    construct(val param: String) {}
-                    construct(val param: String, private val privateParam: String) {}
+                class D {
+                    constructor(param: String) {}
+                    constructor(param: String, privateParam: String) {}
                 }
             """
-            assertThat(ConstructorParameterNaming().lint(code)).isEmpty()
+            assertThat(ConstructorParameterNaming().compileAndLint(code)).isEmpty()
         }
 
         it("should find some violations") {
@@ -27,18 +27,18 @@ class ParameterNamingSpec : Spek({
                 class C(val PARAM: String, private val PRIVATE_PARAM: String)
 
                 class C {
-                    construct(val PARAM: String) {}
-                    construct(val PARAM: String, private val PRIVATE_PARAM: String) {}
+                    constructor(PARAM: String) {}
+                    constructor(PARAM: String, PRIVATE_PARAM: String) {}
                 }
             """
-            assertThat(NamingRules().lint(code)).hasSize(5)
+            assertThat(NamingRules().compileAndLint(code)).hasSize(5)
         }
 
         it("should find a violation in the correct text locaction") {
             val code = """
                 class C(val PARAM: String)
             """
-            val findings = NamingRules().lint(code)
+            val findings = NamingRules().compileAndLint(code)
             assertThat(findings).hasTextLocations(8 to 25)
         }
     }
@@ -51,26 +51,28 @@ class ParameterNamingSpec : Spek({
                     fun someStuff(param: String) {}
                 }
             """
-            assertThat(ConstructorParameterNaming().lint(code)).isEmpty()
+            assertThat(ConstructorParameterNaming().compileAndLint(code)).isEmpty()
         }
 
         it("should not detect violations in overridden function by default") {
             val code = """
-                class C {
+                class C : I {
                     override fun someStuff(`object`: String) {}
                 }
+                interface I { fun someStuff(`object`: String) }
             """
-            assertThat(FunctionParameterNaming().lint(code)).isEmpty()
+            assertThat(FunctionParameterNaming().compileAndLint(code)).hasSize(1) // Only reports the interface
         }
 
         it("should detect violations in overridden function if ignoreOverriddenFunctions is false") {
             val code = """
-                class C {
+                class C : I {
                     override fun someStuff(`object`: String) {}
                 }
+                interface I { fun someStuff(`object`: String) }
             """
             val config = TestConfig(mapOf(FunctionParameterNaming.IGNORE_OVERRIDDEN_FUNCTIONS to "false"))
-            assertThat(FunctionParameterNaming(config).lint(code)).hasSize(1)
+            assertThat(FunctionParameterNaming(config).compileAndLint(code)).hasSize(2)
         }
 
         it("should find some violations") {
@@ -79,7 +81,7 @@ class ParameterNamingSpec : Spek({
                     fun someStuff(PARAM: String) {}
                 }
             """
-            assertThat(NamingRules().lint(code)).hasSize(1)
+            assertThat(NamingRules().compileAndLint(code)).hasSize(1)
         }
     }
 
@@ -90,15 +92,15 @@ class ParameterNamingSpec : Spek({
         it("should not detect function parameter") {
             val code = """
                 class Excluded {
-                    fun f(PARAM: Int)
+                    fun f(PARAM: Int) {}
                 }
             """
-            assertThat(FunctionParameterNaming(config).lint(code)).isEmpty()
+            assertThat(FunctionParameterNaming(config).compileAndLint(code)).isEmpty()
         }
 
         it("should not detect constructor parameter") {
             val code = "class Excluded(val PARAM: Int) {}"
-            assertThat(ConstructorParameterNaming(config).lint(code)).isEmpty()
+            assertThat(ConstructorParameterNaming(config).compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/CompileExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/CompileExtensions.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.test
 
+import org.intellij.lang.annotations.Language
 import java.nio.file.Path
 
 /**
  * Use this method if you define a kt file/class as a plain string in your test.
  */
-fun compileContentForTest(content: String, filename: String = TEST_FILENAME) =
+fun compileContentForTest(@Language("kotlin") content: String, filename: String = TEST_FILENAME) =
     KtTestCompiler.compileFromContent(content, filename)
 
 /**

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.test
 
 import io.gitlab.arturbosch.detekt.api.internal.ABSOLUTE_PATH
 import io.gitlab.arturbosch.detekt.core.KtCompiler
+import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
@@ -31,7 +32,7 @@ object KtTestCompiler : KtCompiler() {
 
     fun compile(path: Path) = compile(root, path)
 
-    fun compileFromContent(content: String, filename: String = TEST_FILENAME): KtFile {
+    fun compileFromContent(@Language("kotlin") content: String, filename: String = TEST_FILENAME): KtFile {
         val file = psiFileFactory.createFileFromText(
             filename,
             KotlinLanguage.INSTANCE,


### PR DESCRIPTION
I moved lots of uses of `lint` to use `compileAndLint`.