### PR TITLE
Kotlin 1.3.60 with fix for "Unable to load JNA library" warning

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/KotlinEnvironmentUtils.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/KotlinEnvironmentUtils.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.api.internal
 
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoots
+import org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
@@ -28,7 +29,7 @@ import java.nio.file.Path
  * This environment also allows to modify the resulting AST files.
  */
 fun createKotlinCoreEnvironment(configuration: CompilerConfiguration = CompilerConfiguration()): KotlinCoreEnvironment {
-    System.setProperty("idea.io.use.fallback", "true")
+    setIdeaIoUseFallback()
     configuration.put(
         CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY,
         PrintingMessageCollector(System.err, MessageRenderer.PLAIN_FULL_PATHS, false)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/KotlinEnvironmentUtils.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/KotlinEnvironmentUtils.kt
@@ -29,6 +29,7 @@ import java.nio.file.Path
  * This environment also allows to modify the resulting AST files.
  */
 fun createKotlinCoreEnvironment(configuration: CompilerConfiguration = CompilerConfiguration()): KotlinCoreEnvironment {
+    // https://github.com/JetBrains/kotlin/commit/2568804eaa2c8f6b10b735777218c81af62919c1
     setIdeaIoUseFallback()
     configuration.put(
         CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY,

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     `maven-publish`
     id("com.gradle.plugin-publish") version "0.10.1"
     id("com.jfrog.bintray") version "1.8.4"
-    kotlin("jvm") version "1.3.50"
+    kotlin("jvm") version "1.3.60"
     id("org.jetbrains.dokka") version "0.10.0"
     id("com.github.ben-manes.versions") version "0.27.0"
     id("io.gitlab.arturbosch.detekt") version "1.2.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ buildScanVersion=3.0
 dokkaVersion=0.10.0
 gradleVersionsPluginVersion=0.27.0
 jacocoVersion=0.8.5
-kotlinVersion=1.3.50
+kotlinVersion=1.3.60
 shadowVersion=5.2.0
 sonarQubeVersion=2.8
 


### PR DESCRIPTION
Update to 1.3.60 which also fixes #2118

As mentioned in https://github.com/JetBrains/kotlin/commit/2568804eaa2c8f6b10b735777218c81af62919c1 by enabling NIO2 in the Kotlin compiler environment it will not attempt to use JNA libraries, avoiding the warning raised in #2118.

This also changes what detekt does to call the function in the Kotlin compiler instead of applying fallback config function in the Kotlin compiler. It's assumed that function will be kept up to date with any necessary fixes/workarounds in future, and also would have avoided the JNA lib warning in the first place.