### PR TITLE
Unify yaml strings

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -9,8 +9,8 @@ build:
 
 config:
   validation: true
-  # when writing own rules with new properties, exclude the property path e.g.: "my_rule_set,.*>.*>[my_property]"
-  excludes: ""
+  # when writing own rules with new properties, exclude the property path e.g.: 'my_rule_set,.*>.*>[my_property]'
+  excludes: ''
 
 processors:
   active: true
@@ -33,7 +33,7 @@ console-reports:
 
 comments:
   active: true
-  excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+  excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
   AbsentOrWrongFileLicense:
     active: false
     licenseTemplateFile: 'license.template'
@@ -73,7 +73,7 @@ complexity:
     nestingFunctions: run,let,apply,with,also,use,forEach,isNotNull,ifNull
   LabeledExpression:
     active: false
-    ignoredLabels: ""
+    ignoredLabels: ''
   LargeClass:
     active: true
     threshold: 600
@@ -92,14 +92,14 @@ complexity:
     threshold: 4
   StringLiteralDuplication:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     threshold: 3
     ignoreAnnotation: true
     excludeStringsWithLessThan5Characters: true
     ignoreStringsRegex: '$^'
   TooManyFunctions:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     thresholdInFiles: 11
     thresholdInClasses: 11
     thresholdInInterfaces: 11
@@ -120,7 +120,7 @@ empty-blocks:
   active: true
   EmptyCatchBlock:
     active: true
-    allowedExceptionNameRegex: "^(_|(ignore|expected).*)"
+    allowedExceptionNameRegex: '^(_|(ignore|expected).*)'
   EmptyClassBlock:
     active: true
   EmptyDefaultConstructor:
@@ -158,7 +158,7 @@ exceptions:
     methodNames: 'toString,hashCode,equals,finalize'
   InstanceOfCheckForException:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
   NotImplementedDeclaration:
     active: false
   PrintStackTrace:
@@ -171,7 +171,7 @@ exceptions:
   SwallowedException:
     active: false
     ignoredExceptionTypes: 'InterruptedException,NumberFormatException,ParseException,MalformedURLException'
-    allowedExceptionNameRegex: "^(_|(ignore|expected).*)"
+    allowedExceptionNameRegex: '^(_|(ignore|expected).*)'
   ThrowingExceptionFromFinally:
     active: false
   ThrowingExceptionInMain:
@@ -183,7 +183,7 @@ exceptions:
     active: false
   TooGenericExceptionCaught:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     exceptionNames:
      - ArrayIndexOutOfBoundsException
      - Error
@@ -193,7 +193,7 @@ exceptions:
      - IndexOutOfBoundsException
      - RuntimeException
      - Throwable
-    allowedExceptionNameRegex: "^(_|(ignore|expected).*)"
+    allowedExceptionNameRegex: '^(_|(ignore|expected).*)'
   TooGenericExceptionThrown:
     active: true
     exceptionNames:
@@ -315,40 +315,40 @@ naming:
   active: true
   ClassNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     classPattern: '[A-Z$][a-zA-Z0-9$]*'
   ConstructorParameterNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     parameterPattern: '[a-z][A-Za-z0-9]*'
     privateParameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
     ignoreOverridden: true
   EnumNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     enumEntryPattern: '^[A-Z][_a-zA-Z0-9]*'
   ForbiddenClassName:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     forbiddenName: ''
   FunctionMaxLength:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     maximumFunctionNameLength: 30
   FunctionMinLength:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     minimumFunctionNameLength: 3
   FunctionNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
     excludeClassPattern: '$^'
     ignoreOverridden: true
   FunctionParameterNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     parameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
     ignoreOverridden: true
@@ -363,31 +363,31 @@ naming:
     ignoreOverridden: true
   ObjectPropertyNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     constantPattern: '[A-Za-z][_A-Za-z0-9]*'
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
   PackageNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     packagePattern: '^[a-z]+(\.[a-z][A-Za-z0-9]*)*$'
   TopLevelPropertyNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     constantPattern: '[A-Z][_A-Z0-9]*'
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
   VariableMaxLength:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     maximumVariableNameLength: 64
   VariableMinLength:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     minimumVariableNameLength: 1
   VariableNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     variablePattern: '[a-z][A-Za-z0-9]*'
     privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
@@ -399,10 +399,10 @@ performance:
     active: true
   ForEachOnRange:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
   SpreadOperator:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
   UnnecessaryTemporaryInstantiation:
     active: true
 
@@ -430,9 +430,9 @@ potential-bugs:
     active: true
   LateinitUsage:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
