### PR TITLE
Update config:maxIssues value to 0

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -1,5 +1,5 @@
 build:
-  maxIssues: 10
+  maxIssues: 0
   excludeCorrectable: false
   weights:
     # complexity: 2

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigurationsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigurationsSpec.kt
@@ -197,8 +197,8 @@ internal class ConfigurationsSpec : Spek({
             assertThat(config.subConfig("comments").subConfig("CommentOverPrivateFunction").valueOrDefault("active", true)).isFalse()
         }
 
-        it("should be maxIssues=10 by default") {
-            assertThat(config.subConfig("build").valueOrDefault("maxIssues", -1)).isEqualTo(10)
+        it("should be maxIssues=0 by default") {
+            assertThat(config.subConfig("build").valueOrDefault("maxIssues", -1)).isEqualTo(0)
         }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -17,7 +17,8 @@ import java.nio.file.Paths
 
 class RunnerSpec : Spek({
 
-    val inputPath: Path = Paths.get(resource("/cases/Poko.kt"))
+    val inputPath: Path = Paths.get(resource("cases/Poko.kt"))
+    val charSetName = Charset.defaultCharset().name()
 
     describe("executes the runner with different maxIssues configurations") {
 
@@ -91,10 +92,12 @@ class RunnerSpec : Spek({
         val errorPrinterBuffer by memoized { ByteArrayOutputStream() }
         val errorPrinter by memoized { PrintStream(errorPrinterBuffer) }
 
-        context("execute with default config") {
+        context("execute with default config which allows no issues") {
+
+            val path: Path = Paths.get(resource("/cases/CleanPoko.kt"))
 
             beforeEachTest {
-                val args = CliArgs.parse(arrayOf("--input", inputPath.toString()))
+                val args = CliArgs.parse(arrayOf("--input", path.toString()))
 
                 Runner(args, outputPrinter, errorPrinter).execute()
 
@@ -105,12 +108,12 @@ class RunnerSpec : Spek({
                 errorPrinter.close()
             }
 
-            it("writes output to output printer") {
-                assertThat(outputPrinterBuffer.toString(Charset.defaultCharset().name())).contains("Build succeeded")
+            it("writes no build related output to output printer") {
+                assertThat(outputPrinterBuffer.toString(charSetName)).doesNotContain("Build")
             }
 
             it("does not write anything to error printer") {
-                assertThat(errorPrinterBuffer.toString(Charset.defaultCharset().name())).isEmpty()
+                assertThat(errorPrinterBuffer.toString(charSetName)).isEmpty()
             }
         }
 
@@ -134,11 +137,11 @@ class RunnerSpec : Spek({
             }
 
             it("writes output to output printer") {
-                assertThat(outputPrinterBuffer.toString(Charset.defaultCharset().name())).contains("Build failed")
+                assertThat(outputPrinterBuffer.toString(charSetName)).contains("Build failed")
             }
 
             it("does not write anything to error printer") {
-                assertThat(errorPrinterBuffer.toString(Charset.defaultCharset().name())).isEmpty()
+                assertThat(errorPrinterBuffer.toString(charSetName)).isEmpty()
             }
         }
     }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/TestRules.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/TestRules.kt
@@ -19,6 +19,8 @@ class TestProvider : RuleSetProvider {
 class TestRule : Rule() {
     override val issue = Issue("test", Severity.Minor, "", Debt.FIVE_MINS)
     override fun visitClass(klass: KtClass) {
-        report(CodeSmell(issue, Entity.from(klass), issue.description))
+        if (klass.name == "Poko") {
+            report(CodeSmell(issue, Entity.from(klass), issue.description))
+        }
     }
 }

--- a/detekt-cli/src/test/resources/cases/CleanPoko.kt
+++ b/detekt-cli/src/test/resources/cases/CleanPoko.kt
@@ -1,0 +1,5 @@
+package cases
+
+internal class CleanPoko {
+    val name: String = "CleanPoko"
+}

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -69,7 +69,7 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
 
     private fun defaultBuildConfiguration(): String = """
       build:
-        maxIssues: 10
+        maxIssues: 0
         excludeCorrectable: false
         weights:
           # complexity: 2


### PR DESCRIPTION
A sensible default value is to have zero instead of 10 reported detekt issues. 
Continuing the discussion in #2262