### PR TITLE
Travis: Use consistent Java vendor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ matrix:
       env: COMPILE_TEST_SNIPPETS=true
     - os: linux
       dist: bionic
-      jdk: openjdk11
+      jdk: oraclejdk11
       env: COMPILE_TEST_SNIPPETS=false
     - os: linux
       dist: bionic
-      jdk: openjdk13
+      jdk: oraclejdk13
       env: COMPILE_TEST_SNIPPETS=false
     # JDK 8 - see https://docs.travis-ci.com/user/reference/osx/#jdk-and-macos
     - os: osx


### PR DESCRIPTION
Recommended for build cache: https://guides.gradle.org/using-build-cache/#java_version_tracking

macOS builds use Oracle JDK as well.