### PR TITLE
Introduce DefaultRuleSetProvider interface marking detekt-rules providers as default

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/DefaultRuleSetProvider.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/DefaultRuleSetProvider.kt
@@ -1,0 +1,11 @@
+package io.gitlab.arturbosch.detekt.api.internal
+
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+
+/**
+ * Interface which marks sub-classes as provided by detekt via the rules sub-module.
+ *
+ * Allows to implement "--disable-default-rulesets" effectively without the need
+ * to manage a list of rule set names.
+ */
+interface DefaultRuleSetProvider : RuleSetProvider

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/RuleSetLocator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/RuleSetLocator.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
 import java.util.ServiceLoader
 
 class RuleSetLocator(private val settings: ProcessingSettings) {
@@ -12,10 +13,6 @@ class RuleSetLocator(private val settings: ProcessingSettings) {
             .mapNotNull { it.nullIfDefaultAndExcluded() }
             .toList()
 
-    private fun RuleSetProvider.nullIfDefaultAndExcluded() = if (excludeDefaultRuleSets && provided()) null else this
-
-    private fun RuleSetProvider.provided() = ruleSetId in defaultRuleSetIds
-
-    private val defaultRuleSetIds = listOf("comments", "complexity", "empty-blocks",
-            "exceptions", "potential-bugs", "performance", "style", "naming")
+    private fun RuleSetProvider.nullIfDefaultAndExcluded() =
+        if (excludeDefaultRuleSets && this is DefaultRuleSetProvider) null else this
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/RuleSetLocatorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/RuleSetLocatorTest.kt
@@ -18,14 +18,23 @@ class RuleSetLocatorTest : Spek({
 
             assertThat(providerClasses).isNotEmpty
             providerClasses
-                    .filter { clazz -> providers.firstOrNull { it.javaClass == clazz } == null }
-                    .forEach { fail("$it rule set is not loaded by the RuleSetLocator") }
+                .filter { clazz -> providers.firstOrNull { it.javaClass == clazz } == null }
+                .forEach { fail("$it rule set is not loaded by the RuleSetLocator") }
+        }
+
+        it("does not load any default rule set provider when opt out") {
+            val providers = ProcessingSettings(path, excludeDefaultRuleSets = true)
+                .use { RuleSetLocator(it).load() }
+
+            val defaultProviders = getProviderClasses().toSet()
+
+            assertThat(providers).noneMatch { it.javaClass in defaultProviders }
         }
     }
 })
 
 private fun getProviderClasses(): List<Class<out RuleSetProvider>> {
     return Reflections("io.gitlab.arturbosch.detekt.rules.providers")
-            .getSubTypesOf(RuleSetProvider::class.java)
-            .filter { !Modifier.isAbstract(it.modifiers) }
+        .getSubTypesOf(RuleSetProvider::class.java)
+        .filter { !Modifier.isAbstract(it.modifiers) }
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollector.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.generator.collection
 
 import io.gitlab.arturbosch.detekt.api.DetektVisitor
+import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
 import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidDocumentationException
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -36,6 +37,9 @@ class RuleSetProviderCollector : Collector<RuleSetProvider> {
 private const val TAG_ACTIVE = "active"
 private const val PROPERTY_RULE_SET_ID = "ruleSetId"
 
+private val SUPPORTED_PROVIDERS =
+    setOf(RuleSetProvider::class.simpleName, DefaultRuleSetProvider::class.simpleName)
+
 class RuleSetProviderVisitor : DetektVisitor() {
     var containsRuleSetProvider = false
     private var name: String = ""
@@ -57,9 +61,11 @@ class RuleSetProviderVisitor : DetektVisitor() {
     }
 
     override fun visitSuperTypeList(list: KtSuperTypeList) {
-        containsRuleSetProvider = list.entries
-                ?.map { it.typeAsUserType?.referencedName }
-                ?.contains(RuleSetProvider::class.simpleName) ?: false
+        val superTypes = list.entries
+            ?.map { it.typeAsUserType?.referencedName }
+            ?.toSet()
+            ?: emptySet()
+        containsRuleSetProvider = SUPPORTED_PROVIDERS.any { it in superTypes }
         super.visitSuperTypeList(list)
     }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CommentSmellProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CommentSmellProvider.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.providers
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
-import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
 import io.gitlab.arturbosch.detekt.rules.documentation.CommentOverPrivateFunction
 import io.gitlab.arturbosch.detekt.rules.documentation.CommentOverPrivateProperty
 import io.gitlab.arturbosch.detekt.rules.documentation.KDocStyle
@@ -16,7 +16,7 @@ import io.gitlab.arturbosch.detekt.rules.documentation.UndocumentedPublicPropert
  *
  * @active since v1.0.0
  */
-class CommentSmellProvider : RuleSetProvider {
+class CommentSmellProvider : DefaultRuleSetProvider {
 
     override val ruleSetId: String = "comments"
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/ComplexityProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/ComplexityProvider.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.providers
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
-import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
 import io.gitlab.arturbosch.detekt.rules.complexity.ComplexCondition
 import io.gitlab.arturbosch.detekt.rules.complexity.ComplexInterface
 import io.gitlab.arturbosch.detekt.rules.complexity.ComplexMethod
@@ -20,7 +20,7 @@ import io.gitlab.arturbosch.detekt.rules.complexity.TooManyFunctions
  *
  * @active since v1.0.0
  */
-class ComplexityProvider : RuleSetProvider {
+class ComplexityProvider : DefaultRuleSetProvider {
 
     override val ruleSetId: String = "complexity"
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CoroutinesProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CoroutinesProvider.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.providers
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
-import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
 import io.gitlab.arturbosch.detekt.rules.coroutines.GlobalCoroutineUsage
 import io.gitlab.arturbosch.detekt.rules.coroutines.RedundantSuspendModifier
 
@@ -11,7 +11,7 @@ import io.gitlab.arturbosch.detekt.rules.coroutines.RedundantSuspendModifier
  *
  * @active since v1.4.0
  */
-class CoroutinesProvider : RuleSetProvider {
+class CoroutinesProvider : DefaultRuleSetProvider {
     override val ruleSetId: String = "coroutines"
 
     override fun instance(config: Config): RuleSet {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/EmptyCodeProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/EmptyCodeProvider.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.providers
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
-import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
 import io.gitlab.arturbosch.detekt.rules.empty.EmptyBlocks
 
 /**
@@ -11,7 +11,7 @@ import io.gitlab.arturbosch.detekt.rules.empty.EmptyBlocks
  *
  * @active since v1.0.0
  */
-class EmptyCodeProvider : RuleSetProvider {
+class EmptyCodeProvider : DefaultRuleSetProvider {
 
     override val ruleSetId: String = "empty-blocks"
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/ExceptionsProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/ExceptionsProvider.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.providers
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
-import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
 import io.gitlab.arturbosch.detekt.rules.exceptions.ExceptionRaisedInUnexpectedLocation
 import io.gitlab.arturbosch.detekt.rules.exceptions.InstanceOfCheckForException
 import io.gitlab.arturbosch.detekt.rules.exceptions.NotImplementedDeclaration
@@ -22,7 +22,7 @@ import io.gitlab.arturbosch.detekt.rules.exceptions.TooGenericExceptionThrown
  *
  * @active since v1.0.0
  */
-class ExceptionsProvider : RuleSetProvider {
+class ExceptionsProvider : DefaultRuleSetProvider {
 
     override val ruleSetId: String = "exceptions"
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/NamingProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/NamingProvider.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.providers
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
-import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
 import io.gitlab.arturbosch.detekt.rules.naming.InvalidPackageDeclaration
 import io.gitlab.arturbosch.detekt.rules.naming.MatchingDeclarationName
 import io.gitlab.arturbosch.detekt.rules.naming.MemberNameEqualsClassName
@@ -13,7 +13,7 @@ import io.gitlab.arturbosch.detekt.rules.naming.NamingRules
  *
  * @active since v1.0.0
  */
-class NamingProvider : RuleSetProvider {
+class NamingProvider : DefaultRuleSetProvider {
 
     override val ruleSetId: String = "naming"
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PerformanceProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PerformanceProvider.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.providers
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
-import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
 import io.gitlab.arturbosch.detekt.rules.performance.ArrayPrimitive
 import io.gitlab.arturbosch.detekt.rules.performance.ForEachOnRange
 import io.gitlab.arturbosch.detekt.rules.performance.SpreadOperator
@@ -13,7 +13,7 @@ import io.gitlab.arturbosch.detekt.rules.performance.UnnecessaryTemporaryInstant
  *
  * @active since v1.0.0
  */
-class PerformanceProvider : RuleSetProvider {
+class PerformanceProvider : DefaultRuleSetProvider {
 
     override val ruleSetId: String = "performance"
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.providers
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
-import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
 import io.gitlab.arturbosch.detekt.rules.bugs.Deprecation
 import io.gitlab.arturbosch.detekt.rules.bugs.DuplicateCaseInWhenExpression
 import io.gitlab.arturbosch.detekt.rules.bugs.EqualsAlwaysReturnsTrueOrFalse
@@ -29,7 +29,7 @@ import io.gitlab.arturbosch.detekt.rules.bugs.WrongEqualsTypeParameter
  *
  * @active since v1.0.0
  */
-class PotentialBugProvider : RuleSetProvider {
+class PotentialBugProvider : DefaultRuleSetProvider {
 
     override val ruleSetId: String = "potential-bugs"
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/StyleGuideProvider.kt
@@ -2,20 +2,20 @@ package io.gitlab.arturbosch.detekt.rules.providers
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
-import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
 import io.gitlab.arturbosch.detekt.rules.style.CollapsibleIfStatements
 import io.gitlab.arturbosch.detekt.rules.style.DataClassContainsFunctions
 import io.gitlab.arturbosch.detekt.rules.style.DataClassShouldBeImmutable
 import io.gitlab.arturbosch.detekt.rules.style.EqualsNullCall
 import io.gitlab.arturbosch.detekt.rules.style.EqualsOnSignatureLine
-import io.gitlab.arturbosch.detekt.rules.style.ExplicitItLambdaParameter
 import io.gitlab.arturbosch.detekt.rules.style.ExplicitCollectionElementAccessMethod
+import io.gitlab.arturbosch.detekt.rules.style.ExplicitItLambdaParameter
 import io.gitlab.arturbosch.detekt.rules.style.ExpressionBodySyntax
 import io.gitlab.arturbosch.detekt.rules.style.FileParsingRule
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenComment
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenImport
-import io.gitlab.arturbosch.detekt.rules.style.ForbiddenPublicDataClass
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenMethodCall
+import io.gitlab.arturbosch.detekt.rules.style.ForbiddenPublicDataClass
 import io.gitlab.arturbosch.detekt.rules.style.ForbiddenVoid
 import io.gitlab.arturbosch.detekt.rules.style.FunctionOnlyReturningConstant
 import io.gitlab.arturbosch.detekt.rules.style.LibraryCodeMustSpecifyReturnType
@@ -66,7 +66,7 @@ import io.gitlab.arturbosch.detekt.rules.style.optional.PreferToOverPairSyntax
  *
  * @active since v1.0.0
  */
-class StyleGuideProvider : RuleSetProvider {
+class StyleGuideProvider : DefaultRuleSetProvider {
 
     override val ruleSetId: String = "style"
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RuleProviderConfigTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RuleProviderConfigTest.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules
 
 import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.reflections.Reflections
@@ -15,7 +15,7 @@ class RuleProviderConfigTest : Spek({
         it("should test if the config has been passed to all rules") {
             val config = TestConfig()
             val reflections = Reflections("io.gitlab.arturbosch.detekt.rules.providers")
-            val providers = reflections.getSubTypesOf(RuleSetProvider::class.java)
+            val providers = reflections.getSubTypesOf(DefaultRuleSetProvider::class.java)
 
             providers.forEach {
                 val provider = it.getDeclaredConstructor().newInstance()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RuleProviderTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RuleProviderTest.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.MultiRule
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
 import io.gitlab.arturbosch.detekt.rules.providers.CommentSmellProvider
 import io.gitlab.arturbosch.detekt.rules.providers.ComplexityProvider
 import io.gitlab.arturbosch.detekt.rules.providers.CoroutinesProvider
@@ -26,34 +27,33 @@ class RuleProviderTest : Spek({
 
         it("checks whether all rules are called in the corresponding RuleSetProvider") {
             val reflections = Reflections("io.gitlab.arturbosch.detekt.rules.providers")
-            val providers = reflections.getSubTypesOf(RuleSetProvider::class.java)
+            val providers = reflections.getSubTypesOf(DefaultRuleSetProvider::class.java)
             providers.forEach { providerType ->
                 val packageName = getRulesPackageNameForProvider(providerType)
                 val provider = providerType.getDeclaredConstructor().newInstance()
                 val rules = getRules(provider)
                 val classes = getClasses(packageName)
-                classes
-                    .forEach { clazz ->
-                        val rule = rules.singleOrNull { it.javaClass.simpleName == clazz.simpleName }
-                        assertThat(rule).withFailMessage(
-                            "Rule $clazz is not called in the corresponding RuleSetProvider $providerType")
-                            .isNotNull()
-                    }
+                classes.forEach { clazz ->
+                    val rule = rules.singleOrNull { it.javaClass.simpleName == clazz.simpleName }
+                    assertThat(rule).withFailMessage(
+                        "Rule $clazz is not called in the corresponding RuleSetProvider $providerType"
+                    ).isNotNull()
+                }
             }
         }
     }
 })
 
 private val ruleMap = mapOf<Class<*>, String>(
-    Pair(CommentSmellProvider().javaClass, "io.gitlab.arturbosch.detekt.rules.documentation"),
-    Pair(ComplexityProvider().javaClass, "io.gitlab.arturbosch.detekt.rules.complexity"),
-    Pair(EmptyCodeProvider().javaClass, "io.gitlab.arturbosch.detekt.rules.empty"),
-    Pair(ExceptionsProvider().javaClass, "io.gitlab.arturbosch.detekt.rules.exceptions"),
-    Pair(NamingProvider().javaClass, "io.gitlab.arturbosch.detekt.rules.naming"),
-    Pair(PerformanceProvider().javaClass, "io.gitlab.arturbosch.detekt.rules.performance"),
-    Pair(PotentialBugProvider().javaClass, "io.gitlab.arturbosch.detekt.rules.bugs"),
-    Pair(StyleGuideProvider().javaClass, "io.gitlab.arturbosch.detekt.rules.style"),
-    Pair(CoroutinesProvider().javaClass, "io.gitlab.arturbosch.detekt.rules.coroutines")
+    CommentSmellProvider().javaClass to "io.gitlab.arturbosch.detekt.rules.documentation",
+    ComplexityProvider().javaClass to "io.gitlab.arturbosch.detekt.rules.complexity",
+    EmptyCodeProvider().javaClass to "io.gitlab.arturbosch.detekt.rules.empty",
+    ExceptionsProvider().javaClass to "io.gitlab.arturbosch.detekt.rules.exceptions",
+    NamingProvider().javaClass to "io.gitlab.arturbosch.detekt.rules.naming",
+    PerformanceProvider().javaClass to "io.gitlab.arturbosch.detekt.rules.performance",
+    PotentialBugProvider().javaClass to "io.gitlab.arturbosch.detekt.rules.bugs",
+    StyleGuideProvider().javaClass to "io.gitlab.arturbosch.detekt.rules.style",
+    CoroutinesProvider().javaClass to "io.gitlab.arturbosch.detekt.rules.coroutines"
 )
 
 private fun getRulesPackageNameForProvider(providerType: Class<out RuleSetProvider>): String {

--- a/docs/pages/kdoc/detekt-api/alltypes/index.md
+++ b/docs/pages/kdoc/detekt-api/alltypes/index.md
@@ -115,6 +115,13 @@ Default [Context](../io.gitlab.arturbosch.detekt.api/-context/index.html) implem
 
 |
 
+##### [io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider](../io.gitlab.arturbosch.detekt.api.internal/-default-rule-set-provider.html)
+
+Interface which marks sub-classes as provided by detekt via the rules sub-module.
+
+
+|
+
 ##### [io.gitlab.arturbosch.detekt.api.Detektion](../io.gitlab.arturbosch.detekt.api/-detektion/index.html)
 
 Storage for all kinds of findings and additional information

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-default-rule-set-provider.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-default-rule-set-provider.md
@@ -1,0 +1,15 @@
+---
+title: DefaultRuleSetProvider - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api.internal](index.html) / [DefaultRuleSetProvider](./-default-rule-set-provider.html)
+
+# DefaultRuleSetProvider
+
+`interface DefaultRuleSetProvider : `[`RuleSetProvider`](../io.gitlab.arturbosch.detekt.api/-rule-set-provider/index.html)
+
+Interface which marks sub-classes as provided by detekt via the rules sub-module.
+
+Allows to implement "--disable-default-rulesets" effectively without the need
+to manage a list of rule set names.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/index.md
@@ -10,6 +10,7 @@ title: io.gitlab.arturbosch.detekt.api.internal - detekt-api
 
 | [CommaSeparatedPattern](-comma-separated-pattern/index.html) | `class CommaSeparatedPattern : `[`SplitPattern`](../io.gitlab.arturbosch.detekt.api/-split-pattern/index.html) |
 | [CyclomaticComplexity](-cyclomatic-complexity/index.html) | Counts the cyclomatic complexity of nodes.`class CyclomaticComplexity : `[`DetektVisitor`](../io.gitlab.arturbosch.detekt.api/-detekt-visitor/index.html) |
+| [DefaultRuleSetProvider](-default-rule-set-provider.html) | Interface which marks sub-classes as provided by detekt via the rules sub-module.`interface DefaultRuleSetProvider : `[`RuleSetProvider`](../io.gitlab.arturbosch.detekt.api/-rule-set-provider/index.html) |
 | [DetektPomModel](-detekt-pom-model/index.html) | Adapted from https://github.com/pinterest/ktlint/blob/master/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt Licenced under the MIT licence - https://github.com/pinterest/ktlint/blob/master/LICENSE`class DetektPomModel : UserDataHolderBase, PomModel` |
 | [FailFastConfig](-fail-fast-config/index.html) | `data class FailFastConfig : `[`Config`](../io.gitlab.arturbosch.detekt.api/-config/index.html)`, `[`ValidatableConfiguration`](-validatable-configuration/index.html) |
 | [PathFilters](-path-filters/index.html) | `class PathFilters` |

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set-provider/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-rule-set-provider/index.md
@@ -22,3 +22,7 @@ http://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html
 | [buildRuleset](build-ruleset.html) | Can return a rule set if this specific rule set is not considered as ignore.`open fun buildRuleset(config: `[`Config`](../-config/index.html)`): `[`RuleSet`](../-rule-set/index.html)`?` |
 | [instance](instance.html) | This function must be implemented to provide custom rule sets. Make sure to pass the configuration to each rule to allow rules to be self configurable.`abstract fun instance(config: `[`Config`](../-config/index.html)`): `[`RuleSet`](../-rule-set/index.html) |
 
+### Inheritors
+
+| [DefaultRuleSetProvider](../../io.gitlab.arturbosch.detekt.api.internal/-default-rule-set-provider.html) | Interface which marks sub-classes as provided by detekt via the rules sub-module.`interface DefaultRuleSetProvider : `[`RuleSetProvider`](./index.html) |
+


### PR DESCRIPTION
This way we won't forget to add new Provider's like we did with `CoroutinesProvider`.
