### PR TITLE
Create UnnecessaryAnnotationUseSiteTargetRule

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -535,6 +535,8 @@ style:
   UnnecessaryAbstractClass:
     active: true
     excludeAnnotatedClasses: "dagger.Module"
+  UnnecessaryAnnotationUseSiteTarget:
+    active: false
   UnnecessaryApply:
     active: false
   UnnecessaryInheritance:

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -78,7 +78,7 @@ internal class RuleVisitor : DetektVisitor() {
         active = classOrObject.kDocSection()?.findTagByName(TAG_ACTIVE) != null
         autoCorrect = classOrObject.kDocSection()?.findTagByName(TAG_AUTO_CORRECT) != null
 
-        val comment = classOrObject.kDocSection()?.getContent()?.trim() ?: return
+        val comment = classOrObject.kDocSection()?.getContent()?.trim()?.replace("@@", "@") ?: return
         extractRuleDocumentation(comment)
         configuration.addAll(classOrObject.parseConfigurationTags())
     }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -92,7 +92,7 @@ internal class RuleVisitor : DetektVisitor() {
                 extractCompliantDocumentation(comment, compliantIndex)
             }
             compliantIndex != -1 -> throw InvalidCodeExampleDocumentationException(
-                    "Rule $name contains a compliant without a noncompliant code definition.")
+                    "Rule $name contains a compliant without a noncompliant code definition")
             else -> description = comment
         }
     }
@@ -101,7 +101,7 @@ internal class RuleVisitor : DetektVisitor() {
         val nonCompliantEndIndex = comment.indexOf(ENDTAG_NONCOMPLIANT)
         if (nonCompliantEndIndex == -1) {
             throw InvalidCodeExampleDocumentationException(
-                    "Rule $name contains an incorrect noncompliant code definition.")
+                    "Rule $name contains an incorrect noncompliant code definition")
         }
         description = comment.substring(0, nonCompliantIndex).trim()
         nonCompliant = comment.substring(nonCompliantIndex + TAG_NONCOMPLIANT.length, nonCompliantEndIndex)
