### PR TITLE
Fix sample rules not properly calling the superclass

### DIFF
--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctions.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctions.kt
@@ -34,6 +34,7 @@ class TooManyFunctions : Rule() {
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
+        super.visitNamedFunction(function)
         amount++
     }
 }

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctionsTwo.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctionsTwo.kt
@@ -44,6 +44,7 @@ class TooManyFunctionsTwo(config: Config) : ThresholdRule(config, THRESHOLD) {
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
+        super.visitNamedFunction(function)
         amount++
     }
 }


### PR DESCRIPTION
This makes sure that the rule doesn't break any behaviour which the
superclasses might introduce in the future.

reference #2283
