### PR TITLE
Create rule: ForbiddenPublicDataClass

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SplitPattern.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SplitPattern.kt
@@ -13,9 +13,7 @@ open class SplitPattern(
 
     @Suppress("detekt.SpreadOperator")
     private val excludes = text
-        .splitToSequence(*delimiters.toCharArray())
-        .map { it.trim() }
-        .filter { it.isNotBlank() }
+        .commaSeparatedPattern(*delimiters.toCharArray().map { it.toString() }.toTypedArray())
         .mapIf(removeTrailingAsterisks) { seq ->
             seq.map { it.removePrefix("*") }
                 .map { it.removeSuffix("*") }
@@ -65,4 +63,34 @@ open class SplitPattern(
      * Transforms all parts by given [transform] function.
      */
     fun <T> mapAll(transform: (String) -> T): List<T> = excludes.map(transform)
+}
+
+/**
+ * Splits given String into a sequence of strings splited by the provided delimiters ("," by default).
+ *
+ * It also trims the strings and removes the empty ones
+ */
+@Suppress("detekt.SpreadOperator")
+fun String.commaSeparatedPattern(vararg delimiters: String = arrayOf(",")): Sequence<String> {
+    return this
+        .splitToSequence(*delimiters)
+        .filter { it.isNotBlank() }
+        .map { it.trim() }
+}
+
+/**
+ * Convert a simple pattern String to a Regex
+ *
+ * The simple pattern is a subset of the shell pattern matching or
+ * [glob][https://en.wikipedia.org/wiki/Glob_(programming)]
+ *
+ * '*' matches any zero or more characters
+ * '?' matches any one character
+ */
+fun String.simplePatternToRegex(): Regex {
+    return this
+        .replace(".", "\\.")
+        .replace("*", ".*")
+        .replace("?", ".?")
+        .toRegex()
 }

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -455,6 +455,8 @@ style:
     active: false
     imports: ''
     forbiddenPatterns: ""
+  ForbiddenPublicDataClass:
+    active: false
   ForbiddenVoid:
     active: false
     ignoreOverridden: false

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -457,6 +457,7 @@ style:
     forbiddenPatterns: ""
   ForbiddenPublicDataClass:
     active: false
+    ignorePackages: '*.internal,*.internal.*'
   ForbiddenVoid:
     active: false
     ignoreOverridden: false

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -13,6 +13,7 @@ import io.gitlab.arturbosch.detekt.rules.style.ExpressionBodySyntax
 import io.gitlab.arturbosch.detekt.rules.style.FileParsingRule
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenComment
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenImport
+import io.gitlab.arturbosch.detekt.rules.style.ForbiddenPublicDataClass
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenVoid
 import io.gitlab.arturbosch.detekt.rules.style.FunctionOnlyReturningConstant
 import io.gitlab.arturbosch.detekt.rules.style.LibraryCodeMustSpecifyReturnType
@@ -80,6 +81,7 @@ class StyleGuideProvider : RuleSetProvider {
                 EqualsNullCall(config),
                 ForbiddenComment(config),
                 ForbiddenImport(config),
+                ForbiddenPublicDataClass(config),
                 FunctionOnlyReturningConstant(config),
                 SpacingBetweenPackageAndImports(config),
                 LoopWithTooManyJumpStatements(config),

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -67,6 +67,7 @@ class StyleGuideProvider : RuleSetProvider {
 
     override val ruleSetId: String = "style"
 
+    @Suppress("LongMethod")
     override fun instance(config: Config): RuleSet {
         return RuleSet(
             ruleSetId,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -7,6 +7,8 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.commaSeparatedPattern
+import io.gitlab.arturbosch.detekt.api.simplePatternToRegex
 import org.jetbrains.kotlin.psi.KtImportDirective
 
 /**
@@ -33,13 +35,10 @@ class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
         Debt.TEN_MINS
     )
 
-    private val forbiddenImports = valueOrDefault(IMPORTS, "").split(",")
-        .asSequence()
-        .map { it.trim() }
-        .filter { it.isNotBlank() }
-        .map { it.replace(".", "\\.") }
-        .map { it.replace("*", ".*") }
-        .map { Regex(it) }
+    private val forbiddenImports = valueOrDefault(IMPORTS, "")
+        .commaSeparatedPattern()
+        .distinct()
+        .map { it.simplePatternToRegex() }
         .toList()
 
     private val forbiddenPatterns: Regex = Regex(valueOrDefault(FORBIDDEN_PATTERNS, ""))

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClass.kt
@@ -11,6 +11,7 @@ import io.gitlab.arturbosch.detekt.api.commaSeparatedPattern
 import io.gitlab.arturbosch.detekt.api.simplePatternToRegex
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
 
 /**
@@ -46,6 +47,9 @@ class ForbiddenPublicDataClass(config: Config = Config.empty) : Rule(config) {
         .distinct()
         .map { it.simplePatternToRegex() }
         .toList()
+
+    override fun visitCondition(root: KtFile): Boolean =
+        super.visitCondition(root) && filters != null
 
     override fun visitClass(klass: KtClass) {
         val packageName = klass.containingKtFile.packageDirective?.packageNameExpression?.text

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClass.kt
@@ -7,6 +7,8 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.commaSeparatedPattern
+import io.gitlab.arturbosch.detekt.api.simplePatternToRegex
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
@@ -40,12 +42,9 @@ class ForbiddenPublicDataClass(config: Config = Config.empty) : Rule(config) {
     )
 
     private val ignorablePackages = valueOrDefault(IGNORE_PACKAGES, "*.internal,*.internal.*")
-        .splitToSequence(",")
-        .map { it.trim() }
-        .filter { it.isNotBlank() }
-        .map { it.replace(".", "\\.") }
-        .map { it.replace("*", ".*") }
-        .map { Regex(it) }
+        .commaSeparatedPattern()
+        .distinct()
+        .map { it.simplePatternToRegex() }
         .toList()
 
     override fun visitClass(klass: KtClass) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClass.kt
@@ -1,0 +1,50 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
+
+/**
+ * The data classes are bad for the binary compatibility in public APIs. Avoid to use it.
+ *
+ * This rule is aimed to library maintainers. If you are developing a final application you don't need to care about
+ * this issue.
+ *
+ * More info: https://jakewharton.com/public-api-challenges-in-kotlin/
+ *
+ * <noncompliant>
+ * data class C(val a: String) // violation: public data class
+ * </noncompliant>
+ *
+ * <compliant>
+ * internal data class C(val a: String)
+ * </compliant>
+ */
+class ForbiddenPublicDataClass(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "The data classes are bad for the binary compatibility in public APIs. Avoid to use it.",
+        Debt.TWENTY_MINS
+    )
+
+    override fun visitClass(klass: KtClass) {
+        val isPublicOrProtected = klass.visibilityModifierTypeOrDefault().let { visibility ->
+            visibility != KtTokens.INTERNAL_KEYWORD && visibility != KtTokens.PRIVATE_KEYWORD
+        }
+        if (isPublicOrProtected) {
+            if (klass.isData()) {
+                report(CodeSmell(issue, Entity.from(klass.nameIdentifier ?: klass), ""))
+            }
+            super.visitClass(klass)
+        }
+    }
+}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClassSpec.kt
@@ -123,7 +123,7 @@ class ForbiddenPublicDataClassSpec : Spek({
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
-        it("public data class inside a random should fail") {
+        it("public data class inside a random package should fail") {
             val code = """
                 package com.example
                 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClassSpec.kt
@@ -1,0 +1,82 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class ForbiddenPublicDataClassSpec : Spek({
+    describe("ForbiddenPublicDataClass rule") {
+        it("public data class should fail") {
+            val code = """
+                data class C(val a: String)                
+            """
+
+            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).hasSize(1)
+        }
+
+        it("private data class should pass") {
+            val code = """
+                private data class C(val a: String)                
+            """
+
+            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+        }
+
+        it("internal data class should pass") {
+            val code = """
+                internal data class C(val a: String)                
+            """
+
+            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+        }
+
+        it("public class should pass") {
+            val code = """
+                class C(val a: String) 
+            """
+
+            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+        }
+
+        it("private data class inside a public class should pass") {
+            val code = """
+                class C {
+                    private data class D(val a: String)   
+                }
+            """
+
+            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+        }
+
+        it("public data class inside a public class should fail") {
+            val code = """
+                class C {
+                    data class D(val a: String)   
+                }
+            """
+
+            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).hasSize(1)
+        }
+
+        it("protected data class inside a public class should fail") {
+            val code = """
+                open class C {
+                    protected data class D(val a: String)   
+                }
+            """
+
+            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).hasSize(1)
+        }
+
+        it("public data class inside an internal class should pass") {
+            val code = """
+                internal class C {
+                    data class D(val a: String)   
+                }
+            """
+
+            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+        }
+    }
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClassSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
@@ -8,12 +9,24 @@ import org.spekframework.spek2.style.specification.describe
 
 class ForbiddenPublicDataClassSpec : Spek({
     describe("ForbiddenPublicDataClass rule") {
+        it("public data class should pass without explicit filters set") {
+            val code = """
+                data class C(val a: String)                
+            """
+
+            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+        }
+
+        val subject by memoized {
+            ForbiddenPublicDataClass(TestConfig(Config.INCLUDES_KEY to "*.kt"))
+        }
+
         it("public data class should fail") {
             val code = """
                 data class C(val a: String)                
             """
 
-            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("private data class should pass") {
@@ -21,7 +34,7 @@ class ForbiddenPublicDataClassSpec : Spek({
                 private data class C(val a: String)                
             """
 
-            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("internal data class should pass") {
@@ -29,7 +42,7 @@ class ForbiddenPublicDataClassSpec : Spek({
                 internal data class C(val a: String)                
             """
 
-            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("public class should pass") {
@@ -37,7 +50,7 @@ class ForbiddenPublicDataClassSpec : Spek({
                 class C(val a: String) 
             """
 
-            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("private data class inside a public class should pass") {
@@ -47,7 +60,7 @@ class ForbiddenPublicDataClassSpec : Spek({
                 }
             """
 
-            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("public data class inside a public class should fail") {
@@ -57,7 +70,7 @@ class ForbiddenPublicDataClassSpec : Spek({
                 }
             """
 
-            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("protected data class inside a public class should fail") {
@@ -67,7 +80,7 @@ class ForbiddenPublicDataClassSpec : Spek({
                 }
             """
 
-            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("public data class inside an internal class should pass") {
@@ -77,7 +90,7 @@ class ForbiddenPublicDataClassSpec : Spek({
                 }
             """
 
-            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("public data class inside an internal package should pass") {
@@ -87,7 +100,7 @@ class ForbiddenPublicDataClassSpec : Spek({
                 data class C(val a: String)                
             """
 
-            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("public data class inside an internal subpackage should pass") {
@@ -97,7 +110,7 @@ class ForbiddenPublicDataClassSpec : Spek({
                 data class C(val a: String)                
             """
 
-            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("public data class inside an internalise package should fail") {
@@ -107,7 +120,7 @@ class ForbiddenPublicDataClassSpec : Spek({
                 data class C(val a: String)                
             """
 
-            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("public data class inside a random should fail") {
@@ -117,7 +130,7 @@ class ForbiddenPublicDataClassSpec : Spek({
                 data class C(val a: String)                
             """
 
-            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("public data class inside an ignored package should pass") {
@@ -127,7 +140,7 @@ class ForbiddenPublicDataClassSpec : Spek({
                 data class C(val a: String)                
             """
 
-            val config = TestConfig(mapOf("ignorePackages" to "*.hello,com.example"))
+            val config = TestConfig("ignorePackages" to "*.hello,com.example", Config.INCLUDES_KEY to "*.kt")
             assertThat(ForbiddenPublicDataClass(config).compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClassSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
@@ -77,6 +78,57 @@ class ForbiddenPublicDataClassSpec : Spek({
             """
 
             assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+        }
+
+        it("public data class inside an internal package should pass") {
+            val code = """
+                package com.example.internal
+                
+                data class C(val a: String)                
+            """
+
+            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+        }
+
+        it("public data class inside an internal subpackage should pass") {
+            val code = """
+                package com.example.internal.other
+                
+                data class C(val a: String)                
+            """
+
+            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+        }
+
+        it("public data class inside an internalise package should fail") {
+            val code = """
+                package com.example.internalise
+                
+                data class C(val a: String)                
+            """
+
+            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).hasSize(1)
+        }
+
+        it("public data class inside a random should fail") {
+            val code = """
+                package com.example
+                
+                data class C(val a: String)                
+            """
+
+            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).hasSize(1)
+        }
+
+        it("public data class inside an ignored package should pass") {
+            val code = """
+                package com.example
+                
+                data class C(val a: String)                
+            """
+
+            val config = TestConfig(mapOf("ignorePackages" to "*.hello,com.example"))
+            assertThat(ForbiddenPublicDataClass(config).compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -277,6 +277,31 @@ import kotlin.jvm.JvmField
 import kotlin.SinceKotlin
 ```
 
+### ForbiddenPublicDataClass
+
+The data classes are bad for the binary compatibility in public APIs. Avoid to use it.
+
+This rule is aimed to library maintainers. If you are developing a final application you don't need to care about
+this issue.
+
+More info: https://jakewharton.com/public-api-challenges-in-kotlin/
+
+**Severity**: Style
+
+**Debt**: 20min
+
+#### Noncompliant Code:
+
+```kotlin
+data class C(val a: String) // violation: public data class
+```
+
+#### Compliant Code:
+
+```kotlin
+internal data class C(val a: String)
+```
+
 ### ForbiddenVoid
 
 This rule detects usages of `Void` and reports them as forbidden.

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -290,6 +290,12 @@ More info: https://jakewharton.com/public-api-challenges-in-kotlin/
 
 **Debt**: 20min
 
+#### Configuration options:
+
+* ``ignorePackages`` (default: ``'*.internal,*.internal.*'``)
+
+   ignores classes in the specified packages. Split by commas ','
+
 #### Noncompliant Code:
 
 ```kotlin

--- a/docs/pages/kdoc/detekt-api/alltypes/index.md
+++ b/docs/pages/kdoc/detekt-api/alltypes/index.md
@@ -361,6 +361,11 @@ Basic use cases are to specify different function or class names in the detekt
 yaml config and test for their appearance in specific rules.
 
 
+| (extensions in package io.gitlab.arturbosch.detekt.api)
+
+##### [kotlin.String](../io.gitlab.arturbosch.detekt.api/kotlin.-string/index.html)
+
+
 |
 
 ##### [io.gitlab.arturbosch.detekt.api.TextLocation](../io.gitlab.arturbosch.detekt.api/-text-location/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/index.md
@@ -54,6 +54,7 @@ title: io.gitlab.arturbosch.detekt.api - detekt-api
 
 ### Extensions for External Classes
 
+| [kotlin.String](kotlin.-string/index.html) |  |
 | [org.jetbrains.kotlin.psi.KtAnnotated](org.jetbrains.kotlin.psi.-kt-annotated/index.html) |  |
 | [org.jetbrains.kotlin.psi.KtElement](org.jetbrains.kotlin.psi.-kt-element/index.html) |  |
 

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/kotlin.-string/comma-separated-pattern.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/kotlin.-string/comma-separated-pattern.md
@@ -1,0 +1,14 @@
+---
+title: commaSeparatedPattern - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [kotlin.String](index.html) / [commaSeparatedPattern](./comma-separated-pattern.html)
+
+# commaSeparatedPattern
+
+`fun `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`.commaSeparatedPattern(vararg delimiters: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)` = arrayOf(",")): `[`Sequence`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.sequences/-sequence/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>`
+
+Splits given String into a sequence of strings splited by the provided delimiters ("," by default).
+
+It also trims the strings and removes the empty ones
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/kotlin.-string/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/kotlin.-string/index.md
@@ -1,0 +1,11 @@
+---
+title: io.gitlab.arturbosch.detekt.api.kotlin.String - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [kotlin.String](./index.html)
+
+### Extensions for kotlin.String
+
+| [commaSeparatedPattern](comma-separated-pattern.html) | Splits given String into a sequence of strings splited by the provided delimiters ("," by default).`fun `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`.commaSeparatedPattern(vararg delimiters: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)` = arrayOf(",")): `[`Sequence`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.sequences/-sequence/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`>` |
+| [simplePatternToRegex](simple-pattern-to-regex.html) | Convert a simple pattern String to a Regex`fun `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`.simplePatternToRegex(): `[`Regex`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/-regex/index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/kotlin.-string/simple-pattern-to-regex.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/kotlin.-string/simple-pattern-to-regex.md
@@ -1,0 +1,18 @@
+---
+title: simplePatternToRegex - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [kotlin.String](index.html) / [simplePatternToRegex](./simple-pattern-to-regex.html)
+
+# simplePatternToRegex
+
+`fun `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`.simplePatternToRegex(): `[`Regex`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/-regex/index.html)
+
+Convert a simple pattern String to a Regex
+
+The simple pattern is a subset of the shell pattern matching or
+[glob](https://en.wikipedia.org/wiki/Glob_programming)
+
+'*' matches any zero or more characters
+'?' matches any one character
+

--- a/docs/pages/kdoc/detekt-api/package-list
+++ b/docs/pages/kdoc/detekt-api/package-list
@@ -1,7 +1,9 @@
 $dokka.format:jekyll
 $dokka.linkExtension:html
+$dokka.location:io.gitlab.arturbosch.detekt.api$commaSeparatedPattern(kotlin.String, kotlin.Array((kotlin.String)))io.gitlab.arturbosch.detekt.api/kotlin.-string/comma-separated-pattern.html
 $dokka.location:io.gitlab.arturbosch.detekt.api$isSuppressedBy(org.jetbrains.kotlin.psi.KtAnnotated, kotlin.String, kotlin.collections.Set((kotlin.String)))io.gitlab.arturbosch.detekt.api/org.jetbrains.kotlin.psi.-kt-annotated/is-suppressed-by.html
 $dokka.location:io.gitlab.arturbosch.detekt.api$isSuppressedBy(org.jetbrains.kotlin.psi.KtElement, kotlin.String, kotlin.collections.Set((kotlin.String)))io.gitlab.arturbosch.detekt.api/org.jetbrains.kotlin.psi.-kt-element/is-suppressed-by.html
+$dokka.location:io.gitlab.arturbosch.detekt.api$simplePatternToRegex(kotlin.String)io.gitlab.arturbosch.detekt.api/kotlin.-string/simple-pattern-to-regex.html
 $dokka.location:io.gitlab.arturbosch.detekt.api.internal$absolutePath(org.jetbrains.kotlin.psi.KtFile)io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-file/absolute-path.html
 $dokka.location:io.gitlab.arturbosch.detekt.api.internal$isSuppressedBy(org.jetbrains.kotlin.psi.KtAnnotated, kotlin.String, kotlin.collections.Set((kotlin.String)), kotlin.String)io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-annotated/is-suppressed-by.html
 $dokka.location:io.gitlab.arturbosch.detekt.api.internal$isSuppressedBy(org.jetbrains.kotlin.psi.KtElement, kotlin.String, kotlin.collections.Set((kotlin.String)), kotlin.String)io.gitlab.arturbosch.detekt.api.internal/org.jetbrains.kotlin.psi.-kt-element/is-suppressed-by.html


### PR DESCRIPTION
Closes #2115 

If you expose data classes is too easy to create binary-incompatible bytecode in next versions of your library. This rule allows the library maintainers to ensure that they avoid that problem.