### PR TITLE
Stop compiling with experimental flag

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -184,8 +184,7 @@ subprojects {
         kotlinOptions.freeCompilerArgs = listOf(
             "-progressive",
             "-Xskip-runtime-version-check",
-            "-Xdisable-default-scripting-plugin",
-            "-Xuse-experimental=kotlin.Experimental"
+            "-Xdisable-default-scripting-plugin"
         )
         kotlinOptions.allWarningsAsErrors = shouldTreatCompilerWarningsAsErrors()
     }


### PR DESCRIPTION
It's not necessary now that the only usage of experimental code was removed in #2396 

It should also keep the code a little more stable as it won't be possible to accidentally introduce any experimental Kotlin features before they're ready.