### PR TITLE
Deprecate implementations of Config

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CompositeConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CompositeConfig.kt
@@ -1,28 +1,9 @@
-package io.gitlab.arturbosch.detekt.api
+@file:Suppress("unused")
 
-import io.gitlab.arturbosch.detekt.api.internal.ValidatableConfiguration
-import io.gitlab.arturbosch.detekt.api.internal.validateConfig
+package io.gitlab.arturbosch.detekt.api
 
 /**
  * Wraps two different configuration which should be considered when retrieving properties.
  */
-class CompositeConfig(private val lookFirst: Config, private val lookSecond: Config) :
-    Config, ValidatableConfiguration {
-
-    override fun subConfig(key: String): Config =
-        CompositeConfig(lookFirst.subConfig(key), lookSecond.subConfig(key))
-
-    override fun <T : Any> valueOrDefault(key: String, default: T): T =
-        lookFirst.valueOrNull(key) ?: lookSecond.valueOrDefault(key, default)
-
-    override fun <T : Any> valueOrNull(key: String): T? =
-        lookFirst.valueOrNull(key) ?: lookSecond.valueOrNull(key)
-
-    override fun toString(): String = "CompositeConfig(lookFirst=$lookFirst, lookSecond=$lookSecond)"
-
-    /**
-     * Validates both sides of the composite config according to defined properties of the baseline config.
-     */
-    override fun validate(baseline: Config, excludePatterns: Set<Regex>): List<Notification> =
-        validateConfig(lookFirst, baseline, excludePatterns) + validateConfig(lookSecond, baseline, excludePatterns)
-}
+@Deprecated("Rule authors should not rely on a specific configuration kind.")
+typealias CompositeConfig = io.gitlab.arturbosch.detekt.api.internal.CompositeConfig

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -1,7 +1,8 @@
+@file:Suppress("unused")
+
 package io.gitlab.arturbosch.detekt.api
 
-import io.gitlab.arturbosch.detekt.api.Config.Companion.PRIMITIVES
-import java.util.ArrayDeque
+import io.gitlab.arturbosch.detekt.api.internal.EmptyConfig
 import kotlin.reflect.KClass
 
 /**
@@ -78,63 +79,7 @@ interface HierarchicalConfig : Config {
 }
 
 /**
- * NOP-implementation of a config object.
- */
-internal object EmptyConfig : HierarchicalConfig {
-
-    override val parent: HierarchicalConfig.Parent? = null
-
-    override fun subConfig(key: String): EmptyConfig = this
-
-    @Suppress("UNCHECKED_CAST")
-    override fun <T : Any> valueOrNull(key: String): T? = when (key) {
-        "active" -> true as? T
-        else -> null
-    }
-}
-
-/**
  * Convenient base configuration which parses/casts the configuration value based on the type of the default value.
  */
