### PR TITLE
Rename default const containing _ACCEPTED_

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -47,7 +47,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  */
 class ComplexMethod(
     config: Config = Config.empty,
-    threshold: Int = DEFAULT_ACCEPTED_METHOD_COMPLEXITY
+    threshold: Int = DEFAULT_THRESHOLD_METHOD_COMPLEXITY
 ) : ThresholdRule(config, threshold) {
 
     override val issue = Issue("ComplexMethod",
@@ -102,7 +102,7 @@ class ComplexMethod(
         this is KtReturnExpression && this.returnedExpression is KtWhenExpression
 
     companion object {
-        const val DEFAULT_ACCEPTED_METHOD_COMPLEXITY = 15
+        const val DEFAULT_THRESHOLD_METHOD_COMPLEXITY = 15
         const val IGNORE_SINGLE_WHEN_EXPRESSION = "ignoreSingleWhenExpression"
         const val IGNORE_SIMPLE_WHEN_ENTRIES = "ignoreSimpleWhenEntries"
         const val IGNORE_NESTING_FUNCTIONS = "ignoreNestingFunctions"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -27,7 +27,7 @@ import java.util.IdentityHashMap
  */
 class LargeClass(
     config: Config = Config.empty,
-    threshold: Int = DEFAULT_ACCEPTED_CLASS_LENGTH
+    threshold: Int = DEFAULT_THRESHOLD_CLASS_LENGTH
 ) : ThresholdRule(config, threshold) {
 
     override val issue = Issue("LargeClass",
@@ -76,6 +76,6 @@ class LargeClass(
     }
 
     companion object {
-        const val DEFAULT_ACCEPTED_CLASS_LENGTH = 600
+        const val DEFAULT_THRESHOLD_CLASS_LENGTH = 600
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -27,7 +27,7 @@ import java.util.IdentityHashMap
  */
 class LongMethod(
     config: Config = Config.empty,
-    threshold: Int = DEFAULT_ACCEPTED_METHOD_LENGTH
+    threshold: Int = DEFAULT_THRESHOLD_METHOD_LENGTH
 ) : ThresholdRule(config, threshold) {
 
     override val issue = Issue("LongMethod",
@@ -77,6 +77,6 @@ class LongMethod(
     }
 
     companion object {
-        const val DEFAULT_ACCEPTED_METHOD_LENGTH = 60
+        const val DEFAULT_THRESHOLD_METHOD_LENGTH = 60
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.psi.KtParameterList
  */
 class LongParameterList(
     config: Config = Config.empty,
-    threshold: Int = DEFAULT_ACCEPTED_PARAMETER_LENGTH
+    threshold: Int = DEFAULT_THRESHOLD_PARAMETER_LENGTH
 ) : ThresholdRule(config, threshold) {
 
     override val issue = Issue("LongParameterList",
@@ -58,6 +58,6 @@ class LongParameterList(
 
     companion object {
         const val IGNORE_DEFAULT_PARAMETERS = "ignoreDefaultParameters"
-        const val DEFAULT_ACCEPTED_PARAMETER_LENGTH = 6
+        const val DEFAULT_THRESHOLD_PARAMETER_LENGTH = 6
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
  */
 class MethodOverloading(
     config: Config = Config.empty,
-    threshold: Int = DEFAULT_ACCEPTED_OVERLOAD_COUNT
+    threshold: Int = DEFAULT_THRESHOLD_OVERLOAD_COUNT
 ) : ThresholdRule(config, threshold) {
 
     override val issue = Issue("MethodOverloading", Severity.Maintainability,
@@ -73,6 +73,6 @@ class MethodOverloading(
     }
 
     companion object {
-        const val DEFAULT_ACCEPTED_OVERLOAD_COUNT = 6
+        const val DEFAULT_THRESHOLD_OVERLOAD_COUNT = 6
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
@@ -31,7 +31,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  */
 class NestedBlockDepth(
     config: Config = Config.empty,
-    threshold: Int = DEFAULT_ACCEPTED_NESTING
+    threshold: Int = DEFAULT_THRESHOLD_NESTING
 ) : ThresholdRule(config, threshold) {
 
     override val issue = Issue("NestedBlockDepth",
@@ -118,6 +118,6 @@ class NestedBlockDepth(
     }
 
     companion object {
-        const val DEFAULT_ACCEPTED_NESTING = 4
+        const val DEFAULT_THRESHOLD_NESTING = 4
     }
 }


### PR DESCRIPTION
I'm renaming all the occurrences of `_ACCEPTED_` with `_THRESHOLD_` in constant for default threshold values.

Having `_ACCEPTED_` in the name of the variable is really confusing as the value is actually _not accepted_ but rather triggering the rules. See #2202 for more context

Fixes #2202 

