### PR TITLE
Use PrinterStream in AstPrinter

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -62,7 +62,7 @@ fun buildRunner(
         arguments.showVersion -> VersionPrinter(outputPrinter)
         arguments.generateConfig -> ConfigExporter(arguments)
         arguments.runRule != null -> SingleRuleRunner(arguments)
-        arguments.printAst -> AstPrinter(arguments)
+        arguments.printAst -> AstPrinter(arguments, outputPrinter)
         else -> Runner(arguments, outputPrinter, errorPrinter)
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinter.kt
@@ -3,8 +3,12 @@ package io.gitlab.arturbosch.detekt.cli.runners
 import io.gitlab.arturbosch.detekt.cli.CliArgs
 import io.gitlab.arturbosch.detekt.core.KtCompiler
 import io.gitlab.arturbosch.detekt.core.isFile
+import java.io.PrintStream
 
-class AstPrinter(private val arguments: CliArgs) : Executable {
+class AstPrinter(
+    private val arguments: CliArgs,
+    private val outPrinter: PrintStream
+) : Executable {
 
     override fun execute() {
         val optionalInput = arguments.inputPaths.singleOrNull()
@@ -17,6 +21,6 @@ class AstPrinter(private val arguments: CliArgs) : Executable {
         }
 
         val ktFile = KtCompiler().compile(input, input)
-        println(ElementPrinter.dump(ktFile))
+        outPrinter.println(ElementPrinter.dump(ktFile))
     }
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.cli.runners.ConfigExporter
 import io.gitlab.arturbosch.detekt.cli.runners.Runner
 import io.gitlab.arturbosch.detekt.cli.runners.SingleRuleRunner
 import io.gitlab.arturbosch.detekt.cli.runners.VersionPrinter
+import io.gitlab.arturbosch.detekt.test.NullPrintStream
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
@@ -18,7 +19,7 @@ class MainSpec : Spek({
 
     describe("build runner") {
 
-        listOf(PrintStream(ByteArrayOutputStream()), null).forEach { printer ->
+        listOf(NullPrintStream(), null).forEach { printer ->
 
             context("printer is [${if (printer == null) "default" else "provided"}]") {
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinterSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/AstPrinterSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.cli.runners
 
 import io.gitlab.arturbosch.detekt.cli.CliArgs
+import io.gitlab.arturbosch.detekt.test.NullPrintStream
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
@@ -18,21 +19,12 @@ class AstPrinterSpec : Spek({
 
         describe("successful AST printing") {
 
-            val outStream = System.out
             val output = ByteArrayOutputStream()
-
-            beforeEachTest {
-                System.setOut(PrintStream(output))
-            }
-
-            afterEachTest {
-                System.setOut(outStream)
-            }
 
             it("should print the AST as string") {
                 val args = CliArgs()
                 args.input = Paths.get(resource("cases/Poko.kt")).toString()
-                val printer = AstPrinter(args)
+                val printer = AstPrinter(args, PrintStream(output))
 
                 printer.execute()
 
@@ -44,7 +36,7 @@ class AstPrinterSpec : Spek({
             val multiplePaths = "$path,$path"
             val args = CliArgs()
             args.input = multiplePaths
-            val printer = AstPrinter(args)
+            val printer = AstPrinter(args, NullPrintStream())
 
             assertThatIllegalArgumentException()
                 .isThrownBy { printer.execute() }
@@ -54,7 +46,7 @@ class AstPrinterSpec : Spek({
         it("throws an exception when trying to print the AST of a directory") {
             val args = CliArgs()
             args.input = path
-            val printer = AstPrinter(args)
+            val printer = AstPrinter(args, NullPrintStream())
 
             assertThatIllegalArgumentException()
                 .isThrownBy { printer.execute() }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/NullOutputStream.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/NullOutputStream.kt
@@ -1,0 +1,9 @@
+package io.gitlab.arturbosch.detekt.test
+
+import java.io.OutputStream
+
+internal class NullOutputStream : OutputStream() {
+    override fun write(b: Int) {
+        // no-op
+    }
+}

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/NullPrintStream.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/NullPrintStream.kt
@@ -1,0 +1,5 @@
+package io.gitlab.arturbosch.detekt.test
+
+import java.io.PrintStream
+
+class NullPrintStream : PrintStream(NullOutputStream())


### PR DESCRIPTION
This is the first of a serie of PRs related with how we manage the output.

The main ideas:
- Always use `PrinterStream.println` instead of `println`
- Don't have a default `printerStream`. Because that is the same as use `println`.
- Reduce the noise in out tests. If we always use `PrinterStream` to print output we can use `NullPrinterStream` or other types of `PrinterStream` so we don't print to the stdout when we run tests. With this we can reduce the log size related with tests about 40%.