-abstract class BaseConfig : HierarchicalConfig {
-
-    protected open fun valueOrDefaultInternal(key: String, result: Any?, default: Any): Any {
-        return try {
-            if (result != null) {
-                when {
-                    result is String -> tryParseBasedOnDefault(result, default)
-                    default::class in PRIMITIVES &&
-                        result::class != default::class -> throw ClassCastException()
-                    else -> result
-                }
-            } else {
-                default
-            }
-        } catch (_: ClassCastException) {
-            error("Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of" +
-                " required type ${default::class.simpleName}.")
-        } catch (_: NumberFormatException) {
-            error("Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of" +
-                " required type ${default::class.simpleName}.")
-        }
-    }
-
-    private fun keySequence(key: String): String {
-        val seq = ArrayDeque<String>()
-        var current = parent
-        while (current != null) {
-            seq.addFirst(current.key)
-            current = (current.config as? HierarchicalConfig)?.parent
-        }
-        val keySeq = seq.joinToString(" > ")
-        return if (keySeq.isEmpty()) key else "$keySeq > $key"
-    }
-
-    protected open fun tryParseBasedOnDefault(result: String, defaultResult: Any): Any = when (defaultResult) {
-        is Int -> result.toInt()
-        is Boolean -> result.toBoolean()
-        is Double -> result.toDouble()
-        is String -> result
-        else -> throw ClassCastException()
-    }
-}
+@Deprecated("'BaseConfig' exposes implementation details of 'YamlConfig' and should't be relied on.")
+typealias BaseConfig = io.gitlab.arturbosch.detekt.api.internal.BaseConfig

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -29,6 +29,7 @@ interface Config {
     /**
      * Is thrown when loading a configuration results in errors.
      */
+    @Deprecated("Default value of parameter 'msg' applies only to YamlConfig and will be removed in the future")
     class InvalidConfigurationError(
         msg: String = "Provided configuration file is invalid:" +
             " Structure must be from type Map<String,Any>!"

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/YamlConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/YamlConfig.kt
@@ -1,76 +1,10 @@
-package io.gitlab.arturbosch.detekt.api
+@file:Suppress("unused")
 
-import io.gitlab.arturbosch.detekt.api.internal.ValidatableConfiguration
-import io.gitlab.arturbosch.detekt.api.internal.validateConfig
-import org.yaml.snakeyaml.Yaml
-import java.io.BufferedReader
-import java.net.URL
-import java.nio.file.Path
+package io.gitlab.arturbosch.detekt.api
 
 /**
  * Config implementation using the yaml format. SubConfigurations can return sub maps according to the
  * yaml specification.
  */
-@Suppress("UNCHECKED_CAST")
-class YamlConfig internal constructor(
-    val properties: Map<String, Any>,
-    override val parent: HierarchicalConfig.Parent?
-) : BaseConfig(), ValidatableConfiguration {
-
-    override fun subConfig(key: String): Config {
-        val subProperties = properties.getOrElse(key) { mapOf<String, Any>() }
-        return YamlConfig(subProperties as Map<String, Any>, HierarchicalConfig.Parent(this, key))
-    }
-
-    override fun <T : Any> valueOrDefault(key: String, default: T): T {
-        val result = properties[key]
-        return valueOrDefaultInternal(key, result, default) as T
-    }
-
-    override fun <T : Any> valueOrNull(key: String): T? {
-        return properties[key] as? T?
-    }
-
-    override fun toString(): String {
-        return "YamlConfig(properties=$properties)"
-    }
-
-    override fun validate(baseline: Config, excludePatterns: Set<Regex>): List<Notification> =
-        validateConfig(this, baseline, excludePatterns)
-
-    companion object {
-
-        /**
-         * Factory method to load a yaml configuration. Given path must exist
-         * and point to a readable file.
-         */
-        fun load(path: Path): Config =
-            load(path.toFile().apply {
-                require(exists()) { "Configuration does not exist: $path" }
-                require(isFile) { "Configuration must be a file: $path" }
-                require(canRead()) { "Configuration must be readable: $path" }
-            }.bufferedReader())
-
-        /**
-         * Factory method to load a yaml configuration from a URL.
-         */
-        fun loadResource(url: URL): Config = load(url.openStream().bufferedReader())
-
-        private fun load(reader: BufferedReader): Config = reader.use {
-            val yamlInput = it.lineSequence().joinToString("\n")
-            if (yamlInput.isEmpty()) {
-                Config.empty
-            } else {
-                val map: Any = Yaml().load(yamlInput)
-                if (map is Map<*, *>) {
-                    YamlConfig(map as Map<String, Any>, parent = null)
-                } else {
-                    @Suppress("DEPRECATION")
-                    throw Config.InvalidConfigurationError(
-                        "Provided configuration file is invalid: Structure must be of type 'Map<String,Any>'."
-                    )
-                }
-            }
-        }
-    }
-}
+@Deprecated("Rule authors should not rely on a specific configuration kind.")
+typealias YamlConfig = io.gitlab.arturbosch.detekt.api.internal.YamlConfig

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/YamlConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/YamlConfig.kt
@@ -65,7 +65,10 @@ class YamlConfig internal constructor(
                 if (map is Map<*, *>) {
                     YamlConfig(map as Map<String, Any>, parent = null)
                 } else {
-                    throw Config.InvalidConfigurationError()
+                    @Suppress("DEPRECATION")
+                    throw Config.InvalidConfigurationError(
+                        "Provided configuration file is invalid: Structure must be of type 'Map<String,Any>'."
+                    )
                 }
             }
         }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/CompositeConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/CompositeConfig.kt
@@ -1,0 +1,28 @@
+package io.gitlab.arturbosch.detekt.api.internal
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Notification
+
+/**
+ * Wraps two different configuration which should be considered when retrieving properties.
+ */
+class CompositeConfig(private val lookFirst: Config, private val lookSecond: Config) :
+    Config, ValidatableConfiguration {
+
+    override fun subConfig(key: String): Config =
+        CompositeConfig(lookFirst.subConfig(key), lookSecond.subConfig(key))
+
+    override fun <T : Any> valueOrDefault(key: String, default: T): T =
+        lookFirst.valueOrNull(key) ?: lookSecond.valueOrDefault(key, default)
+
+    override fun <T : Any> valueOrNull(key: String): T? =
+        lookFirst.valueOrNull(key) ?: lookSecond.valueOrNull(key)
+
+    override fun toString(): String = "CompositeConfig(lookFirst=$lookFirst, lookSecond=$lookSecond)"
+
+    /**
+     * Validates both sides of the composite config according to defined properties of the baseline config.
+     */
+    override fun validate(baseline: Config, excludePatterns: Set<Regex>): List<Notification> =
+        validateConfig(lookFirst, baseline, excludePatterns) + validateConfig(lookSecond, baseline, excludePatterns)
+}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/EmptyConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/EmptyConfig.kt
@@ -1,0 +1,19 @@
+package io.gitlab.arturbosch.detekt.api.internal
+
+import io.gitlab.arturbosch.detekt.api.HierarchicalConfig
+
+/**
+ * NOP-implementation of a config object.
+ */
+internal object EmptyConfig : HierarchicalConfig {
+
+    override val parent: HierarchicalConfig.Parent? = null
+
+    override fun subConfig(key: String): EmptyConfig = this
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any> valueOrNull(key: String): T? = when (key) {
+        "active" -> true as? T
+        else -> null
+    }
+}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/ValidatableConfiguration.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/ValidatableConfiguration.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.api.internal
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Notification
-import io.gitlab.arturbosch.detekt.api.YamlConfig
 
 interface ValidatableConfiguration {
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/YamlConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/YamlConfig.kt
@@ -1,0 +1,77 @@
+package io.gitlab.arturbosch.detekt.api.internal
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.HierarchicalConfig
+import io.gitlab.arturbosch.detekt.api.Notification
+import org.yaml.snakeyaml.Yaml
+import java.io.BufferedReader
+import java.net.URL
+import java.nio.file.Path
+
+/**
+ * Config implementation using the yaml format. SubConfigurations can return sub maps according to the
+ * yaml specification.
+ */
+@Suppress("UNCHECKED_CAST")
+class YamlConfig internal constructor(
+    val properties: Map<String, Any>,
+    override val parent: HierarchicalConfig.Parent?
+) : BaseConfig(), ValidatableConfiguration {
+
+    override fun subConfig(key: String): Config {
+        val subProperties = properties.getOrElse(key) { mapOf<String, Any>() }
+        return YamlConfig(subProperties as Map<String, Any>, HierarchicalConfig.Parent(this, key))
+    }
+
+    override fun <T : Any> valueOrDefault(key: String, default: T): T {
+        val result = properties[key]
+        return valueOrDefaultInternal(key, result, default) as T
+    }
+
+    override fun <T : Any> valueOrNull(key: String): T? {
+        return properties[key] as? T?
+    }
+
+    override fun toString(): String {
+        return "YamlConfig(properties=$properties)"
+    }
+
+    override fun validate(baseline: Config, excludePatterns: Set<Regex>): List<Notification> =
+        validateConfig(this, baseline, excludePatterns)
+
+    companion object {
+
+        /**
+         * Factory method to load a yaml configuration. Given path must exist
+         * and point to a readable file.
+         */
+        fun load(path: Path): Config =
+            load(path.toFile().apply {
+                require(exists()) { "Configuration does not exist: $path" }
+                require(isFile) { "Configuration must be a file: $path" }
+                require(canRead()) { "Configuration must be readable: $path" }
+            }.bufferedReader())
+
+        /**
+         * Factory method to load a yaml configuration from a URL.
+         */
+        fun loadResource(url: URL): Config = load(url.openStream().bufferedReader())
+
+        private fun load(reader: BufferedReader): Config = reader.use {
+            val yamlInput = it.lineSequence().joinToString("\n")
+            if (yamlInput.isEmpty()) {
+                Config.empty
+            } else {
+                val map: Any = Yaml().load(yamlInput)
+                if (map is Map<*, *>) {
+                    YamlConfig(map as Map<String, Any>, parent = null)
+                } else {
+                    @Suppress("DEPRECATION")
+                    throw Config.InvalidConfigurationError(
+                        "Provided configuration file is invalid: Structure must be of type 'Map<String,Any>'."
+                    )
+                }
+            }
+        }
+    }
+}

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/CompositeConfigTest.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/CompositeConfigTest.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.api
+package io.gitlab.arturbosch.detekt.api.internal
 
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
@@ -12,7 +12,10 @@ class CompositeConfigTest : Spek({
         val first = yamlConfig("detekt.yml")
         val compositeConfig = CompositeConfig(second, first)
 
-        it("should have style sub config with active false which is overridden in `second` config regardless of default value") {
+        it("""
+            should have style sub config with active false which is overridden
+            in `second` config regardless of default value
+        """) {
             val styleConfig = compositeConfig.subConfig("style").subConfig("WildcardImport")
             assertThat(styleConfig.valueOrDefault("active", true)).isEqualTo(false)
             assertThat(styleConfig.valueOrDefault("active", false)).isEqualTo(false)

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigValidationSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigValidationSpec.kt
@@ -1,12 +1,11 @@
 package io.gitlab.arturbosch.detekt.api.internal
 
-import io.gitlab.arturbosch.detekt.api.CompositeConfig
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/YamlConfigSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/YamlConfigSpec.kt
@@ -1,5 +1,6 @@
-package io.gitlab.arturbosch.detekt.api
+package io.gitlab.arturbosch.detekt.api.internal
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
@@ -7,7 +8,8 @@ import org.assertj.core.api.Assertions.fail
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
-class ConfigSpec : Spek({
+@Suppress("DEPRECATION")
+class YamlConfigSpec : Spek({
 
     describe("load yaml config") {
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -1,11 +1,11 @@
 package io.gitlab.arturbosch.detekt.cli
 
-import io.gitlab.arturbosch.detekt.api.CompositeConfig
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.YamlConfig
+import io.gitlab.arturbosch.detekt.api.internal.CompositeConfig
 import io.gitlab.arturbosch.detekt.api.internal.DisabledAutoCorrectConfig
 import io.gitlab.arturbosch.detekt.api.internal.FailFastConfig
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
+import io.gitlab.arturbosch.detekt.api.internal.YamlConfig
 import java.nio.file.Path
 
 fun CliArgs.createFilters(): PathFilters? = PathFilters.of(includes, excludes)

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigAssert.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigAssert.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.cli
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.YamlConfig
+import io.gitlab.arturbosch.detekt.api.internal.YamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.reflections.Reflections
@@ -53,8 +53,7 @@ class ConfigAssert(
         for (ymlOption in filter) {
             val configField = configFields.singleOrNull { ymlOption.key == it.get(null) }
             if (configField == null) {
-                fail<String>("${ymlOption.key} option for ${ruleClass.simpleName} rule is not correctly " +
-                        "defined")
+                fail<String>("${ymlOption.key} option for ${ruleClass.simpleName} rule is not correctly defined")
             }
         }
     }
@@ -64,8 +63,8 @@ class ConfigAssert(
 
     private fun getRuleClasses(): List<Class<out Rule>> {
         return Reflections(packageName)
-                .getSubTypesOf(Rule::class.java)
-                .filter { !Modifier.isAbstract(it.modifiers) }
+            .getSubTypesOf(Rule::class.java)
+            .filter { !Modifier.isAbstract(it.modifiers) }
     }
 
     private fun isPublicStaticFinal(it: Field): Boolean {

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigurationsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ConfigurationsSpec.kt
@@ -79,6 +79,7 @@ internal class ConfigurationsSpec : Spek({
         }
 
         it("should fail on invalid config value") {
+            @Suppress("DEPRECATION")
             assertThatExceptionOfType(Config.InvalidConfigurationError::class.java)
                 .isThrownBy { CliArgs { configResource = "," }.loadConfiguration() }
             assertThatExceptionOfType(ParameterException::class.java)

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/DetektYmlConfigTest.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/DetektYmlConfigTest.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.cli
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.YamlConfig
+import io.gitlab.arturbosch.detekt.api.internal.YamlConfig
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.nio.file.Paths

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionSpec.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
-import io.gitlab.arturbosch.detekt.api.YamlConfig
+import io.gitlab.arturbosch.detekt.api.internal.YamlConfig
 import io.gitlab.arturbosch.detekt.core.rules.createRuleSet
 import io.gitlab.arturbosch.detekt.core.rules.visitFile
 import io.gitlab.arturbosch.detekt.rules.Case

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/Resources.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/Resources.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.test
 
-import io.gitlab.arturbosch.detekt.api.YamlConfig
+import io.gitlab.arturbosch.detekt.api.internal.YamlConfig
 import java.net.URI
 
 internal object Resources

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
@@ -1,7 +1,9 @@
+@file:Suppress("DEPRECATION")
+
 package io.gitlab.arturbosch.detekt.test
 
-import io.gitlab.arturbosch.detekt.api.BaseConfig
 import io.gitlab.arturbosch.detekt.api.HierarchicalConfig
+import io.gitlab.arturbosch.detekt.api.internal.BaseConfig
 
 @Suppress("UNCHECKED_CAST")
 open class TestConfig(

--- a/docs/pages/kdoc/detekt-api/alltypes/index.md
+++ b/docs/pages/kdoc/detekt-api/alltypes/index.md
@@ -15,7 +15,14 @@ is present over the element.
 
 |
 
-##### [io.gitlab.arturbosch.detekt.api.BaseConfig](../io.gitlab.arturbosch.detekt.api/-base-config/index.html)
+##### [io.gitlab.arturbosch.detekt.api.BaseConfig](../io.gitlab.arturbosch.detekt.api/-base-config.html)
+
+Convenient base configuration which parses/casts the configuration value based on the type of the default value.
+
+
+|
+
+##### [io.gitlab.arturbosch.detekt.api.internal.BaseConfig](../io.gitlab.arturbosch.detekt.api.internal/-base-config/index.html)
 
 Convenient base configuration which parses/casts the configuration value based on the type of the default value.
 
@@ -49,7 +56,14 @@ Provides a compact string representation.
 
 |
 
-##### [io.gitlab.arturbosch.detekt.api.CompositeConfig](../io.gitlab.arturbosch.detekt.api/-composite-config/index.html)
+##### [io.gitlab.arturbosch.detekt.api.CompositeConfig](../io.gitlab.arturbosch.detekt.api/-composite-config.html)
+
+Wraps two different configuration which should be considered when retrieving properties.
+
+
+|
+
+##### [io.gitlab.arturbosch.detekt.api.internal.CompositeConfig](../io.gitlab.arturbosch.detekt.api.internal/-composite-config/index.html)
 
 Wraps two different configuration which should be considered when retrieving properties.
 
@@ -415,7 +429,15 @@ but can be also obtained from within a configuration object.
 
 |
 
-##### [io.gitlab.arturbosch.detekt.api.YamlConfig](../io.gitlab.arturbosch.detekt.api/-yaml-config/index.html)
+##### [io.gitlab.arturbosch.detekt.api.YamlConfig](../io.gitlab.arturbosch.detekt.api/-yaml-config.html)
+
+Config implementation using the yaml format. SubConfigurations can return sub maps according to the
+yaml specification.
+
+
+|
+
+##### [io.gitlab.arturbosch.detekt.api.internal.YamlConfig](../io.gitlab.arturbosch.detekt.api.internal/-yaml-config/index.html)
 
 Config implementation using the yaml format. SubConfigurations can return sub maps according to the
 yaml specification.

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-base-config/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-base-config/-init-.md
@@ -1,0 +1,12 @@
+---
+title: BaseConfig.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [BaseConfig](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`BaseConfig()`
+
+Convenient base configuration which parses/casts the configuration value based on the type of the default value.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-base-config/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-base-config/index.md
@@ -1,0 +1,25 @@
+---
+title: BaseConfig - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [BaseConfig](./index.html)
+
+# BaseConfig
+
+`abstract class BaseConfig : `[`HierarchicalConfig`](../../io.gitlab.arturbosch.detekt.api/-hierarchical-config/index.html)
+
+Convenient base configuration which parses/casts the configuration value based on the type of the default value.
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | Convenient base configuration which parses/casts the configuration value based on the type of the default value.`BaseConfig()` |
+
+### Functions
+
+| [tryParseBasedOnDefault](try-parse-based-on-default.html) | `open fun tryParseBasedOnDefault(result: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, defaultResult: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`): `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html) |
+| [valueOrDefaultInternal](value-or-default-internal.html) | `open fun valueOrDefaultInternal(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, result: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`?, default: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`): `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html) |
+
+### Inheritors
+
+| [YamlConfig](../-yaml-config/index.html) | Config implementation using the yaml format. SubConfigurations can return sub maps according to the yaml specification.`class YamlConfig : `[`BaseConfig`](./index.html)`, `[`ValidatableConfiguration`](../-validatable-configuration/index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-base-config/try-parse-based-on-default.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-base-config/try-parse-based-on-default.md
@@ -1,0 +1,9 @@
+---
+title: BaseConfig.tryParseBasedOnDefault - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [BaseConfig](index.html) / [tryParseBasedOnDefault](./try-parse-based-on-default.html)
+
+# tryParseBasedOnDefault
+
+`protected open fun tryParseBasedOnDefault(result: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, defaultResult: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`): `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-base-config/value-or-default-internal.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-base-config/value-or-default-internal.md
@@ -1,0 +1,9 @@
+---
+title: BaseConfig.valueOrDefaultInternal - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [BaseConfig](index.html) / [valueOrDefaultInternal](./value-or-default-internal.html)
+
+# valueOrDefaultInternal
+
+`protected open fun valueOrDefaultInternal(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, result: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`?, default: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`): `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-composite-config/-init-.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-composite-config/-init-.md
@@ -1,0 +1,12 @@
+---
+title: CompositeConfig.<init> - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [CompositeConfig](index.html) / [&lt;init&gt;](./-init-.html)
+
+# &lt;init&gt;
+
+`CompositeConfig(lookFirst: `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)`, lookSecond: `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)`)`
+
+Wraps two different configuration which should be considered when retrieving properties.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-composite-config/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-composite-config/index.md
@@ -1,0 +1,24 @@
+---
+title: CompositeConfig - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [CompositeConfig](./index.html)
+
+# CompositeConfig
+
+`class CompositeConfig : `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)`, `[`ValidatableConfiguration`](../-validatable-configuration/index.html)
+
+Wraps two different configuration which should be considered when retrieving properties.
+
+### Constructors
+
+| [&lt;init&gt;](-init-.html) | Wraps two different configuration which should be considered when retrieving properties.`CompositeConfig(lookFirst: `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)`, lookSecond: `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)`)` |
+
+### Functions
+
+| [subConfig](sub-config.html) | Tries to retrieve part of the configuration based on given key.`fun subConfig(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html) |
+| [toString](to-string.html) | `fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [validate](validate.html) | Validates both sides of the composite config according to defined properties of the baseline config.`fun validate(baseline: `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)`, excludePatterns: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`Regex`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/-regex/index.html)`>): `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Notification`](../../io.gitlab.arturbosch.detekt.api/-notification/index.html)`>` |
+| [valueOrDefault](value-or-default.html) | Retrieves a sub configuration or value based on given key. If configuration property cannot be found the specified default value is returned.`fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrDefault(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, default: T): T` |
+| [valueOrNull](value-or-null.html) | Retrieves a sub configuration or value based on given key. If the configuration property cannot be found, null is returned.`fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): T?` |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-composite-config/sub-config.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-composite-config/sub-config.md
@@ -1,0 +1,12 @@
+---
+title: CompositeConfig.subConfig - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [CompositeConfig](index.html) / [subConfig](./sub-config.html)
+
+# subConfig
+
+`fun subConfig(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)
+
+Tries to retrieve part of the configuration based on given key.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-composite-config/to-string.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-composite-config/to-string.md
@@ -1,0 +1,9 @@
+---
+title: CompositeConfig.toString - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [CompositeConfig](index.html) / [toString](./to-string.html)
+
+# toString
+
+`fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-composite-config/validate.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-composite-config/validate.md
@@ -1,0 +1,12 @@
+---
+title: CompositeConfig.validate - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [CompositeConfig](index.html) / [validate](./validate.html)
+
+# validate
+
+`fun validate(baseline: `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)`, excludePatterns: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`Regex`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/-regex/index.html)`>): `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Notification`](../../io.gitlab.arturbosch.detekt.api/-notification/index.html)`>`
+
+Validates both sides of the composite config according to defined properties of the baseline config.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-composite-config/value-or-default.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-composite-config/value-or-default.md
@@ -1,0 +1,13 @@
+---
+title: CompositeConfig.valueOrDefault - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [CompositeConfig](index.html) / [valueOrDefault](./value-or-default.html)
+
+# valueOrDefault
+
+`fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrDefault(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, default: T): T`
+
+Retrieves a sub configuration or value based on given key. If configuration property cannot be found
+the specified default value is returned.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-composite-config/value-or-null.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-composite-config/value-or-null.md
@@ -1,0 +1,13 @@
+---
+title: CompositeConfig.valueOrNull - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [CompositeConfig](index.html) / [valueOrNull](./value-or-null.html)
+
+# valueOrNull
+
+`fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): T?`
+
+Retrieves a sub configuration or value based on given key.
+If the configuration property cannot be found, null is returned.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-validatable-configuration/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-validatable-configuration/index.md
@@ -14,8 +14,8 @@ title: ValidatableConfiguration - detekt-api
 
 ### Inheritors
 
-| [CompositeConfig](../../io.gitlab.arturbosch.detekt.api/-composite-config/index.html) | Wraps two different configuration which should be considered when retrieving properties.`class CompositeConfig : `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)`, `[`ValidatableConfiguration`](./index.html) |
+| [CompositeConfig](../-composite-config/index.html) | Wraps two different configuration which should be considered when retrieving properties.`class CompositeConfig : `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)`, `[`ValidatableConfiguration`](./index.html) |
 | [DisabledAutoCorrectConfig](../-disabled-auto-correct-config/index.html) | `class DisabledAutoCorrectConfig : `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)`, `[`ValidatableConfiguration`](./index.html) |
 | [FailFastConfig](../-fail-fast-config/index.html) | `data class FailFastConfig : `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)`, `[`ValidatableConfiguration`](./index.html) |
-| [YamlConfig](../../io.gitlab.arturbosch.detekt.api/-yaml-config/index.html) | Config implementation using the yaml format. SubConfigurations can return sub maps according to the yaml specification.`class YamlConfig : `[`BaseConfig`](../../io.gitlab.arturbosch.detekt.api/-base-config/index.html)`, `[`ValidatableConfiguration`](./index.html) |
+| [YamlConfig](../-yaml-config/index.html) | Config implementation using the yaml format. SubConfigurations can return sub maps according to the yaml specification.`class YamlConfig : `[`BaseConfig`](../-base-config/index.html)`, `[`ValidatableConfiguration`](./index.html) |
 

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/index.md
@@ -1,0 +1,31 @@
+---
+title: YamlConfig - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [YamlConfig](./index.html)
+
+# YamlConfig
+
+`class YamlConfig : `[`BaseConfig`](../-base-config/index.html)`, `[`ValidatableConfiguration`](../-validatable-configuration/index.html)
+
+Config implementation using the yaml format. SubConfigurations can return sub maps according to the
+yaml specification.
+
+### Properties
+
+| [parent](parent.html) | Returns the parent config which encloses this config part.`val parent: Parent?` |
+| [properties](properties.html) | `val properties: `[`Map`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`>` |
+
+### Functions
+
+| [subConfig](sub-config.html) | Tries to retrieve part of the configuration based on given key.`fun subConfig(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html) |
+| [toString](to-string.html) | `fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [validate](validate.html) | `fun validate(baseline: `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)`, excludePatterns: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`Regex`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/-regex/index.html)`>): `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Notification`](../../io.gitlab.arturbosch.detekt.api/-notification/index.html)`>` |
+| [valueOrDefault](value-or-default.html) | Retrieves a sub configuration or value based on given key. If configuration property cannot be found the specified default value is returned.`fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrDefault(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, default: T): T` |
+| [valueOrNull](value-or-null.html) | Retrieves a sub configuration or value based on given key. If the configuration property cannot be found, null is returned.`fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): T?` |
+
+### Companion Object Functions
+
+| [load](load.html) | Factory method to load a yaml configuration. Given path must exist and point to a readable file.`fun load(path: `[`Path`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html)`): `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html) |
+| [loadResource](load-resource.html) | Factory method to load a yaml configuration from a URL.`fun loadResource(url: `[`URL`](https://docs.oracle.com/javase/8/docs/api/java/net/URL.html)`): `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/load-resource.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/load-resource.md
@@ -1,0 +1,12 @@
+---
+title: YamlConfig.loadResource - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [YamlConfig](index.html) / [loadResource](./load-resource.html)
+
+# loadResource
+
+`fun loadResource(url: `[`URL`](https://docs.oracle.com/javase/8/docs/api/java/net/URL.html)`): `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)
+
+Factory method to load a yaml configuration from a URL.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/load.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/load.md
@@ -1,0 +1,13 @@
+---
+title: YamlConfig.load - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [YamlConfig](index.html) / [load](./load.html)
+
+# load
+
+`fun load(path: `[`Path`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html)`): `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)
+
+Factory method to load a yaml configuration. Given path must exist
+and point to a readable file.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/parent.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/parent.md
@@ -1,0 +1,12 @@
+---
+title: YamlConfig.parent - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [YamlConfig](index.html) / [parent](./parent.html)
+
+# parent
+
+`val parent: Parent?`
+
+Returns the parent config which encloses this config part.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/properties.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/properties.md
@@ -1,0 +1,9 @@
+---
+title: YamlConfig.properties - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [YamlConfig](index.html) / [properties](./properties.html)
+
+# properties
+
+`val properties: `[`Map`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/sub-config.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/sub-config.md
@@ -1,0 +1,12 @@
+---
+title: YamlConfig.subConfig - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [YamlConfig](index.html) / [subConfig](./sub-config.html)
+
+# subConfig
+
+`fun subConfig(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)
+
+Tries to retrieve part of the configuration based on given key.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/to-string.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/to-string.md
@@ -1,0 +1,9 @@
+---
+title: YamlConfig.toString - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [YamlConfig](index.html) / [toString](./to-string.html)
+
+# toString
+
+`fun toString(): `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/validate.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/validate.md
@@ -1,0 +1,9 @@
+---
+title: YamlConfig.validate - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [YamlConfig](index.html) / [validate](./validate.html)
+
+# validate
+
+`fun validate(baseline: `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)`, excludePatterns: `[`Set`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-set/index.html)`<`[`Regex`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/-regex/index.html)`>): `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Notification`](../../io.gitlab.arturbosch.detekt.api/-notification/index.html)`>`

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/value-or-default.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/value-or-default.md
@@ -1,0 +1,13 @@
+---
+title: YamlConfig.valueOrDefault - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [YamlConfig](index.html) / [valueOrDefault](./value-or-default.html)
+
+# valueOrDefault
+
+`fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrDefault(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, default: T): T`
+
+Retrieves a sub configuration or value based on given key. If configuration property cannot be found
+the specified default value is returned.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/value-or-null.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-yaml-config/value-or-null.md
@@ -1,0 +1,13 @@
+---
+title: YamlConfig.valueOrNull - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api.internal](../index.html) / [YamlConfig](index.html) / [valueOrNull](./value-or-null.html)
+
+# valueOrNull
+
+`fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> valueOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): T?`
+
+Retrieves a sub configuration or value based on given key.
+If the configuration property cannot be found, null is returned.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/index.md
@@ -8,7 +8,9 @@ title: io.gitlab.arturbosch.detekt.api.internal - detekt-api
 
 ### Types
 
