### PR TITLE
Exclude yet unknown new build property

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,6 +1,10 @@
 build:
   maxIssues: 1
 
+# can be removed after 1.3.1 is published
+config:
+  excludes: "build>excludeCorrectable"
+
 comments:
   CommentOverPrivateProperty:
     active: true


### PR DESCRIPTION
detekt analysis on the gradle plugin is not run due to "invalid config".
This is exactly what happened to our users in #2168 and #2169 and will be fixed in 1.3.1 :).