### PR TITLE
Choose a minimum codecov patch coverage ratio

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,5 +13,6 @@ coverage:
         threshold: 0.1
     patch:
       default:
+        target: 80%
         # Only post a patch status to pull requests
         only_pulls: true


### PR DESCRIPTION
Chooses a minimum patch coverage ratio that the commit must meet to be considered a success.
This applies only to PRs.

Docs:
https://docs.codecov.io/docs/commit-status
