### PR TITLE
Call detekt reflectively

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/ClassLoaderCache.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/ClassLoaderCache.kt
@@ -1,0 +1,34 @@
+package io.gitlab.arturbosch.detekt.internal
+
+import org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport
+import org.gradle.api.file.FileCollection
+import java.net.URLClassLoader
+
+object ClassLoaderCache {
+
+    private var cached: URLClassLoader? = null
+    private var lastSeenClasspath: FileCollection? = null
+
+    fun getOrCreate(classpath: FileCollection): URLClassLoader {
+        val lastClasspath = lastSeenClasspath
+        if (lastClasspath == null) {
+            cache(classpath)
+        } else {
+            synchronized(ClassLoaderCache) {
+                if (!lastClasspath.minus(classpath).isEmpty) {
+                    DefaultGroovyMethodsSupport.closeQuietly(cached)
+                    cache(classpath)
+                }
+            }
+        }
+        return cached ?: throw IllegalStateException("Detekt classloader expected.")
+    }
+
+    private fun cache(classpath: FileCollection) {
+        lastSeenClasspath = classpath
+        cached = URLClassLoader(
+            classpath.map { it.toURI().toURL() }.toTypedArray(),
+            null /* isolate detekt environment */
+        )
+    }
+}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -3,6 +3,9 @@ package io.gitlab.arturbosch.detekt.invoke
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
+import java.io.PrintStream
+import java.lang.reflect.InvocationTargetException
+import java.net.URLClassLoader
 
 internal interface DetektInvoker {
     fun invokeCli(
@@ -28,11 +31,6 @@ internal interface DetektInvoker {
     }
 }
 
-private const val NORMAL_RUN = 0
-private const val UNEXPECTED_RUN = 1
-private const val ISSUE_THRESHOLD_MET = 2
-private const val INVALID_CONFIG = 3
-
 private class DefaultCliInvoker(private val project: Project) : DetektInvoker {
 
     override fun invokeCli(
@@ -41,38 +39,33 @@ private class DefaultCliInvoker(private val project: Project) : DetektInvoker {
         taskName: String,
         ignoreFailures: Boolean
     ) {
-        val detektTmpDir = project.mkdir("${project.buildDir}/tmp/detekt")
-        val argsFile = project.file("$detektTmpDir/$taskName.args")
-
         val cliArguments = arguments.flatMap(CliArgument::toArgument)
-
-        argsFile.writeText(cliArguments.joinToString("\n"))
-
-        project.logger.debug(cliArguments.joinToString(" "))
-
-        val proc = project.javaexec {
-            it.main = DETEKT_MAIN
-            it.classpath = classpath
-            it.args = listOf("@${argsFile.absolutePath}")
-            it.isIgnoreExitValue = true
-        }
-        val exitValue = proc.exitValue
-        project.logger.debug("Detekt finished with exit value $exitValue")
-
-        when (exitValue) {
-            NORMAL_RUN -> return
-            UNEXPECTED_RUN -> throw GradleException("There was a problem running detekt.")
-            ISSUE_THRESHOLD_MET -> if (!ignoreFailures) {
-                throw GradleException("MaxIssues count exceeded.")
+        try {
+            val loader = URLClassLoader(
+                classpath.map { it.toURI().toURL() }.toTypedArray(),
+                null /* isolate detekt environment */
+            )
+            loader.use {
+                val clazz = it.loadClass("io.gitlab.arturbosch.detekt.cli.Main")
+                val runner = clazz.getMethod("buildRunner",
+                    Array<String>::class.java,
+                    PrintStream::class.java,
+                    PrintStream::class.java
+                ).invoke(null, cliArguments.toTypedArray(), System.out, System.err)
+                runner::class.java.getMethod("execute").invoke(runner)
             }
-            INVALID_CONFIG -> throw GradleException("Invalid detekt configuration file detected.")
-            else -> throw GradleException("Unexpected detekt exit with code '$exitValue'.")
+        } catch (reflectionWrapper: InvocationTargetException) {
+            val cause = reflectionWrapper.targetException
+            val message = cause.message
+            if (message != null && isBuildFailure(message) && ignoreFailures) {
+                return
+            }
+            throw GradleException(message ?: "There was a problem running detekt.", cause)
         }
     }
 
-    companion object {
-        private const val DETEKT_MAIN = "io.gitlab.arturbosch.detekt.cli.Main"
-    }
+    private fun isBuildFailure(msg: String?) =
+        msg != null && "Build failed with" in msg && "issues" in msg
 }
 
 private class DryRunInvoker(private val project: Project) : DetektInvoker {


### PR DESCRIPTION
Continuation of https://github.com/arturbosch/detekt/pull/2200 with hopefully most of the classloader leaks fixed ...
Metaspace OOM issues may still occur as every detekt run loads ~50mb of classes when using `--parallel`.

Following screenshot shows that the gradle daemon can unload detekt classes though:
![2020-01-19-222256_704x365_scrot](https://user-images.githubusercontent.com/20924106/72688722-4e719600-3b0a-11ea-8560-f4862d35da00.png)

Insights from previous PR:
- hard coding the detekt version is 3x faster than our current Gradle Plugin
  - downside is that we can't dynamically set the detekt classpath (changing versions etc)
  - we can't use our plugin mechanism!
    - we may convert the extra plugin classpath to `--plugins jars...` parameters however when trying this I got unexpected crashes ...
- using the `project.ant` method like the gradle builtin quality tools fork a jvm
  - an anttask can be run without forking the JVM, but again Metaspace
  - performance was nearly the same as now with worse logging `anttask: detekt output` on every line
- Calling detekt reflectively revealed some classloader memory leaks
  - still not sure about the performance though the Metaspace issues are still present
  - I hope that with this way we can save ~200ms JVM starting overhead?
- Did not try out the worker api though reading it's docu does not show how a javaexec could be speed up
  - To my knownledge the worker api brings performance benefits for easier tasks than starting a new process?