@@ -114,7 +114,7 @@ internal class RuleVisitor : DetektVisitor() {
         if (compliantIndex != -1) {
             if (compliantEndIndex == -1) {
                 throw InvalidCodeExampleDocumentationException(
-                        "Rule $name contains an incorrect compliant code definition.")
+                        "Rule $name contains an incorrect compliant code definition")
             }
             compliant = comment.substring(compliantIndex + TAG_COMPLIANT.length, compliantEndIndex)
                     .trimStartingLineBreaks()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -34,6 +34,7 @@ import io.gitlab.arturbosch.detekt.rules.style.SpacingBetweenPackageAndImports
 import io.gitlab.arturbosch.detekt.rules.style.ThrowsCount
 import io.gitlab.arturbosch.detekt.rules.style.UnderscoresInNumericLiterals
 import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryAbstractClass
+import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryAnnotationUseSiteTarget
 import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryApply
 import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryInheritance
 import io.gitlab.arturbosch.detekt.rules.style.UnnecessaryLet
@@ -85,6 +86,7 @@ class StyleGuideProvider : RuleSetProvider {
                 LoopWithTooManyJumpStatements(config),
                 SafeCast(config),
                 UnnecessaryAbstractClass(config),
+                UnnecessaryAnnotationUseSiteTarget(config),
                 UnnecessaryParentheses(config),
                 UnnecessaryInheritance(config),
                 UtilityClassWithPublicConstructor(config),

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTarget.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTarget.kt
@@ -1,0 +1,78 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Location
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtAnnotationUseSiteTarget
+import org.jetbrains.kotlin.psi.KtPrimaryConstructor
+import org.jetbrains.kotlin.psi.KtProperty
+
+/**
+ * This rule inspects the use of the Annotation use-site Target. In case that the use-site Target is not needed it can
+ * be removed. For more information check the kotlin documentation:
+ * https://kotlinlang.org/docs/reference/annotations.html#annotation-use-site-targets
+ *
+ * <noncompliant>
+ * @@property:Inject private val foo: String = "bar" // violation: unnecessary @property:
+ *
+ * class Module(@param:Inject private val foo: String) // violation: unnecessary @param:
+ * </noncompliant>
+ *
+ * <compliant>
+ * class Module(@Inject private val foo: String)
+ * </compliant>
+ */
+class UnnecessaryAnnotationUseSiteTarget(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Unnecessary Annotation use-site Target. It can be removed.",
+        Debt.FIVE_MINS
+    )
+
+    override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
+        constructor.valueParameters.forEach { parameter ->
+            checkForUnnecessaryUseSiteTarget(parameter.annotationEntries, UseSiteTarget.PARAM)
+        }
+        super.visitPrimaryConstructor(constructor)
+    }
+
+    override fun visitProperty(property: KtProperty) {
+        checkForUnnecessaryUseSiteTarget(property.annotationEntries, UseSiteTarget.PROPERTY)
+        super.visitProperty(property)
+    }
+
+    private fun checkForUnnecessaryUseSiteTarget(annotations: List<KtAnnotationEntry>, useSiteTarget: UseSiteTarget) {
+        annotations.forEach { annotationEntry ->
+            val useSite = annotationEntry.useSiteTarget
+            if (useSite != null && useSite.text == useSiteTarget.useSiteTarget) {
+                report(useSite, useSiteTarget.message)
+            }
+        }
+    }
+
+    private fun report(useSite: KtAnnotationUseSiteTarget, message: String) {
+        val location = Location.from(useSite).let { location ->
+            location.copy(text = location.text.copy(end = location.text.end + 1))
+        }
+        report(CodeSmell(issue, Entity.from(useSite, location), message))
+    }
+
+    private enum class UseSiteTarget(val useSiteTarget: String, val message: String) {
+        PARAM(
+            "param",
+            "An annotation over a parameter doesn't need the use-site target @param."
+        ),
+        PROPERTY(
+            "property",
+            "An annotation over a property, that it's not a parameter, doesn't need the use-site target @property."
+        )
+    }
+}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTargetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTargetSpec.kt
@@ -1,0 +1,68 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class UnnecessaryAnnotationUseSiteTargetSpec : Spek({
+
+    describe("UnnecessaryAnnotationUseSiteTarget rule") {
+
+        context("Unnecessary @param: in a property constructor") {
+            val code = """
+                class C(@param:Asdf private val foo: String)
+
+                annotation class Asdf
+            """
+            assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).hasTextLocations("param:")
+        }
+
+        context("Unnecessary @param: in a constructor") {
+            val code = """
+                class C(@param:Asdf foo: String)
+
+                annotation class Asdf
+            """
+            assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).hasTextLocations("param:")
+        }
+
+        context("Necessary @get:") {
+            val code = """
+                class C(@get:Asdf private val foo: String)
+
+                annotation class Asdf
+            """
+            assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).isEmpty()
+        }
+
+        context("Necessary @property:") {
+            val code = """
+                class C(@property:Asdf private val foo: String)
+
+                annotation class Asdf
+            """
+            assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).isEmpty()
+        }
+
+        context("Unnecessary @property:") {
+            val code = """
+                class C {
+                    @property:Asdf private val foo: String = "bar"
+                }
+
+                annotation class Asdf
+            """
+            assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).hasTextLocations("property:")
+        }
+
+        context("Unnecessary @property: at a top level property") {
+            val code = """
+                @property:Asdf private val foo: String = "bar"
+
+                annotation class Asdf
+            """
+            assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).hasTextLocations("property:")
+        }
+    }
+})

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -1067,6 +1067,30 @@ abstract class OnlyConcreteMembersInAbstractClass { // violation: no abstract me
 }
 ```
 
+### UnnecessaryAnnotationUseSiteTarget
+
+This rule inspects the use of the Annotation use-site Target. In case that the use-site Target is not needed it can
+be removed. For more information check the kotlin documentation:
+https://kotlinlang.org/docs/reference/annotations.html#annotation-use-site-targets
+
+**Severity**: Style
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+@property:Inject private val foo: String = "bar" // violation: unnecessary @property:
+
+class Module(@param:Inject private val foo: String) // violation: unnecessary @param:
+```
+
+#### Compliant Code:
+
+```kotlin
+class Module(@Inject private val foo: String)
+```
+
 ### UnnecessaryApply
 
 `apply` expressions are used frequently, but sometimes their usage should be replaced with


### PR DESCRIPTION
Closes #1138

Extracted from the issue:

> Quite often I see that the annotation use site targets are used inappropriately.
> 
> For instance:
> 
> ```kotlin
> class Presenter(
>   ...
>   @param:SchedulerMain private val mainScheduler: Scheduler,
>   @param:SchedulerComputation private val computationScheduler: Scheduler
> )
> ```
> 
> `param:` isn't required and hence it should be flagged.

This new rule flags that.