### PR TITLE
Bugfix: MagicNumber with ignoreNamedArgument and a negative value

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Michael Lotkowski](https://github.com/DownMoney) - Rule improvement: False positive UnusedImport for componentN
 - [Nuno Caro](https://github.com/Pak3nuh) - Adds TXT report support on Gradle plugin
 - [Minsuk Eom](https://github.com/boxresin) - Rule fix: PackageNaming
+- [Jonas Alves](https://github.com/jonasfa) - Rule fix: MagicNumber with ignoreNamedArgument and a negative value
 
 ### Mentions
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -170,7 +170,15 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun KtConstantExpression.isNamedArgument(): Boolean {
-        val valueArgument = ((parent as? KtPrefixExpression)?.parent ?: parent) as? KtValueArgument
+        /**
+         * The information we need is in the enclosing [KtValueArgument]. When the number being evaluated is
+         * negative, there will be an [KtPrefixExpression] in between the receiver and the [KtValueArgument].
+         */
+        val valueArgument = when (parent) {
+            is KtPrefixExpression -> parent.parent
+            else -> parent
+        } as? KtValueArgument
+
         return valueArgument?.isNamed() == true && isPartOf<KtCallElement>()
     }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -169,8 +169,10 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
                 .removeSuffix("f")
     }
 
-    private fun KtConstantExpression.isNamedArgument() =
-        (parent as? KtValueArgument)?.isNamed() == true && isPartOf<KtCallElement>()
+    private fun KtConstantExpression.isNamedArgument(): Boolean {
+        val valueArgument = ((parent as? KtPrefixExpression)?.parent ?: parent) as? KtValueArgument
+        return valueArgument?.isNamed() == true && isPartOf<KtCallElement>()
+    }
 
     private fun KtConstantExpression.isPartOfFunctionReturnConstant() =
         parent is KtNamedFunction || parent is KtReturnExpression && parent.parent.children.size == 1

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -4,9 +4,9 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assert
 import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -554,6 +554,11 @@ class MagicNumberSpec : Spek({
                 it("should ignore numbers when 'ignoreNamedArgument' is set to true") {
                     val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NAMED_ARGUMENT to "true")))
                     assertThat(rule.lint(code("53"))).isEmpty()
+                }
+
+                it("should ignore numbers when 'ignoreNamedArgument' is set to true and value is negative") {
+                    val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NAMED_ARGUMENT to "true")))
+                    assertThat(rule.lint(code("-53"))).isEmpty()
                 }
 
                 it("should ignore named arguments in inheritance - #992") {


### PR DESCRIPTION
Fixes https://github.com/arturbosch/detekt/issues/530

