### PR TITLE
Stop using kotlin-reflect

### DIFF
--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -11,7 +11,6 @@ val spekVersion: String by project
 dependencies {
     implementation("org.yaml:snakeyaml:$yamlVersion")
     api(kotlin("compiler-embeddable"))
-    implementation(kotlin("reflect"))
 
     testImplementation(project(":detekt-test"))
 }

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -88,7 +88,6 @@ dependencies {
     implementation(project(":detekt-rules"))
     implementation(project(":detekt-formatting"))
     implementation("com.beust:jcommander:$jcommanderVersion")
-    implementation(kotlin("reflect"))
 
     testImplementation(project(":detekt-test"))
 }

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -4,5 +4,4 @@ dependencies {
     implementation(project(":detekt-api"))
 
     testImplementation(project(":detekt-test"))
-    testImplementation(kotlin("reflect"))
 }


### PR DESCRIPTION
With Kotlin 1.3.70 it's no longer necessary to use the reflect library for some code that previously required it (e.g. kClass.simpleName).

Fortunately detekt doesn't need this library anymore so it can be removed as a dependency.