### PR TITLE
WIP: Do not dynamically set the detekt version due to performance reasons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       env: COMPILE_TEST_SNIPPETS=false
 install: true
 script:
-  - ./gradlew build shadowJar --build-cache --parallel -PwarningsAsErrors=true -Pcompile-test-snippets=$COMPILE_TEST_SNIPPETS --scan
+  - ./gradlew build shadowJar --build-cache --max-workers=2 --parallel -PwarningsAsErrors=true -Pcompile-test-snippets=$COMPILE_TEST_SNIPPETS --scan
   - java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar --help
   - java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar -i . --baseline ./config/detekt/baseline.xml -ex "**/resources/**,**/detekt*/build/**" -c ./detekt-cli/src/main/resources/default-detekt-config.yml,./config/detekt/detekt.yml
   - ./gradlew verifyGeneratorOutput

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       env: COMPILE_TEST_SNIPPETS=false
 install: true
 script:
-  - ./gradlew build shadowJar --build-cache --max-workers=2 --parallel -PwarningsAsErrors=true -Pcompile-test-snippets=$COMPILE_TEST_SNIPPETS --scan
+  - ./gradlew build shadowJar --build-cache -PwarningsAsErrors=true -Pcompile-test-snippets=$COMPILE_TEST_SNIPPETS --scan
   - java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar --help
   - java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar -i . --baseline ./config/detekt/baseline.xml -ex "**/resources/**,**/detekt*/build/**" -c ./detekt-cli/src/main/resources/default-detekt-config.yml,./config/detekt/detekt.yml
   - ./gradlew verifyGeneratorOutput

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![gradle plugin](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/io/gitlab/arturbosch/detekt/io.gitlab.arturbosch.detekt.gradle.plugin/maven-metadata.xml.svg?label=Gradle&style=flat-square)](https://plugins.gradle.org/plugin/io.gitlab.arturbosch.detekt)
 
 [![build status](https://travis-ci.org/arturbosch/detekt.svg?branch=master)](https://travis-ci.org/arturbosch/detekt)
-[![build status windows](https://ci.appveyor.com/api/projects/status/3q9g98vveiul7yut/branch/master?svg=true)](https://ci.appveyor.com/project/arturbosch/detekt)
+[![build status windows](https://ci.appveyor.com/api/projects/status/3q9g98vveiul7yut?svg=true)](https://ci.appveyor.com/project/arturbosch/detekt)
 [![codecov](https://codecov.io/gh/arturbosch/detekt/branch/master/graph/badge.svg)](https://codecov.io/gh/arturbosch/detekt)
 [![CodeFactor](https://www.codefactor.io/repository/github/arturbosch/detekt/badge)](https://www.codefactor.io/repository/github/arturbosch/detekt)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Farturbosch%2Fdetekt-intellij-plugin.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Farturbosch%2Fdetekt?ref=badge_shield)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
   - gradlew.bat --version
 
 build_script:
-  - gradlew build installShadowDist --build-cache --max-workers=2 --parallel -PwarningsAsErrors=true -Pcompile-test-snippets=%COMPILE_TEST_SNIPPETS%
+  - gradlew build installShadowDist --build-cache -PwarningsAsErrors=true -Pcompile-test-snippets=%COMPILE_TEST_SNIPPETS%
   - detekt-cli\build\install\detekt-cli-shadow\bin\detekt-cli --help
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
   - gradlew.bat --version
 
 build_script:
-  - gradlew build installShadowDist --build-cache --parallel -PwarningsAsErrors=true -Pcompile-test-snippets=%COMPILE_TEST_SNIPPETS%
+  - gradlew build installShadowDist --build-cache --max-workers=2 --parallel -PwarningsAsErrors=true -Pcompile-test-snippets=%COMPILE_TEST_SNIPPETS%
   - detekt-cli\build\install\detekt-cli-shadow\bin\detekt-cli --help
 
 test_script:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -213,7 +213,7 @@ subprojects {
     }
 
     publishing {
-        publications.create<MavenPublication>(detektPublication) {
+        publications.register<MavenPublication>(detektPublication) {
             from(components["java"])
             artifact(sourcesJar)
             artifact(javadocJar)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -123,7 +123,7 @@ subprojects {
         }
     }
 
-    tasks.withType<Test>().configureEach {
+    tasks.withType<Test>() {
         useJUnitPlatform()
         systemProperty("SPEK_TIMEOUT", 0) // disable test timeout
         val compileSnippetText: Boolean = if (project.hasProperty("compile-test-snippets")) {
@@ -147,7 +147,7 @@ subprojects {
         }
     }
 
-    tasks.withType<KotlinCompile>().configureEach {
+    tasks.withType<KotlinCompile>() {
         kotlinOptions.jvmTarget = projectJvmTarget
         // https://youtrack.jetbrains.com/issue/KT-24946
         kotlinOptions.freeCompilerArgs = listOf(

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -4,8 +4,6 @@ plugins {
     id("org.jetbrains.dokka")
 }
 
-configurations.testImplementation.get().extendsFrom(configurations.kotlinTest.get())
-
 val yamlVersion: String by project
 val junitPlatformVersion: String by project
 val spekVersion: String by project
@@ -14,11 +12,7 @@ dependencies {
     implementation("org.yaml:snakeyaml:$yamlVersion")
     api(kotlin("compiler-embeddable"))
     implementation(kotlin("reflect"))
-
     testImplementation(project(":detekt-test"))
-
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }
 
 tasks.withType<DokkaTask>().configureEach {

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -9,9 +9,6 @@ val detektVersion: String by project
 val reflectionsVersion: String by project
 val mockkVersion: String by project
 
-// implementation.extendsFrom kotlin is not enough for using cli in a gradle task - #58
-configurations.testImplementation.get().extendsFrom(configurations.kotlinTest.get())
-
 dependencies {
     implementation(project(":detekt-core"))
     runtimeOnly(project(":detekt-rules"))
@@ -20,10 +17,6 @@ dependencies {
 
     testImplementation(project(":detekt-test"))
     testImplementation(project(":detekt-rules"))
-    testImplementation("org.reflections:reflections:$reflectionsVersion")
-    testImplementation("io.mockk:mockk:$mockkVersion")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }
 
 // bundle detekt's version for debug logging on rule exceptions

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -192,6 +192,6 @@ class CliArgs : Args {
          * Creates an instance of [CliArgs]. Verification if the settings are sound
          * must be made by the caller.
          */
-        fun parse(args: Array<String>): CliArgs = parseArguments<CliArgs>(args).first
+        fun parse(args: Array<String>): CliArgs = parseArguments(args)
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/HelpRequest.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/HelpRequest.kt
@@ -1,0 +1,3 @@
+package io.gitlab.arturbosch.detekt.cli
+
+class HelpRequest : RuntimeException()

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
@@ -2,10 +2,18 @@ package io.gitlab.arturbosch.detekt.cli
 
 import com.beust.jcommander.JCommander
 import com.beust.jcommander.ParameterException
-import kotlin.system.exitProcess
+import java.io.PrintStream
 
-inline fun <reified T : Args> parseArguments(args: Array<String>): Pair<T, JCommander> {
-    val cli = T::class.java.declaredConstructors.firstOrNull()?.newInstance() as? T
+@Suppress("detekt.SpreadOperator", "detekt.ThrowsCount")
+inline fun <reified T : Args> parseArguments(
+    args: Array<String>,
+    outPrinter: PrintStream = System.out,
+    errorPrinter: PrintStream = System.err,
+    validateCli: T.(MessageCollector) -> Unit = {}
+): T {
+    val cli = T::class.java.declaredConstructors
+        .firstOrNull()
+        ?.newInstance() as? T
         ?: throw IllegalStateException("Could not create Args object for class ${T::class.java}")
 
     val jCommander = JCommander()
@@ -14,30 +22,36 @@ inline fun <reified T : Args> parseArguments(args: Array<String>): Pair<T, JComm
     jCommander.programName = "detekt"
 
     try {
-        @Suppress("SpreadOperator")
         jCommander.parse(*args)
     } catch (ex: ParameterException) {
-        val message = ex.message
-        jCommander.failWithErrorMessages(message)
+        errorPrinter.println("${ex.message}\n")
+        jCommander.usage(outPrinter)
+        throw IllegalArgumentException("Unexpected argument parsing error.")
     }
 
     if (cli.help) {
-        jCommander.usage()
-        exitProcess(0)
+        jCommander.usage(outPrinter)
+        throw HelpRequest()
     }
 
-    return cli to jCommander
-}
-
-fun JCommander.failWithErrorMessages(vararg messages: String?) {
-    failWithErrorMessages(messages.asIterable())
-}
-
-fun JCommander.failWithErrorMessages(messages: Iterable<String?>) {
-    messages.forEach {
-        println(it)
+    val violations = mutableListOf<String>()
+    validateCli(cli, object : MessageCollector {
+        override fun plusAssign(msg: String) {
+            violations += msg
+        }
+    })
+    if (violations.isNotEmpty()) {
+        violations.forEach(errorPrinter::println)
+        errorPrinter.println()
+        jCommander.usage(outPrinter)
+        throw IllegalStateException("Unexpected argument violation.")
     }
-    println()
-    this.usage()
-    exitProcess(1)
+
+    return cli
+}
+
+fun JCommander.usage(outPrinter: PrintStream) {
+    val usage = StringBuilder()
+    this.usageFormatter.usage(usage)
+    outPrinter.println(usage.toString())
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.cli.runners.ConfigExporter
 import io.gitlab.arturbosch.detekt.cli.runners.Executable
 import io.gitlab.arturbosch.detekt.cli.runners.Runner
 import io.gitlab.arturbosch.detekt.cli.runners.SingleRuleRunner
-import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import java.io.PrintStream
 import kotlin.system.exitProcess
 
@@ -15,6 +14,8 @@ import kotlin.system.exitProcess
 fun main(args: Array<String>) {
     try {
         buildRunner(args).execute()
+    } catch (_: HelpRequest) {
+        // handled by JCommander, exit normally
     } catch (e: InvalidConfig) {
         e.printStackTrace()
         exitProcess(ExitCode.INVALID_CONFIG.number)
@@ -33,30 +34,19 @@ fun buildRunner(
     outputPrinter: PrintStream = System.out,
     errorPrinter: PrintStream = System.err
 ): Executable {
-    val arguments = parseArguments(args)
+    val arguments = parseArguments<CliArgs>(
+        args,
+        outputPrinter,
+        errorPrinter
+    ) { messages ->
+        if (createBaseline && baseline == null) {
+            messages += "Creating a baseline.xml requires the --baseline parameter to specify a path."
+        }
+    }
     return when {
         arguments.generateConfig -> ConfigExporter(arguments)
         arguments.runRule != null -> SingleRuleRunner(arguments)
         arguments.printAst -> AstPrinter(arguments)
         else -> Runner(arguments, outputPrinter, errorPrinter)
     }
-}
-
-private fun parseArguments(args: Array<String>): CliArgs {
-    val (arguments, jcommander) = parseArguments<CliArgs>(args)
-    val messages = validateCli(arguments)
-    messages.ifNotEmpty {
-        jcommander.failWithErrorMessages(messages)
-    }
-    return arguments
-}
-
-private fun validateCli(arguments: CliArgs): List<String> {
-    val violations = ArrayList<String>()
-    with(arguments) {
-        if (createBaseline && baseline == null) {
-            violations += "Creating a baseline.xml requires the --baseline parameter to specify a path."
-        }
-    }
-    return violations
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/MessageCollector.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/MessageCollector.kt
@@ -1,0 +1,5 @@
+package io.gitlab.arturbosch.detekt.cli
+
+interface MessageCollector {
+    operator fun plusAssign(msg: String)
+}

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -20,6 +20,7 @@ import io.gitlab.arturbosch.detekt.cli.loadDefaultConfig
 import io.gitlab.arturbosch.detekt.cli.maxIssues
 import io.gitlab.arturbosch.detekt.core.DetektFacade
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
+import io.gitlab.arturbosch.detekt.core.whichDetekt
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import java.io.PrintStream
 
@@ -31,6 +32,7 @@ class Runner(
 
     override fun execute() {
         createSettings().use { settings ->
+            settings.debug { "Running detekt '${whichDetekt()}'" }
             checkConfiguration(settings)
             val (time, result) = measure { DetektFacade.create(settings).run() }
             result.add(SimpleNotification("detekt finished in $time ms."))

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -16,13 +16,13 @@ internal class CliArgsSpec : Spek({
     describe("Parsing the input path") {
 
         it("the current working directory is used if parameter is not set") {
-            val (cli, _) = parseArguments<CliArgs>(emptyArray())
+            val cli = parseArguments<CliArgs>(emptyArray())
             assertThat(cli.inputPaths).hasSize(1)
             assertThat(cli.inputPaths.first()).isEqualTo(Paths.get(System.getProperty("user.dir")))
         }
 
         it("a single value is converted to a path") {
-            val (cli, _) = parseArguments<CliArgs>(arrayOf("--input", "$projectPath"))
+            val cli = parseArguments<CliArgs>(arrayOf("--input", "$projectPath"))
             assertThat(cli.inputPaths).hasSize(1)
             assertThat(cli.inputPaths.first().toAbsolutePath()).isEqualTo(projectPath)
         }
@@ -30,8 +30,8 @@ internal class CliArgsSpec : Spek({
         it("multiple imput paths can be separated by comma") {
             val mainPath = projectPath.resolve("src/main").toAbsolutePath()
             val testPath = projectPath.resolve("src/test").toAbsolutePath()
-            val (cli, _) = parseArguments<CliArgs>(arrayOf(
-                    "--input", "$mainPath,$testPath")
+            val cli = parseArguments<CliArgs>(arrayOf(
+                "--input", "$mainPath,$testPath")
             )
             assertThat(cli.inputPaths).hasSize(2)
             assertThat(cli.inputPaths.map(Path::toAbsolutePath)).containsExactlyInAnyOrder(mainPath, testPath)
@@ -42,8 +42,8 @@ internal class CliArgsSpec : Spek({
             val params = arrayOf("--input", "$pathToNonExistentDirectory")
 
             assertThatExceptionOfType(ParameterException::class.java)
-                    .isThrownBy { parseArguments<CliArgs>(params).first.inputPaths }
-                    .withMessageContaining("does not exist")
+                .isThrownBy { parseArguments<CliArgs>(params).inputPaths }
+                .withMessageContaining("does not exist")
         }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/ReportsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/ReportsSpec.kt
@@ -21,12 +21,12 @@ internal class ReportsSpec : Spek({
 
             val reportUnderTest = TestOutputReport::class.java.simpleName
             val args = arrayOf(
-                    "--report", "xml:/tmp/path1",
-                    "--report", "txt:/tmp/path2",
-                    "--report", "$reportUnderTest:/tmp/path3",
-                    "--report", "html:D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html"
+                "--report", "xml:/tmp/path1",
+                "--report", "txt:/tmp/path2",
+                "--report", "$reportUnderTest:/tmp/path3",
+                "--report", "html:D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html"
             )
-            val (cli, _) = parseArguments<CliArgs>(args)
+            val cli = parseArguments<CliArgs>(args)
 
             val reports = cli.reportPaths
 
@@ -55,7 +55,9 @@ internal class ReportsSpec : Spek({
             it("it should properly parse HTML report entry") {
                 val htmlReport = reports[3]
                 assertThat(htmlReport.kind).isEqualTo(HtmlOutputReport::class.java.simpleName)
-                assertThat(htmlReport.path).isEqualTo(Paths.get("D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html"))
+                assertThat(htmlReport.path).isEqualTo(
+                    Paths.get("D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html")
+                )
             }
 
             val extensions = ReportLocator(ProcessingSettings(listOf())).load()
@@ -67,12 +69,12 @@ internal class ReportsSpec : Spek({
 
             it("should recognize custom output format") {
                 assertThat(reports).haveExactly(1,
-                        Condition(Predicate { it.kind == reportUnderTest },
-                                "Corresponds exactly to the test output report."))
+                    Condition(Predicate { it.kind == reportUnderTest },
+                        "Corresponds exactly to the test output report."))
 
                 assertThat(extensions).haveExactly(1,
-                        Condition(Predicate { it is TestOutputReport && it.ending == "yml" },
-                                "Is exactly the test output report."))
+                    Condition(Predicate { it is TestOutputReport && it.ending == "yml" },
+                        "Is exactly the test output report."))
             }
         }
     }

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -1,15 +1,6 @@
-configurations.testImplementation.get().extendsFrom(configurations.kotlinTest.get())
-
-val junitPlatformVersion: String by project
-val spekVersion: String by project
-val reflectionsVersion: String by project
-
 dependencies {
     api(project(":detekt-api"))
 
     testImplementation(project(":detekt-rules"))
     testImplementation(project(":detekt-test"))
-    testImplementation("org.reflections:reflections:$reflectionsVersion")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }

--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -1,8 +1,4 @@
-configurations.testImplementation.get().extendsFrom(configurations.kotlinTest.get())
-
 val ktlintVersion: String by project
-val junitPlatformVersion: String by project
-val spekVersion: String by project
 
 dependencies {
     implementation(project(":detekt-api"))
@@ -15,11 +11,8 @@ dependencies {
     implementation("com.pinterest.ktlint:ktlint-ruleset-experimental:$ktlintVersion") {
         exclude(group = "org.jetbrains.kotlin")
     }
-
     testImplementation(project(":detekt-test"))
     testImplementation(project(":detekt-core"))
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }
 
 tasks.withType<Jar>().configureEach {

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -10,9 +10,6 @@ val jar by tasks.getting(Jar::class) {
     }
 }
 
-// implementation.extendsFrom kotlin is not enough for using cli in a gradle task - #58
-configurations.testImplementation.get().extendsFrom(configurations.kotlinTest.get())
-
 val detektVersion: String by project
 
 val generateDocumentation by tasks.registering {
@@ -92,8 +89,5 @@ dependencies {
     implementation(project(":detekt-formatting"))
     implementation("com.beust:jcommander:$jcommanderVersion")
     implementation(kotlin("reflect"))
-
     testImplementation(project(":detekt-test"))
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Main.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Main.kt
@@ -2,38 +2,25 @@
 
 package io.gitlab.arturbosch.detekt.generator
 
-import io.gitlab.arturbosch.detekt.cli.failWithErrorMessages
 import io.gitlab.arturbosch.detekt.cli.parseArguments
 import io.gitlab.arturbosch.detekt.core.isFile
-import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import java.nio.file.Files
 
 fun main(args: Array<String>) {
-    val arguments = parseArgumentsCheckingReportDirectory(args)
-    val executable = Runner(arguments)
-    executable.execute()
-}
-
-private fun parseArgumentsCheckingReportDirectory(args: Array<String>): GeneratorArgs {
-    val (arguments, jcommander) = parseArguments<GeneratorArgs>(args)
-    val messages = validateCli(arguments)
-    messages.ifNotEmpty {
-        jcommander.failWithErrorMessages(messages)
-    }
-    return arguments
-}
-
-private fun validateCli(arguments: GeneratorArgs): List<String> {
-    val violations = ArrayList<String>()
-    with(arguments) {
+    val arguments = parseArguments<GeneratorArgs>(
+        args,
+        System.out,
+        System.err
+    ) { messages ->
         if (Files.exists(documentationPath) && documentationPath.isFile()) {
-            violations += "Documentation path must be a directory."
+            messages += "Documentation path must be a directory."
         }
 
         if (Files.exists(configPath) && configPath.isFile()) {
-            violations += "Config path must be a directory."
+            messages += "Config path must be a directory."
         }
         // input paths are validated by MultipleExistingPathConverter
     }
-    return violations
+    val executable = Runner(arguments)
+    executable.execute()
 }

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -24,9 +24,10 @@ version = "1.4.0"
 val spekVersion = "2.0.9"
 val junitPlatformVersion = "1.5.2"
 val assertjVersion = "3.14.0"
-val detektFormattingVersion = "1.3.1"
+val detektVersion = "1.3.1"
 
 dependencies {
+    implementation("io.gitlab.arturbosch.detekt:detekt-cli:$detektVersion")
     implementation(kotlin("stdlib"))
     implementation(kotlin("gradle-plugin"))
     implementation(kotlin("gradle-plugin-api"))
@@ -36,7 +37,7 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
     testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$detektFormattingVersion")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$detektVersion")
 }
 
 gradlePlugin {
@@ -105,7 +106,7 @@ val generateDefaultDetektVersionFile by tasks.registering {
         defaultDetektVersionFile.writeText("""
             package io.gitlab.arturbosch.detekt
 
-            internal const val DEFAULT_DETEKT_VERSION = "$version"
+            internal const val DEFAULT_DETEKT_VERSION = "$detektVersion"
 
             """.trimIndent()
         )

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -1,43 +1,16 @@
-import com.jfrog.bintray.gradle.BintrayExtension
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.gradle.api.tasks.testing.logging.TestLogEvent
-import java.util.Date
-
-repositories {
-    jcenter()
-}
-
 plugins {
     `java-gradle-plugin`
     `maven-publish`
-    id("com.gradle.plugin-publish") version "0.10.1"
-    id("com.jfrog.bintray") version "1.8.4"
-    kotlin("jvm") version "1.3.61"
-    id("org.jetbrains.dokka") version "0.10.0"
-    id("com.github.ben-manes.versions") version "0.27.0"
-    id("io.gitlab.arturbosch.detekt") version "1.4.0"
+    id("com.gradle.plugin-publish")
+    id("org.jetbrains.dokka")
 }
 
-group = "io.gitlab.arturbosch.detekt"
-version = "1.4.0"
-
-val spekVersion = "2.0.9"
-val junitPlatformVersion = "1.5.2"
-val assertjVersion = "3.14.0"
-val detektVersion = "1.3.1"
-
 dependencies {
-    implementation("io.gitlab.arturbosch.detekt:detekt-cli:$detektVersion")
+    implementation("io.gitlab.arturbosch.detekt:detekt-cli:$version")
     implementation(kotlin("stdlib"))
     implementation(kotlin("gradle-plugin"))
     implementation(kotlin("gradle-plugin-api"))
-
-    testImplementation("org.assertj:assertj-core:$assertjVersion")
-    testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
-
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$detektVersion")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$version")
 }
 
 gradlePlugin {
@@ -49,24 +22,6 @@ gradlePlugin {
     }
 }
 
-tasks.test {
-    useJUnitPlatform()
-    systemProperty("SPEK_TIMEOUT", 0) // disable test timeout
-    testLogging {
-        // set options for log level LIFECYCLE
-        events = setOf(
-            TestLogEvent.FAILED,
-            TestLogEvent.PASSED,
-            TestLogEvent.SKIPPED,
-            TestLogEvent.STANDARD_OUT
-        )
-        exceptionFormat = TestExceptionFormat.FULL
-        showExceptions = true
-        showCauses = true
-        showStackTraces = true
-    }
-}
-
 tasks.validatePlugins {
     enableStricterValidation.set(true)
 }
@@ -75,7 +30,7 @@ pluginBundle {
     website = "https://arturbosch.github.io/detekt"
     vcsUrl = "https://github.com/arturbosch/detekt"
     description = "Static code analysis for Kotlin"
-    tags = listOf("kotlin", "detekt", "code-analysis", "badsmells", "codesmells")
+    tags = listOf("kotlin", "static-code-analysis", "linter", "code-smells")
 
     (plugins) {
         "detektPlugin" {
@@ -106,7 +61,7 @@ val generateDefaultDetektVersionFile by tasks.registering {
         defaultDetektVersionFile.writeText("""
             package io.gitlab.arturbosch.detekt
 
-            internal const val DEFAULT_DETEKT_VERSION = "$detektVersion"
+            internal const val DEFAULT_DETEKT_VERSION = "${rootProject.version}"
 
             """.trimIndent()
         )
@@ -117,96 +72,4 @@ sourceSets.main.get().java.srcDir("$buildDir/generated/src")
 
 tasks.compileKotlin {
     dependsOn(generateDefaultDetektVersionFile)
-}
-
-val sourcesJar by tasks.creating(Jar::class) {
-    dependsOn(tasks.classes)
-    archiveClassifier.set("sources")
-    from(sourceSets.main.get().allSource)
-}
-
-val javadocJar by tasks.creating(Jar::class) {
-    dependsOn(tasks.dokka)
-    archiveClassifier.set("javadoc")
-    from(buildDir.resolve("javadoc"))
-}
-
-artifacts {
-    archives(sourcesJar)
-    archives(javadocJar)
-}
-
-detekt {
-    buildUponDefaultConfig = true
-    config.setFrom(file("../config/detekt/detekt.yml"))
-}
-
-val bintrayUser = findProperty("bintrayUser")?.toString() ?: System.getenv("BINTRAY_USER")
-val bintrayKey = findProperty("bintrayKey")?.toString() ?: System.getenv("BINTRAY_API_KEY")
-val detektPublication = "DetektPublication"
-
-publishing {
-    publications.create<MavenPublication>(detektPublication) {
-        from(components["java"])
-        artifact(sourcesJar)
-        artifact(javadocJar)
-        groupId = rootProject.group as? String
-        artifactId = rootProject.name
-        version = rootProject.version as? String
-        pom {
-            description.set("Static code analysis for Kotlin")
-            name.set("detekt")
-            url.set("https://github.com/arturbosch/detekt")
-            licenses {
-                license {
-                    name.set("The Apache Software License, Version 2.0")
-                    url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                    distribution.set("repo")
-                }
-            }
-            developers {
-                developer {
-                    id.set("Artur Bosch")
-                    name.set("Artur Bosch")
-                    email.set("arturbosch@gmx.de")
-                }
-            }
-            scm {
-                url.set("https://github.com/arturbosch/detekt")
-            }
-        }
-    }
-}
-
-bintray {
-    user = bintrayUser
-    key = bintrayKey
-    val mavenCentralUser = System.getenv("MAVEN_CENTRAL_USER") ?: ""
-    val mavenCentralPassword = System.getenv("MAVEN_CENTRAL_PW") ?: ""
-
-    setPublications(detektPublication)
-
-    pkg(delegateClosureOf<BintrayExtension.PackageConfig> {
-        repo = "code-analysis"
-        name = "detekt"
-        userOrg = "arturbosch"
-        setLicenses("Apache-2.0")
-        vcsUrl = "https://github.com/arturbosch/detekt"
-
-        version(delegateClosureOf<BintrayExtension.VersionConfig> {
-            name = project.version as? String
-            released = Date().toString()
-
-            gpg(delegateClosureOf<BintrayExtension.GpgConfig> {
-                sign = true
-            })
-
-            mavenCentralSync(delegateClosureOf<BintrayExtension.MavenCentralSyncConfig> {
-                sync = true
-                user = mavenCentralUser
-                password = mavenCentralPassword
-                close = "1"
-            })
-        })
-    })
 }

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 val selfAnalysisVersion: String by project
 
 dependencies {
-    implementation(project(":detekt-cli"))
     implementation(kotlin("stdlib"))
     implementation(kotlin("gradle-plugin"))
     implementation(kotlin("gradle-plugin-api"))

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -2,7 +2,6 @@
 
 plugins {
     `java-gradle-plugin`
-    `maven-publish`
     id("com.gradle.plugin-publish")
     id("org.jetbrains.dokka")
 }

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 plugins {
     `java-gradle-plugin`
     `maven-publish`

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -5,12 +5,14 @@ plugins {
     id("org.jetbrains.dokka")
 }
 
+val selfAnalysisVersion: String by project
+
 dependencies {
-    implementation("io.gitlab.arturbosch.detekt:detekt-cli:$version")
+    implementation(project(":detekt-cli"))
     implementation(kotlin("stdlib"))
     implementation(kotlin("gradle-plugin"))
     implementation(kotlin("gradle-plugin-api"))
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$version")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$selfAnalysisVersion")
 }
 
 gradlePlugin {

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -1,5 +1,0 @@
-// DO NOT DELETE - REQUIRED FOR PROPER INTELLIJ GRADLE INTEGRATION
-
-// If this file is removed it is not possible to run a task in the included build  directly from the Gradle Tool Window
-// in IntelliJ, and this error will  be shown:
-// Project directory '...\detekt\detekt-gradle-plugin' is not part of the build defined by settings file '...\detekt\settings.gradle.kts'. If this is an unrelated build, it must have its own settings file.

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "UnstableApiUsage", "DeprecatedCallableAddReplaceWith")
+
 package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.extensions.CustomDetektReport

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -152,13 +152,18 @@ class DetektPlugin : Plugin<Project> {
             configuration.isTransitive = true
             configuration.description = "The $CONFIGURATION_DETEKT dependencies to be used for this project."
 
-            if (toolVersion() != null) {
+            val version = toolVersion()
+            if (version != null) {
                 project.logger.warn(
                     """ |Using 'detekt.toolVersion' is deprecated due to performance reasons.
-                        |This property will exist in the future due to Gradle api requirements but has no use anymore.
+                        |You can use it to test snapshot releases of detekt but is discouraged to use in production.
+                        |This property will exist in the future due to Gradle api requirements.
                         |This plugin ships with version '$DEFAULT_DETEKT_VERSION' by default.
                     """.trimMargin()
                 )
+                configuration.defaultDependencies { dependencySet ->
+                    dependencySet.add(project.dependencies.create("$DETEKT_CLI_ARTIFACT:$version"))
+                }
             }
         }
     }
@@ -180,6 +185,7 @@ class DetektPlugin : Plugin<Project> {
     }
 
     companion object {
+        private const val DETEKT_CLI_ARTIFACT = "io.gitlab.arturbosch.detekt:detekt-cli"
         private const val DETEKT_TASK_NAME = "detekt"
         private const val IDEA_FORMAT = "detektIdeaFormat"
         private const val IDEA_INSPECT = "detektIdeaInspect"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -138,6 +138,9 @@ class DetektPlugin : Plugin<Project> {
     ): Provider<FileCollection> = project.provider { extension.input.filter { it.exists() } }
 
     private fun configurePluginDependencies(project: Project, extension: DetektExtension) {
+
+        fun toolVersion(): String? = extension.toolVersion // force it to be nullable for the compiler
+
         project.configurations.create(CONFIGURATION_DETEKT_PLUGINS) { configuration ->
             configuration.isVisible = false
             configuration.isTransitive = true
@@ -149,9 +152,13 @@ class DetektPlugin : Plugin<Project> {
             configuration.isTransitive = true
             configuration.description = "The $CONFIGURATION_DETEKT dependencies to be used for this project."
 
-            configuration.defaultDependencies { dependencySet ->
-                val version = extension.toolVersion ?: DEFAULT_DETEKT_VERSION
-                dependencySet.add(project.dependencies.create("io.gitlab.arturbosch.detekt:detekt-cli:$version"))
+            if (toolVersion() != null) {
+                project.logger.warn(
+                    """ |Using 'detekt.toolVersion' is deprecated due to performance reasons.
+                        |This property will exist in the future due to Gradle api requirements but has no use anymore.
+                        |This plugin ships with version '$DEFAULT_DETEKT_VERSION' by default.
+                    """.trimMargin()
+                )
             }
         }
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -152,18 +152,10 @@ class DetektPlugin : Plugin<Project> {
             configuration.isTransitive = true
             configuration.description = "The $CONFIGURATION_DETEKT dependencies to be used for this project."
 
-            val version = toolVersion()
-            if (version != null) {
-                project.logger.warn(
-                    """ |Using 'detekt.toolVersion' is deprecated due to performance reasons.
-                        |You can use it to test snapshot releases of detekt but is discouraged to use in production.
-                        |This property will exist in the future due to Gradle api requirements.
-                        |This plugin ships with version '$DEFAULT_DETEKT_VERSION' by default.
-                    """.trimMargin()
-                )
-                configuration.defaultDependencies { dependencySet ->
-                    dependencySet.add(project.dependencies.create("$DETEKT_CLI_ARTIFACT:$version"))
-                }
+            configuration.defaultDependencies { dependencySet ->
+                dependencySet.add(project.dependencies.create(
+                    "$DETEKT_CLI_ARTIFACT:${toolVersion() ?: DEFAULT_DETEKT_VERSION}"
+                ))
             }
         }
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/GradleCompat.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/GradleCompat.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "UnstableApiUsage")
+
 package io.gitlab.arturbosch.detekt.internal
 
 import org.gradle.api.Project

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -47,14 +47,15 @@ private class DefaultCliInvoker(private val project: Project) : DetektInvoker {
                 classpath.map { it.toURI().toURL() }.toTypedArray(),
                 null /* isolate detekt environment */
             )
-
-            val clazz = loader.loadClass("io.gitlab.arturbosch.detekt.cli.Main")
-            val runner = clazz.getMethod("buildRunner",
-                Array<String>::class.java,
-                PrintStream::class.java,
-                PrintStream::class.java
-            ).invoke(null, cliArguments.toTypedArray(), System.out, System.err)
-            runner::class.java.getMethod("execute").invoke(runner)
+            loader.use {
+                val clazz = it.loadClass("io.gitlab.arturbosch.detekt.cli.Main")
+                val runner = clazz.getMethod("buildRunner",
+                    Array<String>::class.java,
+                    PrintStream::class.java,
+                    PrintStream::class.java
+                ).invoke(null, cliArguments.toTypedArray(), System.out, System.err)
+                runner::class.java.getMethod("execute").invoke(runner)
+            }
         } catch (reflectionWrapper: InvocationTargetException) {
             val cause = reflectionWrapper.targetException
             val message = cause.message

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -438,10 +438,6 @@ internal object DetektTaskDslTest : Spek({
                     it("successfully checks dependencies") {
                         assertThat(result.task(":dependencies")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
                     }
-
-                    it("adds the custom detekt version to the dependencies") {
-                        assertThat(result.output).contains("io.gitlab.arturbosch.detekt:detekt-cli:$customVersion")
-                    }
                 }
             }
         }

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -1,17 +1,7 @@
-configurations.testImplementation.get().extendsFrom(configurations.kotlinTest.get())
-
 tasks.build { finalizedBy(":detekt-generator:generateDocumentation") }
-
-val junitPlatformVersion: String by project
-val spekVersion: String by project
-val reflectionsVersion: String by project
 
 dependencies {
     implementation(project(":detekt-api"))
-
-    testImplementation("org.reflections:reflections:$reflectionsVersion")
     testImplementation(project(":detekt-test"))
     testImplementation(kotlin("reflect"))
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -206,5 +206,4 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
         }
     }
-
 })

--- a/docs/pages/documentation/count_rules.kts
+++ b/docs/pages/documentation/count_rules.kts
@@ -1,0 +1,11 @@
+import java.io.File
+
+val root = File(".").absoluteFile
+
+val numberOfRules = root
+	.list()
+	.map { File(root, it) }
+	.flatMap { it.readLines().filter { it.startsWith("### ") } }
+	.size
+
+println("#rules: $numberOfRules")

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/-init-.md
@@ -10,7 +10,7 @@ title: ConsoleReport.<init> - detekt-api
 
 Extension point which describes how findings should be printed on the console.
 
-Additional [ConsoleReport](index.html)'s can be made available through the [java.util.ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) pattern.
+Additional [ConsoleReport](index.html)'s can be made available through the [java.util.ServiceLoader](#) pattern.
 If the default reporting mechanism should be turned off, exclude the entry 'FindingsReport'
 in the 'console-reports' property of a detekt yaml config.
 

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/-init-.md
@@ -10,7 +10,7 @@ title: ConsoleReport.<init> - detekt-api
 
 Extension point which describes how findings should be printed on the console.
 
-Additional [ConsoleReport](index.html)'s can be made available through the [java.util.ServiceLoader](#) pattern.
+Additional [ConsoleReport](index.html)'s can be made available through the [java.util.ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) pattern.
 If the default reporting mechanism should be turned off, exclude the entry 'FindingsReport'
 in the 'console-reports' property of a detekt yaml config.
 

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/index.md
@@ -10,7 +10,7 @@ title: ConsoleReport - detekt-api
 
 Extension point which describes how findings should be printed on the console.
 
-Additional [ConsoleReport](./index.html)'s can be made available through the [java.util.ServiceLoader](#) pattern.
+Additional [ConsoleReport](./index.html)'s can be made available through the [java.util.ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) pattern.
 If the default reporting mechanism should be turned off, exclude the entry 'FindingsReport'
 in the 'console-reports' property of a detekt yaml config.
 

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/index.md
@@ -10,7 +10,7 @@ title: ConsoleReport - detekt-api
 
 Extension point which describes how findings should be printed on the console.
 
-Additional [ConsoleReport](./index.html)'s can be made available through the [java.util.ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) pattern.
+Additional [ConsoleReport](./index.html)'s can be made available through the [java.util.ServiceLoader](#) pattern.
 If the default reporting mechanism should be turned off, exclude the entry 'FindingsReport'
 in the 'console-reports' property of a detekt yaml config.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,7 @@ sonarQubeVersion=2.8
 
 # Gradle version
 gradleVersion=6.0.1
+gradlePublishVersion=0.10.1
 
 kotlin.code.style=official
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 detektVersion=1.4.0
+selfAnalysisVersion=1.4.0
 
 # Project dependencies
 assertjVersion=3.14.0

--- a/scripts/profile_detekt.groovy
+++ b/scripts/profile_detekt.groovy
@@ -1,0 +1,33 @@
+@groovy.lang.Grab("io.gitlab.arturbosch.detekt:detekt-cli:1.5.0-SNAPSHOT")
+import io.gitlab.arturbosch.detekt.cli.Main
+
+def invokeDetekt() {
+    def clazz = getClass().classLoader.loadClass("io.gitlab.arturbosch.detekt.cli.Main")
+    def runner = clazz.getMethod(
+            "buildRunner",
+            String[].class,
+            PrintStream.class,
+            PrintStream.class
+    ).invoke(null, ['--help'] as String[], System.out, System.err)
+    runner.class.getMethod("execute")
+            .invoke(runner)
+}
+
+def console = System.console()
+if (!console) {
+    println("No System.console() available.")
+    System.exit(1)
+}
+
+println("Welcome to detekt interactive run. Connect to visualvm to profile for memory leaks.")
+while (true) {
+    def command = console.readLine("detekt> ")
+    switch (command) {
+        case "run":
+//            invokeDetekt()
+            Main.main(['--help'] as String[])
+            break
+        case "exit":
+            return
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 rootProject.name = "detekt"
+
 include("detekt-api",
     "detekt-core",
     "detekt-rules",
@@ -6,9 +7,9 @@ include("detekt-api",
     "detekt-test",
     "detekt-sample-extensions",
     "detekt-generator",
-    "detekt-formatting")
-
-includeBuild("detekt-gradle-plugin")
+    "detekt-formatting",
+    "detekt-gradle-plugin"
+)
 
 pluginManagement {
     val artifactoryVersion: String by settings
@@ -18,6 +19,8 @@ pluginManagement {
     val kotlinVersion: String by settings
     val shadowVersion: String by settings
     val sonarQubeVersion: String by settings
+    val detektVersion: String by settings
+    val gradlePublishVersion: String by settings
 
     plugins {
         id("com.jfrog.artifactory") version artifactoryVersion
@@ -27,6 +30,8 @@ pluginManagement {
         kotlin("jvm") version kotlinVersion
         id("com.github.johnrengelman.shadow") version shadowVersion
         id("org.sonarqube") version sonarQubeVersion
+        id("io.gitlab.arturbosch.detekt") version detektVersion
+        id("com.gradle.plugin-publish") version gradlePublishVersion
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
     val kotlinVersion: String by settings
     val shadowVersion: String by settings
     val sonarQubeVersion: String by settings
-    val detektVersion: String by settings
+    val selfAnalysisVersion: String by settings
     val gradlePublishVersion: String by settings
 
     plugins {
@@ -30,7 +30,7 @@ pluginManagement {
         kotlin("jvm") version kotlinVersion
         id("com.github.johnrengelman.shadow") version shadowVersion
         id("org.sonarqube") version sonarQubeVersion
-        id("io.gitlab.arturbosch.detekt") version detektVersion
+        id("io.gitlab.arturbosch.detekt") version selfAnalysisVersion
         id("com.gradle.plugin-publish") version gradlePublishVersion
     }
 }


### PR DESCRIPTION
This incorporates the changes proposed by @BraisGabin in #2035 .
Having the gradle plugin perform nearly as fast as the cli is huge enough that we should deprecate choosing the shipped detekt version.

Closes #2035