-    excludeAnnotatedProperties: ""
-    ignoreOnClassesPattern: ""
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
+    excludeAnnotatedProperties: ''
+    ignoreOnClassesPattern: ''
   MapGetWithNotNullAssertionOperator:
     active: false
   MissingWhenCase:
@@ -475,11 +475,11 @@ style:
   ForbiddenComment:
     active: true
     values: 'TODO:,FIXME:,STOPSHIP:'
-    allowedPatterns: ""
+    allowedPatterns: ''
   ForbiddenImport:
     active: false
     imports: ''
-    forbiddenPatterns: ""
+    forbiddenPatterns: ''
   ForbiddenMethodCall:
     active: false
     methods: ''
@@ -494,7 +494,7 @@ style:
     active: true
     ignoreOverridableFunction: true
     excludedFunctions: 'describeContents'
-    excludeAnnotatedFunction: "dagger.Provides"
+    excludeAnnotatedFunction: 'dagger.Provides'
   LibraryCodeMustSpecifyReturnType:
     active: true
   LoopWithTooManyJumpStatements:
@@ -502,7 +502,7 @@ style:
     maxJumpCount: 1
   MagicNumber:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     ignoreNumbers: '-1,0,1,2'
     ignoreHashCodeFunction: true
     ignorePropertyDeclaration: false
@@ -548,7 +548,7 @@ style:
   ReturnCount:
     active: true
     max: 2
-    excludedFunctions: "equals"
+    excludedFunctions: 'equals'
     excludeLabeled: false
     excludeReturnFromLambda: true
     excludeGuardClauses: false
@@ -568,7 +568,7 @@ style:
     acceptableDecimalLength: 5
   UnnecessaryAbstractClass:
     active: true
-    excludeAnnotatedClasses: "dagger.Module"
+    excludeAnnotatedClasses: 'dagger.Module'
   UnnecessaryAnnotationUseSiteTarget:
     active: false
   UnnecessaryApply:
@@ -587,14 +587,14 @@ style:
     active: true
   UnusedPrivateMember:
     active: false
-    allowedNames: "(_|ignored|expected|serialVersionUID)"
+    allowedNames: '(_|ignored|expected|serialVersionUID)'
   UseArrayLiteralsInAnnotations:
     active: false
   UseCheckOrError:
     active: false
   UseDataClass:
     active: false
-    excludeAnnotatedClasses: ""
+    excludeAnnotatedClasses: ''
     allowVars: false
   UseIfInsteadOfWhen:
     active: false
