### PR TITLE
Add MagicNumber:ignoreLocalVariableDeclaration config

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -475,6 +475,7 @@ style:
     ignoreNumbers: '-1,0,1,2'
     ignoreHashCodeFunction: true
     ignorePropertyDeclaration: false
+    ignoreLocalVariableDeclaration: false
     ignoreConstantDeclaration: true
     ignoreCompanionObjectPropertyDeclaration: true
     ignoreAnnotation: false

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -68,6 +68,8 @@ import java.util.Locale
  * (default: `true`)
  * @configuration ignorePropertyDeclaration - whether magic numbers in property declarations should be ignored
  * (default: `false`)
+ * @configuration ignoreLocalVariableDeclaration - whether magic numbers in local variable declarations should be
+ * ignored (default: `false`)
  * @configuration ignoreConstantDeclaration - whether magic numbers in property declarations should be ignored
  * (default: `true`)
  * @configuration ignoreCompanionObjectPropertyDeclaration - whether magic numbers in companion object

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -429,6 +429,11 @@ describing what the magic number means.
 
    whether magic numbers in property declarations should be ignored
 
+* ``ignoreLocalVariableDeclaration`` (default: ``false``)
+
+   whether magic numbers in local variable declarations should be
+ignored
+
 * ``ignoreConstantDeclaration`` (default: ``true``)
 
    whether magic numbers in property declarations should be ignored


### PR DESCRIPTION
This config option wasn't correctly documented.
The generator didn't pick it up.
Hence, the default-detekt-config.yml file didn't include this option.
