### PR TITLE
Fail if `--baseline` file not found

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -9,6 +9,8 @@ import io.gitlab.arturbosch.detekt.cli.runners.Executable
 import io.gitlab.arturbosch.detekt.cli.runners.Runner
 import io.gitlab.arturbosch.detekt.cli.runners.SingleRuleRunner
 import io.gitlab.arturbosch.detekt.cli.runners.VersionPrinter
+import io.gitlab.arturbosch.detekt.core.exists
+import io.gitlab.arturbosch.detekt.core.isFile
 import java.io.PrintStream
 import kotlin.system.exitProcess
 
@@ -44,8 +46,16 @@ fun buildRunner(
         outputPrinter,
         errorPrinter
     ) { messages ->
+        val baseline = baseline
         if (createBaseline && baseline == null) {
             messages += "Creating a baseline.xml requires the --baseline parameter to specify a path."
+        }
+        if (!createBaseline && baseline != null) {
+            if (!baseline.exists()) {
+                messages += "The file specified by --baseline should exist '$baseline'."
+            } else if (!baseline.isFile()) {
+                messages += "The path specified by --baseline should be a file '$baseline'."
+            }
         }
     }
     return when {

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
@@ -112,7 +112,7 @@ class MainSpec : Spek({
             }
         }
 
-        it("succeed with --baseline if the path exists and is a file") {
+        it("succeeds with --baseline if the path exists and is a file") {
             val out = ByteArrayOutputStream()
             val err = ByteArrayOutputStream()
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
@@ -65,7 +65,7 @@ class MainSpec : Spek({
             }
         }
 
-        it("succeed --create-baseline and --baseline") {
+        it("succeeds with --create-baseline and --baseline") {
             val out = ByteArrayOutputStream()
             val err = ByteArrayOutputStream()
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.cli.runners.ConfigExporter
 import io.gitlab.arturbosch.detekt.cli.runners.Runner
 import io.gitlab.arturbosch.detekt.cli.runners.SingleRuleRunner
 import io.gitlab.arturbosch.detekt.cli.runners.VersionPrinter
+import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -42,6 +43,39 @@ class MainSpec : Spek({
                     }
                 }
             }
+        }
+    }
+
+    describe("check arguments") {
+
+        it("fails with --create-baseline but without --baseline") {
+            val out = ByteArrayOutputStream()
+            val err = ByteArrayOutputStream()
+
+            try {
+                val args = arrayOf("--create-baseline")
+
+                buildRunner(args, PrintStream(out), PrintStream(err))
+                Assertions.fail("This should throw an exception.")
+            } catch (_: HandledArgumentViolation) {
+                assertThat(String(err.toByteArray()).trim())
+                    .isEqualTo("Creating a baseline.xml requires the --baseline parameter to specify a path.")
+            }
+        }
+
+        it("succeed --create-baseline and --baseline") {
+            val out = ByteArrayOutputStream()
+            val err = ByteArrayOutputStream()
+
+            val args = arrayOf(
+                "--create-baseline",
+                "--baseline",
+                "baseline.xml"
+            )
+
+            buildRunner(args, PrintStream(out), PrintStream(err))
+
+            assertThat(String(err.toByteArray())).isEmpty()
         }
     }
 })


### PR DESCRIPTION
Close #2374

Check that the file set by `--baseline` exists and is not a folder.