### PR TITLE
Add Git detekt pre-commit hook doc

### DIFF
--- a/docs/_data/sidebars/home_sidebar.yml
+++ b/docs/_data/sidebars/home_sidebar.yml
@@ -50,6 +50,9 @@ entries:
     - title: with Maven Ant Task
       url: /mavenanttask.html
       output: web
+    - title: with a Git pre-commit hook
+      url: /git-pre-commit-hook.html
+      output: web
   - title: Rule Sets
     output: web
     folderitems:

--- a/docs/pages/gettingstarted/git-pre-commit-hook.md
+++ b/docs/pages/gettingstarted/git-pre-commit-hook.md
@@ -17,7 +17,7 @@ The following client-side detekt hook is triggered by a commit operation.
 #!/usr/bin/env bash
 echo "Running detekt check..."
 OUTPUT="/tmp/detekt-$(date +%s)"
-./gradlew detektCheck > $OUTPUT
+./gradlew detekt > $OUTPUT
 EXIT_CODE=$?
 if [ $EXIT_CODE -ne 0 ]; then
   cat $OUTPUT

--- a/docs/pages/gettingstarted/git-pre-commit-hook.md
+++ b/docs/pages/gettingstarted/git-pre-commit-hook.md
@@ -1,0 +1,41 @@
+---
+title: "Run detekt using a Git pre-commit hook"
+keywords: detekt static analysis code kotlin
+tags: [getting_started git]
+sidebar: 
+permalink: git-pre-commit-hook.html
+folder: gettingstarted
+summary:
+---
+
+Detekt can be integrated into your development workflow by using a Git pre-commit hook.
+For that reason Git supports to run custom scripts automatically, when a specific action occurs.
+The mentioned pre-commit hook can be setup locally on your dev-machine.
+The following client-side detekt hook is triggered by a commit operation.
+
+```shell script
+#!/usr/bin/env bash
+echo "Running detekt check..."
+OUTPUT="/tmp/detekt-$(date +%s)"
+./gradlew detektCheck > $OUTPUT
+EXIT_CODE=$?
+if [ $EXIT_CODE -ne 0 ]; then
+  cat $OUTPUT
+  rm $OUTPUT
+  echo "***********************************************"
+  echo "                 Detekt failed                 "
+  echo " Please fix the above issues before committing "
+  echo "***********************************************"
+  exit $EXIT_CODE
+fi
+rm $OUTPUT
+```
+
+The shell script can be installed by copying the content over to `<<your-repo>>/.git/hooks/pre-commit`.
+This pre-commit hook needs to be executable, so you may need to change the permission (`chmod +x pre-commit`).
+More information about Git hooks and how to install them can be found in 
+[Atlassian's tutorial](https://www.atlassian.com/git/tutorials/git-hooks).
+
+A special thanks goes to Mohit Sarveiya for providing this shell script.
+You can watch his excellent talk about **Static Code Analysis For Kotlin** on 
+[YouTube](https://www.youtube.com/watch?v=LT6m5_LO2DQ).


### PR DESCRIPTION
The detekt integration into a Git development has been discussed here:
* #2175
* #1792
* #1057

Thus, this should be persisted on detekt's homepage.