### PR TITLE
Remove printing the whole config for --debug

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -63,7 +63,6 @@ class Runner(
     }
 
     private fun checkConfiguration(settings: ProcessingSettings) {
-        settings.debug { "\n${settings.config}\n" }
         val props = settings.config.subConfig("config")
         val shouldValidate = props.valueOrDefault("validation", true)
 


### PR DESCRIPTION
Spams the whole console page and brings little to no insight.
Never actually used this statement for debugging, somebody did?
