### PR TITLE
Return non-nullable string in DebtSumming class

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/DebtSumming.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/DebtSumming.kt
@@ -22,7 +22,7 @@ class DebtSumming {
     fun printDebtInformation(
         issues: Map<RuleSetId, List<Finding>>,
         totalDebt: DebtSumming
-    ): String? {
+    ): String {
         with(StringBuilder()) {
             issues
                 .filter { it.value.isNotEmpty() }
@@ -51,7 +51,7 @@ class DebtSumming {
         issues: Map<RuleSetId, List<Finding>>,
         fileDebt: DebtSumming,
         totalDebt: DebtSumming
-    ): String? {
+    ): String {
         with(StringBuilder()) {
             issues
                 .filter { it.value.isNotEmpty() }


### PR DESCRIPTION
Since StringBuilder.toString() can't return null, both methods in the
DebtSumming class also can't return null.
