### PR TITLE
Extend ComplexInterface to support exclusion of private member/functions

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -25,6 +25,7 @@ complexity:
     active: true
     threshold: 10
     includeStaticDeclarations: false
+    includePrivateDeclarations: false
   ComplexMethod:
     active: true
     ignoreSingleWhenExpression: true

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,6 +1,10 @@
 build:
   maxIssues: 1
 
+# can be removed after 1.7.0 is published
+config:
+  excludes: "complexity>ComplexInterface>includePrivateDeclarations"
+
 comments:
   CommentOverPrivateProperty:
     active: true

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -64,6 +64,7 @@ complexity:
     active: false
     threshold: 10
     includeStaticDeclarations: false
+    includePrivateDeclarations: false
   ComplexMethod:
     active: true
     threshold: 15

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
@@ -73,7 +73,7 @@ class ComplexInterface(
             if (includePrivateDeclarations) {
                 true
             } else {
-                (it is KtTypeParameterListOwner && !it.isPrivate())
+                it is KtTypeParameterListOwner && !it.isPrivate()
             }
         }
         .count { it is KtNamedFunction || it is KtProperty }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
@@ -9,7 +9,8 @@ import org.spekframework.spek2.style.specification.describe
 class ComplexInterfaceSpec : Spek({
 
     val subject by memoized { ComplexInterface(threshold = THRESHOLD) }
-    val config = TestConfig(mapOf(ComplexInterface.INCLUDE_STATIC_DECLARATIONS to "true"))
+    val staticDeclarationsConfig = TestConfig(mapOf(ComplexInterface.INCLUDE_STATIC_DECLARATIONS to "true"))
+    val privateDeclarationsConfig = TestConfig(mapOf(ComplexInterface.INCLUDE_PRIVATE_DECLARATIONS to "true"))
 
     describe("ComplexInterface rule positives") {
 
@@ -28,7 +29,7 @@ class ComplexInterfaceSpec : Spek({
             }
 
             it("reports complex interface with includeStaticDeclarations config") {
-                val rule = ComplexInterface(config, threshold = THRESHOLD)
+                val rule = ComplexInterface(staticDeclarationsConfig, threshold = THRESHOLD)
                 assertThat(rule.compileAndLint(code)).hasSize(1)
             }
         }
@@ -50,7 +51,7 @@ class ComplexInterfaceSpec : Spek({
             }
 
             it("reports complex interface with includeStaticDeclarations config") {
-                val rule = ComplexInterface(config, threshold = THRESHOLD)
+                val rule = ComplexInterface(staticDeclarationsConfig, threshold = THRESHOLD)
                 assertThat(rule.compileAndLint(code)).hasSize(1)
             }
         }
@@ -72,7 +73,47 @@ class ComplexInterfaceSpec : Spek({
             }
 
             it("reports complex interface with includeStaticDeclarations config") {
-                val rule = ComplexInterface(config, threshold = THRESHOLD)
+                val rule = ComplexInterface(staticDeclarationsConfig, threshold = THRESHOLD)
+                assertThat(rule.compileAndLint(code)).hasSize(1)
+            }
+        }
+
+        context("private function") {
+            val code = """
+                interface I {
+                    fun f1()
+                    fun f2()
+                    val i1: Int
+                    private fun fImpl() {}
+                }
+            """
+
+            it("does not report complex interface") {
+                assertThat(subject.compileAndLint(code)).isEmpty()
+            }
+
+            it("does report complex interface with includePrivateDeclarations config") {
+                val rule = ComplexInterface(privateDeclarationsConfig, threshold = THRESHOLD)
+                assertThat(rule.compileAndLint(code)).hasSize(1)
+            }
+        }
+
+        context("private member") {
+            val code = """
+                interface I {
+                    fun f1()
+                    fun f2()
+                    private val i1: Int
+                    fun fImpl() {}
+                }
+            """
+
+            it("does not report complex interface") {
+                assertThat(subject.compileAndLint(code)).isEmpty()
+            }
+
+            it("does report complex interface with includePrivateDeclarations config") {
+                val rule = ComplexInterface(privateDeclarationsConfig, threshold = THRESHOLD)
                 assertThat(rule.compileAndLint(code)).hasSize(1)
             }
         }
@@ -87,7 +128,7 @@ class ComplexInterfaceSpec : Spek({
                     fun fImpl() {
                         val x = 0 // should not report
                     }
- 
+
                     val i: Int
                     // a comment shouldn't be detected
                 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
@@ -78,7 +78,7 @@ class ComplexInterfaceSpec : Spek({
             }
         }
 
-        context("private function") {
+        context("private functions") {
             val code = """
                 interface I {
                     fun f1()
@@ -98,12 +98,13 @@ class ComplexInterfaceSpec : Spek({
             }
         }
 
-        context("private member") {
+        context("private members") {
             val code = """
                 interface I {
                     fun f1()
                     fun f2()
                     private val i1: Int
+                        get() = 42
                     fun fImpl() {}
                 }
             """

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -67,6 +67,10 @@ to understand and implement.
 
    whether static declarations should be included
 
+* ``includePrivateDeclarations`` (default: ``false``)
+
+   whether private declarations should be included
+
 ### ComplexMethod
 
 Complex methods are hard to understand and read. It might not be obvious what side-effects a complex method has.


### PR DESCRIPTION
Following up discussion on #2446, currently `ComplexInterface` is considering also `private` members/functions. I'm adding a `includePrivateDeclarations` config field (default false) to make this behavior configurable.

Fixes #2446


