### PR TITLE
Don't flag inherited visibility in NestedClassesVisibility

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtEnumEntry
-import org.jetbrains.kotlin.psi.psiUtil.isPublic
 
 /**
  * Nested classes are often used to implement functionality local to the class it is nested in. Therefore it should
@@ -49,7 +48,7 @@ class NestedClassesVisibility(config: Config = Config.empty) : Rule(config) {
     private fun checkDeclarations(klass: KtClass) {
         klass.declarations
                 .filterIsInstance<KtClassOrObject>()
-                .filter { it.isPublic && it.isNoEnum() && it.isNoCompanionObj() }
+                .filter { it.hasModifier(KtTokens.PUBLIC_KEYWORD) && it.isNoEnum() && it.isNoCompanionObj() }
                 .forEach {
                     report(CodeSmell(issue, Entity.from(it),
                             "Nested types are often used for implementing private functionality. " +

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibilitySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibilitySpec.kt
@@ -12,7 +12,7 @@ class NestedClassesVisibilitySpec : Spek({
     describe("NestedClassesVisibility rule") {
 
         it("reports public nested classes") {
-            assertThat(subject.lint(Case.NestedClassVisibilityPositive.path())).hasSize(6)
+            assertThat(subject.lint(Case.NestedClassVisibilityPositive.path())).hasSize(4)
         }
 
         it("does not report internal and (package) private nested classes") {

--- a/detekt-rules/src/test/resources/cases/NestedClassVisibilityNegative.kt
+++ b/detekt-rules/src/test/resources/cases/NestedClassVisibilityNegative.kt
@@ -2,7 +2,9 @@
 
 package cases
 
-internal class NestedClassVisibilityNegative {
+internal class NestedClassVisibilityNegative1 {
+
+    class Inner
 
     // enums with public visibility are excluded
     enum class NestedEnum { One, Two }
@@ -10,6 +12,11 @@ internal class NestedClassVisibilityNegative {
     private interface PrivateTest
     internal interface InternalTest
 
+    // should not detect companion object
+    public companion object C
+}
+
+internal class NestedClassVisibilityNegative2 {
     // should not detect companion object
     companion object C
 }

--- a/detekt-rules/src/test/resources/cases/NestedClassVisibilityNegative.kt
+++ b/detekt-rules/src/test/resources/cases/NestedClassVisibilityNegative.kt
@@ -4,7 +4,8 @@ package cases
 
 internal class NestedClassVisibilityNegative1 {
 
-    class Inner
+    class Nested1
+    internal class Nested2
 
     // enums with public visibility are excluded
     enum class NestedEnum { One, Two }

--- a/detekt-rules/src/test/resources/cases/NestedClassVisibilityNegative.kt
+++ b/detekt-rules/src/test/resources/cases/NestedClassVisibilityNegative.kt
@@ -8,7 +8,8 @@ internal class NestedClassVisibilityNegative1 {
     internal class Nested2
 
     // enums with public visibility are excluded
-    enum class NestedEnum { One, Two }
+    enum class NestedEnum1 { One }
+    public enum class NestedEnum2 { Two }
 
     private interface PrivateTest
     internal interface InternalTest

--- a/detekt-rules/src/test/resources/cases/NestedClassVisibilityPositive.kt
+++ b/detekt-rules/src/test/resources/cases/NestedClassVisibilityPositive.kt
@@ -4,19 +4,13 @@ package cases
 
 internal class NestedClassesVisibilityPositive {
 
-    // reports 1 - public visibility
-    public class NestedPublicClass1
+    // reports 1 - explicit public visibility
+    public interface NestedPublicInterface
 
-    // reports 1 - public visibility
-    class NestedPublicClass2
+    // reports 1 - explicit public visibility
+    public object A
 
-    // reports 1 - public visibility
-    interface NestedPublicInterface
-
-    // reports 1 - public visibility
-    object A
-
-    // reports 1 - public visibility
+    // reports 1 - explicit public visibility
     public class NestedClassWithNestedCLass {
 
         // classes with a nesting depth higher than 1 are excluded
@@ -28,5 +22,5 @@ internal enum class NestedEnumsVisibility {
 
     A;
 
-    class Inner // reports 1 - public visibility inside enum class
+    public class Inner // reports 1 - explicit public visibility inside enum class
 }

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -670,9 +670,12 @@ private internal lateinit val str: String
 
 ### NestedClassesVisibility
 
-Nested classes are often used to implement functionality local to the class it is nested in. Therefore it should
-not be public to other parts of the code.
-Prefer keeping nested classes `private`.
+Nested classes inherit their visibility from the parent class
+and are often used to implement functionality local to the class it is nested in.
+These nested classes can't have a higher visibility than their parent.
+However, the visibility can be further restricted by using a private modifier for instance.
+In internal classes the _explicit_ public modifier for nested classes is misleading and thus unnecessary,
+because the nested class still has an internal visibility.
 
 **Severity**: Style
 
@@ -681,18 +684,18 @@ Prefer keeping nested classes `private`.
 #### Noncompliant Code:
 
 ```kotlin
-internal class NestedClassesVisibility {
-
-    public class NestedPublicClass // should not be public
+internal class Outer {
+    // explicit public modifier still results in an internal nested class
+    public class Nested
 }
 ```
 
 #### Compliant Code:
 
 ```kotlin
-internal class NestedClassesVisibility {
-
-    internal class NestedPublicClass
+internal class Outer {
+    class Nested1
+    internal class Nested2
 }
 ```
 


### PR DESCRIPTION
The rule had an issue that it forced the use of an additional
unnecessary modifier. However, the visibility of nested classes is
inherited from the parent class.
These nested classes can't have a higher visibility than their parent.
The following example outlines the issue.

internal class A1 { // non-compliant
  class B
}
internal class A2 { // compliant
  internal class B
}

Closes #1930