### PR TITLE
Added validation of constructors to LongParameterList

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/ValidatableConfiguration.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/ValidatableConfiguration.kt
@@ -23,6 +23,7 @@ val DEFAULT_PROPERTY_EXCLUDES = setOf(
 ).joinToString(",")
 
 private val DEPRECATED_PROPERTIES = setOf(
+    "complexity>LongParameterList>threshold" to "Use 'functionThreshold' and 'constructorThreshold' instead",
     "empty-blocks>EmptyFunctionBlock>ignoreOverriddenFunctions" to "Use 'ignoreOverridden' instead",
     "naming>FunctionParameterNaming>ignoreOverriddenFunctions" to "Use 'ignoreOverridden' instead",
     "naming>MemberNameEqualsClassName>ignoreOverriddenFunction" to "Use 'ignoreOverridden' instead"

--- a/detekt-api/src/test/resources/config_validation/baseline.yml
+++ b/detekt-api/src/test/resources/config_validation/baseline.yml
@@ -4,7 +4,7 @@ complexity:
     threshold: 20
   LongParameterList:
     active: false
-    threshold: 5
+    functionThreshold: 5
   LargeClass:
     active: false
     threshold: 70

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -83,8 +83,10 @@ complexity:
     threshold: 60
   LongParameterList:
     active: true
-    threshold: 6
+    functionThreshold: 6
+    constructorThreshold: 7
     ignoreDefaultParameters: false
+    ignoreDataClasses: true
   MethodOverloading:
     active: false
     threshold: 6

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
@@ -5,7 +5,7 @@ import org.gradle.testkit.runner.GradleRunner
 import java.io.File
 import java.util.UUID
 
-class DslGradleRunner(
+class DslGradleRunner @Suppress("LongParameterList") constructor(
     val projectLayout: ProjectLayout,
     val buildFileName: String,
     val mainBuildFileContent: String,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -5,36 +5,72 @@ import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Metric
+import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.api.ThresholdRule
 import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
 import io.gitlab.arturbosch.detekt.rules.isOverride
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtConstructor
+import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameterList
+import org.jetbrains.kotlin.psi.KtPrimaryConstructor
+import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 
 /**
- * Reports functions which have more parameters than a certain threshold (default: 6).
+ * Reports functions and constructors which have more parameters than a certain threshold.
  *
  * @configuration threshold - number of parameters required to trigger the rule (default: `6`)
+ * (deprecated: "Use `functionThreshold` and `constructorThreshold` instead")
+ * @configuration functionThreshold - number of function parameters required to trigger the rule (default: `6`)
+ * @configuration constructorThreshold - number of constructor parameters required to trigger the rule (default: `7`)
  * @configuration ignoreDefaultParameters - ignore parameters that have a default value (default: `false`)
+ * @configuration ignoreDataClasses - ignore long constructor parameters list for data classes (default: `true`)
  *
  * @active since v1.0.0
  */
 class LongParameterList(
-    config: Config = Config.empty,
-    threshold: Int = DEFAULT_THRESHOLD_PARAMETER_LENGTH
-) : ThresholdRule(config, threshold) {
+    config: Config = Config.empty
+) : Rule(config) {
 
     override val issue = Issue("LongParameterList",
             Severity.Maintainability,
-            "The more parameters a method has the more complex it is. Long parameter lists are often " +
+            "The more parameters a function has the more complex it is. Long parameter lists are often " +
                     "used to control complex algorithms and violate the Single Responsibility Principle. " +
-                    "Prefer methods with short parameter lists.",
+                    "Prefer functions with short parameter lists.",
             Debt.TWENTY_MINS)
+
+    private val functionThreshold: Int =
+        valueOrDefault(FUNCTION_THRESHOLD, valueOrDefault(THRESHOLD, DEFAULT_FUNCTION_THRESHOLD))
+
+    private val constructorThreshold: Int =
+        valueOrDefault(CONSTRUCTOR_THRESHOLD, valueOrDefault(THRESHOLD, DEFAULT_CONSTRUCTOR_THRESHOLD))
 
     private val ignoreDefaultParameters = valueOrDefault(IGNORE_DEFAULT_PARAMETERS, false)
 
+    private val ignoreDataClasses = valueOrDefault(IGNORE_DATA_CLASSES, true)
+
     override fun visitNamedFunction(function: KtNamedFunction) {
+        validateFunction(function, functionThreshold)
+    }
+
+    override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
+        validateConstructor(constructor)
+    }
+
+    override fun visitSecondaryConstructor(constructor: KtSecondaryConstructor) {
+        validateConstructor(constructor)
+    }
+
+    private fun validateConstructor(constructor: KtConstructor<*>) {
+        val owner = constructor.getContainingClassOrObject()
+        val isDataClass = owner is KtClass && owner.isData()
+        if (!ignoreDataClasses || !isDataClass) {
+            validateFunction(constructor, constructorThreshold)
+        }
+    }
+
+    private fun validateFunction(function: KtFunction, threshold: Int) {
         if (function.isOverride()) return
         val parameterList = function.valueParameterList
         val parameters = parameterList?.parameterCount()
@@ -57,7 +93,13 @@ class LongParameterList(
     }
 
     companion object {
+        const val THRESHOLD = "threshold"
+        const val FUNCTION_THRESHOLD = "functionThreshold"
+        const val CONSTRUCTOR_THRESHOLD = "constructorThreshold"
         const val IGNORE_DEFAULT_PARAMETERS = "ignoreDefaultParameters"
-        const val DEFAULT_THRESHOLD_PARAMETER_LENGTH = 6
+        const val IGNORE_DATA_CLASSES = "ignoreDataClasses"
+
+        const val DEFAULT_FUNCTION_THRESHOLD = 6
+        const val DEFAULT_CONSTRUCTOR_THRESHOLD = 7
     }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -17,7 +17,7 @@ class LongParameterListSpec : Spek({
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
-        it("does not reports short parameter list") {
+        it("does not report short parameter list") {
             val code = "fun long(a: Int, b: Int, c: Int, d: Int, e: Int) {}"
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -31,6 +31,40 @@ class LongParameterListSpec : Spek({
             val config = TestConfig(mapOf(LongParameterList.IGNORE_DEFAULT_PARAMETERS to "true"))
             val rule = LongParameterList(config)
             val code = "fun long(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int = 1, g: Int = 2) {}"
+            assertThat(rule.compileAndLint(code)).isEmpty()
+        }
+
+        it("reports too long parameter list for primary constructors") {
+            val code = "class LongCtor(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int)"
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        it("does not report short parameter list for primary constructors") {
+            val code = "class LongCtor(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int)"
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it("reports too long parameter list for secondary constructors") {
+            val code = "class LongCtor() { constructor(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) : this() }"
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        it("does not report short parameter list for secondary constructors") {
+            val code = "class LongCtor() { constructor(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) : this() }"
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it("reports long parameter list if custom threshold is set") {
+            val config = TestConfig(mapOf(LongParameterList.CONSTRUCTOR_THRESHOLD to "2"))
+            val rule = LongParameterList(config)
+            val code = "class LongCtor(a: Int, b: Int, c: Int)"
+            assertThat(rule.compileAndLint(code)).hasSize(1)
+        }
+
+        it("does not report long parameter list for constructors of data classes if asked") {
+            val config = TestConfig(mapOf(LongParameterList.IGNORE_DATA_CLASSES to "true"))
+            val rule = LongParameterList(config)
+            val code = "data class Data(val a: Int, val b: Int, val c: Int, val d: Int, val e: Int, val f: Int, val g: Int)"
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
     }

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -210,7 +210,7 @@ Extract parts of the functionality of long methods into separate, smaller method
 
 ### LongParameterList
 
-Reports functions which have more parameters than a certain threshold (default: 6).
+Reports functions and constructors which have more parameters than a certain threshold.
 
 **Severity**: Maintainability
 
@@ -218,13 +218,27 @@ Reports functions which have more parameters than a certain threshold (default: 
 
 #### Configuration options:
 
-* ``threshold`` (default: ``6``)
+* ~~``threshold``~~ (default: ``6``)
+
+   **Deprecated**: Use `functionThreshold` and `constructorThreshold` instead
 
    number of parameters required to trigger the rule
+
+* ``functionThreshold`` (default: ``6``)
+
+   number of function parameters required to trigger the rule
+
+* ``constructorThreshold`` (default: ``7``)
+
+   number of constructor parameters required to trigger the rule
 
 * ``ignoreDefaultParameters`` (default: ``false``)
 
    ignore parameters that have a default value
+
+* ``ignoreDataClasses`` (default: ``true``)
+
+   ignore long constructor parameters list for data classes
 
 ### MethodOverloading
 


### PR DESCRIPTION
I've looked through existing rules, seems that nothing covers number of parameters in contructors. LongParameterList is the nearest thing, but it covers only methods.

Does this sound like a useful rule? In discussions over the Internet on argument count limit I mostly see costructors included. Checkstyle, for example, covers [both methods and parameters](https://checkstyle.sourceforge.io/apidocs/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.html), PMD [seems to agree on that](https://stackoverflow.com/q/56492868/2475207).

After adding this plugin `./gradlew detekt` starts failing on the project, as some classes (e.g. CorrectableCodeSmell, see below) have 6 or more parameters in constructors.

https://github.com/arturbosch/detekt/blob/521e96856d841ec8c115a12f2db8230ce01eda86/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt#L44-L51

I'll try to collect proper report, as right now I'm having troubles with it (#2411).
