### PR TITLE
Add detekt-hint to integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Integrations:
 - [Maven plugin that wraps the Detekt CLI](https://github.com/Ozsie/detekt-maven-plugin)
 - [Gradle plugin that helps facilitate GitHub PR checking and automatic commenting of violations](https://github.com/btkelly/gnag)
 - [Codefactor](http://codefactor.io/)
+- [detekt-hint is a plugin to detekt that provides detection of design principle violations through integration with Danger](https://github.com/mkohm/detekt-hint)
 
 #### Credits
 


### PR DESCRIPTION
Simply adding my plugin as an integration to detekt, see #2437.