### PR TITLE
Extend AnnotationExcluder to catch fully qualified annotations

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
@@ -14,12 +14,12 @@ class AnnotationExcluder(
 ) {
 
     private var resolvedAnnotations = root.importList
-        ?.imports
-        ?.asSequence()
-        ?.filterNot { it.isAllUnder }
-        ?.mapNotNull { it.importedFqName?.asString() }
-        ?.map { it.substringAfterLast('.') to it }
-        ?.toMap() ?: emptyMap()
+            ?.imports
+            ?.asSequence()
+            ?.filterNot { it.isAllUnder }
+            ?.mapNotNull { it.importedFqName?.asString() }
+            ?.map { it.substringAfterLast('.') to it }
+            ?.toMap() ?: emptyMap()
 
     /**
      * Is true if any given annotation name is declared in the SplitPattern
@@ -30,9 +30,9 @@ class AnnotationExcluder(
 
     private fun isExcluded(annotation: KtAnnotationEntry): Boolean {
         val annotationText = annotation.typeReference?.text
-
-        return if (resolvedAnnotations.containsKey(annotationText)) {
-            resolvedAnnotations[annotationText]?.let { excludes.contains(it) } ?: false
+        val value = resolvedAnnotations[annotationText]
+        return if (value != null) {
+            excludes.contains(value)
         } else {
             excludes.contains(annotationText)
         }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
@@ -31,19 +31,10 @@ class AnnotationExcluder(
     private fun isExcluded(annotation: KtAnnotationEntry): Boolean {
         val annotationText = annotation.typeReference?.text
 
-        // We check if resolvedAnnotations for annotation both in the keys and in the
-        // values set to catch usages of fully qualified annotations
-        // (eg. @Module and @dagger.Module).
-        return when {
-            resolvedAnnotations.containsKey(annotationText) -> {
-                resolvedAnnotations[annotationText]?.let { excludes.contains(it) } ?: false
-            }
-            resolvedAnnotations.containsValue(annotationText) -> {
-                excludes.contains(annotationText)
-            }
-            else -> {
-                false
-            }
+        return if (resolvedAnnotations.containsKey(annotationText)) {
+            resolvedAnnotations[annotationText]?.let { excludes.contains(it) } ?: false
+        } else {
+            excludes.contains(annotationText)
         }
     }
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
@@ -32,7 +32,7 @@ class AnnotationExcluder(
         val annotationText = annotation.typeReference?.text
 
         // We check if resolvedAnnotations for annotation both in the keys and in the
-        // values set to catch usages of fully qualified annotations 
+        // values set to catch usages of fully qualified annotations
         // (eg. @Module and @dagger.Module).
         return when {
             resolvedAnnotations.containsKey(annotationText) -> {

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
@@ -41,9 +41,9 @@ class AnnotationExcluderSpec : Spek({
             assertThat(excluder.shouldExclude(listOf(fullyQualifiedJvmFieldAnnotation))).isTrue()
         }
 
-        it("should not exclude an annotation that is not imported") {
+        it("should also exclude an annotation that is not imported") {
             val excluder = AnnotationExcluder(file, SplitPattern("SinceKotlin"))
-            assertThat(excluder.shouldExclude(listOf(sinceKotlinAnnotation))).isFalse()
+            assertThat(excluder.shouldExclude(listOf(sinceKotlinAnnotation))).isTrue()
         }
     }
 })

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
@@ -12,6 +12,7 @@ class AnnotationExcluderSpec : Spek({
 
     describe("a kt file with some imports") {
         val jvmFieldAnnotation = psiFactory.createAnnotationEntry("@JvmField")
+        val fullyQualifiedJvmFieldAnnotation = psiFactory.createAnnotationEntry("@kotlin.jvm.JvmField")
         val sinceKotlinAnnotation = psiFactory.createAnnotationEntry("@SinceKotlin")
 
         val file = compileContentForTest("""
@@ -33,6 +34,11 @@ class AnnotationExcluderSpec : Spek({
         it("should not exclude when no annotations should be excluded") {
             val excluder = AnnotationExcluder(file, SplitPattern(""))
             assertThat(excluder.shouldExclude(listOf(jvmFieldAnnotation))).isFalse()
+        }
+
+        it("should exclude when the annotation was found with its fully qualified name") {
+            val excluder = AnnotationExcluder(file, SplitPattern("JvmField"))
+            assertThat(excluder.shouldExclude(listOf(fullyQualifiedJvmFieldAnnotation))).isTrue()
         }
 
         it("should not exclude an annotation that is not imported") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -52,18 +52,6 @@ class UnnecessaryAbstractClassSpec : Spek({
                 assertThat(countViolationsWithDescription(findings, noConcreteMemberDescription)).isEqualTo(0)
             }
         }
-
-        it("abstract class with fully qualified annotations usage"){
-            val code = """
-                @jdk.nashorn.internal.ir.annotations.Ignore
-                abstract class AUselessAbstractClass {
-                    abstract fun doSomething(): Int
-                }
-            """.trimIndent()
-
-            val findings = subject.compileAndLint(code)
-            assertThat(findings).isEmpty()
-        }
     }
 })
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -55,8 +55,6 @@ class UnnecessaryAbstractClassSpec : Spek({
 
         it("abstract class with fully qualified annotations usage"){
             val code = """
-                import jdk.nashorn.internal.ir.annotations.Ignore
-                
                 @jdk.nashorn.internal.ir.annotations.Ignore
                 abstract class AUselessAbstractClass {
                     abstract fun doSomething(): Int

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -3,6 +3,8 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
@@ -49,6 +51,20 @@ class UnnecessaryAbstractClassSpec : Spek({
             it("does not report no concrete member violation") {
                 assertThat(countViolationsWithDescription(findings, noConcreteMemberDescription)).isEqualTo(0)
             }
+        }
+
+        it("abstract class with fully qualified annotations usage"){
+            val code = """
+                import jdk.nashorn.internal.ir.annotations.Ignore
+                
+                @jdk.nashorn.internal.ir.annotations.Ignore
+                abstract class AUselessAbstractClass {
+                    abstract fun doSomething(): Int
+                }
+            """.trimIndent()
+
+            val findings = subject.compileAndLint(code)
+            assertThat(findings).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/resources/cases/UnnecessaryAbstractClassNegative.kt
+++ b/detekt-rules/src/test/resources/cases/UnnecessaryAbstractClassNegative.kt
@@ -29,3 +29,8 @@ abstract class AbstractClassDerivedFrom : EmptyAbstractClass1() {
 abstract class AbstractClassWithModuleAnnotation {
     abstract fun binds(foo: Integer): Number
 }
+
+@jdk.nashorn.internal.ir.annotations.Ignore
+abstract class AbstractClassWithModuleAnnotation {
+    abstract fun binds(foo: Integer): Number
+}


### PR DESCRIPTION
Currently `AnnotationExcluder` is not handling usages of fully qualified annotations (eg. `@dagger.Module`). This is causing the failure reported in #2360.
I'm extending it to catch both simple and fully qualified annotations.

Fixes #2360 
