### PR TITLE
Gradle plugin: Build upon default detekt config

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -133,11 +133,10 @@ artifacts {
 }
 
 detekt {
-    config = files(
-        project.rootDir.resolve("../detekt-cli/src/main/resources/default-detekt-config.yml"),
-        project.rootDir.resolve("../config/detekt/detekt.yml")
-    )
+    buildUponDefaultConfig = true
+    config.setFrom(file("../config/detekt/detekt.yml"))
 }
+
 val bintrayUser = findProperty("bintrayUser")?.toString() ?: System.getenv("BINTRAY_USER")
 val bintrayKey = findProperty("bintrayKey")?.toString() ?: System.getenv("BINTRAY_API_KEY")
 val detektPublication = "DetektPublication"


### PR DESCRIPTION
Fixes #2217 

When a new rule is added before it's available in the version of detekt that the Gradle plugin uses, the config validation fails because the default detekt config file includes a config for the new rule that the Gradle plugin's detekt version doesn't yet know about.