### PR TITLE
Introduce Pull Request Labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,4 +7,5 @@ gradle: detekt-gradle-plugin/src/**/*
 rules: detekt-rules/src/**/*
 
 # miscellaneous
-build: **/build.gradle.kts
+build:
+  - **/build.gradle.kts

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,5 +7,4 @@ gradle: detekt-gradle-plugin/src/**/*
 rules: detekt-rules/src/**/*
 
 # miscellaneous
-build:
-  - **/build.gradle.kts
+build: '**/build.gradle.kts'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,10 @@
+# core modules
+api: detekt-api/src/**/*
+core: detekt-core/src/**/*
+cli: detekt-cli/src/**/*
+formatting: detekt-formatting/src/**/*
+gradle: detekt-gradle-plugin/src/**/*
+rules: detekt-rules/src/**/*
+
+# miscellaneous
+build: **/build.gradle.kts

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Pull request labeler triages PRs based on the paths that are modified in the PR (https://github.com/actions/labeler)

My hope is that it makes it easier to review the list of open PRs. Not every PR will get labelled (e.g. updates to docs, the Gradle wrapper, detekt-generator etc) but changes to the core modules will be. Config is easy to tweak in `labeler.yml` as desired.