### PR TITLE
Only post a code coverage patch status to PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,3 +11,7 @@ coverage:
       default:
         # Fail the status if coverage drops by >= 0.1%
         threshold: 0.1
+    patch:
+      default:
+        # Only post a patch status to pull requests
+        only_pulls: true


### PR DESCRIPTION
This affects the codecov coverage reports.
Patch coverage reports should only run on PRs.
It provides information concerning how well the changes made in a PR were tested.
Previously, many patch reports have failed already merged PRs on the master branch.
The total coverage is not affected by this commit.
See:
https://docs.codecov.io/docs/commit-status#section-only-pulls
