### PR TITLE
Fix #2230 equals() func detection

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 
 fun KtFunction.isEqualsFunction() =
-        this.name == "equals" && hasCorrectEqualsParameter() && this.isOverride()
+        this.name == "equals" && this.isOverride() && hasCorrectEqualsParameter()
 
 fun KtFunction.isHashCodeFunction() =
         this.name == "hashCode" && this.valueParameters.isEmpty() && this.isOverride()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
@@ -8,7 +8,7 @@ fun KtFunction.isEqualsFunction() =
         this.name == "equals" && this.isOverride() && hasCorrectEqualsParameter()
 
 fun KtFunction.isHashCodeFunction() =
-        this.name == "hashCode" && this.valueParameters.isEmpty() && this.isOverride()
+        this.name == "hashCode" && this.isOverride() && this.valueParameters.isEmpty()
 
 private val knownAnys = setOf("Any?", "kotlin.Any?")
 fun KtFunction.hasCorrectEqualsParameter() =

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
@@ -12,7 +12,7 @@ fun KtFunction.isHashCodeFunction() =
 
 private val knownAnys = setOf("Any?", "kotlin.Any?")
 fun KtFunction.hasCorrectEqualsParameter() =
-        this.valueParameters.firstOrNull()?.typeReference?.text in knownAnys
+        this.valueParameters.singleOrNull()?.typeReference?.text in knownAnys
 
 fun KtNamedFunction.isMainFunction() =
         this.isTopLevelMain() || this.isMainInsideObject()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameter.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameter.kt
@@ -51,9 +51,12 @@ class WrongEqualsTypeParameter(config: Config = Config.empty) : Rule(config) {
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        if (function.name == "equals" && !function.isTopLevel && !function.hasCorrectEqualsParameter()) {
+        if (function.name == "equals" && !function.isTopLevel && function.hasWrongEqualsSignature()) {
             report(CodeSmell(issue, Entity.from(function), "equals() methods should only take one parameter " +
                     "of type Any?."))
         }
     }
+
+    private fun KtNamedFunction.hasWrongEqualsSignature() =
+        valueParameters.size == 1 && !hasCorrectEqualsParameter()
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
@@ -47,7 +47,7 @@ class EqualsWithHashCodeExistSpec : Spek({
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
-            it("reports a wrong overridden equals() function signature") {
+            it("reports a different overridden equals() function signature") {
                 val code = """
                 interface I {
                     fun equals(other: Any?, i: Int): Boolean
@@ -56,6 +56,19 @@ class EqualsWithHashCodeExistSpec : Spek({
                 class A : I {
                     override fun equals(other: Any?, i: Int): Boolean { return super.equals(other) }
                     override fun hashCode(): Int { return super.hashCode() }
+                }"""
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+
+            it("reports a different overridden hashCode() function signature") {
+                val code = """
+                interface I {
+                    fun hashCode(i: Int): Int
+                }                    
+
+                class A : I {
+                    override fun equals(other: Any?): Boolean { return super.equals(other) }
+                    override fun hashCode(i: Int): Int { return super.hashCode() }
                 }"""
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
@@ -29,6 +29,24 @@ class EqualsWithHashCodeExistSpec : Spek({
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
+            it("reports a different equals() function signature") {
+                val code = """
+                class A {
+                    fun equals(other: Any?, i: Int): Boolean { return super.equals(other) }
+                    override fun hashCode(): Int { return super.hashCode() }
+                }"""
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+
+            it("reports a different hashcode() function signature") {
+                val code = """
+                class A {
+                    override fun equals(other: Any?): Boolean { return super.equals(other) }
+                    fun hashCode(i: Int): Int { return super.hashCode() }
+                }"""
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+
             it("does not report equals() with hashCode() function") {
                 val code = """
                 class A {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
@@ -47,6 +47,19 @@ class EqualsWithHashCodeExistSpec : Spek({
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
+            it("reports a wrong overridden equals() function signature") {
+                val code = """
+                interface I {
+                    fun equals(other: Any?, i: Int): Boolean
+                }                    
+
+                class A : I {
+                    override fun equals(other: Any?, i: Int): Boolean { return super.equals(other) }
+                    override fun hashCode(): Int { return super.hashCode() }
+                }"""
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+
             it("does not report equals() with hashCode() function") {
                 val code = """
                 class A {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameterSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameterSpec.kt
@@ -31,6 +31,33 @@ class WrongEqualsTypeParameterSpec : Spek({
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
+        it("does not report equals() with an additional parameter") {
+            val code = """
+                class A {
+                    fun equals(other: Any?, i: Int): Boolean {
+                        return super.equals(other)
+                    }
+                }"""
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it("does not report an overridden equals() with a different signature") {
+            val code = """
+                interface I {
+                    fun equals(other: Any?, i: Int): Boolean
+                    fun equals(): Boolean
+                }
+                
+                class A : I {
+                    override fun equals(other: Any?, i: Int): Boolean {
+                        return super.equals(other)
+                    }
+                    
+                    override fun equals() = true
+                }"""
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
         it("does not report an interface declaration") {
             val code = """
                 interface I {
@@ -39,8 +66,11 @@ class WrongEqualsTypeParameterSpec : Spek({
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
-        it("does not report a top level function") {
-            val code = "fun equals(other: String) {}"
+        it("does not report top level functions") {
+            val code = """
+                fun equals(other: String) {}
+                fun equals(other: Any?) {}
+                """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }


### PR DESCRIPTION
The equals() func check should assert that there is exact 1 parameter.