### PR TITLE
Simplify UnnecessaryApplySpec test cases

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -62,7 +62,7 @@ class UnnecessaryApplySpec : Spek({
                 assertThat(subject.compileAndLint("""
                     fun f() {
                         val a : Int? = null
-                        a.apply({
+                        a?.apply({
                             plus(1)
                         })
                     }
@@ -105,7 +105,7 @@ class UnnecessaryApplySpec : Spek({
 
                     fun main() {
                         val a : Int? = null
-                        a.apply {
+                        a?.apply {
                             plus(1)
                             plus(2)
                         }
@@ -136,7 +136,7 @@ class UnnecessaryApplySpec : Spek({
 
             it("is used as return type of extension function") {
                 assertThat(subject.compileAndLint("""
-                    inline class C(var prop: Int)
+                    class C(var prop: Int)
                     
                     fun Int.f() = C(5).apply { prop = 10 }
                 """)).isEmpty()
@@ -154,7 +154,7 @@ class UnnecessaryApplySpec : Spek({
 
             it("should not report apply when using it after returning something") {
                 assertThat(subject.compileAndLint("""
-                    inline class C(var prop: Int)
+                    class C(var prop: Int)
                     
                     fun f() = (C(5)).apply { prop = 10 }
                 """)).isEmpty()
@@ -162,10 +162,10 @@ class UnnecessaryApplySpec : Spek({
 
             it("should not report apply usage inside safe chained expressions") {
                 assertThat(subject.compileAndLint("""
-                    fun test() {
+                    fun f() {
                         val arguments = listOf(1,2,3)
                             ?.map { it * 2 }
-                            ?.apply { if (true) add(4) }
+                            ?.apply { if (true) 4 }
                             ?: listOf(0)
                     }
                 """)).isEmpty()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -61,7 +61,7 @@ class UnnecessaryApplySpec : Spek({
             it("does not report an apply with lambda block") {
                 assertThat(subject.compileAndLint("""
                     fun f() {
-                        val a : Int? = null
+                        val a: Int? = null
                         a?.apply({
                             plus(1)
                         })
@@ -74,7 +74,7 @@ class UnnecessaryApplySpec : Spek({
                     fun b(i : Int?) {}
 
                     fun main() {
-                        val a : Int? = null
+                        val a: Int? = null
                         b(a.apply {
                             toString()
                         })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -84,19 +84,24 @@ class UnnecessaryApplySpec : Spek({
 
             it("does report single assignment statement in apply used as function argument - #1517") {
                 assertThat(subject.compileAndLint("""
-                    fun f() {
-                        val list = MutableList()
+                    class C {
+                        var prop = 0
+                    }
+                        
+                    fun main() {
+                        val list = ArrayList<C>()
                         list.add(
                             if (true) {
-                                SomeObject().apply {
-                                    x = y
+                                C().apply { 
+                                    prop = 1
                                 }
                             } else {
-                                SomeOtherObject()
+                                C()
                             }
                         )
                     }
-                """)).isEmpty()
+                """
+                )).isEmpty()
             }
 
             it("does not report applies with lambda body containing more than one statement") {


### PR DESCRIPTION
* Fixes invalid Kotlin code in test snippets
* Use compileAndLint() instead of lint()
