### PR TITLE
Use JDK 11 (LTS) + 13 for AppVeyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
       JAVA_HOME: C:\Program Files\Java\jdk11
       COMPILE_TEST_SNIPPETS: false
     -
-      JAVA_HOME: C:\Program Files\Java\jdk12
+      JAVA_HOME: C:\Program Files\Java\jdk13
       COMPILE_TEST_SNIPPETS: false
 
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,6 @@ environment:
       JAVA_HOME: C:\Program Files\Java\jdk1.8.0
       COMPILE_TEST_SNIPPETS: true
     -
-      JAVA_HOME: C:\Program Files\Java\jdk11
-      COMPILE_TEST_SNIPPETS: false
-    -
       JAVA_HOME: C:\Program Files\Java\jdk13
       COMPILE_TEST_SNIPPETS: false
 


### PR DESCRIPTION
Detekt uses Gradle 6, which supports JDK 13.
Thus, we should also run a CI build for that.