### PR TITLE
Update codecov run settings to after_n_builds=4

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
     - !appveyor
   notify:
     require_ci_to_pass: no
-    after_n_builds: 3
+    after_n_builds: 4
 coverage:
   status:
     # master branch only


### PR DESCRIPTION
Currently, there are 5 Travis runners.

5 - 1 runner with COMPILE_TEST_SNIPPETS=true 
= 4 for after_n_builds.
