### PR TITLE
Improve travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,7 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
+    - $HOME/.gradle/caches/modules-2/
+    - $HOME/.gradle/wrapper/dists/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,11 +39,10 @@ test_script:
 
 after_test:
   - ps: del C:\Users\appveyor\.gradle\caches\modules-2\modules-2.lock
-  - ps: del -Recurse C:\Users\appveyor\.gradle\caches\*\plugin-resolution
 
 cache:
-  - C:\Users\appveyor\.gradle\wrapper
-  - C:\Users\appveyor\.gradle\caches
+  - C:\Users\appveyor\.gradle\wrapper\dists
+  - C:\Users\appveyor\.gradle\caches\modules-2
 
 on_finish:
   - ps: |


### PR DESCRIPTION
Don't cache no important parts of gradle that invalidate the cache each time.
This invalidation consumes 60~80 seconds each run.

<img width="1011" alt="Captura de pantalla 2020-02-23 a las 11 17 08" src="https://user-images.githubusercontent.com/721244/75110396-0fb18d00-562e-11ea-805e-7d6f6ec8f64c.png">

And, because we are caching less things, the restore should be a bit faster.