+| [BaseConfig](-base-config/index.html) | Convenient base configuration which parses/casts the configuration value based on the type of the default value.`abstract class BaseConfig : `[`HierarchicalConfig`](../io.gitlab.arturbosch.detekt.api/-hierarchical-config/index.html) |
 | [CommaSeparatedPattern](-comma-separated-pattern/index.html) | `class CommaSeparatedPattern : `[`SplitPattern`](../io.gitlab.arturbosch.detekt.api/-split-pattern/index.html) |
+| [CompositeConfig](-composite-config/index.html) | Wraps two different configuration which should be considered when retrieving properties.`class CompositeConfig : `[`Config`](../io.gitlab.arturbosch.detekt.api/-config/index.html)`, `[`ValidatableConfiguration`](-validatable-configuration/index.html) |
 | [CyclomaticComplexity](-cyclomatic-complexity/index.html) | Counts the cyclomatic complexity of nodes.`class CyclomaticComplexity : `[`DetektVisitor`](../io.gitlab.arturbosch.detekt.api/-detekt-visitor/index.html) |
 | [DefaultRuleSetProvider](-default-rule-set-provider.html) | Interface which marks sub-classes as provided by detekt via the rules sub-module.`interface DefaultRuleSetProvider : `[`RuleSetProvider`](../io.gitlab.arturbosch.detekt.api/-rule-set-provider/index.html) |
 | [DetektPomModel](-detekt-pom-model/index.html) | Adapted from https://github.com/pinterest/ktlint/blob/master/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/KtLint.kt Licenced under the MIT licence - https://github.com/pinterest/ktlint/blob/master/LICENSE`class DetektPomModel : UserDataHolderBase, PomModel` |
