### PR TITLE
Discourage new Case files

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/Case.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/Case.kt
@@ -4,6 +4,8 @@ import io.gitlab.arturbosch.detekt.test.resource
 import java.nio.file.Path
 import java.nio.file.Paths
 
+/* Do not add new elements to this file.
+   See https://github.com/arturbosch/detekt/issues/1089 */
 enum class Case(val file: String) {
     CollapsibleIfsPositive("/cases/CollapsibleIfsPositive.kt"),
     CollapsibleIfsNegative("/cases/CollapsibleIfsNegative.kt"),

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/Case.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/Case.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.test.resource
 import java.nio.file.Path
 import java.nio.file.Paths
 
-/* Do not add new elements to this file.
+/* Do not add new elements to this file. Instead, use inline code snippets within the tests.
    See https://github.com/arturbosch/detekt/issues/1089 */
 enum class Case(val file: String) {
     CollapsibleIfsPositive("/cases/CollapsibleIfsPositive.kt"),


### PR DESCRIPTION
Closes #1089 

That issue will remain open until all case files are retired, which may take a long time as it's quite a thankless task - instead, add a comment asking contributors not to add new case files with a reference to the PR so the PR can be closed.