### PR TITLE
Use compileAndLint in UnusedPrivateClassSpec

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -17,7 +16,7 @@ class UnusedPrivateClassSpec : Spek({
                 class Bar
                 """
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).hasSize(1)
             with(lint[0].entity) {
@@ -33,7 +32,7 @@ class UnusedPrivateClassSpec : Spek({
                 class Bar
                 """
 
-                val lint = subject.lint(code)
+                val lint = subject.compileAndLint(code)
 
                 assertThat(lint).hasSize(1)
                 with(lint[0].entity) {
@@ -43,30 +42,31 @@ class UnusedPrivateClassSpec : Spek({
 
             it("should not report them if used as parent") {
                 val code = """
-                private class Foo
-                private class Bar : Foo
+                private open class Foo
+                private class Bar : Foo()
                 """
 
-                val lint = subject.lint(code)
+                val lint = subject.compileAndLint(code)
 
                 assertThat(lint).hasSize(1)
                 with(lint[0].entity) {
-                    assertThat(ktElement?.text).isEqualTo("private class Bar : Foo")
+                    assertThat(ktElement?.text).isEqualTo("private class Bar : Foo()")
                 }
             }
 
             it("should not report them used as generic parent type") {
                 val code = """
-                private class Foo<in Bar> {
-                    operator fun invoke(b: Bar): Unit
+                class Bar
+                private interface Foo<in T> {
+                    operator fun invoke(b: T): Unit
                 }
 
-                data class FooOne(val b: Bar2) : Foo<Bar2> {
-                    override fun invoke(b: Bar2): Unit = Unit
+                data class FooOne(val b: Bar) : Foo<Bar> {
+                    override fun invoke(b: Bar): Unit = Unit
                 }
                 """
 
-                val lint = subject.lint(code)
+                val lint = subject.compileAndLint(code)
 
                 assertThat(lint).isEmpty()
             }
@@ -80,7 +80,7 @@ class UnusedPrivateClassSpec : Spek({
                 }
                 """
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).isEmpty()
         }
@@ -88,10 +88,12 @@ class UnusedPrivateClassSpec : Spek({
         it("should not report them if used as function parameter") {
             val code = """
                 private class Foo
-                fun bar(foo: Foo) = Unit
+                private object Bar {
+                  fun bar(foo: Foo) = Unit
+                }
                 """
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).isEmpty()
         }
@@ -99,10 +101,10 @@ class UnusedPrivateClassSpec : Spek({
         it("should not report them if used as nullable variable type") {
             val code = """
                 private class Foo
-                val a: Foo? = null
+                private val a: Foo? = null
                 """
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).isEmpty()
         }
@@ -110,10 +112,10 @@ class UnusedPrivateClassSpec : Spek({
         it("should not report them if used as variable type") {
             val code = """
                 private class Foo
-                lateinit var a: Foo
+                private lateinit var a: Foo
                 """
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).isEmpty()
         }
@@ -121,10 +123,10 @@ class UnusedPrivateClassSpec : Spek({
         it("should not report them if used as generic type") {
             val code = """
                 private class Foo
-                lateinit var foos: List<Foo>
+                private lateinit var foos: List<Foo>
                 """
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).isEmpty()
         }
@@ -132,10 +134,10 @@ class UnusedPrivateClassSpec : Spek({
         it("should not report them if used as nested generic type") {
             val code = """
                 private class Foo
-                lateinit var foos: List<List<Foo>>
+                private lateinit var foos: List<List<Foo>>
                 """
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).isEmpty()
         }
@@ -143,10 +145,10 @@ class UnusedPrivateClassSpec : Spek({
         it("should not report them if used as type with generics") {
             val code = """
                 private class Foo<T>
-                lateinit var foos: Foo<String>
+                private lateinit var foos: Foo<String>
                 """
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).isEmpty()
         }
@@ -154,10 +156,10 @@ class UnusedPrivateClassSpec : Spek({
         it("should not report them if used as nullable type with generics") {
             val code = """
                 private class Foo<T>
-                lateinit var foos: Foo<String>?
+                private var foos: Foo<String>? = Foo()
                 """
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).isEmpty()
         }
@@ -165,10 +167,10 @@ class UnusedPrivateClassSpec : Spek({
         it("should not report them if used as non-argument constructor") {
             val code = """
                 private class Foo
-                val a = Foo()
+                private val a = Foo()
                 """
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).isEmpty()
         }
@@ -176,10 +178,10 @@ class UnusedPrivateClassSpec : Spek({
         it("should not report them if used as constructor with arguments") {
             val code = """
                 private class Foo(val a: String)
-                val a = Foo("test")
+                private val a = Foo("test")
                 """
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).isEmpty()
         }
@@ -187,10 +189,12 @@ class UnusedPrivateClassSpec : Spek({
         it("should not report them if used as function return type") {
             val code = """
                 private class Foo(val a: String)
-                fun foo(): Foo? = null
+                private object Bar {
+                  fun foo(): Foo? = null
+                }
                 """
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).isEmpty()
         }
@@ -198,10 +202,10 @@ class UnusedPrivateClassSpec : Spek({
         it("should not report them if used as lambda declaration parameter") {
             val code = """
                 private class Foo
-                val lambda: ((Foo) -> Unit)? = null
+                private val lambda: ((Foo) -> Unit)? = null
                 """
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).isEmpty()
         }
@@ -209,10 +213,10 @@ class UnusedPrivateClassSpec : Spek({
         it("should not report them if used as lambda declaration return type") {
             val code = """
                 private class Foo
-                val lambda: (() -> Foo)? = null
+                private val lambda: (() -> Foo)? = null
                 """
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).isEmpty()
         }
@@ -220,10 +224,10 @@ class UnusedPrivateClassSpec : Spek({
         it("should not report them if used as lambda declaration generic type") {
             val code = """
                 private class Foo
-                val lambda: (() -> List<Foo>)? = null
+                private val lambda: (() -> List<Foo>)? = null
                 """
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).isEmpty()
         }
@@ -234,12 +238,14 @@ class UnusedPrivateClassSpec : Spek({
                     abstract fun bar()
                 }
 
-                private fun foo() = object : Foo() {
-                    override fun bar() = Unit
+                private object Bar {
+                    private fun foo() = object : Foo() {
+                        override fun bar() = Unit
+                    }
                 }
                 """
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).isEmpty()
         }
@@ -249,11 +255,13 @@ class UnusedPrivateClassSpec : Spek({
 
         it("does not crash when using wildcards in generics - #1345") {
             val code = """
+                import kotlin.reflect.KClass
+                
                 private class Foo
                 fun bar(clazz: KClass<*>) = Unit
             """
 
-            val findings = UnusedPrivateClass().lint(code)
+            val findings = UnusedPrivateClass().compileAndLint(code)
 
             assertThat(findings).hasSize(1)
         }
@@ -273,7 +281,7 @@ class UnusedPrivateClassSpec : Spek({
                     }
                 """
 
-            val findings = UnusedPrivateClass().lint(code)
+            val findings = UnusedPrivateClass().compileAndLint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -286,10 +294,9 @@ class UnusedPrivateClassSpec : Spek({
 
                         private data class AnotherClass(val id: Long)
 
-                        @Test
-                        fun `verify class is used`() {
+                        fun `verify class is used`(): Boolean {
                             val instance = SomeClass(name = "test")
-                            assertNotEquals(AnotherClass::class.java.simpleName, instance::class.java.simpleName)
+                            return AnotherClass::class.java.simpleName == instance::class.java.simpleName
                         }
 
                         fun getSomeObject(): ((String) -> Any) = ::InternalClass
@@ -297,7 +304,7 @@ class UnusedPrivateClassSpec : Spek({
                     }
                 """
 
-            val findings = UnusedPrivateClass().lint(code)
+            val findings = UnusedPrivateClass().compileAndLint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -315,7 +322,7 @@ class UnusedPrivateClassSpec : Spek({
                 }
             """
 
-            val findings = UnusedPrivateClass().lint(code)
+            val findings = UnusedPrivateClass().compileAndLint(code)
 
             assertThat(findings).isEmpty()
         }


### PR DESCRIPTION
This is the commit where I found #2206. Here I'm using a workaround (all those ugly `object`s).