### PR TITLE
Add documentation for cli --version flag

### DIFF
--- a/docs/pages/gettingstarted/cli.md
+++ b/docs/pages/gettingstarted/cli.md
@@ -99,5 +99,6 @@ Usage: detekt [options]
       Entry should consist of: [report-id:path]. Available 'report-id' values:
       'txt', 'xml', 'html'. These can also be used in combination with each
       other e.g. '-r txt:reports/detekt.txt -r xml:reports/detekt.xml'
-
+    --version
+      Prints the detekt CLI version.
 ```


### PR DESCRIPTION
Successor of #2383 since this flag should also be mentioned on the homepage.