### PR TITLE
Remove redundant Javadoc

### DIFF
--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEngine.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinScriptEngine.kt
@@ -11,9 +11,6 @@ object KotlinScriptEngine {
      * Compiles a given code string with the Jsr223 script engine.
      * If a compilation error occurs the script engine is recovered.
      * Afterwards this method throws a [KotlinScriptException].
-     *
-     * @param code the String to compile
-     * @throws ScriptException
      */
     fun compile(code: String) {
         try {


### PR DESCRIPTION
We use Dokka as the primary documentation engine for Kotlin code.
https://github.com/Kotlin/dokka
