### PR TITLE
Add config flag ignoreOverridden to ConstructorParameterNaming

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -304,6 +304,7 @@ naming:
     parameterPattern: '[a-z][A-Za-z0-9]*'
     privateParameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
+    ignoreOverridden: true
   EnumNaming:
     active: true
     excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.identifierName
+import io.gitlab.arturbosch.detekt.rules.isOverride
 import io.gitlab.arturbosch.detekt.rules.naming.util.isContainingExcludedClassOrObject
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
@@ -19,6 +20,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  * @configuration parameterPattern - naming pattern (default: `'[a-z][A-Za-z0-9]*'`)
  * @configuration privateParameterPattern - naming pattern (default: `'[a-z][A-Za-z0-9]*'`)
  * @configuration excludeClassPattern - ignores variables in classes which match this regex (default: `'$^'`)
+ * @configuration ignoreOverridden - ignores constructor properties that have the override modifier (default: `true`)
  *
  * @active since v1.0.0
  */
@@ -32,9 +34,14 @@ class ConstructorParameterNaming(config: Config = Config.empty) : Rule(config) {
     private val parameterPattern by LazyRegex(PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*")
     private val privateParameterPattern by LazyRegex(PRIVATE_PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*")
     private val excludeClassPattern by LazyRegex(EXCLUDE_CLASS_PATTERN, "$^")
+    private val ignoreOverridden = valueOrDefault(IGNORE_OVERRIDDEN, true)
 
     override fun visitParameter(parameter: KtParameter) {
         if (parameter.isContainingExcludedClassOrObject(excludeClassPattern)) {
+            return
+        }
+
+        if (ignoreOverridden && parameter.isOverride()) {
             return
         }
 
@@ -61,5 +68,6 @@ class ConstructorParameterNaming(config: Config = Config.empty) : Rule(config) {
         const val PARAMETER_PATTERN = "parameterPattern"
         const val PRIVATE_PARAMETER_PATTERN = "privateParameterPattern"
         const val EXCLUDE_CLASS_PATTERN = "excludeClassPattern"
+        const val IGNORE_OVERRIDDEN = "ignoreOverridden"
     }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.spekframework.spek2.Spek
@@ -39,5 +40,26 @@ class ConstructorParameterNamingSpec : Spek({
             """
             assertThat(ConstructorParameterNaming().compileAndLint(code)).hasTextLocations(8 to 25)
         }
+
+        it("should not complain about override") {
+            val code = """
+                class C(override val PARAM: String) : I
+
+                interface I { val PARAM: String }
+            """
+            assertThat(ConstructorParameterNaming().compileAndLint(code)).isEmpty()
+        }
+
+        it("should not complain about override") {
+            val code = """
+                class C(override val PARAM: String) : I
+
+                interface I { val PARAM: String }
+            """
+            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
+            assertThat(ConstructorParameterNaming(config).compileAndLint(code)).hasTextLocations(8 to 34)
+        }
     }
 })
+
+private const val IGNORE_OVERRIDDEN = "ignoreOverridden"

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -44,6 +44,10 @@ Reports constructor parameter names which do not follow the specified naming con
 
    ignores variables in classes which match this regex
 
+* ``ignoreOverridden`` (default: ``true``)
+
+   ignores constructor properties that have the override modifier
+
 ### EnumNaming
 
 Reports when enum names which do not follow the specified naming convention are used.


### PR DESCRIPTION
This PR should wait until #2094 is merged.

This PR tries to fix this:

```kotlin
class C(override val PARAM: String) : I

interface I { val PARAM: String }
```

If we override a property of an interface in a constructor we should ignore the naming check by default.