### PR TITLE
Fix detection of CRLF line endings

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
@@ -52,5 +52,5 @@ internal fun String.determineLineSeparator(): String {
     if (i == -1) {
         return if (this.lastIndexOf('\r') == -1) System.getProperty("line.separator") else "\r"
     }
-    return if (i != 0 && this[i] == '\r') "\r\n" else "\n"
+    return if (i != 0 && this[i - 1] == '\r') "\r\n" else "\n"
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtCompilerTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtCompilerTest.kt
@@ -13,7 +13,7 @@ class KtCompilerTest : Spek({
 
             val ktFile = ktCompiler.compile(path, path.resolve("Default.kt"))
 
-            assertThat(ktFile.getUserData(LINE_SEPARATOR)).isEqualTo("\n")
+            assertThat(ktFile.getUserData(LINE_SEPARATOR)).isEqualTo(System.lineSeparator())
             assertThat(ktFile.getUserData(RELATIVE_PATH))
                     .isEqualTo(path.fileName.resolve("Default.kt").toString())
         }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtCompilerTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtCompilerTest.kt
@@ -18,4 +18,18 @@ class KtCompilerTest : Spek({
                     .isEqualTo(path.fileName.resolve("Default.kt").toString())
         }
     }
+
+    describe("line ending detection") {
+        it("detects CRLF line endings") {
+            assertThat("1\r\n2".determineLineSeparator()).isEqualTo("\r\n")
+        }
+
+        it("detects LF line endings") {
+            assertThat("1\n2".determineLineSeparator()).isEqualTo("\n")
+        }
+
+        it("detects CR line endings") {
+            assertThat("1\r2".determineLineSeparator()).isEqualTo("\r")
+        }
+    }
 })


### PR DESCRIPTION
Corrects logic to check that the character before the last '\n' is '\r', and if so, correctly report CRLF ("\r\n") line endings.

The current logic is checking the same character position that '\r' was found in also contains '\n' which always evaluates to `false`.