@@ -17,6 +19,7 @@ title: io.gitlab.arturbosch.detekt.api.internal - detekt-api
 | [PathFilters](-path-filters/index.html) | `class PathFilters` |
 | [SimpleNotification](-simple-notification/index.html) | `data class SimpleNotification : `[`Notification`](../io.gitlab.arturbosch.detekt.api/-notification/index.html) |
 | [ValidatableConfiguration](-validatable-configuration/index.html) | `interface ValidatableConfiguration` |
+| [YamlConfig](-yaml-config/index.html) | Config implementation using the yaml format. SubConfigurations can return sub maps according to the yaml specification.`class YamlConfig : `[`BaseConfig`](-base-config/index.html)`, `[`ValidatableConfiguration`](-validatable-configuration/index.html) |
 
 ### Extensions for External Classes
 

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-config.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-base-config.md
@@ -1,0 +1,13 @@
+---
+title: BaseConfig - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api](index.html) / [BaseConfig](./-base-config.html)
+
+# BaseConfig
+
+`typealias ~~BaseConfig~~ = `[`BaseConfig`](../io.gitlab.arturbosch.detekt.api.internal/-base-config/index.html)
+**Deprecated:** 'BaseConfig' exposes implementation details of 'YamlConfig' and should't be relied on.
+
+Convenient base configuration which parses/casts the configuration value based on the type of the default value.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-composite-config.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-composite-config.md
@@ -1,0 +1,13 @@
+---
+title: CompositeConfig - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api](index.html) / [CompositeConfig](./-composite-config.html)
+
+# CompositeConfig
+
+`typealias ~~CompositeConfig~~ = `[`CompositeConfig`](../io.gitlab.arturbosch.detekt.api.internal/-composite-config/index.html)
+**Deprecated:** Rule authors should not rely on a specific configuration kind.
+
+Wraps two different configuration which should be considered when retrieving properties.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/-invalid-configuration-error/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/-invalid-configuration-error/index.md
@@ -6,7 +6,8 @@ title: Config.InvalidConfigurationError - detekt-api
 
 # InvalidConfigurationError
 
