### PR TITLE
Updated to correct classpath documentation for Android projects.

### DIFF
--- a/docs/pages/gettingstarted/groovydsl.md
+++ b/docs/pages/gettingstarted/groovydsl.md
@@ -55,7 +55,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:[version]'
-        classpath "gradle.plugin.io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[version]"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[version]"
     }
 
 }


### PR DESCRIPTION
It appears that the classpath for adding the detekt-gradle-plugin changed several months ago but the documentation was never updated. This updates that documentation to be correct which allows projects to build correctly. This was originally reported in issue #1451 but it doesn't appear that the documentation has been updated.
