### PR TITLE
Run shadowJar & installShadowDist task with everything else

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ matrix:
       env: COMPILE_TEST_SNIPPETS=false
 install: true
 script:
-  - ./gradlew build --build-cache --parallel -PwarningsAsErrors=true -Pcompile-test-snippets=$COMPILE_TEST_SNIPPETS --scan
-  - ./gradlew shadowJar
+  - ./gradlew build shadowJar --build-cache --parallel -PwarningsAsErrors=true -Pcompile-test-snippets=$COMPILE_TEST_SNIPPETS --scan
   - java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar --help
   - java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar -i . --baseline ./config/detekt/baseline.xml -ex "**/resources/**,**/detekt*/build/**" -c ./detekt-cli/src/main/resources/default-detekt-config.yml,./config/detekt/detekt.yml
   - ./gradlew verifyGeneratorOutput

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,8 +30,7 @@ install:
   - gradlew.bat --version
 
 build_script:
-  - gradlew build --build-cache --parallel -PwarningsAsErrors=true -Pcompile-test-snippets=%COMPILE_TEST_SNIPPETS%
-  - gradlew installShadowDist
+  - gradlew build installShadowDist --build-cache --parallel -PwarningsAsErrors=true -Pcompile-test-snippets=%COMPILE_TEST_SNIPPETS%
   - detekt-cli\build\install\detekt-cli-shadow\bin\detekt-cli --help
 
 test_script:


### PR DESCRIPTION
Enables build cache for shadowJar task (and includes shadowJar & installShadowDist tasks in build scans)