-`class InvalidConfigurationError : `[`RuntimeException`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-runtime-exception/index.html)
+`class ~~InvalidConfigurationError~~ : `[`RuntimeException`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-runtime-exception/index.html)
+**Deprecated:** Default value of parameter 'msg' applies only to YamlConfig and will be removed in the future
 
 Is thrown when loading a configuration results in errors.
 

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-config/index.md
@@ -12,7 +12,7 @@ A configuration holds information about how to configure specific rules.
 
 ### Exceptions
 
-| [InvalidConfigurationError](-invalid-configuration-error/index.html) | Is thrown when loading a configuration results in errors.`class InvalidConfigurationError : `[`RuntimeException`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-runtime-exception/index.html) |
+| [InvalidConfigurationError](-invalid-configuration-error/index.html) | Is thrown when loading a configuration results in errors.`class ~~InvalidConfigurationError~~ : `[`RuntimeException`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-runtime-exception/index.html) |
 
 ### Functions
 
@@ -30,7 +30,7 @@ A configuration holds information about how to configure specific rules.
 
 ### Inheritors
 
-| [CompositeConfig](../-composite-config/index.html) | Wraps two different configuration which should be considered when retrieving properties.`class CompositeConfig : `[`Config`](./index.html)`, `[`ValidatableConfiguration`](../../io.gitlab.arturbosch.detekt.api.internal/-validatable-configuration/index.html) |
+| [CompositeConfig](../../io.gitlab.arturbosch.detekt.api.internal/-composite-config/index.html) | Wraps two different configuration which should be considered when retrieving properties.`class CompositeConfig : `[`Config`](./index.html)`, `[`ValidatableConfiguration`](../../io.gitlab.arturbosch.detekt.api.internal/-validatable-configuration/index.html) |
 | [ConfigAware](../-config-aware/index.html) | Interface which is implemented by each Rule class to provide utility functions to retrieve specific or generic properties from the underlying detekt configuration file.`interface ConfigAware : `[`Config`](./index.html) |
 | [DisabledAutoCorrectConfig](../../io.gitlab.arturbosch.detekt.api.internal/-disabled-auto-correct-config/index.html) | `class DisabledAutoCorrectConfig : `[`Config`](./index.html)`, `[`ValidatableConfiguration`](../../io.gitlab.arturbosch.detekt.api.internal/-validatable-configuration/index.html) |
 | [FailFastConfig](../../io.gitlab.arturbosch.detekt.api.internal/-fail-fast-config/index.html) | `data class FailFastConfig : `[`Config`](./index.html)`, `[`ValidatableConfiguration`](../../io.gitlab.arturbosch.detekt.api.internal/-validatable-configuration/index.html) |

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-hierarchical-config/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-hierarchical-config/index.md
@@ -21,5 +21,5 @@ It's main usage is to recreate the property-path which was taken when using the 
 
 ### Inheritors
 