@@ -608,5 +608,5 @@ style:
     active: false
   WildcardImport:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     excludeImports: 'java.util.*,kotlinx.android.synthetic.*'

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -81,8 +81,8 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
     private fun defaultConfigConfiguration(): String = """
       config:
         validation: true
-        # when writing own rules with new properties, exclude the property path e.g.: "my_rule_set,.*>.*>[my_property]"
-        excludes: ""
+        # when writing own rules with new properties, exclude the property path e.g.: 'my_rule_set,.*>.*>[my_property]'
+        excludes: ''
     """.trimIndent()
 
     private fun defaultProcessorsConfiguration(): String = """

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/TestExclusions.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/TestExclusions.kt
@@ -8,7 +8,7 @@ import io.gitlab.arturbosch.detekt.generator.collection.Rule
  */
 object TestExclusions {
 
-    const val pattern = "\"**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt\""
+    const val pattern = "'**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'"
     val ruleSets = setOf("comments")
     val rules = setOf(
         "NamingRules",

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -168,8 +168,8 @@ class RuleCollectorSpec : Spek({
             val code = """
                 /**
                  * description
-                 * @configuration config - description (default: `""`)
-                 * @configuration config2 - description2 (default: `""`)
+                 * @configuration config - description (default: `''`)
+                 * @configuration config2 - description2 (default: `''`)
                  */
                 class SomeRandomClass: Rule
             """

--- a/detekt-generator/src/test/resources/RuleSetConfig.yml
+++ b/detekt-generator/src/test/resources/RuleSetConfig.yml
@@ -2,7 +2,7 @@ style:
   active: true
   WildcardImport:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: '**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt'
     conf1: foo
   EqualsNull:
     active: false

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -29,8 +29,8 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  * </noncompliant>
  *
  * @configuration excludeAnnotatedProperties - Allows you to provide a list of annotations that disable
- * this check. (default: `""`)
- * @configuration ignoreOnClassesPattern - Allows you to disable the rule for a list of classes (default: `""`)
+ * this check. (default: `''`)
+ * @configuration ignoreOnClassesPattern - Allows you to disable the rule for a list of classes (default: `''`)
  */
 class LateinitUsage(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
@@ -59,7 +59,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
  * </compliant>
  *
  * @configuration ignoredLabels - allows to provide a list of label names which should be ignored by this rule
- * (default: `""`)
+ * (default: `''`)
  */
 class LabeledExpression(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.psi.KtCatchClause
  * Reports empty `catch` blocks. Empty blocks of code serve no purpose and should be removed.
  *
  * @configuration allowedExceptionNameRegex - ignores exception types which match this regex
- * (default: `"^(_|(ignore|expected).*)"`)
+ * (default: `'^(_|(ignore|expected).*)'`)
  * @active since v1.0.0
  */
 class EmptyCatchBlock(config: Config) : EmptyRule(config = config) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -66,7 +66,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  * @configuration ignoredExceptionTypes - exception types which should be ignored by this rule
  * (default: `'InterruptedException,NumberFormatException,ParseException,MalformedURLException'`)
  * @configuration allowedExceptionNameRegex - ignores too generic exception types which match this regex
- * (default: `"^(_|(ignore|expected).*)"`)
+ * (default: `'^(_|(ignore|expected).*)'`)
  */
 class SwallowedException(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
@@ -44,7 +44,7 @@ import org.jetbrains.kotlin.psi.KtTypeReference
  *            - RuntimeException
  *            - Throwable`)
  * @configuration allowedExceptionNameRegex - ignores too generic exception types which match this regex
- * (default: `"^(_|(ignore|expected).*)"`)
+ * (default: `'^(_|(ignore|expected).*)'`)
  * @active since v1.0.0
  */
 class TooGenericExceptionCaught(config: Config) : Rule(config) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiComment
  *
  * @configuration values - forbidden comment strings (default: `'TODO:,FIXME:,STOPSHIP:'`)
  * @configuration allowedPatterns - ignores comments which match the specified regular expression.
-   For example `Ticket|Task`. (default: `""`)
+   For example `Ticket|Task`. (default: `''`)
  * @active since v1.0.0
  */
 class ForbiddenComment(config: Config = Config.empty) : Rule(config) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  * </noncompliant>
  *
  * @configuration imports - imports which should not be used (default: `''`)
- * @configuration forbiddenPatterns - reports imports which match the specified regular expression. For example `net.*R`. (default: `""`)
+ * @configuration forbiddenPatterns - reports imports which match the specified regular expression. For example `net.*R`. (default: `''`)
  */
 class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  *
  * @configuration ignoreOverridableFunction - if overriden functions should be ignored (default: `true`)
  * @configuration excludedFunctions - excluded functions (default: `'describeContents'`)
- * @configuration excludeAnnotatedFunction - allows to provide a list of annotations that disable this check (default: `"dagger.Provides"`)
+ * @configuration excludeAnnotatedFunction - allows to provide a list of annotations that disable this check (default: `'dagger.Provides'`)
  *
  * @active since v1.2.0
  */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -46,7 +46,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
  * @configuration max - define the maximum number of return statements allowed per function
  * (default: `2`)
  * @configuration excludedFunctions - define functions to be ignored by this check
- * (default: `"equals"`)
+ * (default: `'equals'`)
  * @configuration excludeLabeled - if labeled return statements should be ignored
  * (default: `false`)
  * @configuration excludeReturnFromLambda - if labeled return from a lambda should be ignored

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -39,7 +39,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isAbstract
  * </noncompliant>
  *
  * @configuration excludeAnnotatedClasses - Allows you to provide a list of annotations that disable
- * this check. (default: `"dagger.Module"`)
+ * this check. (default: `'dagger.Module'`)
  *
  * @active since v1.2.0
  */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
  * can lead to confusion and potential bugs.
  *
  * @configuration allowedNames - unused private member names matching this regex are ignored
- * (default: `"(_|ignored|expected|serialVersionUID)"`)
+ * (default: `'(_|ignored|expected|serialVersionUID)'`)
  */
 class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -40,7 +40,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPropertyParameter
  * </compliant>
  *
  * @configuration excludeAnnotatedClasses - allows to provide a list of annotations that disable this check
- * (default: `""`)
+ * (default: `''`)
  * @configuration allowVars - allows to relax this rule in order to exclude classes that contains one (or more) Vars (default: `false`)
  */
 class UseDataClass(config: Config = Config.empty) : Rule(config) {

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -127,7 +127,7 @@ way to get the instance of an outer class from an inner class in Kotlin.
 
 #### Configuration options:
 
-* ``ignoredLabels`` (default: ``""``)
+* ``ignoredLabels`` (default: ``''``)
 
    allows to provide a list of label names which should be ignored by this rule
 

--- a/docs/pages/documentation/empty-blocks.md
+++ b/docs/pages/documentation/empty-blocks.md
@@ -19,7 +19,7 @@ Reports empty `catch` blocks. Empty blocks of code serve no purpose and should b
 
 #### Configuration options:
 
-* ``allowedExceptionNameRegex`` (default: ``"^(_|(ignore|expected).*)"``)
+* ``allowedExceptionNameRegex`` (default: ``'^(_|(ignore|expected).*)'``)
 
    ignores exception types which match this regex
 

--- a/docs/pages/documentation/exceptions.md
+++ b/docs/pages/documentation/exceptions.md
@@ -218,7 +218,7 @@ passed into a newly thrown exception.
 
    exception types which should be ignored by this rule
 
-* ``allowedExceptionNameRegex`` (default: ``"^(_|(ignore|expected).*)"``)
+* ``allowedExceptionNameRegex`` (default: ``'^(_|(ignore|expected).*)'``)
 
    ignores too generic exception types which match this regex
 
@@ -395,7 +395,7 @@ exception is too broad it can lead to unintended exceptions being caught.
 
    exceptions which are too generic and should not be caught
 
-* ``allowedExceptionNameRegex`` (default: ``"^(_|(ignore|expected).*)"``)
+* ``allowedExceptionNameRegex`` (default: ``'^(_|(ignore|expected).*)'``)
 
    ignores too generic exception types which match this regex
 

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -285,12 +285,12 @@ guaranteed. Try using constructor injection or delegation to initialize properti
 
 #### Configuration options:
 
-* ``excludeAnnotatedProperties`` (default: ``""``)
+* ``excludeAnnotatedProperties`` (default: ``''``)
 
    Allows you to provide a list of annotations that disable
 this check.
 
-* ``ignoreOnClassesPattern`` (default: ``""``)
+* ``ignoreOnClassesPattern`` (default: ``''``)
 
    Allows you to disable the rule for a list of classes
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -263,7 +263,7 @@ development. Offending code comments will then be reported.
 
    forbidden comment strings
 
-* ``allowedPatterns`` (default: ``""``)
+* ``allowedPatterns`` (default: ``''``)
 
    ignores comments which match the specified regular expression.
 For example `Ticket|Task`.
@@ -292,7 +292,7 @@ or deprecated APIs. Detekt will then report all imports that are forbidden.
 
    imports which should not be used
 
-* ``forbiddenPatterns`` (default: ``""``)
+* ``forbiddenPatterns`` (default: ``''``)
 
    reports imports which match the specified regular expression. For example `net.*R`.
 
@@ -414,7 +414,7 @@ as a `const val`.
 
    excluded functions
 
-* ``excludeAnnotatedFunction`` (default: ``"dagger.Provides"``)
+* ``excludeAnnotatedFunction`` (default: ``'dagger.Provides'``)
 
    allows to provide a list of annotations that disable this check
 
@@ -923,7 +923,7 @@ code.
 
    define the maximum number of return statements allowed per function
 
-* ``excludedFunctions`` (default: ``"equals"``)
+* ``excludedFunctions`` (default: ``'equals'``)
 
    define functions to be ignored by this check
 
@@ -1138,7 +1138,7 @@ refactored into concrete classes.
 
 #### Configuration options:
 
-* ``excludeAnnotatedClasses`` (default: ``"dagger.Module"``)
+* ``excludeAnnotatedClasses`` (default: ``'dagger.Module'``)
 
    Allows you to provide a list of annotations that disable
 this check.
@@ -1351,7 +1351,7 @@ can lead to confusion and potential bugs.
 
 #### Configuration options:
 
-* ``allowedNames`` (default: ``"(_|ignored|expected|serialVersionUID)"``)
+* ``allowedNames`` (default: ``'(_|ignored|expected|serialVersionUID)'``)
 
    unused private member names matching this regex are ignored
 
@@ -1420,7 +1420,7 @@ Read more about `data class`: https://kotlinlang.org/docs/reference/data-classes
 
 #### Configuration options:
 
-* ``excludeAnnotatedClasses`` (default: ``""``)
+* ``excludeAnnotatedClasses`` (default: ``''``)
 
    allows to provide a list of annotations that disable this check
 


### PR DESCRIPTION
In our default yaml we have some strings with `"` and others with `'`. This PR unify all of them using `'`.

The reason about using `'` over `"` is that if you need to write `"hello"` with `'` you write: `'"hello"'` and with `"` you need: `"\"hello\""`.