### PR TITLE
Fix regression not considering baseline file when calculating build failure threshold

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/OutputFacade.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/OutputFacade.kt
@@ -4,31 +4,20 @@ import io.gitlab.arturbosch.detekt.api.ConsoleReport
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.OutputReport
 import io.gitlab.arturbosch.detekt.api.internal.SimpleNotification
-import io.gitlab.arturbosch.detekt.cli.baseline.BaselineFacade
 import io.gitlab.arturbosch.detekt.cli.console.BuildFailureReport
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 
 class OutputFacade(
     arguments: CliArgs,
-    private val detektion: Detektion,
+    private val result: Detektion,
     private val settings: ProcessingSettings
 ) {
 
     private val config = settings.config
-    private val baselineFacade = arguments.baseline?.let { BaselineFacade(it) }
     private val createBaseline = arguments.createBaseline
     private val reportPaths = arguments.reportPaths.toHashMap({ it.kind }, { it.path })
 
     fun run() {
-        if (createBaseline) {
-            val smells = detektion.findings.flatMap { it.value }
-            baselineFacade?.create(smells)
-        }
-
-        val result = if (baselineFacade != null) {
-            FilteredDetectionResult(detektion, baselineFacade)
-        } else detektion
-
         val reports = ReportLocator(settings)
             .load()
             .filterNot { createBaseline && it is BuildFailureReport }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -65,6 +65,23 @@ class RunnerSpec : Spek({
 
             assertThat(Files.readAllLines(tmpReport)).hasSize(1)
         }
+
+        context("with additional baseline file") {
+
+            it("should not throw on maxIssues=0 due to baseline blacklist") {
+                val tmpReport = Files.createTempFile("RunnerSpec", ".txt")
+                val cliArgs = CliArgs.parse(arrayOf(
+                    "--input", inputPath.toString(),
+                    "--report", "txt:$tmpReport",
+                    "--config-resource", "/configs/max-issues-0.yml",
+                    "--baseline", Paths.get(resource("configs/baseline-with-two-excludes.xml")).toString()
+                ))
+
+                Runner(cliArgs).execute()
+
+                assertThat(Files.readAllLines(tmpReport)).isEmpty()
+            }
+        }
     }
 
     describe("executes the runner with create baseline") {

--- a/detekt-cli/src/test/resources/configs/baseline-with-two-excludes.xml
+++ b/detekt-cli/src/test/resources/configs/baseline-with-two-excludes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+    <Blacklist />
+    <Whitelist>
+        <ID>test:Poko.kt$Poko</ID>
+    </Whitelist>
+</SmellBaseline>


### PR DESCRIPTION
@schalkms found after setting `maxIssues=0` and #2266 :+1: 