-| [BaseConfig](../-base-config/index.html) | Convenient base configuration which parses/casts the configuration value based on the type of the default value.`abstract class BaseConfig : `[`HierarchicalConfig`](./index.html) |
+| [BaseConfig](../../io.gitlab.arturbosch.detekt.api.internal/-base-config/index.html) | Convenient base configuration which parses/casts the configuration value based on the type of the default value.`abstract class BaseConfig : `[`HierarchicalConfig`](./index.html) |
 

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config.md
@@ -1,0 +1,14 @@
+---
+title: YamlConfig - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api](index.html) / [YamlConfig](./-yaml-config.html)
+
+# YamlConfig
+
+`typealias ~~YamlConfig~~ = `[`YamlConfig`](../io.gitlab.arturbosch.detekt.api.internal/-yaml-config/index.html)
+**Deprecated:** Rule authors should not rely on a specific configuration kind.
+
+Config implementation using the yaml format. SubConfigurations can return sub maps according to the
+yaml specification.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-yaml-config/index.md
@@ -6,7 +6,7 @@ title: YamlConfig - detekt-api
 
 # YamlConfig
 
-`class YamlConfig : `[`BaseConfig`](../-base-config/index.html)`, `[`ValidatableConfiguration`](../../io.gitlab.arturbosch.detekt.api.internal/-validatable-configuration/index.html)
+`class YamlConfig : `[`BaseConfig`](../-base-config.html)`, `[`ValidatableConfiguration`](../../io.gitlab.arturbosch.detekt.api.internal/-validatable-configuration/index.html)
 
 Config implementation using the yaml format. SubConfigurations can return sub maps according to the
 yaml specification.

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/index.md
@@ -9,11 +9,11 @@ title: io.gitlab.arturbosch.detekt.api - detekt-api
 ### Types
 
 | [AnnotationExcluder](-annotation-excluder/index.html) | Primary use case for an AnnotationExcluder is to decide if a KtElement should be excluded from further analysis. This is done by checking if a special annotation is present over the element.`class AnnotationExcluder` |
