### PR TITLE
UnsafeCast: update documentation to match new behavior

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
@@ -12,17 +12,21 @@ import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
 import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
- * Reports casts which are unsafe. In case the cast is not possible it will throw an exception.
+ * Reports casts that will never succeed.
  *
  * <noncompliant>
- * fun foo(s: Any) {
+ * fun foo(s: String) {
  *     println(s as Int)
+ * }
+ *
+ * fun bar(s: String) {
+ *     println(s as? Int)
  * }
  * </noncompliant>
  *
  * <compliant>
  * fun foo(s: Any) {
- *     println((s as? Int) ?: 0)
+ *     println(s as Int)
  * }
  * </compliant>
  */

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -493,7 +493,7 @@ fun foo(str: String?) {
 
 ### UnsafeCast
 
-Reports casts which are unsafe. In case the cast is not possible it will throw an exception.
+Reports casts that will never succeed.
 
 **Severity**: Defect
 
@@ -504,8 +504,12 @@ Reports casts which are unsafe. In case the cast is not possible it will throw a
 #### Noncompliant Code:
 
 ```kotlin
-fun foo(s: Any) {
+fun foo(s: String) {
     println(s as Int)
+}
+
+fun bar(s: String) {
+    println(s as? Int)
 }
 ```
 
@@ -513,7 +517,7 @@ fun foo(s: Any) {
 
 ```kotlin
 fun foo(s: Any) {
-    println((s as? Int) ?: 0)
+    println(s as Int)
 }
 ```
 


### PR DESCRIPTION
Update the documentation to match the behavior of this rule after https://github.com/arturbosch/detekt/pull/1879.
The rule now report impossible casts.

See https://github.com/arturbosch/detekt/issues/2153