### PR TITLE
showcase use Atrium instead of AssertJ

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,6 @@ tasks.withType<Detekt> {
 }
 
 val detektVersion: String by project
-val assertjVersion: String by project
 val spekVersion: String by project
 val reflectionsVersion: String by project
 val mockkVersion: String by project
@@ -302,7 +301,6 @@ subprojects {
         detekt(project(":detekt-cli"))
         detektPlugins(project(":detekt-formatting"))
 
-        testImplementation("org.assertj:assertj-core:$assertjVersion")
         testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
         testImplementation("org.reflections:reflections:$reflectionsVersion")
         testImplementation("io.mockk:mockk:$mockkVersion")

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -1,12 +1,11 @@
 package io.gitlab.arturbosch.detekt.cli
 
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import ch.tutteli.atrium.api.verbs.expect
 import com.beust.jcommander.ParameterException
 import io.gitlab.arturbosch.detekt.test.resource
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import java.nio.file.Path
 import java.nio.file.Paths
 
 internal class CliArgsSpec : Spek({
@@ -17,14 +16,12 @@ internal class CliArgsSpec : Spek({
 
         it("the current working directory is used if parameter is not set") {
             val cli = parseArguments<CliArgs>(emptyArray())
-            assertThat(cli.inputPaths).hasSize(1)
-            assertThat(cli.inputPaths.first()).isEqualTo(Paths.get(System.getProperty("user.dir")))
+            expect(cli.inputPaths).containsExactly(Paths.get(System.getProperty("user.dir")))
         }
 
         it("a single value is converted to a path") {
             val cli = parseArguments<CliArgs>(arrayOf("--input", "$projectPath"))
-            assertThat(cli.inputPaths).hasSize(1)
-            assertThat(cli.inputPaths.first().toAbsolutePath()).isEqualTo(projectPath)
+            expect(cli.inputPaths).containsExactly(projectPath)
         }
 
         it("multiple input paths can be separated by comma") {
@@ -33,22 +30,24 @@ internal class CliArgsSpec : Spek({
             val cli = parseArguments<CliArgs>(arrayOf(
                 "--input", "$mainPath,$testPath")
             )
-            assertThat(cli.inputPaths).hasSize(2)
-            assertThat(cli.inputPaths.map(Path::toAbsolutePath)).containsExactlyInAnyOrder(mainPath, testPath)
+            expect(cli.inputPaths).contains.inAnyOrder.only.values(mainPath, testPath)
         }
 
         it("reports an error if the input path does not exist") {
             val pathToNonExistentDirectory = projectPath.resolve("nonExistent")
             val params = arrayOf("--input", "$pathToNonExistentDirectory")
 
-            assertThatExceptionOfType(ParameterException::class.java)
-                .isThrownBy { parseArguments<CliArgs>(params).inputPaths }
-                .withMessageContaining("does not exist")
+            expect {
+                parseArguments<CliArgs>(params).inputPaths
+            }.toThrow<ParameterException> {
+                messageContains("does not exist")
+            }
         }
 
         it("reports an error when using --create-baseline without a --baseline file") {
-            assertThatExceptionOfType(HandledArgumentViolation::class.java)
-                .isThrownBy { buildRunner(arrayOf("--create-baseline")) }
+            expect{
+                buildRunner(arrayOf("--create-baseline"))
+            }.toThrow<HandledArgumentViolation>()
         }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigurationsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigurationsSpec.kt
@@ -5,11 +5,8 @@ import ch.tutteli.atrium.api.verbs.expect
 import com.beust.jcommander.ParameterException
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
-import io.gitlab.arturbosch.detekt.test.hasKeyValue
-import io.gitlab.arturbosch.detekt.test.hasNotKey
-import io.gitlab.arturbosch.detekt.test.isIgnored
-import io.gitlab.arturbosch.detekt.test.isNotIgnored
-import io.gitlab.arturbosch.detekt.test.resource
+import io.gitlab.arturbosch.detekt.test.*
+import org.assertj.core.api.Assertions
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -26,6 +23,23 @@ internal class ConfigurationsSpec : Spek({
                 hasNotKey("three")
             }
         }
+
+        it("fail on purpose with AssertJ - should be an empty config") {
+            val config = CliArgs().loadConfiguration()
+            Assertions.assertThat(config.valueOrDefault("one", -1)).isEqualTo(1)
+            Assertions.assertThat(config.valueOrDefault("two", -1)).isEqualTo(1)
+            Assertions.assertThat(config.valueOrDefault("three", -1)).isEqualTo(1)
+        }
+
+        it("fail on purpose with Atrium - should be an empty config") {
+            val config = CliArgs().loadConfiguration()
+            expect(config) {
+                hasKey("one")
+                hasKey("two")
+                hasKey("three")
+            }
+        }
+
     }
 
     describe("parse different path based configuration settings") {
@@ -61,6 +75,32 @@ internal class ConfigurationsSpec : Spek({
             expect { CliArgs { config = "," }.loadConfiguration() }.toThrow<IllegalArgumentException>()
             expect { CliArgs { config = "sfsjfsdkfsd" }.loadConfiguration() }.toThrow<ParameterException>()
             expect { CliArgs { config = "./i.do.not.exist.yml" }.loadConfiguration() }.toThrow<ParameterException>()
+        }
+
+
+
+        it("fail on purpose with AssertJ - should load three configs") {
+            val config = CliArgs { config = "$pathOne, $pathTwo;$pathThree" }.loadConfiguration()
+            Assertions.assertThat(config.valueOrDefault("one", -1)).isEqualTo(1)
+            Assertions.assertThat(config.valueOrDefault("two", -1)).isEqualTo(200)
+            Assertions.assertThat(config.valueOrDefault("three", -1)).isEqualTo(3)
+        }
+
+        it("fail on purpose with Atrium -should load three configs") {
+            val config = CliArgs { config = "$pathOne, $pathTwo;$pathThree" }.loadConfiguration()
+            expect(config) {
+                hasKeyValue("one", 1)
+                hasKeyValue("two", 200)
+                hasKeyValue("three", 3)
+            }
+        }
+
+        it("fail on purpose with AssertJ - should fail on invalid config value") {
+            Assertions.assertThatExceptionOfType(ParameterException::class.java).isThrownBy { CliArgs { config = "," }.loadConfiguration() }
+        }
+
+        it("fail on purpose with Atrium - should fail on invalid config value") {
+            expect { CliArgs { config = "," }.loadConfiguration() }.toThrow<ParameterException>()
         }
     }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
@@ -1,12 +1,13 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
+import ch.tutteli.atrium.api.fluent.en_GB.get
+import ch.tutteli.atrium.api.fluent.en_GB.isA
+import ch.tutteli.atrium.api.fluent.en_GB.toBe
+import ch.tutteli.atrium.api.verbs.expect
 import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
 import io.gitlab.arturbosch.detekt.rules.Case
-import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.isThresholded
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.*
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -83,6 +84,17 @@ class ComplexMethodSpec : Spek({
                     .withThreshold(1)
             }
 
+            fun executeAtrium(config: TestConfig, expectedValue: Int) {
+                val findings = ComplexMethod(config, threshold = 1).lint(code)
+                expect(findings) {
+                    hasSourceLocations(SourceLocation(1, 5))
+                    get(0).isA<ThresholdedCodeSmell> {
+                        value.toBe(expectedValue)
+                        threshhold.toBe(1)
+                    }
+                }
+            }
+
             it("counts three with nesting function 'forEach'") {
                 val config = TestConfig(mapOf(ComplexMethod.IGNORE_NESTING_FUNCTIONS to "false"))
                 execute(config, expectedValue = 3)
@@ -101,6 +113,16 @@ class ComplexMethodSpec : Spek({
             it("skips 'forEach' as it is not specified") {
                 val config = TestConfig(mapOf(ComplexMethod.NESTING_FUNCTIONS to "let,apply,also"))
                 execute(config, expectedValue = 2)
+            }
+
+            it("fail on purpose AssertJ - skips 'forEach' as it is not specified") {
+                val config = TestConfig(mapOf(ComplexMethod.NESTING_FUNCTIONS to "let,apply,also"))
+                execute(config, expectedValue = 4)
+            }
+
+            it("fail on purpose Atrium - skips 'forEach' as it is not specified") {
+                val config = TestConfig(mapOf(ComplexMethod.NESTING_FUNCTIONS to "let,apply,also"))
+                executeAtrium(config, expectedValue = 4)
             }
         }
 

--- a/detekt-test/build.gradle.kts
+++ b/detekt-test/build.gradle.kts
@@ -1,4 +1,5 @@
 val assertjVersion: String by project
+val atriumVersion: String by project
 
 dependencies {
     implementation(kotlin("script-runtime"))
@@ -6,5 +7,7 @@ dependencies {
     implementation(kotlin("scripting-compiler-embeddable"))
 
     api(project(":detekt-core"))
-    implementation("org.assertj:assertj-core:$assertjVersion")
+    api("org.assertj:assertj-core:$assertjVersion")
+    api("ch.tutteli.atrium:atrium-fluent-en_GB:$atriumVersion")
+    api("ch.tutteli.atrium:atrium-api-fluent-en_GB-jdk8:$atriumVersion")
 }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/AtriumExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/AtriumExtensions.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.test
 
 import ch.tutteli.atrium.api.fluent.en_GB.feature
+import ch.tutteli.atrium.api.fluent.en_GB.notToBe
 import ch.tutteli.atrium.api.fluent.en_GB.toBe
 import ch.tutteli.atrium.creating.Expect
 import ch.tutteli.atrium.domain.builders.ExpectImpl
@@ -12,6 +13,10 @@ import java.nio.file.Paths
 
 fun <T : Config> Expect<T>.hasNotKey(key: String): Expect<T> =
     _valueOrNull<T, Any>(this, key) { toBe(null) }
+
+fun <T : Config> Expect<T>.hasKey(key: String): Expect<T> =
+    _valueOrNull<T, Any>(this, key) { notToBe(null) }
+
 
 fun <T : Config, V : Any> Expect<T>.hasKeyValue(key: String, value: V): Expect<T> =
     _valueOrNull<T, V>(this, key) { toBe(value) }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/AtriumExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/AtriumExtensions.kt
@@ -1,0 +1,52 @@
+package io.gitlab.arturbosch.detekt.test
+
+import ch.tutteli.atrium.api.fluent.en_GB.feature
+import ch.tutteli.atrium.api.fluent.en_GB.toBe
+import ch.tutteli.atrium.creating.Expect
+import ch.tutteli.atrium.domain.builders.ExpectImpl
+import ch.tutteli.atrium.domain.creating.changers.ExtractedFeaturePostStep
+import ch.tutteli.atrium.reporting.RawString
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.PathFilters
+import java.nio.file.Paths
+
+fun <T : Config> Expect<T>.hasNotKey(key: String): Expect<T> =
+    _valueOrNull<T, Any>(this, key) { toBe(null) }
+
+fun <T : Config, V : Any> Expect<T>.hasKeyValue(key: String, value: V): Expect<T> =
+    _valueOrNull<T, V>(this, key) { toBe(value) }
+
+private fun <T : Config, V : Any> _valueOrNull(
+    expect: Expect<T>,
+    key: String,
+    assertionCreator: Expect<V?>.() -> Unit
+): Expect<T> =
+    expect.feature("valueOrNull($key)", { valueOrNull(key) }, assertionCreator)
+
+fun <T : Config, V : Any> Expect<T>.valueOrDefault(
+    key: String,
+    default: V
+): Expect<V> = _valueOrDefault(this, key, default).getExpectOfFeature()
+
+fun <T : Config, V : Any> Expect<T>.valueOrDefault(
+    key: String,
+    default: V,
+    assertionCreator: Expect<V>.() -> Unit
+): Expect<T> = _valueOrDefault(this, key, default).addToInitial(assertionCreator)
+
+private fun <T : Config, V : Any> _valueOrDefault(
+    expect: Expect<T>,
+    key: String,
+    default: V
+): ExtractedFeaturePostStep<T, V> = ExpectImpl.feature.manualFeature(expect, "valueOrDefault($key, $default)") {
+    valueOrDefault(key, default)
+}
+
+fun Expect<PathFilters?>.isIgnored(pathAsString: String) =
+    createAndAddAssertion("is", RawString.create("ignored")) { it?.isIgnored(Paths.get(pathAsString)) == true }
+
+fun Expect<PathFilters?>.isNotIgnored(pathAsString: String) =
+    createAndAddAssertion(
+        "is not",
+        RawString.create("ignored")
+    ) { it?.isIgnored(Paths.get(pathAsString)) == false }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -1,5 +1,7 @@
 package io.gitlab.arturbosch.detekt.test
 
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import ch.tutteli.atrium.creating.Expect
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
@@ -12,6 +14,15 @@ fun assertThat(findings: List<Finding>) = FindingsAssert(findings)
 fun assertThat(finding: Finding) = FindingAssert(finding)
 
 fun List<Finding>.assert() = FindingsAssert(this)
+
+fun<E: Finding, T: Iterable<E>> Expect<T>.hasSourceLocations(vararg expected: SourceLocation): Expect<T> =
+    feature("sorted source locations", {
+        asSequence().map { it.location.source }.sortedWith(compareBy({ it.line }, { it.column })).toList()
+    }) {
+        contains.inOrder.only.elementsOf(
+            expected.asSequence().sortedWith(compareBy({ it.line }, { it.column })).toList()
+        )
+    }
 
 class FindingsAssert(actual: List<Finding>) :
         AbstractListAssert<FindingsAssert, List<Finding>,

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert.kt
@@ -1,9 +1,14 @@
 package io.gitlab.arturbosch.detekt.test
 
+import ch.tutteli.atrium.api.fluent.en_GB.feature
+import ch.tutteli.atrium.creating.Expect
 import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
 import org.assertj.core.api.AbstractAssert
 
 fun assertThat(thresholdedCodeSmell: ThresholdedCodeSmell) = ThresholdedCodeSmellAssert(thresholdedCodeSmell)
+
+val <T: ThresholdedCodeSmell> Expect<T>.value get(): Expect<Int> = feature(ThresholdedCodeSmell::value)
+val <T: ThresholdedCodeSmell> Expect<T>.threshhold get(): Expect<Int> = feature(ThresholdedCodeSmell::threshold)
 
 fun FindingAssert.isThresholded(): ThresholdedCodeSmellAssert {
     isNotNull

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ detektVersion=1.5.1
 
 # Project dependencies
 assertjVersion=3.15.0
+atriumVersion=0.9.2
 jcommanderVersion=1.78
 junitPlatformVersion=1.6.0
 ktlintVersion=0.36.0


### PR DESCRIPTION
This PR shows how the usage of Atrium could look like in detekt. I took CliArgsSpec not for special reasons (was the first Spec in detekt-cli) and rewrote ConfigSpec as well as they kind of relate.

Why Atrium and not AssertJ? IMO Atrium:
- has a more readable API
- has better error reporting
- is easy extendable

I have to say, I am of course biased as I am the author of Atrium. Personally, I am mainly interested in migrating detekt to Atrium as it would be a good use case to see how well I can migrate an AssertJ project to Atrium. I am not really an active contributor to detekt; I mainly report bugs. Therefore, you should of course think about if you see the value of Atrium as well or not. 

Please let me know if you are interested in Atrium, I would continue with re-writing the assertions in case you want to switch.
