### PR TITLE
Fix NPE for EqualsAlwaysReturnsTrueOrFalse

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
@@ -68,7 +68,7 @@ class EqualsAlwaysReturnsTrueOrFalse(config: Config = Config.empty) : Rule(confi
         val returnExpressionsInBlock = bodyExpression.collectDescendantsOfType<KtReturnExpression> {
             it.parent == bodyExpression || it.parent is KtAnnotatedExpression && it.parent.parent == bodyExpression
         }
-        val lastValidReturnExpression = returnExpressionsInBlock.first().returnedExpression
+        val lastValidReturnExpression = returnExpressionsInBlock.firstOrNull()?.returnedExpression
         val allReturnExpressions = bodyExpression.collectDescendantsOfType<KtReturnExpression>()
         val hasNoNestedReturnExpression = allReturnExpressions.size == returnExpressionsInBlock.size
         return lastValidReturnExpression?.isBooleanConstant() == true &&

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
@@ -23,14 +23,26 @@ class EqualsAlwaysReturnsTrueOrFalseSpec : Spek({
 
         it("detects and doesn't crash when return expression is annotated - #2021") {
             val code = """
-            class C {
-                override fun equals(other: Any?): Boolean {
-                    @Suppress("UnsafeCallOnNullableType")
-                    return true
+                class C {
+                    override fun equals(other: Any?): Boolean {
+                        @Suppress("UnsafeCallOnNullableType")
+                        return true
+                    }
                 }
-            }
             """
             assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        it("detects and doesn't crash when the equals method contains no return expression - #2103") {
+            val code = """
+                open class SuperClass
+                
+                data class Item(val text: String) : SuperClass() {
+                    override fun equals(other: Any?): Boolean = (other as? Item)?.text == this.text
+                    override fun hashCode(): Int = text.hashCode()
+                }
+            """
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 })


### PR DESCRIPTION
Fixes an exception that occurs when the equals method contains no
dedicated return expression.
Closes #2103
