### PR TITLE
Use yml arrays to list the ForbiddenImports

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -479,7 +479,7 @@ style:
     allowedPatterns: ''
   ForbiddenImport:
     active: false
-    imports: ''
+    imports: []
     forbiddenPatterns: ''
   ForbiddenMethodCall:
     active: false

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules
 
+import io.gitlab.arturbosch.detekt.api.ConfigAware
 import io.gitlab.arturbosch.detekt.api.DetektVisitor
+import io.gitlab.arturbosch.detekt.api.commaSeparatedPattern
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
@@ -34,3 +36,17 @@ fun getIntValueForPsiElement(element: PsiElement): Int? {
 fun KtClass.companionObject() = this.companionObjects.singleOrNull { it.isCompanion() }
 
 inline fun <reified T : Any> Any.safeAs(): T? = this as? T
+
+internal fun ConfigAware.valueOrDefaultCommaSeparated(
+    key: String,
+    default: List<String>,
+    defaultString: String
+): List<String> {
+    return try {
+        valueOrDefault(key, default)
+    } catch (_: IllegalStateException) {
+        valueOrDefault(key, defaultString)
+            .commaSeparatedPattern()
+            .toList()
+    }
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -7,8 +7,8 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.api.commaSeparatedPattern
 import io.gitlab.arturbosch.detekt.api.simplePatternToRegex
+import io.gitlab.arturbosch.detekt.rules.valueOrDefaultCommaSeparated
 import org.jetbrains.kotlin.psi.KtImportDirective
 
 /**
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  * import kotlin.SinceKotlin
  * </noncompliant>
  *
- * @configuration imports - imports which should not be used (default: `''`)
+ * @configuration imports - imports which should not be used (default: `[]`)
  * @configuration forbiddenPatterns - reports imports which match the specified regular expression. For example `net.*R`. (default: `''`)
  */
 class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
@@ -35,8 +35,7 @@ class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
         Debt.TEN_MINS
     )
 
-    private val forbiddenImports = valueOrDefault(IMPORTS, "")
-        .commaSeparatedPattern()
+    private val forbiddenImports = valueOrDefaultCommaSeparated(IMPORTS, emptyList(), "")
         .distinct()
         .map { it.simplePatternToRegex() }
         .toList()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -37,7 +37,7 @@ class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
         Debt.TEN_MINS
     )
 
-    private val forbiddenMethods = valueOrDefault(METHODS, "").commaSeparatedPattern()
+    private val forbiddenMethods = valueOrDefault(METHODS, "").commaSeparatedPattern().toList()
 
     override fun visitQualifiedExpression(expression: KtQualifiedExpression) {
         super.visitQualifiedExpression(expression)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -53,6 +53,13 @@ class ForbiddenImportSpec : Spek({
             assertThat(findings).hasSize(2)
         }
 
+        it("should report kotlin.SinceKotlin and kotlin.jvm.JvmField when specified via fully qualified names list") {
+            val findings =
+                ForbiddenImport(TestConfig(mapOf(
+                    ForbiddenImport.IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField")))).lint(code)
+            assertThat(findings).hasSize(2)
+        }
+
         it("should report kotlin.SinceKotlin when specified via kotlin.Since*") {
             val findings = ForbiddenImport(TestConfig(mapOf(ForbiddenImport.IMPORTS to "kotlin.Since*"))).lint(code)
             assertThat(findings).hasSize(1)

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.BaseConfig
 
 @Suppress("UNCHECKED_CAST")
 open class TestConfig(
-    private val values: Map<String, String> = mutableMapOf(),
+    private val values: Map<String, Any> = mutableMapOf(),
     override val parent: HierarchicalConfig.Parent? = null
 ) : BaseConfig() {
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -288,7 +288,7 @@ or deprecated APIs. Detekt will then report all imports that are forbidden.
 
 #### Configuration options:
 
-* ``imports`` (default: ``''``)
+* ``imports`` (default: ``[]``)
 
    imports which should not be used
 


### PR DESCRIPTION
Fixes #2463

I think that we should add this to the rest of configurations that have lists and deprecate the strings splitted by `,`. And remove the support in 2.0. My reasons:
- It's easier to mantain the configuration using lists than strings
- We don't need to handle strange cases splitting strings (empty strings and similar)

If you agree I can open an issue to track all those configurations.