### PR TITLE
Update trim logic in Debt:toString()

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Debt.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Debt.kt
@@ -26,6 +26,6 @@ data class Debt(val days: Int = 0, val hours: Int = 0, val mins: Int = 0) {
             if (hours > 0) append("${hours}h ")
             if (mins > 0) append("${mins}min")
             toString()
-        }.trim()
+        }.trimEnd()
     }
 }


### PR DESCRIPTION
The mentioned toString() method can only contain whitespaces at the end of the string.
