### PR TITLE
New ktlint rules

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -209,6 +209,9 @@ formatting:
   CommentSpacing:
     active: true
     autoCorrect: true
+  EnumEntryNameCase:
+    active: false
+    autoCorrect: true
   Filename:
     active: true
   FinalNewline:

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -243,6 +243,9 @@ formatting:
   NoEmptyClassBody:
     active: true
     autoCorrect: true
+  NoEmptyFirstLineInMethodBlock:
+    active: false
+    autoCorrect: true
   NoLineBreakAfterElse:
     active: true
     autoCorrect: true

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
@@ -17,6 +17,7 @@ import io.gitlab.arturbosch.detekt.formatting.wrappers.MultiLineIfElse
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoBlankLineBeforeRbrace
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoConsecutiveBlankLines
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoEmptyClassBody
+import io.gitlab.arturbosch.detekt.formatting.wrappers.NoEmptyFirstLineInMethodBlock
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoLineBreakAfterElse
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoLineBreakBeforeAssignment
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoMultipleSpaces
@@ -61,6 +62,7 @@ class KtLintMultiRule(config: Config = Config.empty) : MultiRule() {
         NoBlankLineBeforeRbrace(config),
         NoConsecutiveBlankLines(config),
         NoEmptyClassBody(config),
+        NoEmptyFirstLineInMethodBlock(config),
         NoLineBreakAfterElse(config),
         NoLineBreakBeforeAssignment(config),
         NoMultipleSpaces(config),

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.formatting.wrappers.AnnotationOnSeparateLine
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ChainWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.CommentSpacing
+import io.gitlab.arturbosch.detekt.formatting.wrappers.EnumEntryNameCase
 import io.gitlab.arturbosch.detekt.formatting.wrappers.Filename
 import io.gitlab.arturbosch.detekt.formatting.wrappers.FinalNewline
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ImportOrdering
@@ -49,6 +50,7 @@ class KtLintMultiRule(config: Config = Config.empty) : MultiRule() {
         AnnotationOnSeparateLine(config),
         ChainWrapping(config),
         CommentSpacing(config),
+        EnumEntryNameCase(config),
         Filename(config),
         FinalNewline(config),
         ImportOrdering(config),

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/EnumEntryNameCase.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/EnumEntryNameCase.kt
@@ -1,0 +1,16 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.ruleset.experimental.EnumEntryNameCaseRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
+ *
+ * @autoCorrect since v1.4.0
+ */
+class EnumEntryNameCase(config: Config) : FormattingRule(config) {
+
+    override val wrapping = EnumEntryNameCaseRule()
+    override val issue = issueFor("Reports enum entries with names that don't meet standard conventions.")
+}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyFirstLineInMethodBlock.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyFirstLineInMethodBlock.kt
@@ -1,0 +1,16 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.ruleset.experimental.NoEmptyFirstLineInMethodBlockRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
+ *
+ * @autoCorrect since v1.4.0
+ */
+class NoEmptyFirstLineInMethodBlock(config: Config) : FormattingRule(config) {
+
+    override val wrapping = NoEmptyFirstLineInMethodBlockRule()
+    override val issue = issueFor("Reports methods that have an empty first line.")
+}

--- a/docs/pages/documentation/formatting.md
+++ b/docs/pages/documentation/formatting.md
@@ -87,6 +87,10 @@ See <a href="https://ktlint.github.io/#rule-blank">ktlint-website</a> for docume
 
 See <a href="https://ktlint.github.io/#rule-empty-class-body">ktlint-website</a> for documentation.
 
+### NoEmptyFirstLineInMethodBlock
+
+See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
+
 ### NoLineBreakAfterElse
 
 See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.

--- a/docs/pages/documentation/formatting.md
+++ b/docs/pages/documentation/formatting.md
@@ -27,6 +27,10 @@ See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
 
 See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
 
+### EnumEntryNameCase
+
+See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
+
 ### Filename
 
 See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.


### PR DESCRIPTION
* EnumEntryNameCase
* NoEmptyFirstLineInMethodBlock

Both are from the ktlint experimental rule set so not enabled by default.