### PR TITLE
Use JDK 11 (LTS) + 13 for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       env: COMPILE_TEST_SNIPPETS=false
     - os: linux
       dist: bionic
-      jdk: openjdk12
+      jdk: openjdk13
       env: COMPILE_TEST_SNIPPETS=false
     # JDK 8 - see https://docs.travis-ci.com/user/reference/osx/#jdk-and-macos
     - os: osx


### PR DESCRIPTION
Detekt uses Gradle 6, which supports JDK 13.
Thus, we should also run a CI build for that.