### PR TITLE
Show code snippet erros in html reports

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReport.kt
@@ -112,7 +112,7 @@ class HtmlOutputReport : OutputReport() {
         val psiFile = finding.entity.ktElement?.containingFile
         if (psiFile != null) {
             val lineSequence = psiFile.text.splitToSequence('\n')
-            snippetCode(lineSequence, finding.startPosition, finding.charPosition.length())
+            snippetCode(finding.id, lineSequence, finding.startPosition, finding.charPosition.length())
         }
     }
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtils.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtils.kt
@@ -1,35 +1,48 @@
 package io.gitlab.arturbosch.detekt.cli.out
 
 import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.core.whichDetekt
 import kotlinx.html.FlowContent
+import kotlinx.html.a
 import kotlinx.html.code
+import kotlinx.html.div
+import kotlinx.html.h4
+import kotlinx.html.p
 import kotlinx.html.pre
 import kotlinx.html.span
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.net.URLEncoder
 import kotlin.math.max
 import kotlin.math.min
 
-internal fun FlowContent.snippetCode(lines: Sequence<String>, location: SourceLocation, length: Int) {
-    pre {
-        code {
-            val dropLineCount = max(location.line - 1 - EXTRA_LINES_IN_SNIPPET, 0)
-            val takeLineCount = EXTRA_LINES_IN_SNIPPET + 1 + min(location.line - 1, EXTRA_LINES_IN_SNIPPET)
-            var currentLineNumber = dropLineCount + 1
-            var errorLength = length
-            lines
-                .drop(dropLineCount)
-                .take(takeLineCount)
-                .forEach { line ->
-                    span("lineno") { text("%1$4s ".format(currentLineNumber)) }
-                    if (currentLineNumber >= location.line && errorLength > 0) {
-                        val column = if (currentLineNumber == location.line) location.column - 1 else 0
-                        errorLength -= writeErrorLine(line, column, errorLength) + 1 // we need to consume the \n
-                    } else {
-                        text(line)
+internal fun FlowContent.snippetCode(ruleName: String, lines: Sequence<String>, location: SourceLocation, length: Int) {
+    @Suppress("TooGenericExceptionCaught")
+    try {
+        pre {
+            code {
+                val dropLineCount = max(location.line - 1 - EXTRA_LINES_IN_SNIPPET, 0)
+                val takeLineCount = EXTRA_LINES_IN_SNIPPET + 1 + min(location.line - 1, EXTRA_LINES_IN_SNIPPET)
+                var currentLineNumber = dropLineCount + 1
+                var errorLength = length
+                lines
+                    .drop(dropLineCount)
+                    .take(takeLineCount)
+                    .forEach { line ->
+                        span("lineno") { text("%1$4s ".format(currentLineNumber)) }
+                        if (currentLineNumber >= location.line && errorLength > 0) {
+                            val column = if (currentLineNumber == location.line) location.column - 1 else 0
+                            errorLength -= writeErrorLine(line, column, errorLength) + 1 // we need to consume the \n
+                        } else {
+                            text(line)
+                        }
+                        text("\n")
+                        currentLineNumber++
                     }
-                    text("\n")
-                    currentLineNumber++
-                }
+            }
         }
+    } catch (ex: Throwable) {
+        showError(ruleName, ex)
     }
 }
 
@@ -48,4 +61,48 @@ private fun FlowContent.writeErrorLine(line: String, errorStarts: Int, length: I
     return errorEnds - errorStarts
 }
 
+private fun FlowContent.showError(ruleName: String, throwable: Throwable) {
+    div("exception") {
+        h4 {
+            text("Error showing the code snippet")
+        }
+
+        p {
+            text("This seems to be an error in the rule $ruleName, please ")
+            a(createReportUrl(ruleName, throwable)) {
+                text("report this issue")
+            }
+            text(".")
+        }
+    }
+}
+
+private fun createReportUrl(ruleName: String, throwable: Throwable): String {
+    val title = URLEncoder.encode("HtmlReport error in rule: $ruleName", "UTF8")
+    val stackTrace = throwable.printStackTraceString()
+        .lineSequence()
+        .take(STACK_TRACE_LINES_TO_SHOW)
+        .joinToString("\n")
+    val bodyMessage = """
+            |I found an error in the html report:
+            |- Rule: $ruleName
+            |- Detetk version: ${whichDetekt() ?: "<WRITE HERE THE VERSION OF DETEKT THAT YOU ARE USING>"}
+            |- Stacktrace:
+            |```
+            |$stackTrace
+            |```
+            |- How to reproduce it: <WRITE HERE HOW TO REPRODUCE THIS ISSUE. A CODE SNIPPET IS THE BEST WAY.>
+            |""".trimMargin()
+    val body = URLEncoder.encode(bodyMessage, "UTF8")
+
+    return "https://github.com/arturbosch/detekt/issues/new?body=$body&title=$title"
+}
+
+private fun Throwable.printStackTraceString(): String {
+    val stringWriter = StringWriter()
+    printStackTrace(PrintWriter(stringWriter))
+    return stringWriter.toString()
+}
+
 private const val EXTRA_LINES_IN_SNIPPET = 3
+private const val STACK_TRACE_LINES_TO_SHOW = 6

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtils.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtils.kt
@@ -22,11 +22,7 @@ internal fun FlowContent.snippetCode(lines: Sequence<String>, location: SourceLo
                     span("lineno") { text("%1$4s ".format(currentLineNumber)) }
                     if (currentLineNumber >= location.line && errorLength > 0) {
                         val column = if (currentLineNumber == location.line) location.column - 1 else 0
-                        errorLength -= if (column < line.length) {
-                            writeErrorLine(line, column, errorLength) + 1 // we need to consume the \n
-                        } else {
-                            1
-                        }
+                        errorLength -= writeErrorLine(line, column, errorLength) + 1 // we need to consume the \n
                     } else {
                         text(line)
                     }

--- a/detekt-cli/src/main/resources/default-html-report-template.html
+++ b/detekt-cli/src/main/resources/default-html-report-template.html
@@ -48,6 +48,17 @@ pre {
 .error {
   background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4AwCFR4T/3uLMgAAADxJREFUCNdNyLERQEAABMCjL4lQwIzcjErpguAL+C9AvgKJDbeD/PRpLdm35Hm+MU+cB+tCKaJW4L4YBy+CAiLJrFs9mgAAAABJRU5ErkJggg==) bottom repeat-x;
 }
+.exception {
+  color: #b60808;
+  display: inline-block;
+  background-color: #ecdada;
+  border-color: #b60808;
+  border-radius: 10px;
+  border: solid 2px;
+  padding-left: 16px;
+  padding-right: 16px;
+  margin-bottom: 16px;
+}
 </style>
 </head>
 <body>

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtilsTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtilsTest.kt
@@ -31,7 +31,7 @@ class HtmlUtilsTest : Spek({
 
         it("all line") {
             val snippet = createHTML().div() {
-                snippetCode(code.asSequence(), SourceLocation(7, 1), 34)
+                snippetCode("ruleName", code.asSequence(), SourceLocation(7, 1), 34)
             }
 
             assertThat(snippet).isEqualTo("""
@@ -52,7 +52,7 @@ class HtmlUtilsTest : Spek({
 
         it("part of line") {
             val snippet = createHTML().div() {
-                snippetCode(code.asSequence(), SourceLocation(7, 7), 26)
+                snippetCode("ruleName", code.asSequence(), SourceLocation(7, 7), 26)
             }
 
             assertThat(snippet).isEqualTo("""
@@ -73,7 +73,7 @@ class HtmlUtilsTest : Spek({
 
         it("more than one line") {
             val snippet = createHTML().div() {
-                snippetCode(code.asSequence(), SourceLocation(7, 7), 66)
+                snippetCode("ruleName", code.asSequence(), SourceLocation(7, 7), 66)
             }
 
             assertThat(snippet).isEqualTo("""
@@ -94,7 +94,7 @@ class HtmlUtilsTest : Spek({
 
         it("first line") {
             val snippet = createHTML().div() {
-                snippetCode(code.asSequence(), SourceLocation(1, 1), 1)
+                snippetCode("ruleName", code.asSequence(), SourceLocation(1, 1), 1)
             }
 
             assertThat(snippet).contains((1..4).map { "  $it " })
@@ -102,7 +102,7 @@ class HtmlUtilsTest : Spek({
 
         it("second line") {
             val snippet = createHTML().div() {
-                snippetCode(code.asSequence(), SourceLocation(2, 1), 1)
+                snippetCode("ruleName", code.asSequence(), SourceLocation(2, 1), 1)
             }
 
             assertThat(snippet).contains((1..5).map { "  $it " })
@@ -110,7 +110,7 @@ class HtmlUtilsTest : Spek({
 
         it("penultimate line") {
             val snippet = createHTML().div() {
-                snippetCode(code.asSequence(), SourceLocation(15, 1), 1)
+                snippetCode("ruleName", code.asSequence(), SourceLocation(15, 1), 1)
             }
 
             assertThat(snippet).contains((12..16).map { "  $it " })
@@ -118,10 +118,18 @@ class HtmlUtilsTest : Spek({
 
         it("last line") {
             val snippet = createHTML().div() {
-                snippetCode(code.asSequence(), SourceLocation(16, 1), 1)
+                snippetCode("ruleName", code.asSequence(), SourceLocation(16, 1), 1)
             }
 
             assertThat(snippet).contains((13..16).map { "  $it " })
+        }
+
+        it("when we provide an invalid source location the exception div is shown") {
+            val snippet = createHTML().div() {
+                snippetCode("ruleName", code.asSequence(), SourceLocation(7, 100), 1)
+            }
+
+            assertThat(snippet).contains("""<div class="exception">""")
         }
     }
 })

--- a/detekt-cli/src/test/resources/reports/HtmlOutputFormatTest.html
+++ b/detekt-cli/src/test/resources/reports/HtmlOutputFormatTest.html
@@ -48,6 +48,17 @@ pre {
 .error {
   background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4AwCFR4T/3uLMgAAADxJREFUCNdNyLERQEAABMCjL4lQwIzcjErpguAL+C9AvgKJDbeD/PRpLdm35Hm+MU+cB+tCKaJW4L4YBy+CAiLJrFs9mgAAAABJRU5ErkJggg==) bottom repeat-x;
 }
+.exception {
+  color: #b60808;
+  display: inline-block;
+  background-color: #ecdada;
+  border-color: #b60808;
+  border-radius: 10px;
+  border: solid 2px;
+  padding-left: 16px;
+  padding-right: 16px;
+  margin-bottom: 16px;
+}
 </style>
 </head>
 <body>

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DebugUtils.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DebugUtils.kt
@@ -8,7 +8,7 @@ fun whichOS(): String = System.getProperty("os.name")
 
 fun whichJava(): String = System.getProperty("java.runtime.version")
 
-fun whichDetekt(): String {
+fun whichDetekt(): String? {
     for (resource in Detektor::class.java.classLoader.getResources("META-INF/MANIFEST.MF")) {
         try {
             val version = readDetektVersionInManifest(resource)
@@ -19,7 +19,7 @@ fun whichDetekt(): String {
             // we search for the manifest with the detekt version
         }
     }
-    return "unknown"
+    return null
 }
 
 private fun readDetektVersionInManifest(resource: URL) =

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Detektor.kt
@@ -79,6 +79,6 @@ class Detektor(
     private fun createErrorMessage(file: KtFile, error: Throwable): String =
         "Analyzing '${file.absolutePath()}' led to an exception.\n" +
             "The original exception message was: ${error.localizedMessage}\n" +
-            "Running detekt '${whichDetekt()}' on Java '${whichJava()}' on OS '${whichOS()}'.\n" +
+            "Running detekt '${whichDetekt() ?: "unknown"}' on Java '${whichJava()}' on OS '${whichOS()}'.\n" +
             "If the exception message does not help, please feel free to create an issue on our GitHub page."
 }


### PR DESCRIPTION
This PR is realted with #2134

If an exception is found in the code snippet rendering instead to be too smart, or crash, or hide the error this code shows the error to the user like this:
<img width="532" alt="Captura de pantalla 2019-12-28 a las 14 45 04" src="https://user-images.githubusercontent.com/721244/71544549-34b4b700-2981-11ea-8af8-43170785588d.png">

The link opens the github issue form with some pre-filled information:
<img width="825" alt="Captura de pantalla 2019-12-28 a las 15 08 42" src="https://user-images.githubusercontent.com/721244/71544905-db4e8700-2984-11ea-920a-183538774832.png">

And github render that information like this:
<img width="818" alt="Captura de pantalla 2019-12-28 a las 15 08 48" src="https://user-images.githubusercontent.com/721244/71544909-e0133b00-2984-11ea-8dd6-7a647a98f771.png">

----

Problems in this PR:
- [x] I don't know how to get the detekt version to autofill it. Any idea?
- [x] What if the issue is related with a plugin and not with detekt itself? We are saying to the users to report it here. Should we care about this? If we see a spam of issues related with plugins we can remove the link. What do you think?