### PR TITLE
Number format in some report

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReport.kt
@@ -9,6 +9,16 @@ class ComplexityReport : ConsoleReport() {
 
     override fun render(detektion: Detektion): String? {
         val complexityReportGenerator = ComplexityReportGenerator.create(detektion)
-        return complexityReportGenerator.generate()
+        return complexityReportGenerator.generate()?.let { list ->
+            with(StringBuilder()) {
+                append("Complexity Report:\n")
+                list.forEach {
+                    append(PREFIX)
+                    append(it)
+                    append("\n")
+                }
+                toString()
+            }
+        }
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportGenerator.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportGenerator.kt
@@ -24,7 +24,7 @@ class ComplexityReportGenerator(private val complexityMetric: ComplexityMetric) 
             "%,d comment lines of code (cloc)".format(Locale.US, complexityMetric.cloc),
             "%,d McCabe complexity (mcc)".format(Locale.US, complexityMetric.mcc),
             "%,d number of total code smells".format(Locale.US, numberOfSmells),
-            "%,d %% comment source ratio".format(Locale.US, commentSourceRatio),
+            "%,d%% comment source ratio".format(Locale.US, commentSourceRatio),
             "%,d mcc per 1,000 lloc".format(Locale.US, mccPerThousandLines),
             "%,d code smells per 1,000 lloc".format(Locale.US, smellPerThousandLines)
         )

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportGenerator.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportGenerator.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.cli.console
 
 import io.gitlab.arturbosch.detekt.api.Detektion
+import java.util.Locale
 
 class ComplexityReportGenerator(private val complexityMetric: ComplexityMetric) {
 
@@ -17,15 +18,15 @@ class ComplexityReportGenerator(private val complexityMetric: ComplexityMetric) 
     fun generate(): List<String>? {
         if (cannotGenerate()) return null
         return listOf(
-            "${complexityMetric.loc} lines of code (loc)",
-            "${complexityMetric.sloc} source lines of code (sloc)",
-            "${complexityMetric.lloc} logical lines of code (lloc)",
-            "${complexityMetric.cloc} comment lines of code (cloc)",
-            "${complexityMetric.mcc} McCabe complexity (mcc)",
-            "$numberOfSmells number of total code smells",
-            "$commentSourceRatio % comment source ratio",
-            "$mccPerThousandLines mcc per 1000 lloc",
-            "$smellPerThousandLines code smells per 1000 lloc"
+            "%,d lines of code (loc)".format(Locale.US, complexityMetric.loc),
+            "%,d source lines of code (sloc)".format(Locale.US, complexityMetric.sloc),
+            "%,d logical lines of code (lloc)".format(Locale.US, complexityMetric.lloc),
+            "%,d comment lines of code (cloc)".format(Locale.US, complexityMetric.cloc),
+            "%,d McCabe complexity (mcc)".format(Locale.US, complexityMetric.mcc),
+            "%,d number of total code smells".format(Locale.US, numberOfSmells),
+            "%,d %% comment source ratio".format(Locale.US, commentSourceRatio),
+            "%,d mcc per 1,000 lloc".format(Locale.US, mccPerThousandLines),
+            "%,d code smells per 1,000 lloc".format(Locale.US, smellPerThousandLines)
         )
     }
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportGenerator.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportGenerator.kt
@@ -14,21 +14,19 @@ class ComplexityReportGenerator(private val complexityMetric: ComplexityMetric) 
             ComplexityReportGenerator(ComplexityMetric(detektion))
     }
 
-    fun generate(): String? {
+    fun generate(): List<String>? {
         if (cannotGenerate()) return null
-        return with(StringBuilder()) {
-            append("Complexity Report:".format())
-            append("${complexityMetric.loc} lines of code (loc)".format(PREFIX))
-            append("${complexityMetric.sloc} source lines of code (sloc)".format(PREFIX))
-            append("${complexityMetric.lloc} logical lines of code (lloc)".format(PREFIX))
-            append("${complexityMetric.cloc} comment lines of code (cloc)".format(PREFIX))
-            append("${complexityMetric.mcc} McCabe complexity (mcc)".format(PREFIX))
-            append("$numberOfSmells number of total code smells".format(PREFIX))
-            append("$commentSourceRatio % comment source ratio".format(PREFIX))
-            append("$mccPerThousandLines mcc per 1000 lloc".format(PREFIX))
-            append("$smellPerThousandLines code smells per 1000 lloc".format(PREFIX))
-            toString()
-        }
+        return listOf(
+            "${complexityMetric.loc} lines of code (loc)",
+            "${complexityMetric.sloc} source lines of code (sloc)",
+            "${complexityMetric.lloc} logical lines of code (lloc)",
+            "${complexityMetric.cloc} comment lines of code (cloc)",
+            "${complexityMetric.mcc} McCabe complexity (mcc)",
+            "$numberOfSmells number of total code smells",
+            "$commentSourceRatio % comment source ratio",
+            "$mccPerThousandLines mcc per 1000 lloc",
+            "$smellPerThousandLines code smells per 1000 lloc"
+        )
     }
 
     private fun cannotGenerate(): Boolean {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReport.kt
@@ -41,10 +41,10 @@ class HtmlOutputReport : OutputReport() {
     override val name = "HTML report"
 
     override fun render(detektion: Detektion) =
-            ClasspathResourceConverter().convert(DEFAULT_TEMPLATE).openStream().bufferedReader().use { it.readText() }
-                    .replace(PLACEHOLDER_METRICS, renderMetrics(detektion.metrics))
-                    .replace(PLACEHOLDER_COMPLEXITY_REPORT, renderComplexity(getComplexityMetrics(detektion)))
-                    .replace(PLACEHOLDER_FINDINGS, renderFindings(detektion.findings))
+        ClasspathResourceConverter().convert(DEFAULT_TEMPLATE).openStream().bufferedReader().use { it.readText() }
+            .replace(PLACEHOLDER_METRICS, renderMetrics(detektion.metrics))
+            .replace(PLACEHOLDER_COMPLEXITY_REPORT, renderComplexity(getComplexityMetrics(detektion)))
+            .replace(PLACEHOLDER_FINDINGS, renderFindings(detektion.findings))
 
     private fun renderMetrics(metrics: Collection<ProjectMetric>) = createHTML().div {
         ul {
@@ -118,13 +118,7 @@ class HtmlOutputReport : OutputReport() {
     }
 
     private fun getComplexityMetrics(detektion: Detektion): List<String> {
-        val complexityReport = ComplexityReportGenerator.create(detektion).generate()
-        return if (complexityReport.isNullOrBlank()) {
-            emptyList()
-        } else {
-            val complexities = complexityReport.split("\n")
-            return complexities.subList(1, complexities.size - 1)
-        }
+        return ComplexityReportGenerator.create(detektion).generate() ?: emptyList()
     }
 }
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReport.kt
@@ -24,6 +24,7 @@ import kotlinx.html.span
 import kotlinx.html.stream.createHTML
 import kotlinx.html.ul
 import kotlinx.html.visit
+import java.util.Locale
 
 private const val DEFAULT_TEMPLATE = "default-html-report-template.html"
 private const val PLACEHOLDER_METRICS = "@@@metrics@@@"
@@ -48,7 +49,7 @@ class HtmlOutputReport : OutputReport() {
     private fun renderMetrics(metrics: Collection<ProjectMetric>) = createHTML().div {
         ul {
             metrics.forEach {
-                li { text("${it.type}: ${it.value}") }
+                li { text("${it.type}: %,d".format(Locale.US, it.value)) }
             }
         }
     }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportGeneratorSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportGeneratorSpec.kt
@@ -12,26 +12,24 @@ import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
-internal class ComplexityReportSpec : Spek({
+internal class ComplexityReportGeneratorSpec : Spek({
 
-    describe("complexity report") {
+    describe("complexity report generator") {
 
         context("several complexity metrics") {
 
             it("successfully generates a complexity report") {
-                val report = ComplexityReport()
                 val expectedContent = readResource("complexity-report.txt")
                 val detektion = createDetektion()
                 addData(detektion)
                 // Casting expectedContent to Any is workaround for
                 // https://github.com/joel-costigliola/assertj-core/issues/1440#issuecomment-465032464
-                assertThat(report.render(detektion)).isEqualTo(expectedContent as Any)
+                assertThat(generateComplexityReport(detektion)).isEqualTo(expectedContent as Any)
             }
 
-            it("returns null for missing complexity metrics in report") {
-                val report = ComplexityReport()
+            it("returns null for missing complexity metrics") {
                 val detektion = createDetektion()
-                assertThat(report.render(detektion)).isNull()
+                assertThat(generateComplexityReport(detektion)).isNull()
             }
         }
     }
@@ -45,4 +43,10 @@ private fun addData(detektion: Detektion) {
     detektion.addData(sourceLinesKey, 6)
     detektion.addData(logicalLinesKey, 5)
     detektion.addData(commentLinesKey, 4)
+}
+
+private fun generateComplexityReport(detektion: Detektion): String? {
+    val complexityMetric = ComplexityMetric(detektion)
+    val generator = ComplexityReportGenerator(complexityMetric)
+    return generator.generate()
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportGeneratorSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportGeneratorSpec.kt
@@ -19,12 +19,20 @@ internal class ComplexityReportGeneratorSpec : Spek({
         context("several complexity metrics") {
 
             it("successfully generates a complexity report") {
-                val expectedContent = readResource("complexity-report.txt")
+                val expectedContent = listOf(
+                    "10 lines of code (loc)",
+                    "6 source lines of code (sloc)",
+                    "5 logical lines of code (lloc)",
+                    "4 comment lines of code (cloc)",
+                    "2 McCabe complexity (mcc)",
+                    "1 number of total code smells",
+                    "66 % comment source ratio",
+                    "400 mcc per 1000 lloc",
+                    "200 code smells per 1000 lloc"
+                )
                 val detektion = createDetektion()
                 addData(detektion)
-                // Casting expectedContent to Any is workaround for
-                // https://github.com/joel-costigliola/assertj-core/issues/1440#issuecomment-465032464
-                assertThat(generateComplexityReport(detektion)).isEqualTo(expectedContent as Any)
+                assertThat(generateComplexityReport(detektion)).isEqualTo(expectedContent)
             }
 
             it("returns null for missing complexity metrics") {
@@ -45,7 +53,7 @@ private fun addData(detektion: Detektion) {
     detektion.addData(commentLinesKey, 4)
 }
 
-private fun generateComplexityReport(detektion: Detektion): String? {
+private fun generateComplexityReport(detektion: Detektion): List<String>? {
     val complexityMetric = ComplexityMetric(detektion)
     val generator = ComplexityReportGenerator(complexityMetric)
     return generator.generate()

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportGeneratorSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportGeneratorSpec.kt
@@ -20,15 +20,15 @@ internal class ComplexityReportGeneratorSpec : Spek({
 
             it("successfully generates a complexity report") {
                 val expectedContent = listOf(
-                    "10 lines of code (loc)",
+                    "1,000 lines of code (loc)",
                     "6 source lines of code (sloc)",
                     "5 logical lines of code (lloc)",
                     "4 comment lines of code (cloc)",
                     "2 McCabe complexity (mcc)",
                     "1 number of total code smells",
                     "66 % comment source ratio",
-                    "400 mcc per 1000 lloc",
-                    "200 code smells per 1000 lloc"
+                    "400 mcc per 1,000 lloc",
+                    "200 code smells per 1,000 lloc"
                 )
                 val detektion = createDetektion()
                 addData(detektion)
@@ -47,7 +47,7 @@ private fun createDetektion(): Detektion = DetektResult(mapOf(Pair("Key", listOf
 
 private fun addData(detektion: Detektion) {
     detektion.addData(complexityKey, 2)
-    detektion.addData(linesKey, 10)
+    detektion.addData(linesKey, 1000)
     detektion.addData(sourceLinesKey, 6)
     detektion.addData(logicalLinesKey, 5)
     detektion.addData(commentLinesKey, 4)

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportGeneratorSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportGeneratorSpec.kt
@@ -26,7 +26,7 @@ internal class ComplexityReportGeneratorSpec : Spek({
                     "4 comment lines of code (cloc)",
                     "2 McCabe complexity (mcc)",
                     "1 number of total code smells",
-                    "66 % comment source ratio",
+                    "66% comment source ratio",
                     "400 mcc per 1,000 lloc",
                     "200 code smells per 1,000 lloc"
                 )

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReportSpec.kt
@@ -54,5 +54,5 @@ private fun addData(detektion: Detektion) {
 private fun generateComplexityReport(detektion: Detektion): String? {
     val complexityMetric = ComplexityMetric(detektion)
     val generator = ComplexityReportGenerator(complexityMetric)
-    return generator.generate()?.trimEnd()
+    return generator.generate()
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/FileBasedFindingsReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/FileBasedFindingsReportSpec.kt
@@ -34,7 +34,7 @@ class FileBasedFindingsReportSpec : Spek({
             }
 
             it("has the reference content") {
-                val output = subject.render(detektion)?.trimEnd()?.decolorized()
+                val output = subject.render(detektion)?.decolorized()
                 assertThat(output).isEqualTo(expectedContent)
             }
         }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/FindingsReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/FindingsReportSpec.kt
@@ -26,7 +26,7 @@ class FindingsReportSpec : Spek({
             var output: String? = null
 
             beforeEachTest {
-                output = subject.render(detektion)?.trimEnd()?.decolorized()
+                output = subject.render(detektion)?.decolorized()
             }
 
             it("has the reference content") {

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ResourceReader.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ResourceReader.kt
@@ -6,5 +6,5 @@ import java.nio.file.Paths
 
 internal fun readResource(filename: String): String {
     val path = Paths.get(resource(filename))
-    return Files.readAllLines(path).joinToString("\n").trimEnd()
+    return Files.readAllLines(path).joinToString("\n") + "\n"
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
@@ -93,9 +93,9 @@ class HtmlOutputFormatTest : Spek({
             detektion.addData(commentLinesKey, 2)
             detektion.addData(linesKey, 22)
             val result = outputFormat.render(detektion)
-            assertThat(result).contains("<li>- 22 lines of code (loc)</li>")
-            assertThat(result).contains("<li>- 20 source lines of code (sloc)</li>")
-            assertThat(result).contains("<li>- 10 logical lines of code (lloc)</li>")
+            assertThat(result).contains("<li>22 lines of code (loc)</li>")
+            assertThat(result).contains("<li>20 source lines of code (sloc)</li>")
+            assertThat(result).contains("<li>10 logical lines of code (lloc)</li>")
         }
 
         it("testRenderResultWithBlankComplexityReport") {

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
@@ -77,11 +77,11 @@ class HtmlOutputFormatTest : Spek({
         it("testRenderResultContainingAtLeastOneMetric") {
             val detektion = object : TestDetektion() {
                 override val metrics: Collection<ProjectMetric> = listOf(
-                    ProjectMetric("M1", 1), ProjectMetric("M2", 2)
+                    ProjectMetric("M1", 10000), ProjectMetric("M2", 2)
                 )
             }
             val result = outputFormat.render(detektion)
-            assertThat(result).contains("<li>M1: 1</li>")
+            assertThat(result).contains("<li>M1: 10,000</li>")
             assertThat(result).contains("<li>M2: 2</li>")
         }
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
@@ -91,9 +91,9 @@ class HtmlOutputFormatTest : Spek({
             detektion.addData(sourceLinesKey, 20)
             detektion.addData(logicalLinesKey, 10)
             detektion.addData(commentLinesKey, 2)
-            detektion.addData(linesKey, 22)
+            detektion.addData(linesKey, 2222)
             val result = outputFormat.render(detektion)
-            assertThat(result).contains("<li>22 lines of code (loc)</li>")
+            assertThat(result).contains("<li>2,222 lines of code (loc)</li>")
             assertThat(result).contains("<li>20 source lines of code (sloc)</li>")
             assertThat(result).contains("<li>10 logical lines of code (lloc)</li>")
         }

--- a/detekt-cli/src/test/resources/complexity-report.txt
+++ b/detekt-cli/src/test/resources/complexity-report.txt
@@ -6,5 +6,5 @@ Complexity Report:
 	- 2 McCabe complexity (mcc)
 	- 1 number of total code smells
 	- 66 % comment source ratio
-	- 400 mcc per 1000 lloc
-	- 200 code smells per 1000 lloc
+	- 400 mcc per 1,000 lloc
+	- 200 code smells per 1,000 lloc

--- a/detekt-cli/src/test/resources/complexity-report.txt
+++ b/detekt-cli/src/test/resources/complexity-report.txt
@@ -5,6 +5,6 @@ Complexity Report:
 	- 4 comment lines of code (cloc)
 	- 2 McCabe complexity (mcc)
 	- 1 number of total code smells
-	- 66 % comment source ratio
+	- 66% comment source ratio
 	- 400 mcc per 1,000 lloc
 	- 200 code smells per 1,000 lloc


### PR DESCRIPTION
Add thousand separators. Remove useless `- ` and remove space between value and %

This is before:
<img width="287" alt="Captura de pantalla 2020-01-24 a las 22 59 46" src="https://user-images.githubusercontent.com/721244/73107412-0da8c100-3efe-11ea-85f5-0e64ca483b8f.png">
and this is after this PR:
<img width="286" alt="Captura de pantalla 2020-01-24 a las 23 04 14" src="https://user-images.githubusercontent.com/721244/73107428-14373880-3efe-11ea-9ed4-9fddc100ad00.png">

This changes are made for the console output too. If we don't want them I can refactorice them