-| [BaseConfig](-base-config/index.html) | Convenient base configuration which parses/casts the configuration value based on the type of the default value.`abstract class BaseConfig : `[`HierarchicalConfig`](-hierarchical-config/index.html) |
+| [BaseConfig](-base-config.html) | Convenient base configuration which parses/casts the configuration value based on the type of the default value.`typealias ~~BaseConfig~~ = `[`BaseConfig`](../io.gitlab.arturbosch.detekt.api.internal/-base-config/index.html) |
 | [BaseRule](-base-rule/index.html) | Defines the visiting mechanism for KtFile's.`abstract class BaseRule : `[`DetektVisitor`](-detekt-visitor/index.html)`, `[`Context`](-context/index.html) |
 | [CodeSmell](-code-smell/index.html) | A code smell indicates any possible design problem inside a program's source code. The type of a code smell is described by an [Issue](-issue/index.html).`open class CodeSmell : `[`Finding`](-finding/index.html) |
 | [Compactable](-compactable/index.html) | Provides a compact string representation.`interface Compactable` |
-| [CompositeConfig](-composite-config/index.html) | Wraps two different configuration which should be considered when retrieving properties.`class CompositeConfig : `[`Config`](-config/index.html)`, `[`ValidatableConfiguration`](../io.gitlab.arturbosch.detekt.api.internal/-validatable-configuration/index.html) |
+| [CompositeConfig](-composite-config.html) | Wraps two different configuration which should be considered when retrieving properties.`typealias ~~CompositeConfig~~ = `[`CompositeConfig`](../io.gitlab.arturbosch.detekt.api.internal/-composite-config/index.html) |
 | [Config](-config/index.html) | A configuration holds information about how to configure specific rules.`interface Config` |
 | [ConfigAware](-config-aware/index.html) | Interface which is implemented by each Rule class to provide utility functions to retrieve specific or generic properties from the underlying detekt configuration file.`interface ConfigAware : `[`Config`](-config/index.html) |
 | [ConfigValidator](-config-validator/index.html) | An extension which allows users to validate parts of the configuration.`interface ConfigValidator : `[`Extension`](-extension/index.html) |
