### PR TITLE
Fix ExplicitCollectionElementAccessMethod crash

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
@@ -50,7 +50,7 @@ class ExplicitCollectionElementAccessMethod(config: Config = Config.empty) : Rul
         )
 
     override fun visitCallExpression(expression: KtCallExpression) {
-        if (isGetOrPut(expression) && isMapMethod(expression)) {
+        if (isMapMethod(expression) && isGetOrPut(expression)) {
             report(CodeSmell(issue, Entity.from(expression), "Prefer usage of indexed access operator []."))
         }
         super.visitCallExpression(expression)
@@ -62,7 +62,7 @@ class ExplicitCollectionElementAccessMethod(config: Config = Config.empty) : Rul
 
     private fun isMapMethod(expression: KtCallExpression): Boolean {
         val dotExpression = expression.prevSibling
-        val caller = when (dotExpression.parent) {
+        val caller = when (dotExpression?.parent) {
             is KtDotQualifiedExpression,
             is KtSafeQualifiedExpression -> dotExpression.prevSibling
             else -> return false

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -207,4 +207,16 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
     }
 
+    describe("getters") {
+
+        it("does not crash for getter") {
+            val code = """
+                class A {
+                    val i1: Int? = get() ?: throw IllegalArgumentException("getter")
+                    val i2: Int = get()
+                }
+            """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+        }
+    }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -212,8 +212,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         it("does not crash for getter") {
             val code = """
                 class A {
-                    val i1: Int? = get() ?: throw IllegalArgumentException("getter")
-                    val i2: Int = get()
+                    val i: Int get() = 1 + 2
+                    val c: Char? get() = "".first() ?: throw IllegalArgumentException("getter")
                 }
             """
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()


### PR DESCRIPTION
The rule shouldn't crash for getter and setter that have no parent expression.
Fixes #2301