### PR TITLE
Refactor FindingsReport + FileBasedFindingsReport

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/DebtSumming.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/DebtSumming.kt
@@ -15,14 +15,7 @@ class DebtSumming() {
         debtList.add(debt)
     }
 
-    fun calculateDebt(): Debt? {
-        if (debtList.isEmpty()) {
-            return null
-        }
-        return calculate()
-    }
-
-    private fun calculate(): Debt {
+    fun calculateDebt(): Debt {
         var minutes = 0
         var hours = 0
         var days = 0

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/FileBasedFindingsReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/FileBasedFindingsReport.kt
@@ -33,21 +33,15 @@ class FileBasedFindingsReport : ConsoleReport() {
                 .forEach { (filename, issues) ->
                     val fileDebt = DebtSumming(issues)
                     val debt = fileDebt.calculateDebt()
-                    if (debt != null) {
-                        totalDebt.add(debt)
-                        append("$filename - $debt debt".format())
-                        val issuesString = issues.joinToString("") {
-                            it.compact().format("\t")
-                        }
-                        append(issuesString.yellow())
-                    } else {
-                        append("\n")
+                    totalDebt.add(debt)
+                    append("$filename - $debt debt".format())
+                    val issuesString = issues.joinToString("") {
+                        it.compact().format("\t")
                     }
+                    append(issuesString.yellow())
                 }
             val debt = totalDebt.calculateDebt()
-            if (debt != null) {
-                append("Overall debt: $debt".format("\n"))
-            }
+            append("Overall debt: $debt".format("\n"))
             toString()
         }
     }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/FindingsReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/FindingsReport.kt
@@ -30,21 +30,15 @@ class FindingsReport : ConsoleReport() {
             findings.forEach { (ruleSetId, issues) ->
                 val debtSumming = DebtSumming(issues)
                 val debt = debtSumming.calculateDebt()
-                if (debt != null) {
-                    totalDebt.add(debt)
-                    append("Ruleset: $ruleSetId - $debt debt".format())
-                    val issuesString = issues.joinToString("") {
-                        it.compact().format("\t")
-                    }
-                    append(issuesString.yellow())
-                } else {
-                    append("\n")
+                totalDebt.add(debt)
+                append("Ruleset: $ruleSetId - $debt debt".format())
+                val issuesString = issues.joinToString("") {
+                    it.compact().format("\t")
                 }
+                append(issuesString.yellow())
             }
             val debt = totalDebt.calculateDebt()
-            if (debt != null) {
-                append("Overall debt: $debt".format("\n"))
-            }
+            append("Overall debt: $debt".format("\n"))
             toString()
         }
     }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/DebtSummingSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/DebtSummingSpec.kt
@@ -20,14 +20,10 @@ internal class DebtSummingSpec : Spek({
         it("outputs correct minutes") {
             assertThat(createDebtSumming(mins = 42).toString()).isEqualTo("42min")
         }
-
-        it("outputs no debt") {
-            assertThat(DebtSumming().calculateDebt()).isNull()
-        }
     }
 })
 
-private fun createDebtSumming(days: Int = 0, hours: Int = 0, mins: Int): Debt? {
+private fun createDebtSumming(days: Int = 0, hours: Int = 0, mins: Int = 0): Debt {
     val debt = Debt(days, hours, mins)
     val debtReport = DebtSumming()
     debtReport.add(debt)

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/DebtSummingSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/DebtSummingSpec.kt
@@ -23,7 +23,7 @@ internal class DebtSummingSpec : Spek({
     }
 })
 
-private fun createDebtSumming(days: Int = 0, hours: Int = 0, mins: Int = 0): Debt {
+private fun createDebtSumming(days: Int = 0, hours: Int = 0, mins: Int): Debt {
     val debt = Debt(days, hours, mins)
     val debtReport = DebtSumming()
     debtReport.add(debt)


### PR DESCRIPTION
This change removes complexity from both report classes.

If there are no findings reported, both classes return null.
This is done before the printing logic is executed.
Thus, we don't need if-else conditionals for this case.

The debt of existing issues can't be null.
This is guaranteed by the Debt class.
