### PR TITLE
Improve naming tests

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
@@ -10,7 +10,7 @@ class ClassNamingSpec : Spek({
     describe("different naming conventions inside classes") {
 
         it("should detect no violations") {
-            val findings = NamingRules().compileAndLint(
+            val findings = ClassNaming().compileAndLint(
                     """
                     class MyClassWithNumbers5
 
@@ -22,7 +22,7 @@ class ClassNamingSpec : Spek({
         }
 
         it("should find two violations") {
-            val findings = NamingRules().compileAndLint(
+            val findings = ClassNaming().compileAndLint(
                     """
                     class _NamingConventions
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
@@ -1,0 +1,44 @@
+package io.gitlab.arturbosch.detekt.rules.naming
+
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class ConstructorParameterNamingSpec : Spek({
+
+    describe("parameters in a constructor of a class") {
+
+        it("should detect no violations") {
+            val code = """
+                class C(val param: String, private val privateParam: String)
+
+                class D {
+                    constructor(param: String) {}
+                    constructor(param: String, privateParam: String) {}
+                }
+            """
+            assertThat(ConstructorParameterNaming().compileAndLint(code)).isEmpty()
+        }
+
+        it("should find some violations") {
+            val code = """
+                class C(val PARAM: String, private val PRIVATE_PARAM: String)
+
+                class C {
+                    constructor(PARAM: String) {}
+                    constructor(PARAM: String, PRIVATE_PARAM: String) {}
+                }
+            """
+            assertThat(NamingRules().compileAndLint(code)).hasSize(5)
+        }
+
+        it("should find a violation in the correct text locaction") {
+            val code = """
+                class C(val PARAM: String)
+            """
+            val findings = NamingRules().compileAndLint(code)
+            assertThat(findings).hasTextLocations(8 to 25)
+        }
+    }
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
@@ -30,15 +30,14 @@ class ConstructorParameterNamingSpec : Spek({
                     constructor(PARAM: String, PRIVATE_PARAM: String) {}
                 }
             """
-            assertThat(NamingRules().compileAndLint(code)).hasSize(5)
+            assertThat(ConstructorParameterNaming().compileAndLint(code)).hasSize(5)
         }
 
         it("should find a violation in the correct text locaction") {
             val code = """
                 class C(val PARAM: String)
             """
-            val findings = NamingRules().compileAndLint(code)
-            assertThat(findings).hasTextLocations(8 to 25)
+            assertThat(ConstructorParameterNaming().compileAndLint(code)).hasTextLocations(8 to 25)
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -10,7 +10,7 @@ class EnumNamingSpec : Spek({
     describe("some enum entry declarations") {
 
         it("should detect no violation") {
-            val findings = NamingRules().compileAndLint(
+            val findings = EnumNaming().compileAndLint(
                     """
                 enum class WorkFlow {
                     ACTIVE, NOT_ACTIVE, Unknown, Number1
@@ -25,7 +25,7 @@ class EnumNamingSpec : Spek({
                 enum class WorkFlow {
                     _Default
                 }"""
-            assertThat(NamingRules().compileAndLint(code)).hasSize(1)
+            assertThat(EnumNaming().compileAndLint(code)).hasSize(1)
         }
 
         it("no reports an underscore in enum name because it's suppressed") {
@@ -33,7 +33,7 @@ class EnumNamingSpec : Spek({
                 enum class WorkFlow {
                     @Suppress("EnumNaming") _Default
                 }"""
-            assertThat(NamingRules().compileAndLint(code)).isEmpty()
+            assertThat(EnumNaming().compileAndLint(code)).isEmpty()
         }
 
         it("reports the correct text location in enum name") {
@@ -41,7 +41,7 @@ class EnumNamingSpec : Spek({
                 enum class WorkFlow {
                     _Default,
                 }"""
-            val findings = NamingRules().compileAndLint(code)
+            val findings = EnumNaming().compileAndLint(code)
             assertThat(findings).hasTextLocations(26 to 34)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -20,6 +20,14 @@ class EnumNamingSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
+        it("enum name that start with lowercase") {
+            val code = """
+                enum class WorkFlow {
+                    default
+                }"""
+            assertThat(NamingRules().compileAndLint(code)).hasSize(1)
+        }
+
         it("reports an underscore in enum name") {
             val code = """
                 enum class WorkFlow {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
@@ -6,42 +6,7 @@ import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
-class ParameterNamingSpec : Spek({
-
-    describe("parameters in a constructor of a class") {
-
-        it("should detect no violations") {
-            val code = """
-                class C(val param: String, private val privateParam: String)
-
-                class D {
-                    constructor(param: String) {}
-                    constructor(param: String, privateParam: String) {}
-                }
-            """
-            assertThat(ConstructorParameterNaming().compileAndLint(code)).isEmpty()
-        }
-
-        it("should find some violations") {
-            val code = """
-                class C(val PARAM: String, private val PRIVATE_PARAM: String)
-
-                class C {
-                    constructor(PARAM: String) {}
-                    constructor(PARAM: String, PRIVATE_PARAM: String) {}
-                }
-            """
-            assertThat(NamingRules().compileAndLint(code)).hasSize(5)
-        }
-
-        it("should find a violation in the correct text locaction") {
-            val code = """
-                class C(val PARAM: String)
-            """
-            val findings = NamingRules().compileAndLint(code)
-            assertThat(findings).hasTextLocations(8 to 25)
-        }
-    }
+class FunctionParameterNamingSpec : Spek({
 
     describe("parameters in a function of a class") {
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
@@ -46,7 +46,7 @@ class FunctionParameterNamingSpec : Spek({
                     fun someStuff(PARAM: String) {}
                 }
             """
-            assertThat(NamingRules().compileAndLint(code)).hasSize(1)
+            assertThat(FunctionParameterNaming().compileAndLint(code)).hasSize(1)
         }
     }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
@@ -16,43 +16,26 @@ class NamingRulesSpec : Spek({
 
         it("should detect all positive cases") {
             val code = """
-                class C(val CONST_PARAMETER: String, private val PRIVATE_CONST_PARAMETER: Int) {
+                class C {
                     private val _FIELD = 5
                     val FIELD get() = _field
                     val camel_Case_Property = 5
-                    const val MY_CONST = 7
-                    const val MYCONST = 7
-                    fun doStuff(FUN_PARAMETER: String) {}
                 }
             """
             assertThat(subject.lint(code))
                 .hasSourceLocations(
-                    SourceLocation(1, 9),
-                    SourceLocation(1, 38),
                     SourceLocation(2, 5),
                     SourceLocation(3, 5),
-                    SourceLocation(4, 5),
-                    SourceLocation(5, 5),
-                    SourceLocation(6, 5),
-                    SourceLocation(7, 17)
+                    SourceLocation(4, 5)
                 )
         }
 
         it("checks all negative cases") {
             val code = """
-                class C(val constParameter: String, private val privateConstParameter: Int) {
+                class C {
                     private val _field = 5
                     val field get() = _field
                     val camelCaseProperty = 5
-                    const val myConst = 7
-
-                    data class D(val i: Int, val j: Int)
-                    fun doStuff() {
-                        val (_, holyGrail) = D(5, 4)
-                        emptyMap<String, String>().forEach { _, v -> println(v) }
-                    }
-                    val doable: (Int) -> Unit = { _ -> Unit }
-                    fun doStuff(funParameter: String) {}
                 }
             """
             assertThat(subject.lint(code)).isEmpty()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
@@ -70,7 +70,7 @@ class NamingRulesSpec : Spek({
                     @Suppress("VariableNaming") val SHOULD_NOT_BE_FLAGGED: String
                 }
             """
-            assertThat(NamingRules().compileAndLint(code)).isEmpty()
+            assertThat(VariableNaming().compileAndLint(code)).isEmpty()
         }
 
         it("doesn't ignore overridden member properties if ignoreOverridden is false") {
@@ -86,7 +86,7 @@ class NamingRulesSpec : Spek({
                 }
             """
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
-            assertThat(NamingRules(config).compileAndLint(code))
+            assertThat(VariableNaming(config).compileAndLint(code))
                 .hasSourceLocations(
                     SourceLocation(2, 5),
                     SourceLocation(5, 5)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.lint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -18,11 +17,11 @@ class NamingRulesSpec : Spek({
             val code = """
                 class C {
                     private val _FIELD = 5
-                    val FIELD get() = _field
+                    val FIELD get() = _FIELD
                     val camel_Case_Property = 5
                 }
             """
-            assertThat(subject.lint(code))
+            assertThat(subject.compileAndLint(code))
                 .hasSourceLocations(
                     SourceLocation(2, 5),
                     SourceLocation(3, 5),
@@ -38,7 +37,7 @@ class NamingRulesSpec : Spek({
                     val camelCaseProperty = 5
                 }
             """
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("should not flag overridden member properties by default") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
@@ -1,78 +1,11 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
-import io.gitlab.arturbosch.detekt.api.SourceLocation
-import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class NamingRulesSpec : Spek({
-
-    describe("properties in classes") {
-
-        it("should detect all positive cases") {
-            val code = """
-                class C {
-                    private val _FIELD = 5
-                    val FIELD get() = _FIELD
-                    val camel_Case_Property = 5
-                }
-            """
-            assertThat(VariableNaming().compileAndLint(code))
-                .hasSourceLocations(
-                    SourceLocation(2, 5),
-                    SourceLocation(3, 5),
-                    SourceLocation(4, 5)
-                )
-        }
-
-        it("checks all negative cases") {
-            val code = """
-                class C {
-                    private val _field = 5
-                    val field get() = _field
-                    val camelCaseProperty = 5
-                }
-            """
-            assertThat(VariableNaming().compileAndLint(code)).isEmpty()
-        }
-
-        it("should not flag overridden member properties by default") {
-            val code = """
-                class C : I {
-                    override val SHOULD_NOT_BE_FLAGGED = "banana"
-                }
-                interface I : I2 {
-                    override val SHOULD_NOT_BE_FLAGGED: String
-                }
-                interface I2 {
-                    @Suppress("VariableNaming") val SHOULD_NOT_BE_FLAGGED: String
-                }
-            """
-            assertThat(VariableNaming().compileAndLint(code)).isEmpty()
-        }
-
-        it("doesn't ignore overridden member properties if ignoreOverridden is false") {
-            val code = """
-                class C : I {
-                    override val SHOULD_BE_FLAGGED = "banana"
-                }
-                interface I : I2 {
-                    override val SHOULD_BE_FLAGGED: String
-                }
-                interface I2 {
-                    @Suppress("VariableNaming") val SHOULD_BE_FLAGGED: String
-                }
-            """
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
-            assertThat(VariableNaming(config).compileAndLint(code))
-                .hasSourceLocations(
-                    SourceLocation(2, 5),
-                    SourceLocation(5, 5)
-                )
-        }
-    }
 
     describe("naming like in constants is allowed for destructuring and lambdas") {
         it("should not detect any") {
@@ -87,5 +20,3 @@ class NamingRulesSpec : Spek({
         }
     }
 })
-
-const val IGNORE_OVERRIDDEN = "ignoreOverridden"

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
@@ -9,8 +9,6 @@ import org.spekframework.spek2.style.specification.describe
 
 class NamingRulesSpec : Spek({
 
-    val subject by memoized { NamingRules() }
-
     describe("properties in classes") {
 
         it("should detect all positive cases") {
@@ -21,7 +19,7 @@ class NamingRulesSpec : Spek({
                     val camel_Case_Property = 5
                 }
             """
-            assertThat(subject.compileAndLint(code))
+            assertThat(VariableNaming().compileAndLint(code))
                 .hasSourceLocations(
                     SourceLocation(2, 5),
                     SourceLocation(3, 5),
@@ -37,7 +35,7 @@ class NamingRulesSpec : Spek({
                     val camelCaseProperty = 5
                 }
             """
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(VariableNaming().compileAndLint(code)).isEmpty()
         }
 
         it("should not flag overridden member properties by default") {
@@ -85,7 +83,7 @@ class NamingRulesSpec : Spek({
                     emptyMap<String, String>().forEach { _, V -> println(V) }
                 }
             """
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(NamingRules().compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -124,7 +124,7 @@ class ObjectPropertyNamingSpec : Spek({
 
         val subject by memoized { ObjectPropertyNaming() }
 
-        it("should not detect public constants complying to the naming rules") {
+        it("should not detect public variables complying to the naming rules") {
             val code = compileContentForTest("""
                 object O {
                     ${PublicVal.negative}
@@ -133,7 +133,7 @@ class ObjectPropertyNamingSpec : Spek({
             assertThat(subject.lint(code)).isEmpty()
         }
 
-        it("should detect public constants not complying to the naming rules") {
+        it("should detect public variables not complying to the naming rules") {
             val code = compileContentForTest("""
                 object O {
                     ${PublicVal.positive}
@@ -142,7 +142,7 @@ class ObjectPropertyNamingSpec : Spek({
             assertThat(subject.lint(code)).hasSize(1)
         }
 
-        it("should not detect private constants complying to the naming rules") {
+        it("should not detect private variables complying to the naming rules") {
             val code = compileContentForTest("""
                 object O {
                     ${PrivateVal.negative}
@@ -151,7 +151,7 @@ class ObjectPropertyNamingSpec : Spek({
             assertThat(subject.lint(code)).isEmpty()
         }
 
-        it("should detect private constants not complying to the naming rules") {
+        it("should detect private variables not complying to the naming rules") {
             val code = compileContentForTest("""
                 object O {
                     private val __NAME = "Artur"

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
@@ -10,19 +10,19 @@ class PackageNamingSpec : Spek({
     describe("PackageNaming rule") {
 
         it("should find a uppercase package name") {
-            assertThat(NamingRules().compileAndLint("package FOO.BAR")).hasSize(1)
+            assertThat(PackageNaming().compileAndLint("package FOO.BAR")).hasSize(1)
         }
 
         it("should find a upper camel case package name") {
-            assertThat(NamingRules().compileAndLint("package Foo.Bar")).hasSize(1)
+            assertThat(PackageNaming().compileAndLint("package Foo.Bar")).hasSize(1)
         }
 
         it("should find a camel case package name") {
-            assertThat(NamingRules().compileAndLint("package fOO.bAR")).hasSize(1)
+            assertThat(PackageNaming().compileAndLint("package fOO.bAR")).hasSize(1)
         }
 
         it("should check an valid package name") {
-            assertThat(NamingRules().compileAndLint("package foo.bar")).isEmpty()
+            assertThat(PackageNaming().compileAndLint("package foo.bar")).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNamingSpec.kt
@@ -1,0 +1,78 @@
+package io.gitlab.arturbosch.detekt.rules.naming
+
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class VariableNamingSpec : Spek({
+
+    describe("properties in classes") {
+
+        it("should detect all positive cases") {
+            val code = """
+                class C {
+                    private val _FIELD = 5
+                    val FIELD get() = _FIELD
+                    val camel_Case_Property = 5
+                }
+            """
+            assertThat(VariableNaming().compileAndLint(code))
+                .hasSourceLocations(
+                    SourceLocation(2, 5),
+                    SourceLocation(3, 5),
+                    SourceLocation(4, 5)
+                )
+        }
+
+        it("checks all negative cases") {
+            val code = """
+                class C {
+                    private val _field = 5
+                    val field get() = _field
+                    val camelCaseProperty = 5
+                }
+            """
+            assertThat(VariableNaming().compileAndLint(code)).isEmpty()
+        }
+
+        it("should not flag overridden member properties by default") {
+            val code = """
+                class C : I {
+                    override val SHOULD_NOT_BE_FLAGGED = "banana"
+                }
+                interface I : I2 {
+                    override val SHOULD_NOT_BE_FLAGGED: String
+                }
+                interface I2 {
+                    @Suppress("VariableNaming") val SHOULD_NOT_BE_FLAGGED: String
+                }
+            """
+            assertThat(VariableNaming().compileAndLint(code)).isEmpty()
+        }
+
+        it("doesn't ignore overridden member properties if ignoreOverridden is false") {
+            val code = """
+                class C : I {
+                    override val SHOULD_BE_FLAGGED = "banana"
+                }
+                interface I : I2 {
+                    override val SHOULD_BE_FLAGGED: String
+                }
+                interface I2 {
+                    @Suppress("VariableNaming") val SHOULD_BE_FLAGGED: String
+                }
+            """
+            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
+            assertThat(VariableNaming(config).compileAndLint(code))
+                .hasSourceLocations(
+                    SourceLocation(2, 5),
+                    SourceLocation(5, 5)
+                )
+        }
+    }
+})
+
+private const val IGNORE_OVERRIDDEN = "ignoreOverridden"

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEngine.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEngine.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.test
 
+import org.intellij.lang.annotations.Language
 import javax.script.ScriptException
 
 /**
@@ -15,7 +16,7 @@ object KotlinScriptEngine {
      * @param code the String to compile
      * @throws ScriptException
      */
-    fun compile(code: String) {
+    fun compile(@Language("kotlin") code: String) {
         try {
             KotlinScriptEnginePool.getEngine().compile(code)
         } catch (e: ScriptException) {

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -14,7 +14,7 @@ fun BaseRule.compileAndLint(@Language("kotlin") content: String): List<Finding> 
     return lint(content)
 }
 
-fun BaseRule.lint(content: String): List<Finding> {
+fun BaseRule.lint(@Language("kotlin") content: String): List<Finding> {
     val ktFile = KtTestCompiler.compileFromContent(content.trimIndent())
     return findingsAfterVisit(ktFile)
 }
@@ -44,7 +44,7 @@ private fun BaseRule.findingsAfterVisit(
     return this.findings
 }
 
-fun Rule.format(content: String): String {
+fun Rule.format(@Language("kotlin") content: String): String {
     val ktFile = KtTestCompiler.compileFromContent(content.trimIndent())
     return contentAfterVisit(ktFile)
 }


### PR DESCRIPTION
This PR is a general refactor in the naming tests. Split tests in different files, simplify some, fix typos, reduce the scope of others...