### PR TITLE
Add tests for setting KtLint's config

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
@@ -29,7 +29,9 @@ class Indentation(config: Config) : FormattingRule(config) {
                 indentSize = indentSize,
                 continuationIndentSize = continuationIndentSize)
     }
-}
 
-private const val INDENT_SIZE = "indentSize"
-private const val CONTINUATION_INDENT_SIZE = "continuationIndentSize"
+    companion object {
+        const val INDENT_SIZE = "indentSize"
+        const val CONTINUATION_INDENT_SIZE = "continuationIndentSize"
+    }
+}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MaximumLineLength.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MaximumLineLength.kt
@@ -34,6 +34,6 @@ class MaximumLineLength(config: Config) : FormattingRule(config) {
     }
 
     companion object {
-        private const val MAX_LINE_LENGTH = "maxLineLength"
+        const val MAX_LINE_LENGTH = "maxLineLength"
     }
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
@@ -26,6 +26,8 @@ class ParameterListWrapping(config: Config) : FormattingRule(config) {
         EditorConfig.merge(it,
                 indentSize = indentSize)
     }
-}
 
-private const val INDENT_SIZE = "indentSize"
+    companion object {
+        const val INDENT_SIZE = "indentSize"
+    }
+}

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ChainWrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ChainWrappingSpec.kt
@@ -7,7 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
-class ChainWrappingRegressionSpec : Spek({
+class ChainWrappingSpec : Spek({
     describe("tests integration of formatting") {
 
         it("should work like KtLint") {

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
@@ -8,7 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
-class FinalNewlineRegressionSpec : Spek({
+class FinalNewlineSpec : Spek({
 
     describe("FinalNewline rule") {
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
@@ -1,0 +1,35 @@
+package io.gitlab.arturbosch.detekt.formatting
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.wrappers.Indentation
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class IndentationSpec : Spek({
+
+    val subject by memoized { Indentation(Config.empty) }
+
+    describe("Indentation rule") {
+
+        describe("indentation level equals 1") {
+
+            val code = "fun main() {\n println()\n}"
+
+            it("reports wrong indentation level") {
+                assertThat(subject.lint(code)).hasSize(1)
+            }
+
+            it("does not report when using an indentation level config of 1") {
+                val config = TestConfig(Indentation.INDENT_SIZE to "1")
+                assertThat(Indentation(config).lint(code)).isEmpty()
+            }
+        }
+
+        it("does not report correct indentation level") {
+            val code = "fun main() {\n    println()\n}"
+            assertThat(subject.lint(code)).isEmpty()
+        }
+    }
+})

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
@@ -1,0 +1,37 @@
+package io.gitlab.arturbosch.detekt.formatting
+
+import io.gitlab.arturbosch.detekt.formatting.wrappers.MaximumLineLength
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class MaximumLineLengthSpec : Spek({
+
+    val subject by memoized {
+        val config = TestConfig(MaximumLineLength.MAX_LINE_LENGTH to "10")
+        MaximumLineLength(config)
+    }
+
+    describe("MaximumLineLength rule") {
+
+        describe("a single function") {
+
+            val code = "fun f() { }"
+
+            it("reports line which exceeds the threshold") {
+                assertThat(subject.lint(code)).hasSize(1)
+            }
+
+            it("does not report line which does not exceed the threshold") {
+                val config = TestConfig(MaximumLineLength.MAX_LINE_LENGTH to "11")
+                assertThat(MaximumLineLength(config).lint(code)).isEmpty()
+            }
+        }
+
+        it("does not report line which does not exceed the threshold") {
+            val code = "val a = 1"
+            assertThat(subject.lint(code)).isEmpty()
+        }
+    }
+})

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ParameterListWrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ParameterListWrappingSpec.kt
@@ -1,0 +1,35 @@
+package io.gitlab.arturbosch.detekt.formatting
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.wrappers.ParameterListWrapping
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class ParameterListWrappingSpec : Spek({
+
+    val subject by memoized { ParameterListWrapping(Config.empty) }
+
+    describe("ParameterListWrapping rule") {
+
+        describe("indent size equals 1") {
+
+            val code = "fun f(\n a: Int\n) {}"
+
+            it("reports wrong indent size") {
+                assertThat(subject.lint(code)).hasSize(1)
+            }
+
+            it("does not report when using an indentation level config of 1") {
+                val config = TestConfig(ParameterListWrapping.INDENT_SIZE to "1")
+                assertThat(ParameterListWrapping(config).lint(code)).isEmpty()
+            }
+        }
+
+        it("does not report correct ParameterListWrapping level") {
+            val code = "fun f(\n    a: Int\n) {}"
+            assertThat(subject.lint(code)).isEmpty()
+        }
+    }
+})


### PR DESCRIPTION
The tests assert that the config options for KtLints rules are set correctly via detekt.