### PR TITLE
StringIndexOutOfBoundsException when generating HTML report

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtils.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtils.kt
@@ -22,7 +22,11 @@ internal fun FlowContent.snippetCode(lines: Sequence<String>, location: SourceLo
                     span("lineno") { text("%1$4s ".format(currentLineNumber)) }
                     if (currentLineNumber >= location.line && errorLength > 0) {
                         val column = if (currentLineNumber == location.line) location.column - 1 else 0
-                        errorLength -= writeErrorLine(line, column, errorLength) + 1 // we need to consume the \n
+                        errorLength -= if (column < line.length) {
+                            writeErrorLine(line, column, errorLength) + 1 // we need to consume the \n
+                        } else {
+                            1
+                        }
                     } else {
                         text(line)
                     }


### PR DESCRIPTION
This fixes the bug related to the issue #2134 
