### PR TITLE
Don't normalize file content twice

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
@@ -25,8 +25,7 @@ open class KtCompiler(
         val absolutePath = subPath.toAbsolutePath().normalize()
         val content = subPath.toFile().readText()
         val lineSeparator = content.determineLineSeparator()
-        val normalizedContent = StringUtilRt.convertLineSeparators(content)
-        val ktFile = createKtFile(normalizedContent, absolutePath)
+        val ktFile = createKtFile(content, absolutePath)
 
         return ktFile.apply {
             putUserData(LINE_SEPARATOR, lineSeparator)


### PR DESCRIPTION
File content is normalised in `createKtFile` so there's no need to normalise content before passing the string to that function.