### PR TITLE
Don't compile test snippets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,22 @@ matrix:
     - os: linux
       dist: trusty
       jdk: oraclejdk8
+      env: COMPILE_TEST_SNIPPETS=true
     - os: linux
       dist: bionic
       jdk: openjdk11
+      env: COMPILE_TEST_SNIPPETS=false
     - os: linux
       dist: bionic
       jdk: openjdk12
+      env: COMPILE_TEST_SNIPPETS=false
     # JDK 8 - see https://docs.travis-ci.com/user/reference/osx/#jdk-and-macos
     - os: osx
       osx_image: xcode9.3
+      env: COMPILE_TEST_SNIPPETS=false
 install: true
 script:
-  - ./gradlew build --build-cache --parallel -PwarningsAsErrors=true --scan
+  - ./gradlew build --build-cache --parallel -PwarningsAsErrors=true -Pcompile-test-snippets=$COMPILE_TEST_SNIPPETS --scan
   - ./gradlew shadowJar
   - java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar --help
   - java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar -i . --baseline ./config/detekt/baseline.xml -ex "**/resources/**,**/detekt*/build/**" -c ./detekt-cli/src/main/resources/default-detekt-config.yml,./config/detekt/detekt.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,15 @@ clone_depth: 10
 environment:
   TERM: dumb
   matrix:
-    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-    - JAVA_HOME: C:\Program Files\Java\jdk11
-    - JAVA_HOME: C:\Program Files\Java\jdk12
+    -
+      JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+      COMPILE_TEST_SNIPPETS: true
+    -
+      JAVA_HOME: C:\Program Files\Java\jdk11
+      COMPILE_TEST_SNIPPETS: false
+    -
+      JAVA_HOME: C:\Program Files\Java\jdk12
+      COMPILE_TEST_SNIPPETS: false
 
 init:
   - git config --global --unset core.autocrlf
@@ -27,7 +33,7 @@ install:
   - gradlew.bat --version
 
 build_script:
-  - gradlew build --build-cache --parallel -PwarningsAsErrors=true
+  - gradlew build --build-cache --parallel -PwarningsAsErrors=true -Pcompile-test-snippets=%COMPILE_TEST_SNIPPETS%
   - gradlew installShadowDist
   - detekt-cli\build\install\detekt-cli-shadow\bin\detekt-cli --help
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,6 +143,12 @@ subprojects {
     tasks.withType<Test>().configureEach {
         useJUnitPlatform()
         systemProperty("SPEK_TIMEOUT", 0) // disable test timeout
+        val compileSnippetText: Boolean = if (project.hasProperty("compile-test-snippets")) {
+            (project.property("compile-test-snippets") as String).toBoolean()
+        } else {
+            false
+        }
+        systemProperty("compile-snippet-tests", compileSnippetText)
         testLogging {
             // set options for log level LIFECYCLE
             events = setOf(

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -9,8 +9,12 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import java.nio.file.Path
 
+private val compileTestSnippets: Boolean = System.getProperty("compile-snippet-tests", "false")!!.toBoolean()
+
 fun BaseRule.compileAndLint(@Language("kotlin") content: String): List<Finding> {
-    KotlinScriptEngine.compile(content)
+    if (compileTestSnippets) {
+        KotlinScriptEngine.compile(content)
+    }
     return lint(content)
 }
 


### PR DESCRIPTION
Closes #2095

We need to check that our production is OK every time. But we don't need to check that our tests are OK every time too.

This change speeds up the tests about 2.5 times.

What do you think about the naming? I'm not sure...