### PR TITLE
Lazy init KotlinScriptEnginePool

### DIFF
--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEnginePool.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEnginePool.kt
@@ -12,12 +12,10 @@ object KotlinScriptEnginePool {
 
     private const val NUMBER_OF_ENGINES = 8
 
-    private val engines: Array<KotlinJsr223JvmLocalScriptEngine>
-    private var id = 0
-
-    init {
-        engines = Array(NUMBER_OF_ENGINES) { createEngine() }
+    private val engines: Array<KotlinJsr223JvmLocalScriptEngine> by lazy {
+        Array(NUMBER_OF_ENGINES) { createEngine() }
     }
+    private var id = 0
 
     fun getEngine(): KotlinJsr223JvmLocalScriptEngine {
         id++


### PR DESCRIPTION
This only initializes the Jsr223 KotlinScriptEngines when they are used
for the first time. This helps to reduce the test execution time when
rules don't use these engines.
reference: #2095
