### PR TITLE
Don't use println :detekt-generator

### DIFF
--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Main.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Main.kt
@@ -21,6 +21,6 @@ fun main(args: Array<String>) {
         }
         // input paths are validated by MultipleExistingPathConverter
     }
-    val executable = Runner(arguments)
+    val executable = Runner(arguments, System.out, System.err)
     executable.execute()
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Runner.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Runner.kt
@@ -36,6 +36,6 @@ class Runner(
             printer.print(collector.items)
         }
 
-        println("\nGenerated all detekt documentation in $time ms.")
+        outPrinter.println("\nGenerated all detekt documentation in $time ms.")
     }
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Runner.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Runner.kt
@@ -4,16 +4,23 @@ import io.gitlab.arturbosch.detekt.core.KtTreeCompiler
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.generator.collection.DetektCollector
 import io.gitlab.arturbosch.detekt.generator.printer.DetektPrinter
+import java.io.PrintStream
 import java.nio.file.Path
 import kotlin.system.measureTimeMillis
 
-class Runner(private val arguments: GeneratorArgs) {
+class Runner(
+    private val arguments: GeneratorArgs,
+    private val outPrinter: PrintStream,
+    private val errPrinter: PrintStream
+) {
     private val listeners = listOf(DetektProgressListener())
     private val collector = DetektCollector()
     private val printer = DetektPrinter(arguments)
 
-    private fun createCompiler(path: Path) =
-        KtTreeCompiler.instance(ProcessingSettings(path))
+    private fun createCompiler(path: Path) = KtTreeCompiler.instance(ProcessingSettings(
+        path,
+        outPrinter = outPrinter,
+        errorPrinter = errPrinter))
 
     fun execute() {
         val time = measureTimeMillis {


### PR DESCRIPTION
This is the second of a serie of PRs related with how we manage the output.

The main ideas:
- Always use `PrinterStream.println` instead of `println`
- Don't have a default `printerStream`. Because that is the same as use `println`.
- Reduce the noise in out tests. If we always use `PrinterStream` to print output we can use `NullPrinterStream` or other types of `PrinterStream` so we don't print to the stdout when we run tests. With this we can reduce the log size related with tests about 40%.