### PR TITLE
Restore KotlinExtension

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/KotlinExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/KotlinExtension.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Project
 
-@Deprecated("Either apply detekt plugin to root project or follow this advice: https://docs.gradle.org/current/userguide/kotlin_dsl.html#sec:multi_project_builds_applying_plugins")
+@Deprecated("""Either apply detekt plugin to root project or follow this advice:
+https://docs.gradle.org/current/userguide/kotlin_dsl.html#sec:multi_project_builds_applying_plugins""")
 fun Project.detekt(configure: DetektExtension.() -> Unit) =
     extensions.configure(DetektExtension::class.java, configure)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/KotlinExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/KotlinExtension.kt
@@ -1,0 +1,8 @@
+package io.gitlab.arturbosch.detekt
+
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import org.gradle.api.Project
+
+@Deprecated("Either apply detekt plugin to root project or follow this advice: https://docs.gradle.org/current/userguide/kotlin_dsl.html#sec:multi_project_builds_applying_plugins")
+fun Project.detekt(configure: DetektExtension.() -> Unit) =
+    extensions.configure(DetektExtension::class.java, configure)


### PR DESCRIPTION
Restore the extension with a deprecation warning. See https://github.com/arturbosch/detekt/issues/2152#issuecomment-560960247

Fixes #2152