### PR TITLE
Minor change in the HTML report: Remove extra space when you copy the file path

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReport.kt
@@ -14,7 +14,6 @@ import kotlinx.html.HTMLTag
 import kotlinx.html.HtmlTagMarker
 import kotlinx.html.TagConsumer
 import kotlinx.html.attributesMapOf
-import kotlinx.html.br
 import kotlinx.html.details
 import kotlinx.html.div
 import kotlinx.html.h3
@@ -119,7 +118,6 @@ class HtmlOutputReport : OutputReport() {
         }
 
         if (finding.message.isNotEmpty()) {
-            br()
             span("message") { text(finding.message) }
         }
 

--- a/detekt-cli/src/main/resources/default-html-report-template.html
+++ b/detekt-cli/src/main/resources/default-html-report-template.html
@@ -31,6 +31,7 @@ h3 {
   font-size: 0.8em;
   color: #444444;
   display: block;
+  margin-top: 1pt;
 }
 .rule-container {
   border: 0.1em dashed #dddddd;

--- a/detekt-cli/src/main/resources/default-html-report-template.html
+++ b/detekt-cli/src/main/resources/default-html-report-template.html
@@ -25,10 +25,12 @@ h3 {
 .location {
   color: #690505;
   font-family: monospace;
+  display: block;
 }
 .message {
   font-size: 0.8em;
   color: #444444;
+  display: block;
 }
 .rule-container {
   border: 0.1em dashed #dddddd;

--- a/detekt-cli/src/test/resources/reports/HtmlOutputFormatTest.html
+++ b/detekt-cli/src/test/resources/reports/HtmlOutputFormatTest.html
@@ -31,6 +31,7 @@ h3 {
   font-size: 0.8em;
   color: #444444;
   display: block;
+  margin-top: 1pt;
 }
 .rule-container {
   border: 0.1em dashed #dddddd;

--- a/detekt-cli/src/test/resources/reports/HtmlOutputFormatTest.html
+++ b/detekt-cli/src/test/resources/reports/HtmlOutputFormatTest.html
@@ -25,10 +25,12 @@ h3 {
 .location {
   color: #690505;
   font-family: monospace;
+  display: block;
 }
 .message {
   font-size: 0.8em;
   color: #444444;
+  display: block;
 }
 .rule-container {
   border: 0.1em dashed #dddddd;
@@ -85,7 +87,7 @@ pre {
   <details id="id_a" open="open">
     <summary class="rule-container"><span class="rule">id_a: 2 </span><span class="description">Description id_a</span></summary>
     <ul>
-      <li><span class="location">src/main/com/sample/Sample1.kt:11:1</span><br><span class="message">Message finding 1</span>
+      <li><span class="location">src/main/com/sample/Sample1.kt:11:1</span><span class="message">Message finding 1</span>
         <pre><code><span class="lineno">   8 </span>
 <span class="lineno">   9 </span>
 <span class="lineno">  10 </span>
@@ -94,7 +96,7 @@ pre {
 <span class="lineno">  13 </span>
 </code></pre>
       </li>
-      <li><span class="location">src/main/com/sample/Sample2.kt:22:2</span><br><span class="message">Message finding 2</span></li>
+      <li><span class="location">src/main/com/sample/Sample2.kt:22:2</span><span class="message">Message finding 2</span></li>
     </ul>
   </details>
   <h3>Section 2: 1</h3>


### PR DESCRIPTION
# Description:
In the current version, if you perform a double click in the file path, an extra space is added at the end of the line (`Sample1.kt:11:1 `):
![image](https://user-images.githubusercontent.com/8472881/74246280-0685ff00-4cc3-11ea-9d84-7dbd4a9c6991.png)

If you copy this line and paste it in an Intellij IDE to find the file (using Search everywhere), the ide doesn't recognize it, you have to remove the end character.

My pr fixes this issue:
![image](https://user-images.githubusercontent.com/8472881/74248089-d855ee80-4cc5-11ea-8481-220546fe13e5.png)

So now `Sample1.kt:11:1 ` is changed to `Sample1.kt:11:1`.
