### PR TITLE
Update AppVeyor branch conf to comply with Travis

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - master
+
 version: '{build}'
 
 skip_tags: true


### PR DESCRIPTION
Only build the master branch for AppVeyor and TravisCI.

Source:
https://www.appveyor.com/docs/branches/
