### PR TITLE
Fix Detekt gradle task cache restoration issue (#2180)

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -39,6 +39,7 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.VerificationTask
@@ -53,6 +54,11 @@ open class Detekt : SourceTask(), VerificationTask {
 
     @get:Classpath
     val pluginClasspath = project.configurableFileCollection()
+
+    @InputFiles
+    @SkipWhenEmpty
+    @PathSensitive(PathSensitivity.RELATIVE)
+    override fun getSource() = super.getSource()
 
     @get:InputFile
     @get:Optional


### PR DESCRIPTION
`Detekt` gradle task is marked as `@CacheableTask` but it's input source files are
marked with `PathSensitivity.ABSOLUTE` annotation from `source` property defined in
parent `SourceTask`.

Having task inputs with absolute path sensitivity effectively disables cache reusability:
https://guides.gradle.org/using-build-cache/#relocatability