### PR TITLE
Prepare 1.3.0 release

### DIFF
--- a/docs/pages/changelog 1.x.x.md
+++ b/docs/pages/changelog 1.x.x.md
@@ -6,6 +6,61 @@ permalink: changelog.html
 toc: true
 ---
 
+#### 1.3.0
+
+##### Notable changes
+
+- Minimal Gradle version increased to 5.0
+- New rules: 
+    - `UnnecessaryAnnotationUseSiteTargetRule`
+    - `MapGetWithNotNullAssertionOperator`
+
+##### Changelog
+
+- Add printers to the command line runner - [#2188](https://github.com/arturbosch/detekt/pull/2188)
+- Fix documentation of UseArrayLiteralsInAnnotations - [#2186](https://github.com/arturbosch/detekt/pull/2186)
+- Inline resolving severity label for XML reports - [#2184](https://github.com/arturbosch/detekt/pull/2184)
+- Extract common jvm target value, add jvmTarget into documentation. Cl… - [#2183](https://github.com/arturbosch/detekt/pull/2183)
+- Fix Detekt gradle task cache restoration issue (#2180) - [#2182](https://github.com/arturbosch/detekt/pull/2182)
+- Fix exception when running ArrayPrimitive on star-projected arrays - [#2181](https://github.com/arturbosch/detekt/pull/2181)
+- Gradle cache restoration issue - [#2180](https://github.com/arturbosch/detekt/issues/2180)
+- Add MacOS JDK13 build job to TravisCI - [#2177](https://github.com/arturbosch/detekt/pull/2177)
+- Running "ArrayPrimitive" rule on "Array<*>" causes detekt to throw exception - [#2176](https://github.com/arturbosch/detekt/issues/2176)
+- Update Spek to v2.0.9 - [#2173](https://github.com/arturbosch/detekt/pull/2173)
+- Create Rule: MapGetWithNotNullAssertionOperator - [#2171](https://github.com/arturbosch/detekt/pull/2171)
+- EqualsAlwaysReturnsTrueOrFalse fails hard on `override fun equals(other:Any) = ...` - [#2167](https://github.com/arturbosch/detekt/issues/2167)
+- Prepare 1.3.0 release - [#2165](https://github.com/arturbosch/detekt/pull/2165)
+- UnsafeCast: update documentation to match new behavior - [#2164](https://github.com/arturbosch/detekt/pull/2164)
+- Add jvmTarget change into documentation - [#2157](https://github.com/arturbosch/detekt/issues/2157)
+- Create UnnecessaryAnnotationUseSiteTargetRule - [#2099](https://github.com/arturbosch/detekt/pull/2099)
+- Gradle 6 - [#1902](https://github.com/arturbosch/detekt/pull/1902)
+- Gradle 6 planning - [#1820](https://github.com/arturbosch/detekt/issues/1820)
+
+See all issues at: [1.3.0](https://github.com/arturbosch/detekt/milestone/51)
+
+#### 1.2.2
+
+##### Notable Changes
+
+- 1.2.1 introduced breaking changes for users of Gradle < 5. This was reverted.
+- 1.3.0 will drop support for Gradle < 5.
+- Fixed a regression in the html report.
+
+##### Changelog
+
+- regression updating 1.2.0 to 1.2.1, unknown property 'filters' for object of type DetektExtension - [#2163](https://github.com/arturbosch/detekt/issues/2163)
+- StringIndexOutOfBoundsException when generating HTML report - [#2160](https://github.com/arturbosch/detekt/pull/2160)
+- Restore KotlinExtension - [#2159](https://github.com/arturbosch/detekt/pull/2159)
+- 1.2.1 breaks the build with: unresolved reference: detekt - [#2152](https://github.com/arturbosch/detekt/issues/2152)
+- Updated to correct classpath documentation for Android projects. - [#2149](https://github.com/arturbosch/detekt/pull/2149)
+- Update to Kotlin v1.3.61 - [#2147](https://github.com/arturbosch/detekt/pull/2147)
+- Document how to exclude detekt from the check task - #1894 - [#2144](https://github.com/arturbosch/detekt/pull/2144)
+- Use JDK 11 (LTS) + 13 for Travis builds - [#2142](https://github.com/arturbosch/detekt/pull/2142)
+- Don't compile test snippets (bindingContext) - [#2137](https://github.com/arturbosch/detekt/pull/2137)
+- StringIndexOutOfBoundsException: String index out of range: 8 when generating HTML report after update to 1.2.0 - [#2134](https://github.com/arturbosch/detekt/issues/2134)
+
+See all issues at: [1.2.2](https://github.com/arturbosch/detekt/milestone/53)
+
 #### 1.2.1
 
 ##### Notable changes

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-detektVersion=1.2.1
+detektVersion=1.3.0
 
 # Project dependencies
 assertjVersion=3.14.0


### PR DESCRIPTION
This release sets the minimum supported Gradle version to 5.
1.2.2 was released to support gradle 4.9+ for the last time and include the `Project.detekt` deprecation warning.