### PR TITLE
Fix formatting rule signatures

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReport.kt
@@ -56,7 +56,7 @@ class HtmlOutputReport : OutputReport() {
     private fun renderComplexity(complexityReport: List<String>) = createHTML().div {
         ul {
             complexityReport.forEach {
-                li { text("${it.trim()}") }
+                li { text(it.trim()) }
             }
         }
     }
@@ -118,8 +118,10 @@ class HtmlOutputReport : OutputReport() {
 
     private fun getComplexityMetrics(detektion: Detektion): List<String> {
         val complexityReport = ComplexityReportGenerator.create(detektion).generate()
-        return if (complexityReport.isNullOrBlank()) listOf<String>() else {
-            var complexities = complexityReport.split("\n")
+        return if (complexityReport.isNullOrBlank()) {
+            emptyList()
+        } else {
+            val complexities = complexityReport.split("\n")
             return complexities.subList(1, complexities.size - 1)
         }
     }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtils.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtils.kt
@@ -12,7 +12,7 @@ internal fun FlowContent.snippetCode(lines: Sequence<String>, location: SourceLo
     pre {
         code {
             val dropLineCount = max(location.line - 1 - EXTRA_LINES_IN_SNIPPET, 0)
-            val takeLineCount = EXTRA_LINES_IN_SNIPPET + 1 + Math.min(location.line - 1, EXTRA_LINES_IN_SNIPPET)
+            val takeLineCount = EXTRA_LINES_IN_SNIPPET + 1 + min(location.line - 1, EXTRA_LINES_IN_SNIPPET)
             var currentLineNumber = dropLineCount + 1
             var errorLength = length
             lines

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -44,8 +44,7 @@ abstract class FormattingRule(config: Config) : Rule(config) {
         this.root = root
         root.node.putUserData(KtLint.ANDROID_USER_DATA_KEY, isAndroid)
         positionByOffset = calculateLineColByOffset(root.text).let {
-            val offsetDueToLineBreakNormalization = calculateLineBreakOffset(root.text)
-            return@let { offset: Int -> it(offset + offsetDueToLineBreakNormalization(offset)) }
+            return@let { offset: Int -> it(offset) }
         }
         editorConfigUpdater()?.let { updateFunc ->
             val oldEditorConfig = root.node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/OffsetsToLineColumn.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/OffsetsToLineColumn.kt
@@ -27,21 +27,6 @@ internal fun calculateLineColByOffset(text: String): (offset: Int) -> Pair<Int, 
     }
 }
 
-internal fun calculateLineBreakOffset(fileContent: String): (offset: Int) -> Int {
-    val arr = ArrayList<Int>()
-    var i = 0
-    do {
-        arr.add(i)
-        i = fileContent.indexOf("\r\n", i + 1)
-    } while (i != -1)
-    arr.add(fileContent.length)
-    return if (arr.size != 2) {
-        SegmentTree(arr.toIntArray()).let { return { offset -> it.indexOf(offset) } }
-    } else { _ ->
-        0
-    }
-}
-
 internal class SegmentTree(sortedArray: IntArray) {
 
     private val segments: List<Segment>
@@ -60,7 +45,7 @@ internal class SegmentTree(sortedArray: IntArray) {
         require(sortedArray.size > 1) { "At least two data points are required" }
         sortedArray.reduce { r, v -> require(r <= v) { "Data points are not sorted (ASC)" }; v }
         segments = sortedArray.take(sortedArray.size - 1)
-                .mapIndexed { i: Int, v: Int -> Segment(v, sortedArray[i + 1] - 1) }
+            .mapIndexed { i: Int, v: Int -> Segment(v, sortedArray[i + 1] - 1) }
     }
 }
 


### PR DESCRIPTION
TODO:
```
CorrectableCodeSmell(autoCorrectEnabled=true,issue=Issue(id='NoBlankLineBeforeRbrace', severity=Style, debt=5min), entity=Entity(name=parseTestResult, className=SurefireStaxHandler, signature=SurefireStaxHandler.kt$SurefireStaxHandler$ , location=Location(source=112:57, text=4775:4793, locationString=(112, 57), file=/home/artur/git/repos/sonar-kotlin/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/data/SurefireStaxHandler.kt), ktElement=BLOCK), message=Unexpected blank line(s) before "}", metrics=[], references=[], id='NoBlankLineBeforeRbrace')
java.lang.StringIndexOutOfBoundsException: begin 0, end 56, length 17
        at java.base/java.lang.String.checkBoundsBeginEnd(String.java:3319)
        at java.base/java.lang.String.substring(String.java:1874)
        at io.gitlab.arturbosch.detekt.cli.out.HtmlUtilsKt.writeErrorLine(HtmlUtils.kt:38)
        at io.gitlab.arturbosch.detekt.cli.out.HtmlUtilsKt.access$writeErrorLine(HtmlUtils.kt:1)
        at io.gitlab.arturbosch.detekt.cli.out.HtmlUtilsKt$snippetCode$1$1.invoke(HtmlUtils.kt:25)
        at io.gitlab.arturbosch.detekt.cli.out.HtmlUtilsKt$snippetCode$1$1.invoke(HtmlUtils.kt)
        at kotlinx.html.ApiKt.visit(api.kt:80)
        at kotlinx.html.Gen_tag_unionsKt.code(gen-tag-unions.kt:161)
        at kotlinx.html.Gen_tag_unionsKt.code$default(gen-tag-unions.kt:161)
        at io.gitlab.arturbosch.detekt.cli.out.HtmlUtilsKt$snippetCode$1.invoke(HtmlUtils.kt:13)
        at io.gitlab.arturbosch.detekt.cli.out.HtmlUtilsKt$snippetCode$1.invoke(HtmlUtils.kt)
        at kotlinx.html.ApiKt.visit(api.kt:80)

```