### PR TITLE
bump versions

### DIFF
--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     implementation(project(":detekt-core"))
     runtimeOnly(project(":detekt-rules"))
     implementation("com.beust:jcommander:$jcommanderVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:0.6.12")
+    implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.1")
 
     testImplementation(project(":detekt-test"))
     testImplementation(project(":detekt-rules"))

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputFormatTest.kt
@@ -115,7 +115,7 @@ class HtmlOutputFormatTest : Spek({
             Files.write(tmpReport, result.toByteArray())
 
             try {
-                assertThat(tmpReport).hasSameContentAs(Paths.get(resource("/reports/HtmlOutputFormatTest.html")))
+                assertThat(tmpReport).hasSameTextualContentAs(Paths.get(resource("/reports/HtmlOutputFormatTest.html")))
             } finally {
                 Files.delete(tmpReport)
             }
@@ -137,7 +137,7 @@ class HtmlOutputFormatTest : Spek({
             Files.write(tmpReport2, result2.toByteArray())
 
             try {
-                assertThat(tmpReport1).hasSameContentAs(tmpReport2)
+                assertThat(tmpReport1).hasSameTextualContentAs(tmpReport2)
             } finally {
                 Files.delete(tmpReport1)
                 Files.delete(tmpReport2)

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
     id("com.gradle.plugin-publish") version "0.10.1"
     id("com.jfrog.bintray") version "1.8.4"
     kotlin("jvm") version "1.3.61"
-    id("org.jetbrains.dokka") version "0.10.0"
+    id("org.jetbrains.dokka") version "0.10.1"
     id("com.github.ben-manes.versions") version "0.27.0"
     id("io.gitlab.arturbosch.detekt") version "1.5.1"
 }
@@ -22,8 +22,8 @@ group = "io.gitlab.arturbosch.detekt"
 version = "1.5.1"
 
 val spekVersion = "2.0.9"
-val junitPlatformVersion = "1.5.2"
-val assertjVersion = "3.14.0"
+val junitPlatformVersion = "1.6.0"
+val assertjVersion = "3.15.0"
 val detektFormattingVersion = "1.3.1"
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
 detektVersion=1.5.1
 
 # Project dependencies
-assertjVersion=3.14.0
+assertjVersion=3.15.0
 jcommanderVersion=1.78
-junitPlatformVersion=1.5.2
+junitPlatformVersion=1.6.0
 ktlintVersion=0.36.0
-reflectionsVersion=0.9.11
+reflectionsVersion=0.9.12
 spekVersion=2.0.9
 yamlVersion=1.25
 mockkVersion=1.9.3
@@ -14,7 +14,7 @@ mockkVersion=1.9.3
 artifactoryVersion=4.13.0
 bintrayVersion=1.8.4
 buildScanVersion=3.1.1
-dokkaVersion=0.10.0
+dokkaVersion=0.10.1
 gradleVersionsPluginVersion=0.27.0
 jacocoVersion=0.8.5
 kotlinVersion=1.3.61


### PR DESCRIPTION
Update version. The main purpose - bump kotlinx.html to newer version, [which inlines code](https://github.com/Kotlin/kotlinx.html/releases/tag/0.7.1) to reduce lambda allocations.

So new versions need less heap memory (potentially).

Other versions were updated just to keep all of them as latest.