### PR TITLE
Deprecate ignoreOverriddenFunction/s in favor of ignoreOverridden

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Notification.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Notification.kt
@@ -8,6 +8,8 @@ package io.gitlab.arturbosch.detekt.api
 interface Notification {
     val message: String
     val level: Level
+    val isError: Boolean
+        get() = level == Level.Error
 
     /**
      * Level of severity of the notification

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Notification.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Notification.kt
@@ -7,4 +7,13 @@ package io.gitlab.arturbosch.detekt.api
  */
 interface Notification {
     val message: String
+    val level: Level
+
+    /**
+     * Level of severity of the notification
+     */
+    enum class Level {
+        Warning,
+        Error
+    }
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Notification.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Notification.kt
@@ -13,6 +13,7 @@ interface Notification {
      * Level of severity of the notification
      */
     enum class Level {
+        Info,
         Warning,
         Error
     }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/SimpleNotification.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/SimpleNotification.kt
@@ -2,7 +2,10 @@ package io.gitlab.arturbosch.detekt.api.internal
 
 import io.gitlab.arturbosch.detekt.api.Notification
 
-data class SimpleNotification(override val message: String) : Notification {
+data class SimpleNotification(
+    override val message: String,
+    override val level: Notification.Level = Notification.Level.Error
+) : Notification {
 
     override fun toString(): String = message
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -53,7 +53,7 @@ class Runner(
         if (shouldValidate) {
             val notifications = validateConfig(settings.config, loadDefaultConfig(), patterns())
             notifications.map(Notification::message).forEach(settings::info)
-            val errors = notifications.filter { it.level == Notification.Level.Error }
+            val errors = notifications.filter(Notification::isError)
             if (errors.isNotEmpty()) {
                 val propsString = if (errors.size == 1) "property" else "properties"
                 throw InvalidConfig("Run failed with ${errors.size} invalid config $propsString.")

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -52,10 +52,11 @@ class Runner(
 
         if (shouldValidate) {
             val notifications = validateConfig(settings.config, loadDefaultConfig(), patterns())
-            if (notifications.isNotEmpty()) {
-                notifications.map(Notification::message).forEach(settings::info)
-                val propsString = if (notifications.size == 1) "property" else "properties"
-                throw InvalidConfig("Run failed with ${notifications.size} invalid config $propsString.")
+            notifications.map(Notification::message).forEach(settings::info)
+            val errors = notifications.filter { it.level == Notification.Level.Error }
+            if (errors.isNotEmpty()) {
+                val propsString = if (errors.size == 1) "property" else "properties"
+                throw InvalidConfig("Run failed with ${errors.size} invalid config $propsString.")
             }
         }
     }

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -126,7 +126,7 @@ empty-blocks:
     active: true
   EmptyFunctionBlock:
     active: true
-    ignoreOverriddenFunctions: false
+    ignoreOverridden: false
   EmptyIfBlock:
     active: true
   EmptyInitBlock:
@@ -333,7 +333,7 @@ naming:
     excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
     parameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
-    ignoreOverriddenFunctions: true
+    ignoreOverridden: true
   InvalidPackageDeclaration:
     active: false
     rootPackage: ''
@@ -341,7 +341,7 @@ naming:
     active: true
   MemberNameEqualsClassName:
     active: true
-    ignoreOverriddenFunction: true
+    ignoreOverridden: true
   ObjectPropertyNaming:
     active: true
     excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ModificationNotification.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ModificationNotification.kt
@@ -6,6 +6,6 @@ import java.nio.file.Path
 class ModificationNotification(path: Path) : Notification {
 
     override val message: String = "File $path was modified."
-    override val level: Notification.Level = Notification.Level.Error
+    override val level: Notification.Level = Notification.Level.Info
     override fun toString(): String = message
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ModificationNotification.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ModificationNotification.kt
@@ -6,5 +6,6 @@ import java.nio.file.Path
 class ModificationNotification(path: Path) : Notification {
 
     override val message: String = "File $path was modified."
+    override val level: Notification.Level = Notification.Level.Error
     override fun toString(): String = message
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Configuration.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Configuration.kt
@@ -3,5 +3,6 @@ package io.gitlab.arturbosch.detekt.generator.collection
 data class Configuration(
     val name: String,
     val description: String,
-    val defaultValue: String
+    val defaultValue: String,
+    val deprecated: String?
 )

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/KDocTags.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/KDocTags.kt
@@ -21,10 +21,15 @@ fun KDocTag.parseConfigTag(): Configuration {
             ?.groupValues
             ?.get(1)
             ?.trim() ?: ""
+    val deprecatedMessage = configurationDeprecatedRegex.find(content)
+            ?.groupValues
+            ?.get(1)
+            ?.trim()
     val description = content.substring(delimiterIndex + 1)
             .replace(configurationDefaultValueRegex, "")
+            .replace(configurationDeprecatedRegex, "")
             .trim()
-    return Configuration(name, description, defaultValue)
+    return Configuration(name, description, defaultValue, deprecatedMessage)
 }
 
 private const val EXPECTED_CONFIGURATION_FORMAT =
@@ -47,4 +52,5 @@ fun KDocTag.isValidConfigurationTag(entity: String = "Rule"): Boolean {
 }
 
 val configurationDefaultValueRegex = "\\(default: `(.+)`\\)".toRegex(RegexOption.DOT_MATCHES_ALL)
+val configurationDeprecatedRegex = "\\(deprecated: \"(.+)\"\\)".toRegex(RegexOption.DOT_MATCHES_ALL)
 const val TAG_CONFIGURATION = "configuration"

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Markdown.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Markdown.kt
@@ -26,6 +26,7 @@ inline fun MarkdownContent.markdown(markdown: () -> String) = append(markdown())
 inline fun MarkdownContent.paragraph(content: () -> String) = append("${content()}\n")
 
 inline fun MarkdownContent.bold(content: () -> String) = "**${content()}**"
+inline fun MarkdownContent.crossOut(code: () -> String) = "~~${code()}~~"
 
 inline fun MarkdownContent.h1(heading: () -> String) = append("# ${heading()}\n")
 inline fun MarkdownContent.h2(heading: () -> String) = append("## ${heading()}\n")

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Yaml.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Yaml.kt
@@ -45,9 +45,13 @@ fun YamlNode.node(name: String, node: YamlNode.() -> Unit) {
     append(yamlNode.content)
 }
 
-inline fun YamlNode.keyValue(keyValue: () -> Pair<String, String>) {
+inline fun YamlNode.keyValue(comment: String = "", keyValue: () -> Pair<String, String>) {
     val (key, value) = keyValue()
-    append("$key: $value")
+    if (comment.isBlank()) {
+        append("$key: $value")
+    } else {
+        append("$key: $value # $comment")
+    }
 }
 
 fun YamlNode.list(name: String, list: List<String>) {

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -36,7 +36,8 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
             if (ruleSet.name in TestExclusions.ruleSets) {
                 keyValue { Config.EXCLUDES_KEY to TestExclusions.pattern }
             }
-            ruleSet.configuration.forEach { configuration ->
+            ruleSet.configuration
+                .forEach { configuration ->
                 if (configuration.defaultValue.isYamlList()) {
                     list(configuration.name, configuration.defaultValue.toList())
                 } else {
@@ -52,10 +53,11 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
                     if (rule.isExcludedInTests()) {
                         keyValue { Config.EXCLUDES_KEY to TestExclusions.pattern }
                     }
-                    rule.configuration.forEach { configuration ->
+                    rule.configuration
+                        .forEach { configuration ->
                         if (configuration.defaultValue.isYamlList()) {
                             list(configuration.name, configuration.defaultValue.toList())
-                        } else {
+                        } else if (configuration.deprecated == null) {
                             keyValue { configuration.name to configuration.defaultValue }
                         }
                     }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/RuleSetPagePrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/RuleSetPagePrinter.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.generator.out.MarkdownContent
 import io.gitlab.arturbosch.detekt.generator.out.bold
 import io.gitlab.arturbosch.detekt.generator.out.code
 import io.gitlab.arturbosch.detekt.generator.out.codeBlock
+import io.gitlab.arturbosch.detekt.generator.out.crossOut
 import io.gitlab.arturbosch.detekt.generator.out.description
 import io.gitlab.arturbosch.detekt.generator.out.h3
 import io.gitlab.arturbosch.detekt.generator.out.h4
@@ -61,7 +62,14 @@ object RuleSetPagePrinter : DocumentationPrinter<RuleSetPage> {
                 h4 { "Configuration options:" }
                 list {
                     rule.configuration.forEach {
-                        item { "${code { it.name }} (default: ${code { it.defaultValue }})" }
+                        if (it.deprecated != null) {
+                            item {
+                                crossOut { code { it.name } } + " (default: ${code { it.defaultValue }})"
+                            }
+                            description { "${bold { "Deprecated" }}: ${it.deprecated}" }
+                        } else {
+                            item { "${code { it.name }} (default: ${code { it.defaultValue }})" }
+                        }
                         description { it.description }
                     }
                 }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
@@ -13,7 +13,9 @@ internal fun createRuleSetPage(): RuleSetPage {
 
 internal fun createRules(): List<Rule> {
     val rule1 = Rule("WildcardImport", "a wildcard import", "import foo.*", "import foo.bar", true, "Defect",
-            "10min", "alias1, alias2", "", listOf(Configuration("conf1", "a config option", "foo", null)))
+            "10min", "alias1, alias2", "", listOf(
+                    Configuration("conf1", "a config option", "foo", null),
+                    Configuration("conf2", "deprecated config", "false", "use conf1 instead")))
     val rule2 = Rule("EqualsNull", "equals null", "", "", false, "",
             "", null, "WildcardImport", emptyList())
     val rule3 = Rule("NoUnitKeyword", "removes :Unit", "fun stuff(): Unit {}",

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
@@ -13,7 +13,7 @@ internal fun createRuleSetPage(): RuleSetPage {
 
 internal fun createRules(): List<Rule> {
     val rule1 = Rule("WildcardImport", "a wildcard import", "import foo.*", "import foo.bar", true, "Defect",
-            "10min", "alias1, alias2", "", listOf(Configuration("conf1", "a config option", "foo")))
+            "10min", "alias1, alias2", "", listOf(Configuration("conf1", "a config option", "foo", null)))
     val rule2 = Rule("EqualsNull", "equals null", "", "", false, "",
             "", null, "WildcardImport", emptyList())
     val rule3 = Rule("NoUnitKeyword", "removes :Unit", "fun stuff(): Unit {}",

--- a/detekt-generator/src/test/resources/RuleSet.md
+++ b/detekt-generator/src/test/resources/RuleSet.md
@@ -16,6 +16,12 @@ a wildcard import
 
    a config option
 
+* ~~``conf2``~~ (default: ``false``)
+
+   **Deprecated**: use conf1 instead
+
+   deprecated config
+
 #### Noncompliant Code:
 
 ```kotlin

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
@@ -12,16 +12,19 @@ import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
  * This rule will not report functions with the override modifier that have a comment as their only body contents
  * (e.g., a // no-op comment in an unused listener function).
  *
- * Set the [ignoreOverriddenFunctions] parameter to `true` to exclude all functions which are overriding other
+ * Set the [ignoreOverridden] parameter to `true` to exclude all functions which are overriding other
  * functions from the superclass or from an interface (i.e., functions declared with the override modifier).
  *
  * @configuration ignoreOverriddenFunctions - Excludes all the overridden functions (default: `false`)
+ * (deprecated: "Use `ignoreOverridden` instead")
+ * @configuration ignoreOverridden - Excludes all the overridden functions (default: `false`)
  *
  * @active since v1.0.0
  */
 class EmptyFunctionBlock(config: Config) : EmptyRule(config) {
 
-    private val ignoreOverriddenFunctions = valueOrDefault(IGNORE_OVERRIDDEN_FUNCTIONS, false)
+    private val ignoreOverridden =
+        valueOrDefault(IGNORE_OVERRIDDEN, valueOrDefault(IGNORE_OVERRIDDEN_FUNCTIONS, false))
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         super.visitNamedFunction(function)
@@ -29,7 +32,7 @@ class EmptyFunctionBlock(config: Config) : EmptyRule(config) {
             return
         }
         val bodyExpression = function.bodyExpression
-        if (!ignoreOverriddenFunctions) {
+        if (!ignoreOverridden) {
             if (function.isOverride()) {
                 bodyExpression?.addFindingIfBlockExprIsEmptyAndNotCommented()
             } else {
@@ -45,5 +48,6 @@ class EmptyFunctionBlock(config: Config) : EmptyRule(config) {
 
     companion object {
         const val IGNORE_OVERRIDDEN_FUNCTIONS = "ignoreOverriddenFunctions"
+        const val IGNORE_OVERRIDDEN = "ignoreOverridden"
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
@@ -19,6 +19,8 @@ import org.jetbrains.kotlin.psi.KtParameter
  * @configuration parameterPattern - naming pattern (default: `'[a-z][A-Za-z0-9]*'`)
  * @configuration excludeClassPattern - ignores variables in classes which match this regex (default: `'$^'`)
  * @configuration ignoreOverriddenFunctions - ignores overridden functions with parameters not matching the pattern
+ * (default: `true`) (deprecated: "Use `ignoreOverridden` instead")
+ * @configuration ignoreOverridden - ignores overridden functions with parameters not matching the pattern
  * (default: `true`)
  *
  * @active since v1.0.0
@@ -32,14 +34,14 @@ class FunctionParameterNaming(config: Config = Config.empty) : Rule(config) {
 
     private val parameterPattern by LazyRegex(PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*")
     private val excludeClassPattern by LazyRegex(EXCLUDE_CLASS_PATTERN, "$^")
-    private val ignoreOverriddenFunctions = valueOrDefault(IGNORE_OVERRIDDEN_FUNCTIONS, true)
+    private val ignoreOverridden = valueOrDefault(IGNORE_OVERRIDDEN, valueOrDefault(IGNORE_OVERRIDDEN_FUNCTIONS, true))
 
     override fun visitParameter(parameter: KtParameter) {
         if (parameter.isContainingExcludedClass(excludeClassPattern)) {
             return
         }
 
-        if (ignoreOverriddenFunctions && parameter.ownerFunction?.isOverride() == true) {
+        if (ignoreOverridden && parameter.ownerFunction?.isOverride() == true) {
             return
         }
 
@@ -56,5 +58,6 @@ class FunctionParameterNaming(config: Config = Config.empty) : Rule(config) {
         const val PARAMETER_PATTERN = "parameterPattern"
         const val EXCLUDE_CLASS_PATTERN = "excludeClassPattern"
         const val IGNORE_OVERRIDDEN_FUNCTIONS = "ignoreOverriddenFunctions"
+        const val IGNORE_OVERRIDDEN = "ignoreOverridden"
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -46,6 +46,8 @@ import org.jetbrains.kotlin.psi.KtObjectDeclaration
  * </compliant>
  *
  * @configuration ignoreOverriddenFunction - if overridden functions and properties should be ignored (default: `true`)
+ * (deprecated: "Use `ignoreOverridden` instead")
+ * @configuration ignoreOverridden - if overridden functions and properties should be ignored (default: `true`)
  *
  * @active since v1.2.0
  */
@@ -60,7 +62,7 @@ class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
     private val objectMessage = "A member is named after the object. " +
             "This might result in confusion. Please rename the member."
 
-    private val ignoreOverriddenFunction = valueOrDefault(IGNORE_OVERRIDDEN_FUNCTION, true)
+    private val ignoreOverridden = valueOrDefault(IGNORE_OVERRIDDEN, valueOrDefault(IGNORE_OVERRIDDEN_FUNCTION, true))
 
     override fun visitClass(klass: KtClass) {
         if (!klass.isInterface()) {
@@ -81,7 +83,7 @@ class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
     private fun getMisnamedMembers(klassOrObject: KtClassOrObject, name: String?): Sequence<KtNamedDeclaration> {
         val body = klassOrObject.body ?: return emptySequence()
         return (body.functions.asSequence() as Sequence<KtNamedDeclaration> + body.properties)
-            .filterNot { ignoreOverriddenFunction && it.isOverride() }
+            .filterNot { ignoreOverridden && it.isOverride() }
             .filter { it.name?.equals(name, ignoreCase = true) == true }
     }
 
@@ -100,5 +102,6 @@ class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
 
     companion object {
         const val IGNORE_OVERRIDDEN_FUNCTION = "ignoreOverriddenFunction"
+        const val IGNORE_OVERRIDDEN = "ignoreOverridden"
     }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
@@ -102,8 +102,8 @@ class EmptyFunctionBlockSpec : Spek({
                 assertThat(subject.compileAndLint(code)).hasSourceLocation(12, 31)
             }
 
-            it("should not flag overridden functions with ignoreOverriddenFunctions") {
-                val config = TestConfig(mapOf(EmptyFunctionBlock.IGNORE_OVERRIDDEN_FUNCTIONS to "true"))
+            it("should not flag overridden functions with ignoreOverridden") {
+                val config = TestConfig(mapOf(EmptyFunctionBlock.IGNORE_OVERRIDDEN to "true"))
                 assertThat(EmptyFunctionBlock(config).compileAndLint(code)).isEmpty()
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
@@ -29,14 +29,14 @@ class FunctionParameterNamingSpec : Spek({
             assertThat(FunctionParameterNaming().compileAndLint(code)).isEmpty()
         }
 
-        it("should detect violations in overridden function if ignoreOverriddenFunctions is false") {
+        it("should detect violations in overridden function if ignoreOverridden is false") {
             val code = """
                 class C : I {
                     override fun someStuff(`object`: String) {}
                 }
                 interface I { fun someStuff(`object`: String) }
             """
-            val config = TestConfig(mapOf(FunctionParameterNaming.IGNORE_OVERRIDDEN_FUNCTIONS to "false"))
+            val config = TestConfig(mapOf(FunctionParameterNaming.IGNORE_OVERRIDDEN to "false"))
             assertThat(FunctionParameterNaming(config).compileAndLint(code)).hasSize(2)
         }
 

--- a/docs/pages/documentation/empty-blocks.md
+++ b/docs/pages/documentation/empty-blocks.md
@@ -77,7 +77,7 @@ Reports empty functions. Empty blocks of code serve no purpose and should be rem
 This rule will not report functions with the override modifier that have a comment as their only body contents
 (e.g., a // no-op comment in an unused listener function).
 
-Set the [ignoreOverriddenFunctions] parameter to `true` to exclude all functions which are overriding other
+Set the [ignoreOverridden] parameter to `true` to exclude all functions which are overriding other
 functions from the superclass or from an interface (i.e., functions declared with the override modifier).
 
 **Severity**: Minor
@@ -86,7 +86,13 @@ functions from the superclass or from an interface (i.e., functions declared wit
 
 #### Configuration options:
 
-* ``ignoreOverriddenFunctions`` (default: ``false``)
+* ~~``ignoreOverriddenFunctions``~~ (default: ``false``)
+
+   **Deprecated**: Use `ignoreOverridden` instead
+
+   Excludes all the overridden functions
+
+* ``ignoreOverridden`` (default: ``false``)
 
    Excludes all the overridden functions
 

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -150,7 +150,13 @@ Reports function parameter names which do not follow the specified naming conven
 
    ignores variables in classes which match this regex
 
-* ``ignoreOverriddenFunctions`` (default: ``true``)
+* ~~``ignoreOverriddenFunctions``~~ (default: ``true``)
+
+   **Deprecated**: Use `ignoreOverridden` instead
+
+   ignores overridden functions with parameters not matching the pattern
+
+* ``ignoreOverridden`` (default: ``true``)
 
    ignores overridden functions with parameters not matching the pattern
 
@@ -217,7 +223,13 @@ Factory functions that create an instance of the class are exempt from this rule
 
 #### Configuration options:
 
-* ``ignoreOverriddenFunction`` (default: ``true``)
+* ~~``ignoreOverriddenFunction``~~ (default: ``true``)
+
+   **Deprecated**: Use `ignoreOverridden` instead
+
+   if overridden functions and properties should be ignored
+
+* ``ignoreOverridden`` (default: ``true``)
 
    if overridden functions and properties should be ignored
 

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-simple-notification/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-simple-notification/-init-.md
@@ -6,4 +6,4 @@ title: SimpleNotification.<init> - detekt-api
 
 # &lt;init&gt;
 
-`SimpleNotification(message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`)`
+`SimpleNotification(message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, level: Level = Notification.Level.Error)`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-simple-notification/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-simple-notification/index.md
@@ -10,10 +10,11 @@ title: SimpleNotification - detekt-api
 
 ### Constructors
 
-| [&lt;init&gt;](-init-.html) | `SimpleNotification(message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`)` |
+| [&lt;init&gt;](-init-.html) | `SimpleNotification(message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, level: Level = Notification.Level.Error)` |
 
 ### Properties
 
+| [level](level.html) | `val level: Level` |
 | [message](message.html) | `val message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
 
 ### Functions

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-simple-notification/level.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-simple-notification/level.md
@@ -1,0 +1,9 @@
+---
+title: SimpleNotification.level - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [SimpleNotification](index.html) / [level](./level.html)
+
+# level
+
+`val level: Level`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/-level/-error.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/-level/-error.md
@@ -1,0 +1,9 @@
+---
+title: Notification.Level.Error - detekt-api
+---
+
+[detekt-api](../../../index.html) / [io.gitlab.arturbosch.detekt.api](../../index.html) / [Notification](../index.html) / [Level](index.html) / [Error](./-error.html)
+
+# Error
+
+`Error`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/-level/-info.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/-level/-info.md
@@ -1,0 +1,9 @@
+---
+title: Notification.Level.Info - detekt-api
+---
+
+[detekt-api](../../../index.html) / [io.gitlab.arturbosch.detekt.api](../../index.html) / [Notification](../index.html) / [Level](index.html) / [Info](./-info.html)
+
+# Info
+
+`Info`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/-level/-warning.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/-level/-warning.md
@@ -1,0 +1,9 @@
+---
+title: Notification.Level.Warning - detekt-api
+---
+
+[detekt-api](../../../index.html) / [io.gitlab.arturbosch.detekt.api](../../index.html) / [Notification](../index.html) / [Level](index.html) / [Warning](./-warning.html)
+
+# Warning
+
+`Warning`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/-level/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/-level/index.md
@@ -1,0 +1,17 @@
+---
+title: Notification.Level - detekt-api
+---
+
+[detekt-api](../../../index.html) / [io.gitlab.arturbosch.detekt.api](../../index.html) / [Notification](../index.html) / [Level](./index.html)
+
+# Level
+
+`enum class Level`
+
+Level of severity of the notification
+
+### Enum Values
+
+| [Warning](-warning.html) |  |
+| [Error](-error.html) |  |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/-level/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/-level/index.md
@@ -12,6 +12,7 @@ Level of severity of the notification
 
 ### Enum Values
 
+| [Info](-info.html) |  |
 | [Warning](-warning.html) |  |
 | [Error](-error.html) |  |
 

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/index.md
@@ -12,8 +12,13 @@ Any kind of notification which should be printed to the console.
 For example when using the formatting rule set, any change to
 your kotlin file is a notification.
 
+### Types
+
+| [Level](-level/index.html) | Level of severity of the notification`enum class Level` |
+
 ### Properties
 
+| [level](level.html) | `abstract val level: Level` |
 | [message](message.html) | `abstract val message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
 
 ### Inheritors

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/index.md
@@ -18,6 +18,7 @@ your kotlin file is a notification.
 
 ### Properties
 
+| [isError](is-error.html) | `open val isError: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html) |
 | [level](level.html) | `abstract val level: Level` |
 | [message](message.html) | `abstract val message: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
 

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/is-error.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/is-error.md
@@ -1,0 +1,9 @@
+---
+title: Notification.isError - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Notification](index.html) / [isError](./is-error.html)
+
+# isError
+
+`open val isError: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/level.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-notification/level.md
@@ -1,0 +1,9 @@
+---
+title: Notification.level - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [Notification](index.html) / [level](./level.html)
+
+# level
+
+`abstract val level: Level`


### PR DESCRIPTION
Closes #2096 

`EmptyFunctionBlock`, `FunctionParameterNaming` and `MemberNameEqualsClassName` uses the configuration flag `ignoreOverriddenFunction(s)` but the rest of rules uses the generic `ignoreOverridden`. This PR change this to get an API a bit more consistent.