### PR TITLE
Add printers to the command line runner

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -28,7 +28,11 @@ fun main(args: Array<String>) {
     exitProcess(ExitCode.NORMAL_RUN.number)
 }
 
-fun buildRunner(args: Array<String>, outputPrinter: PrintStream = System.out, errorPrinter: PrintStream = System.err): Executable {
+fun buildRunner(
+    args: Array<String>,
+    outputPrinter: PrintStream = System.out,
+    errorPrinter: PrintStream = System.err
+): Executable {
     val arguments = parseArguments(args)
     return when {
         arguments.generateConfig -> ConfigExporter(arguments)

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.cli.runners.Executable
 import io.gitlab.arturbosch.detekt.cli.runners.Runner
 import io.gitlab.arturbosch.detekt.cli.runners.SingleRuleRunner
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
+import java.io.PrintStream
 import kotlin.system.exitProcess
 
 @Suppress("TooGenericExceptionCaught")
@@ -27,13 +28,13 @@ fun main(args: Array<String>) {
     exitProcess(ExitCode.NORMAL_RUN.number)
 }
 
-fun buildRunner(args: Array<String>): Executable {
+fun buildRunner(args: Array<String>, outputPrinter: PrintStream = System.out, errorPrinter: PrintStream = System.err): Executable {
     val arguments = parseArguments(args)
     return when {
         arguments.generateConfig -> ConfigExporter(arguments)
         arguments.runRule != null -> SingleRuleRunner(arguments)
         arguments.printAst -> AstPrinter(arguments)
-        else -> Runner(arguments)
+        else -> Runner(arguments, outputPrinter, errorPrinter)
     }
 }
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -24,8 +24,8 @@ import java.io.PrintStream
 
 class Runner(
     private val arguments: CliArgs,
-    private val outputPrinter: PrintStream,
-    private val errorPrinter: PrintStream
+    private val outputPrinter: PrintStream = System.out,
+    private val errorPrinter: PrintStream = System.err
 ) : Executable {
 
     override fun execute() {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -20,8 +20,13 @@ import io.gitlab.arturbosch.detekt.cli.loadDefaultConfig
 import io.gitlab.arturbosch.detekt.cli.maxIssues
 import io.gitlab.arturbosch.detekt.core.DetektFacade
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
+import java.io.PrintStream
 
-class Runner(private val arguments: CliArgs) : Executable {
+class Runner(
+    private val arguments: CliArgs,
+    private val outputPrinter: PrintStream,
+    private val errorPrinter: PrintStream
+) : Executable {
 
     override fun execute() {
         createSettings().use { settings ->
@@ -81,7 +86,9 @@ class Runner(private val arguments: CliArgs) : Executable {
             classpath = createClasspath(),
             languageVersion = languageVersion,
             jvmTarget = jvmTarget,
-            debug = arguments.debug
+            debug = arguments.debug,
+            outPrinter = outputPrinter,
+            errorPrinter = errorPrinter
         )
     }
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
@@ -1,0 +1,45 @@
+package io.gitlab.arturbosch.detekt.cli
+
+import io.gitlab.arturbosch.detekt.cli.runners.AstPrinter
+import io.gitlab.arturbosch.detekt.cli.runners.ConfigExporter
+import io.gitlab.arturbosch.detekt.cli.runners.Runner
+import io.gitlab.arturbosch.detekt.cli.runners.SingleRuleRunner
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+class MainSpec : Spek({
+
+    describe("build runner") {
+
+        listOf(PrintStream(ByteArrayOutputStream()), null).forEach { printer ->
+
+            context("printer is [${if (printer == null) "default" else "provided"}]") {
+
+                listOf(
+                    arrayOf("--generate-config"),
+                    arrayOf("--run-rule", "Rule"),
+                    arrayOf("--print-ast"),
+                    emptyArray()
+                ).forEach { args ->
+
+                    val expectedRunnerClass = when  {
+                        args.contains("--generate-config") -> ConfigExporter::class
+                        args.contains("--run-rule") -> SingleRuleRunner::class
+                        args.contains("--print-ast") -> AstPrinter::class
+                        else -> Runner::class
+                    }
+
+                    it("returns [${expectedRunnerClass.simpleName}] when arguments are $args") {
+                        val runner = if (printer == null) buildRunner(args) else buildRunner(args, printer, printer)
+
+                        assertThat(runner).isExactlyInstanceOf(expectedRunnerClass.java)
+                    }
+                }
+            }
+        }
+    }
+
+})

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -8,6 +8,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.Charset
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -77,6 +80,66 @@ class RunnerSpec : Spek({
             Runner(cliArgs).execute()
 
             assertThat(Files.readAllLines(tmpReport)).hasSize(1)
+        }
+    }
+
+    describe("printers") {
+
+        val outputPrinterBuffer by memoized { ByteArrayOutputStream() }
+        val outputPrinter by memoized { PrintStream(outputPrinterBuffer) }
+
+        val errorPrinterBuffer by memoized { ByteArrayOutputStream() }
+        val errorPrinter by memoized { PrintStream(errorPrinterBuffer) }
+
+        context("execute with default config") {
+
+            beforeEachTest {
+                val args = CliArgs.parse(arrayOf("--input", inputPath.toString()))
+
+                Runner(args, outputPrinter, errorPrinter).execute()
+
+                outputPrinter.flush()
+                outputPrinter.close()
+
+                errorPrinter.flush()
+                errorPrinter.close()
+            }
+
+            it("writes output to output printer") {
+                assertThat(outputPrinterBuffer.toString(Charset.defaultCharset().name())).contains("Build succeeded")
+            }
+
+            it("does not write anything to error printer") {
+                assertThat(errorPrinterBuffer.toString(Charset.defaultCharset().name())).isEmpty()
+            }
+        }
+
+        context("execute with strict config") {
+
+            beforeEachTest {
+                val args = CliArgs.parse(
+                    arrayOf("--input", inputPath.toString(), "--config-resource", "/configs/max-issues-0.yml")
+                )
+
+                try {
+                    Runner(args, outputPrinter, errorPrinter).execute()
+                } catch (ignored: BuildFailure) {
+                }
+
+                outputPrinter.flush()
+                outputPrinter.close()
+
+                errorPrinter.flush()
+                errorPrinter.close()
+            }
+
+            it("writes output to output printer") {
+                assertThat(outputPrinterBuffer.toString(Charset.defaultCharset().name())).contains("Build failed")
+            }
+
+            it("does not write anything to error printer") {
+                assertThat(errorPrinterBuffer.toString(Charset.defaultCharset().name())).isEmpty()
+            }
         }
     }
 })


### PR DESCRIPTION
A bit of context to understand the motivation behind the change.

Me and @artem-zinnatullin are working on [the Bazel rule for Detekt](https://github.com/buildfoundation/bazel_rules_detekt). One of the features of the rule is the [persistent workers](https://blog.bazel.build/2015/12/10/java-workers.html) support.

* The thing with workers is that standard inputs and outputs are reserved for the Bazel / worker communication. Since there is no API to limit Detekt standard output usage we were forced to create [a workaround](https://github.com/buildfoundation/bazel_rules_detekt/blob/d5ceef75df618fdd22a0e4a4a87cba381daa29f6/detekt/wrapper/src/main/kotlin/io/buildfoundation/bazel/rulesdetekt/wrapper/SandboxExecutor.kt) which replaces system standard output streams with file-based ones.
* This worked fine (though a bit hacky) until we thought about [multiplexing](https://docs.bazel.build/versions/master/multiplex-worker.html). The multiplexing will change the flow, essentially we’ll be calling multiple Detekt runners in parallel. Unfortunately, the replace-system-streams workaround will not work in a multi-thread environment since it will be almost impossible to understand which runner printed which output to a singleton system stream.

If this change is accepted (and eventually published) we’ll be able to make Detekt invocations more or less hermetic. At the same time, the API change is backwards-compatible (arguments fall back to default values) and kinda makes sense abstracting from our personal needs (there is no way to change printers since `ProcessingSettings` in `Runner` are not accessible).