### PR TITLE
Add --version to cli

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -173,6 +173,12 @@ class CliArgs : Args {
     )
     var jvmTarget: JvmTarget = JvmTarget.DEFAULT
 
+    @Parameter(
+        names = ["--version"],
+        description = "Prints the detekt CLI version."
+    )
+    var showVersion: Boolean = false
+
     val inputPaths: List<Path> by lazy {
         MultipleExistingPathConverter().convert(input ?: System.getProperty("user.dir"))
     }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.cli.runners.ConfigExporter
 import io.gitlab.arturbosch.detekt.cli.runners.Executable
 import io.gitlab.arturbosch.detekt.cli.runners.Runner
 import io.gitlab.arturbosch.detekt.cli.runners.SingleRuleRunner
+import io.gitlab.arturbosch.detekt.cli.runners.VersionPrinter
 import java.io.PrintStream
 import kotlin.system.exitProcess
 
@@ -48,6 +49,7 @@ fun buildRunner(
         }
     }
     return when {
+        arguments.showVersion -> VersionPrinter(outputPrinter)
         arguments.generateConfig -> ConfigExporter(arguments)
         arguments.runRule != null -> SingleRuleRunner(arguments)
         arguments.printAst -> AstPrinter(arguments)

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/VersionPrinter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/VersionPrinter.kt
@@ -1,0 +1,16 @@
+package io.gitlab.arturbosch.detekt.cli.runners
+
+import io.gitlab.arturbosch.detekt.core.whichDetekt
+import java.io.PrintStream
+
+class VersionPrinter(private val outputPrinter: PrintStream) : Executable {
+
+    override fun execute() {
+        val version = whichDetekt()
+        if (version != null) {
+            outputPrinter.println(version)
+        } else {
+            throw IllegalStateException("Can't find the detekt version")
+        }
+    }
+}

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.cli.runners.AstPrinter
 import io.gitlab.arturbosch.detekt.cli.runners.ConfigExporter
 import io.gitlab.arturbosch.detekt.cli.runners.Runner
 import io.gitlab.arturbosch.detekt.cli.runners.SingleRuleRunner
+import io.gitlab.arturbosch.detekt.cli.runners.VersionPrinter
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -22,10 +23,12 @@ class MainSpec : Spek({
                     arrayOf("--generate-config"),
                     arrayOf("--run-rule", "Rule"),
                     arrayOf("--print-ast"),
+                    arrayOf("--version"),
                     emptyArray()
                 ).forEach { args ->
 
                     val expectedRunnerClass = when {
+                        args.contains("--version") -> VersionPrinter::class
                         args.contains("--generate-config") -> ConfigExporter::class
                         args.contains("--run-rule") -> SingleRuleRunner::class
                         args.contains("--print-ast") -> AstPrinter::class

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/VersionPrinterSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/VersionPrinterSpec.kt
@@ -1,0 +1,24 @@
+package io.gitlab.arturbosch.detekt.cli.runners
+
+import io.gitlab.arturbosch.detekt.core.Detektor
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.Charset
+
+class VersionPrinterSpec : Spek({
+
+    describe("version printer") {
+
+        it("print the version") {
+            val byteArrayOutputStream = ByteArrayOutputStream()
+
+            VersionPrinter(PrintStream(byteArrayOutputStream)).execute()
+
+            assertThat(String(byteArrayOutputStream.toByteArray(), Charset.forName("UTF-8")))
+                .isEqualTo("1.6.0" + System.lineSeparator())
+        }
+    }
+})

--- a/detekt-cli/src/test/resources/META-INF/MANIFEST.MF
+++ b/detekt-cli/src/test/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+DetektVersion: 1.6.0
+


### PR DESCRIPTION
Closes #2382

This PR adds the --version flag. It prints the version of the running detekt cli.

I have a problem testing this. And It's that `whichVersion()` retutns `null` in test mode. Any idea?