### PR TITLE
Document how to exclude detekt from the check task - #1894

### DIFF
--- a/docs/pages/gettingstarted/groovydsl.md
+++ b/docs/pages/gettingstarted/groovydsl.md
@@ -147,6 +147,24 @@ task detektFailFast(type: io.gitlab.arturbosch.detekt.Detekt) {
 }
 ```
 
+##### <a name="check-lifecycle">Disabling detekt from the check task</a>
+
+detekt tasks by default are verification tasks. They get executed whenever the Gradle check task gets executed.
+This aligns with the behavior of other code analysis plugins for Gradle.
+
+If you are adding detekt to an already long running project you may want to increase the code quality incrementally and therefore
+exclude detekt from the check task.
+
+```gradle
+tasks.getByName("check") {
+    this.setDependsOn(this.dependsOn.filterNot {
+        it is TaskProvider<*> && it.name == "detekt"
+    })
+}
+```
+
+Instead of disabling detekt for the check task, you may want to increase the build failure threshold in the [configuration file](../configurations.md).
+
 ##### <a name="idea">Configure a local IDEA for detekt</a>
 
 - Download the community edition of [IntelliJ IDEA](https://www.jetbrains.com/idea/download/)

--- a/docs/pages/gettingstarted/groovydsl.md
+++ b/docs/pages/gettingstarted/groovydsl.md
@@ -149,7 +149,7 @@ task detektFailFast(type: io.gitlab.arturbosch.detekt.Detekt) {
 
 ##### <a name="check-lifecycle">Disabling detekt from the check task</a>
 
-detekt tasks by default are verification tasks. They get executed whenever the Gradle check task gets executed.
+Detekt tasks by default are verification tasks. They get executed whenever the Gradle check task gets executed.
 This aligns with the behavior of other code analysis plugins for Gradle.
 
 If you are adding detekt to an already long running project you may want to increase the code quality incrementally and therefore


### PR DESCRIPTION
The groovy dsl page has more info sub sections and the kotlin dsl page points to the groovy dsl page.
So it's okay not to duplicate the info ^^