### PR TITLE
Implement ExplicitCollectionElementAccessMethod rule

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -446,6 +446,8 @@ style:
     active: true
   EqualsOnSignatureLine:
     active: false
+  ExplicitCollectionElementAccessMethod:
+    active: false
   ExplicitItLambdaParameter:
     active: false
   ExpressionBodySyntax:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.rules.style.DataClassShouldBeImmutable
 import io.gitlab.arturbosch.detekt.rules.style.EqualsNullCall
 import io.gitlab.arturbosch.detekt.rules.style.EqualsOnSignatureLine
 import io.gitlab.arturbosch.detekt.rules.style.ExplicitItLambdaParameter
+import io.gitlab.arturbosch.detekt.rules.style.ExplicitCollectionElementAccessMethod
 import io.gitlab.arturbosch.detekt.rules.style.ExpressionBodySyntax
 import io.gitlab.arturbosch.detekt.rules.style.FileParsingRule
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenComment
@@ -120,6 +121,7 @@ class StyleGuideProvider : RuleSetProvider {
                 VarCouldBeVal(config),
                 ForbiddenVoid(config),
                 ExplicitItLambdaParameter(config),
+                ExplicitCollectionElementAccessMethod(config),
                 UselessCallOnNotNull(config),
                 UnderscoresInNumericLiterals(config),
                 UseRequire(config),

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
@@ -1,0 +1,90 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.js.descriptorUtils.nameIfStandardType
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.typeUtil.supertypes
+
+/**
+ * Prefer usage of indexed access operator [] for map element access or insert methods.
+ *
+ * <noncompliant>
+ *  val map = Map<String, String>()
+ *  map.put("key", "value")
+ *  val value = map.get("key")
+ * </noncompliant>
+ *
+ * <compliant>
+ *  val map = Map<String, String>()
+ *  map["key"] = "value"
+ *  map["key"]
+ * </compliant>
+ */
+class ExplicitCollectionElementAccessMethod(config: Config = Config.empty) : Rule(config) {
+
+    private val ktCollections = setOf("Map", "List")
+
+    private val ktAndJavaCollections = ktCollections + setOf("AbstractMap", "AbstractList")
+
+    override val issue: Issue =
+        Issue(
+            "ExplicitMapElementAccessMethod",
+            Severity.Style,
+            "Prefer usage of indexed access operator [] for map element access or insert methods",
+            Debt.FIVE_MINS
+        )
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        if (isGetOrPut(expression) && isMapMethod(expression)) {
+            report(CodeSmell(issue, Entity.from(expression), "Prefer usage of indexed access operator []."))
+        }
+        super.visitCallExpression(expression)
+    }
+
+    private fun isGetOrPut(expression: KtCallExpression): Boolean {
+        return expression
+            .calleeExpression
+            ?.text in setOf("get", "put")
+    }
+
+    @Suppress("ReturnCount")
+    private fun isMapMethod(expression: KtCallExpression): Boolean {
+        val dotExpression = expression.prevSibling
+        if (dotExpression.parent !is KtDotQualifiedExpression) return false
+        val caller = dotExpression.prevSibling
+        if (caller !is KtElement) return false
+        val callerReturnType = caller.getResolvedCall(bindingContext)
+            ?.resultingDescriptor
+            ?.returnType
+        val standardTypeName = callerReturnType?.nameIfStandardType
+        standardTypeName?.let {
+            return it.toString() in ktCollections
+        }
+        val returnTypes = callerReturnType?.collectTypes()
+        return returnTypes?.any { it.constructor.toString() in ktAndJavaCollections } ?: false
+    }
+
+    private fun KotlinType.collectTypes(): Set<KotlinType> {
+        val result = mutableSetOf<KotlinType>()
+        this
+            .constructor
+            .supertypes
+            .forEach { type ->
+                result.add(type)
+                type.supertypes().forEach {
+                    result.addAll(it.collectTypes())
+                }
+            }
+        return result
+    }
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.typeUtil.supertypes
 
 /**
- * Prefer usage of indexed access operator [] for map element access or insert methods.
+ * Prefer usage of the indexed access operator [] for map or list element access or insert methods.
  *
  * <noncompliant>
  *  val map = Map<String, String>()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
@@ -38,7 +38,7 @@ class ExplicitCollectionElementAccessMethod(config: Config = Config.empty) : Rul
 
     override val issue: Issue =
         Issue(
-            "ExplicitMapElementAccessMethod",
+            "ExplicitCollectionElementAccessMethod",
             Severity.Style,
             "Prefer usage of indexed access operator [] for map element access or insert methods",
             Debt.FIVE_MINS

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
@@ -32,7 +32,7 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
  */
 class ExplicitCollectionElementAccessMethod(config: Config = Config.empty) : Rule(config) {
 
-    private val ktCollections = setOf("Map", "List")
+    private val ktCollections = setOf("Map", "MutableMap", "List", "MutableList")
 
     private val ktAndJavaCollections = ktCollections + setOf("AbstractMap", "AbstractList")
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
  * <compliant>
  *  val map = Map<String, String>()
  *  map["key"] = "value"
- *  map["key"]
+ *  val value = map["key"]
  * </compliant>
  */
 class ExplicitCollectionElementAccessMethod(config: Config = Config.empty) : Rule(config) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.typeUtil.supertypes
 
 /**
- * Prefer usage of the indexed access operator [] for map or list element access or insert methods.
+ * Prefer the usage of the indexed access operator `[]` for map or list element access or insert methods.
  *
  * <noncompliant>
  *  val map = Map<String, String>()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
@@ -17,6 +17,8 @@ import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.typeUtil.supertypes
 
 /**
+ * In Kotlin functions `get` or `set` can be replaced with the shorter operator — `[]`,
+ * see https://kotlinlang.org/docs/reference/operator-overloading.html#indexed.
  * Prefer the usage of the indexed access operator `[]` for map or list element access or insert methods.
  *
  * <noncompliant>

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
@@ -77,7 +77,7 @@ class ExplicitCollectionElementAccessMethod(config: Config = Config.empty) : Rul
         this?.nameIfStandardType?.let {
             return it.toString() in ktCollections
         }
-        return this?.collectTypes()?.any { it.constructor.toString() in ktAndJavaCollections } ?: false
+        return this?.collectTypes()?.any { it.constructor.toString() in ktAndJavaCollections } == true
     }
 
     private fun KotlinType.collectTypes(): Set<KotlinType> {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -1,0 +1,194 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class ExplicitCollectionElementAccessMethodSpec : Spek({
+
+    val subject by memoized { ExplicitCollectionElementAccessMethod(Config.empty) }
+
+    val wrapper by memoized(
+        factory = { KtTestCompiler.createEnvironment() },
+        destructor = { it.dispose() }
+    )
+
+    describe("Kotlin map") {
+
+        it("reports map element access with get method") {
+            val code = """
+                    fun f() {
+                        val map = mapOf<String, String>() 
+                        val value = map.get("key") 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("reports map put method usage") {
+            val code = """
+                    fun f() {
+                        val map = mapOf<String, String>()
+                        map.put("key", "val") 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("reports map element access with get method of non-abstract map") {
+            val code = """
+                    fun f() {
+                        val map = hashMapOf<String, String>() 
+                        val value = map.get("key") 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("reports map element insert with put method of non-abstract map") {
+            val code = """
+                    fun f() {
+                        val map = hashMapOf<String, String>() 
+                        val value = map.put("key", "value") 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("does not report map access with []") {
+            val code = """
+                    fun f() {
+                        val map = mapOf<String, String>()
+                        map["key"] 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+        }
+
+        it("does not report map insert with []") {
+            val code = """
+                    fun f() {
+                        val map = mapOf<String, String>()
+                        map["key"] = "value" 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+        }
+
+        it("reports map element access with get method from map in a chain") {
+            val code = """
+                    fun f() {
+                        val map = mapOf<String, String>()
+                        val value = listOf("1", "2").associateBy { it }.get("1")
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("reports map element access with get method from non-abstract map") {
+            val code = """
+                    fun f() {
+                        val map = linkedMapOf<String, String>()
+                        val value = map.get("key") 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+    }
+
+    describe("Kotlin list") {
+
+        it("reports list element access with get method") {
+            val code = """
+                    fun f() {
+                        val list = listOf<String>() 
+                        val value = list.get(0) 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("does not report element access with get method") {
+            val code = """
+                    fun f() {
+                        val list = listOf<String>() 
+                        val value = list[0] 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+        }
+
+        it("reports element access with get method of non-abstract list") {
+            val code = """
+                    fun f() {
+                        val list = arrayListOf<String, String>() 
+                        val value = list.get("key") 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+    }
+
+    describe("Java map") {
+
+        it("reports map element access with get method") {
+            val code = """
+                    fun f() {
+                        val map = java.util.HashMap<String, String>() 
+                        val value = map.get("key") 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("reports map put method usage") {
+            val code = """
+                    fun f() {
+                        val map = java.util.HashMap<String, String>() 
+                        map.put("key", "val") 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("does not report map access with []") {
+            val code = """
+                    fun f() {
+                        val map = java.util.HashMap<String, String>() 
+                        map["key"] 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+        }
+
+        it("does not report map insert with []") {
+            val code = """
+                    fun f() {
+                        val map = java.util.HashMap<String, String>() 
+                        map["key"] = "value" 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+        }
+
+        it("reports map element access with get method from map in a chain") {
+            val code = """
+                    fun f() {
+                        val map = java.util.HashMap<String, String>() 
+                        val value = listOf("1", "2").associateBy { it }.get("1") 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+    }
+
+    describe("Java list") {
+
+        it("reports list element access with get method") {
+            val code = """
+                    fun f() {
+                        val list = java.util.ArrayList<String>() 
+                        val value = list.get(0) 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("does not report element access with get method") {
+            val code = """
+                    fun f() {
+                        val list = java.util.ArrayList<String>() 
+                        val value = list[0] 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+        }
+    }
+
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -30,7 +30,7 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         it("reports map put method usage") {
             val code = """
                     fun f() {
-                        val map = mapOf<String, String>()
+                        val map = mutableMapOf<String, String>()
                         map.put("key", "val") 
                     }"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
@@ -66,7 +66,7 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         it("does not report map insert with []") {
             val code = """
                     fun f() {
-                        val map = mapOf<String, String>()
+                        val map = mutableMapOf<String, String>()
                         map["key"] = "value" 
                     }"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
@@ -92,11 +92,19 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
     }
 
     describe("Kotlin list") {
-
         it("reports list element access with get method") {
             val code = """
                     fun f() {
                         val list = listOf<String>() 
+                        val value = list.get(0) 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("reports mutable list element access with get method") {
+            val code = """
+                    fun f() {
+                        val list = mutableListOf<String>()
                         val value = list.get(0) 
                     }"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
@@ -114,8 +122,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         it("reports element access with get method of non-abstract list") {
             val code = """
                     fun f() {
-                        val list = arrayListOf<String, String>() 
-                        val value = list.get("key") 
+                        val list = arrayListOf<String>() 
+                        val value = list.get(0) 
                     }"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -27,6 +27,15 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
         }
 
+        it("reports safe map element access") {
+            val code = """
+                    fun f() {
+                        val map = mapOf<String, String>() 
+                        val value = map?.get("key") 
+                    }"""
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
         it("reports map put method usage") {
             val code = """
                     fun f() {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -58,7 +58,7 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
             val code = """
                     fun f() {
                         val map = mapOf<String, String>()
-                        map["key"] 
+                        val value = map["key"] 
                     }"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -127,7 +127,6 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     }"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
         }
-
     }
 
     describe("Java map") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -110,7 +110,7 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
         }
 
-        it("does not report element access with get method") {
+        it("does not report element access with []") {
             val code = """
                     fun f() {
                         val list = listOf<String>() 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -154,7 +154,7 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
             val code = """
                     fun f() {
                         val map = java.util.HashMap<String, String>() 
-                        map["key"] 
+                        val value = map["key"] 
                     }"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -189,7 +189,7 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
         }
 
-        it("does not report element access with get method") {
+        it("does not report element access with []") {
             val code = """
                     fun f() {
                         val list = java.util.ArrayList<String>() 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -146,6 +146,30 @@ fun stuff() =
 fun <V> foo(): Int where V : Int = 5
 ```
 
+### ExplicitCollectionElementAccessMethod
+
+Prefer usage of indexed access operator [] for map element access or insert methods.
+
+**Severity**: Style
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+val map = Map<String, String>()
+map.put("key", "value")
+val value = map.get("key")
+```
+
+#### Compliant Code:
+
+```kotlin
+val map = Map<String, String>()
+map["key"] = "value"
+map["key"]
+```
+
 ### ExplicitItLambdaParameter
 
 Lambda expressions are one of the core features of the language. They often include very small chunks of

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -148,7 +148,7 @@ fun <V> foo(): Int where V : Int = 5
 
 ### ExplicitCollectionElementAccessMethod
 
-Prefer usage of indexed access operator [] for map element access or insert methods.
+Prefer usage of the indexed access operator [] for map or list element access or insert methods.
 
 **Severity**: Style
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -148,7 +148,7 @@ fun <V> foo(): Int where V : Int = 5
 
 ### ExplicitCollectionElementAccessMethod
 
-Prefer usage of the indexed access operator [] for map or list element access or insert methods.
+Prefer the usage of the indexed access operator `[]` for map or list element access or insert methods.
 
 **Severity**: Style
 
@@ -167,7 +167,7 @@ val value = map.get("key")
 ```kotlin
 val map = Map<String, String>()
 map["key"] = "value"
-map["key"]
+val value = map["key"]
 ```
 
 ### ExplicitItLambdaParameter

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -148,6 +148,8 @@ fun <V> foo(): Int where V : Int = 5
 
 ### ExplicitCollectionElementAccessMethod
 
+In Kotlin functions `get` or `set` can be replaced with the shorter operator — `[]`,
+see https://kotlinlang.org/docs/reference/operator-overloading.html#indexed.
 Prefer the usage of the indexed access operator `[]` for map or list element access or insert methods.
 
 **Severity**: Style


### PR DESCRIPTION
This PR adds new rule `ExplicitCollectionElementAccessMethod ` to `style` ruleset.

Rule `ExplicitCollectionElementAccessMethod` reports usage of `get` or `put` methods and suggests to use [Indexed access operator](https://kotlinlang.org/docs/reference/operator-overloading.html#indexed): `[]`. This rule can be applied to Kotlin collections which implement `Map` or `List` interfaces as well as Java collections `java.util.AbstractMap` and `java.util.AbstractList`.

**Noncompliant Code:**
```kotlin
val map = mapOf<String, String>() 
val list = listOf<String>() 

map.put("key", "val") 
map.get("key") 
list.get(0) 
```

**Compliant Code:**
```kotlin
val map = mapOf<String, String>() 
map["key"] = "val" 
map["key"] 
list[0] 
```

This is a rule for Style ruleset. It is implemented to introduce users to indexed access operator and help them write shorter and more idiomatic code.