### PR TITLE
Add a new line at the end of the txt report

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/TxtOutputReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/TxtOutputReport.kt
@@ -10,7 +10,10 @@ class TxtOutputReport : OutputReport() {
     override val name = "plain text report"
 
     override fun render(detektion: Detektion): String {
-        val smells = detektion.findings.flatMap { it.value }
-        return smells.joinToString("\n") { it.compactWithSignature() }
+        val builder = StringBuilder()
+        detektion.findings
+            .flatMap { it.value }
+            .forEach { builder.append(it.compactWithSignature()).append("\n") }
+        return builder.toString()
     }
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/TxtOutputReportTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/TxtOutputReportTest.kt
@@ -10,10 +10,32 @@ class TxtOutputReportTest : Spek({
 
     describe("TXT output report") {
 
-        it("render") {
+        it("render none") {
+            val report = TxtOutputReport()
+            val detektion = TestDetektion()
+            val renderedText = ""
+            assertThat(report.render(detektion)).isEqualTo(renderedText)
+        }
+
+        it("render one") {
             val report = TxtOutputReport()
             val detektion = TestDetektion(createFinding())
-            val renderedText = "TestSmell - [TestEntity] at TestFile.kt:1:1 - Signature=S1"
+            val renderedText = "TestSmell - [TestEntity] at TestFile.kt:1:1 - Signature=S1\n"
+            assertThat(report.render(detektion)).isEqualTo(renderedText)
+        }
+
+        it("render multiple") {
+            val report = TxtOutputReport()
+            val detektion = TestDetektion(
+                createFinding(ruleName = "TestSmellA"),
+                createFinding(ruleName = "TestSmellB"),
+                createFinding(ruleName = "TestSmellC"))
+            val renderedText = """
+                TestSmellA - [TestEntity] at TestFile.kt:1:1 - Signature=S1
+                TestSmellB - [TestEntity] at TestFile.kt:1:1 - Signature=S1
+                TestSmellC - [TestEntity] at TestFile.kt:1:1 - Signature=S1
+
+            """.trimIndent()
             assertThat(report.render(detektion)).isEqualTo(renderedText)
         }
     }


### PR DESCRIPTION
This PR adds a `\n` at the end of the txt report. This way you can concat all the reports easily. Or you can do something like `wc -l report.txt` to count the number of errors that you and not be off by one

## Context
This is a real minor thing but I lose 10 minutes today because of this. I was counting the errors of different branches using `wc -l report.txt`. And I was getting always one error less than expected. This PR will avoid that problem.