### PR TITLE
Add test for BaselineHandler

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineHandler.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineHandler.kt
@@ -28,7 +28,7 @@ internal class BaselineHandler : DefaultHandler() {
     override fun endElement(uri: String, localName: String, qName: String) {
         when (qName) {
             ID -> {
-                check(content.isNotBlank())
+                check(content.isNotBlank()) { "The content of the ID element must not be empty" }
                 when (current) {
                     BLACKLIST -> blackIds.add(content)
                     WHITELIST -> whiteIds.add(content)

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineHandler.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineHandler.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.cli.baseline
 import org.xml.sax.Attributes
 import org.xml.sax.helpers.DefaultHandler
 
-class BaselineHandler : DefaultHandler() {
+internal class BaselineHandler : DefaultHandler() {
 
     private var current: String? = null
     private var content: String = ""
@@ -27,7 +27,8 @@ class BaselineHandler : DefaultHandler() {
 
     override fun endElement(uri: String, localName: String, qName: String) {
         when (qName) {
-            ID -> if (content.isNotBlank()) {
+            ID -> {
+                check(content.isNotBlank())
                 when (current) {
                     BLACKLIST -> blackIds.add(content)
                     WHITELIST -> whiteIds.add(content)

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFormatSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFormatSpec.kt
@@ -2,12 +2,12 @@ package io.gitlab.arturbosch.detekt.cli.baseline
 
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.nio.file.Files
 import java.nio.file.Paths
-import java.time.Instant
 
 class BaselineFormatSpec : Spek({
 
@@ -26,9 +26,14 @@ class BaselineFormatSpec : Spek({
                 assertThat(whitelist.ids).anySatisfy { it.startsWith("FeatureEnvy") }
             }
 
-            it("throws on an invalid baseline file") {
+            it("throws on an invalid baseline file extension") {
                 val path = Paths.get(resource("/invalid-smell-baseline.txt"))
                 assertThatThrownBy { BaselineFormat().read(path) }.isInstanceOf(InvalidBaselineState::class.java)
+            }
+
+            it("throws on an invalid baseline ID declaration") {
+                val path = Paths.get(resource("/invalid-smell-baseline.xml"))
+                assertThatIllegalStateException().isThrownBy { BaselineFormat().read(path) }
             }
         }
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFormatSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFormatSpec.kt
@@ -33,7 +33,9 @@ class BaselineFormatSpec : Spek({
 
             it("throws on an invalid baseline ID declaration") {
                 val path = Paths.get(resource("/invalid-smell-baseline.xml"))
-                assertThatIllegalStateException().isThrownBy { BaselineFormat().read(path) }
+                assertThatIllegalStateException()
+                    .isThrownBy { BaselineFormat().read(path) }
+                    .withMessage("The content of the ID element must not be empty")
             }
         }
 

--- a/detekt-cli/src/test/resources/invalid-smell-baseline.xml
+++ b/detekt-cli/src/test/resources/invalid-smell-baseline.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<SmellBaseline>
+    <Blacklist>
+        <ID></ID>
+    </Blacklist>
+</SmellBaseline>

--- a/detekt-cli/src/test/resources/smell-baseline.xml
+++ b/detekt-cli/src/test/resources/smell-baseline.xml
@@ -6,5 +6,6 @@
     </Blacklist>
     <Whitelist>
         <ID>FeatureEnvy:Signature</ID>
+        <ID></ID>
     </Whitelist>
 </SmellBaseline>

--- a/detekt-cli/src/test/resources/smell-baseline.xml
+++ b/detekt-cli/src/test/resources/smell-baseline.xml
@@ -6,6 +6,5 @@
     </Blacklist>
     <Whitelist>
         <ID>FeatureEnvy:Signature</ID>
-        <ID></ID>
     </Whitelist>
 </SmellBaseline>


### PR DESCRIPTION
The BaselineHandler xml parser should handle empty ID entries.