@@ -51,7 +51,7 @@ title: io.gitlab.arturbosch.detekt.api - detekt-api
 | [TextLocation](-text-location/index.html) | Stores character start and end positions of an text file.`data class TextLocation` |
 | [ThresholdedCodeSmell](-thresholded-code-smell/index.html) | Represents a code smell for which a specific metric can be determined which is responsible for the existence of this rule violation.`open class ThresholdedCodeSmell : `[`CodeSmell`](-code-smell/index.html) |
 | [ThresholdRule](-threshold-rule/index.html) | Provides a threshold attribute for this rule, which is specified manually for default values but can be also obtained from within a configuration object.`abstract class ThresholdRule : `[`Rule`](-rule/index.html) |
-| [YamlConfig](-yaml-config/index.html) | Config implementation using the yaml format. SubConfigurations can return sub maps according to the yaml specification.`class YamlConfig : `[`BaseConfig`](-base-config/index.html)`, `[`ValidatableConfiguration`](../io.gitlab.arturbosch.detekt.api.internal/-validatable-configuration/index.html) |
+| [YamlConfig](-yaml-config.html) | Config implementation using the yaml format. SubConfigurations can return sub maps according to the yaml specification.`typealias ~~YamlConfig~~ = `[`YamlConfig`](../io.gitlab.arturbosch.detekt.api.internal/-yaml-config/index.html) |
 
 ### Extensions for External Classes
 


### PR DESCRIPTION
Rule authors do not need to know about internal implementations of YamlConfig etc.
They know that the yaml format config is supported and what methods can be used with a Config object.

#2365
