### PR TITLE
Remove tags from core documentation sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ target/
 *.iml
 */out
 /docs/_site
+/docs/.bundle
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     colorator (1.1.0)
     commonmarker (0.17.13)
       ruby-enum (~> 0.5)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     dnsruby (1.61.3)
       addressable (~> 2.5)
     em-websocket (0.5.1)
@@ -28,7 +28,7 @@ GEM
     execjs (2.7.0)
     faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.12.1)
+    ffi (1.12.2)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (204)
@@ -204,9 +204,9 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.14.0)
     multipart-post (2.1.1)
-    nokogiri (1.10.8)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    octokit (4.15.0)
+    octokit (4.17.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.2)
@@ -218,7 +218,7 @@ GEM
     rouge (3.13.0)
     ruby-enum (0.7.2)
       i18n
-    rubyzip (2.1.0)
+    rubyzip (2.3.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -235,8 +235,8 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
-    unicode-display_width (1.6.1)
-    zeitwerk (2.2.2)
+    unicode-display_width (1.7.0)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
@@ -245,4 +245,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   2.1.4
+   1.17.3

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,6 @@
 ---
 title: "detekt"
 keywords: detekt static analysis code kotlin
-tags: [features, quickstart]
 sidebar: 
 permalink: index.html
 summary:

--- a/docs/pages/baseline.md
+++ b/docs/pages/baseline.md
@@ -1,7 +1,6 @@
 ---
 title: "Code Smell Baseline"
 keywords: baseline suppressing smells
-tags: 
 sidebar: 
 permalink: baseline.html
 summary:

--- a/docs/pages/configurations.md
+++ b/docs/pages/configurations.md
@@ -1,7 +1,6 @@
 ---
 title: "Detekt Configuration File"
 keywords: config configuration yaml
-tags:
 sidebar:
 permalink: configurations.html
 summary:

--- a/docs/pages/extensions.md
+++ b/docs/pages/extensions.md
@@ -1,7 +1,6 @@
 ---
 title: "Extending detekt"
 keywords: extensions rulesets 
-tags: 
 sidebar: 
 permalink: extensions.html
 summary:

--- a/docs/pages/failonbuild.md
+++ b/docs/pages/failonbuild.md
@@ -1,7 +1,6 @@
 ---
 title: "Configure Build Failure Thresholds"
 keywords: build fail thresholds
-tags: 
 sidebar: 
 permalink: failonbuild.html
 summary:

--- a/docs/pages/gettingstarted/cli.md
+++ b/docs/pages/gettingstarted/cli.md
@@ -1,7 +1,6 @@
 ---
 title: "Run detekt using Command Line Interface"
 keywords: cli
-tags: [getting_started, cli]
 sidebar: 
 permalink: cli.html
 folder: gettingstarted

--- a/docs/pages/gettingstarted/git-pre-commit-hook.md
+++ b/docs/pages/gettingstarted/git-pre-commit-hook.md
@@ -1,7 +1,6 @@
 ---
 title: "Run detekt using a Git pre-commit hook"
 keywords: detekt static analysis code kotlin
-tags: [getting_started, git]
 sidebar: 
 permalink: git-pre-commit-hook.html
 folder: gettingstarted

--- a/docs/pages/gettingstarted/gradletask.md
+++ b/docs/pages/gettingstarted/gradletask.md
@@ -1,7 +1,6 @@
 ---
 title: "Run detekt using Gradle Task"
 keywords: gradle task
-tags: [getting_started, gradle]
 sidebar: 
 permalink: gradletask.html
 folder: gettingstarted

--- a/docs/pages/gettingstarted/groovydsl.md
+++ b/docs/pages/gettingstarted/groovydsl.md
@@ -1,7 +1,6 @@
 ---
 title: "Run detekt using the Detekt Gradle Plugin"
 keywords: detekt static analysis code kotlin
-tags: [getting_started, gradle, plugin]
 sidebar: 
 permalink: groovydsl.html
 folder: gettingstarted

--- a/docs/pages/gettingstarted/kotlindsl.md
+++ b/docs/pages/gettingstarted/kotlindsl.md
@@ -1,7 +1,6 @@
 ---
 title: "Run detekt using Gradle Kotlin DSL"
 keywords: detekt static analysis code kotlin
-tags: [getting_started gradle]
 sidebar: 
 permalink: kotlindsl.html
 folder: gettingstarted

--- a/docs/pages/gettingstarted/mavenanttask.md
+++ b/docs/pages/gettingstarted/mavenanttask.md
@@ -1,7 +1,6 @@
 ---
 title: "Run detekt using Maven Ant Task"
 keywords: maven anttask
-tags: [getting_started, maven]
 sidebar: 
 permalink: mavenanttask.html
 folder: gettingstarted

--- a/docs/pages/gettingstarted/type-and-symbol-solving.md
+++ b/docs/pages/gettingstarted/type-and-symbol-solving.md
@@ -1,7 +1,6 @@
 ---
 title: "Using Type and Symbol Solving"
 keywords: detekt static analysis code kotlin
-tags: [getting_started, types]
 sidebar: 
 permalink: type-and-symbol-solving.html
 folder: gettingstarted

--- a/docs/pages/suppressing-rules.md
+++ b/docs/pages/suppressing-rules.md
@@ -1,7 +1,6 @@
 ---
 title: "Suppressing Issues"
 keywords: suppressing issues
-tags: 
 sidebar: 
 permalink: suppressing-rules.html
 summary:


### PR DESCRIPTION
Tags for the news/guides are still useful

Closes #2309