### PR TITLE
ProcessingSettings

### DIFF
--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/FileProcessorLocatorSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/FileProcessorLocatorSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.cli
 
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.core.FileProcessorLocator
-import io.gitlab.arturbosch.detekt.core.ProcessingSettings
+import io.gitlab.arturbosch.detekt.test.createProcessingSettings
 import io.gitlab.arturbosch.detekt.test.resource
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
@@ -23,7 +23,7 @@ class FileProcessorLocatorSpec : Spek({
         val path = Paths.get(resource(""))
 
         it("contains all processors") {
-            val processors = ProcessingSettings(path).use { FileProcessorLocator(it).load() }
+            val processors = createProcessingSettings(path).use { FileProcessorLocator(it).load() }
             val processorClasses = getProcessorClasses()
 
             assertThat(processorClasses).isNotEmpty
@@ -34,7 +34,7 @@ class FileProcessorLocatorSpec : Spek({
 
         it("has disabled processors") {
             val config = yamlConfig("configs/disabled-processors.yml")
-            val processors = ProcessingSettings(path, config).use { FileProcessorLocator(it).load() }
+            val processors = createProcessingSettings(path, config).use { FileProcessorLocator(it).load() }
             assertThat(processors).isEmpty()
         }
     }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/OutputFacadeSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/OutputFacadeSpec.kt
@@ -4,8 +4,8 @@ import io.gitlab.arturbosch.detekt.cli.out.HtmlOutputReport
 import io.gitlab.arturbosch.detekt.cli.out.TxtOutputReport
 import io.gitlab.arturbosch.detekt.cli.out.XmlOutputReport
 import io.gitlab.arturbosch.detekt.core.DetektResult
-import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.test.StringPrintStream
+import io.gitlab.arturbosch.detekt.test.createProcessingSettings
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.utils.closeQuietly
@@ -24,7 +24,7 @@ internal class OutputFacadeSpec : Spek({
     val xmlOutputPath = File.createTempFile("detekt", ".xml")
 
     val defaultDetektion = DetektResult(mapOf(Pair("Key", listOf(createFinding()))))
-    val defaultSettings = ProcessingSettings(inputPath, outPrinter = printStream)
+    val defaultSettings = createProcessingSettings(inputPath, outPrinter = printStream)
 
     afterGroup { closeQuietly(defaultSettings) }
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/ReportsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/ReportsSpec.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.cli.CliArgs
 import io.gitlab.arturbosch.detekt.cli.ReportLocator
 import io.gitlab.arturbosch.detekt.cli.parseArguments
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
+import io.gitlab.arturbosch.detekt.test.NullPrintStream
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Condition
@@ -61,7 +62,11 @@ internal class ReportsSpec : Spek({
                 )
             }
 
-            val extensions = ProcessingSettings(listOf()).use { ReportLocator(it).load() }
+            val extensions = ProcessingSettings(
+                listOf(),
+                outPrinter = NullPrintStream(),
+                errorPrinter = NullPrintStream()
+            ).use { ReportLocator(it).load() }
             val extensionsIds = extensions.mapTo(HashSet()) { it.id }
 
             it("should be able to convert to output reports") {
@@ -83,7 +88,12 @@ internal class ReportsSpec : Spek({
 
             it("yields empty extension list") {
                 val config = yamlConfig("configs/disabled-reports.yml")
-                val extensions = ProcessingSettings(listOf(), config).use { ReportLocator(it).load() }
+                val extensions = ProcessingSettings(
+                    listOf(),
+                    config,
+                    outPrinter = NullPrintStream(),
+                    errorPrinter = NullPrintStream()
+                ).use { ReportLocator(it).load() }
                 assertThat(extensions).isEmpty()
             }
         }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
@@ -39,6 +39,7 @@ class SingleRuleRunnerSpec : Spek({
         it("should throw on non existing rule set") {
             val args = createCliArgs("--run-rule", "non_existing:test")
             assertThatThrownBy { SingleRuleRunner(args, NullPrintStream(), NullPrintStream()).execute() }
+                .isExactlyInstanceOf(IllegalArgumentException::class.java)
         }
 
         it("should throw on non existing run-rule") {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -29,7 +29,7 @@ import java.util.concurrent.ForkJoinPool
  */
 @OptIn(UnstableApi::class)
 @Suppress("LongParameterList")
-class ProcessingSettings @JvmOverloads constructor(
+class ProcessingSettings constructor(
     val inputPaths: List<Path>,
     override val config: Config = Config.empty,
     val pathFilters: PathFilters? = null,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -27,8 +27,7 @@ import java.util.concurrent.ExecutorService
  * If using a custom executor service be aware that detekt won't shut it down after use!
  */
 @OptIn(UnstableApi::class)
-@Suppress("LongParameterList")
-class ProcessingSettings constructor(
+class ProcessingSettings @Suppress("LongParameterList") constructor(
     val inputPaths: List<Path>,
     override val config: Config = Config.empty,
     val pathFilters: PathFilters? = null,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -39,8 +39,8 @@ class ProcessingSettings constructor(
     val languageVersion: LanguageVersion? = null,
     val jvmTarget: JvmTarget = JvmTarget.DEFAULT,
     val executorService: ExecutorService? = null,
-    val outPrinter: PrintStream = System.out,
-    val errorPrinter: PrintStream = System.err,
+    val outPrinter: PrintStream,
+    val errorPrinter: PrintStream,
     val autoCorrect: Boolean = false,
     val debug: Boolean = false,
     override val configUris: Collection<URI> = emptyList()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -19,7 +19,6 @@ import java.net.URLClassLoader
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.ForkJoinPool
 
 /**
  * Settings to be used by the detekt engine.
@@ -46,42 +45,6 @@ class ProcessingSettings constructor(
     val debug: Boolean = false,
     override val configUris: Collection<URI> = emptyList()
 ) : AutoCloseable, Closeable, SetupContext {
-    /**
-     * Single project input path constructor.
-     */
-    constructor(
-        inputPath: Path,
-        config: Config = Config.empty,
-        pathFilters: PathFilters? = null,
-        parallelCompilation: Boolean = false,
-        excludeDefaultRuleSets: Boolean = false,
-        pluginPaths: List<Path> = emptyList(),
-        classpath: List<String> = emptyList(),
-        languageVersion: LanguageVersion = LanguageVersion.LATEST_STABLE,
-        jvmTarget: JvmTarget = JvmTarget.DEFAULT,
-        executorService: ExecutorService = ForkJoinPool.commonPool(),
-        outPrinter: PrintStream = System.out,
-        errorPrinter: PrintStream = System.err,
-        autoCorrect: Boolean = false,
-        debug: Boolean = false,
-        configUris: Collection<URI> = emptyList()
-    ) : this(
-        listOf(inputPath),
-        config,
-        pathFilters,
-        parallelCompilation,
-        excludeDefaultRuleSets,
-        pluginPaths,
-        classpath,
-        languageVersion,
-        jvmTarget,
-        executorService,
-        outPrinter,
-        errorPrinter,
-        autoCorrect,
-        debug,
-        configUris
-    )
 
     init {
         pluginPaths.forEach {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.test.compileForTest
+import io.gitlab.arturbosch.detekt.test.createProcessingSettings
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtClass
@@ -37,7 +38,7 @@ class CorrectableRulesFirstSpec : Spek({
 
             val testFile = path.resolve("Test.kt")
             val detector = Detektor(
-                ProcessingSettings(testFile, yamlConfig("one-correctable-rule.yml")),
+                createProcessingSettings(testFile, yamlConfig("one-correctable-rule.yml")),
                 listOf(object : RuleSetProvider {
                     override val ruleSetId: String = "Test"
                     override fun instance(config: Config) = RuleSet(ruleSetId, listOf(Last(config), First(config)))

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CustomRuleSetProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CustomRuleSetProviderSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.core
 
+import io.gitlab.arturbosch.detekt.test.createProcessingSettings
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
@@ -24,7 +25,7 @@ class CustomRuleSetProviderSpec : Spek({
         val sampleRuleSet = Paths.get(resource("sample-rule-set.jar"))
 
         it("should load the sample provider") {
-            val providers = ProcessingSettings(
+            val providers = createProcessingSettings(
                 path,
                 excludeDefaultRuleSets = true,
                 pluginPaths = listOf(sampleRuleSet)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.core
 
+import io.gitlab.arturbosch.detekt.test.createProcessingSettings
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -8,7 +9,7 @@ class DetektSpec : Spek({
 
     describe("default providers must be registered in META-INF/services") {
 
-        val detekt = DetektFacade.create(ProcessingSettings(path))
+        val detekt = DetektFacade.create(createProcessingSettings(path))
 
         it("should detect findings from more than one provider") {
             assertThat(detekt.run().findings).isNotEmpty

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
+import io.gitlab.arturbosch.detekt.test.createProcessingSettings
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
@@ -11,7 +12,7 @@ import java.nio.file.Paths
 class KtTreeCompilerSpec : Spek({
 
     fun fixture(vararg filters: String): KtTreeCompiler =
-        KtTreeCompiler(settings = ProcessingSettings(path,
+        KtTreeCompiler(settings = createProcessingSettings(path,
             pathFilters = PathFilters.of(null, filters.joinToString(","))))
 
     describe("tree compiler functionality") {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/RuleSetLocatorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/RuleSetLocatorTest.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.test.createProcessingSettings
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.reflections.Reflections
@@ -13,7 +14,7 @@ class RuleSetLocatorTest : Spek({
     describe("locating RuleSetProvider's") {
 
         it("contains all RuleSetProviders") {
-            val providers = ProcessingSettings(path).use { RuleSetLocator(it).load() }
+            val providers = createProcessingSettings(path).use { RuleSetLocator(it).load() }
             val providerClasses = getProviderClasses()
 
             assertThat(providerClasses).isNotEmpty
@@ -23,7 +24,7 @@ class RuleSetLocatorTest : Spek({
         }
 
         it("does not load any default rule set provider when opt out") {
-            val providers = ProcessingSettings(path, excludeDefaultRuleSets = true)
+            val providers = createProcessingSettings(path, excludeDefaultRuleSets = true)
                 .use { RuleSetLocator(it).load() }
 
             val defaultProviders = getProviderClasses().toSet()

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.core.DetektFacade
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.core.rules.visitFile
+import io.gitlab.arturbosch.detekt.test.createProcessingSettings
 import io.gitlab.arturbosch.detekt.test.loadRuleSet
 import io.gitlab.arturbosch.detekt.test.resource
 import io.gitlab.arturbosch.detekt.test.yamlConfig
@@ -49,7 +50,7 @@ class AutoCorrectLevelSpec : Spek({
                         assertThat(wasFormatted(files[0])).isTrue()
                     }
                 }
-                val result = ProcessingSettings(project, config).use {
+                val result = createProcessingSettings(project, config).use {
                     DetektFacade.create(it, listOf(FormattingProvider()), listOf(contentChanged)).run()
                 }
                 val findings = result.findings.flatMap { it.value }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Runner.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Runner.kt
@@ -18,7 +18,7 @@ class Runner(
     private val printer = DetektPrinter(arguments)
 
     private fun createCompiler(path: Path) = KtTreeCompiler.instance(ProcessingSettings(
-        path,
+        listOf(path),
         outPrinter = outPrinter,
         errorPrinter = errPrinter))
 

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ProcessingSettingsFactory.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ProcessingSettingsFactory.kt
@@ -14,6 +14,7 @@ import java.util.concurrent.ForkJoinPool
 /**
  * Single project input path constructor.
  */
+@Suppress("LongParameterList")
 fun createProcessingSettings(
     inputPath: Path,
     config: Config = Config.empty,

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ProcessingSettingsFactory.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ProcessingSettingsFactory.kt
@@ -25,8 +25,8 @@ fun createProcessingSettings(
     languageVersion: LanguageVersion = LanguageVersion.LATEST_STABLE,
     jvmTarget: JvmTarget = JvmTarget.DEFAULT,
     executorService: ExecutorService = ForkJoinPool.commonPool(),
-    outPrinter: PrintStream = System.out,
-    errorPrinter: PrintStream = System.err,
+    outPrinter: PrintStream = NullPrintStream(),
+    errorPrinter: PrintStream = NullPrintStream(),
     autoCorrect: Boolean = false,
     debug: Boolean = false,
     configUris: Collection<URI> = emptyList()

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ProcessingSettingsFactory.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ProcessingSettingsFactory.kt
@@ -1,0 +1,49 @@
+package io.gitlab.arturbosch.detekt.test
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.PathFilters
+import io.gitlab.arturbosch.detekt.core.ProcessingSettings
+import org.jetbrains.kotlin.config.JvmTarget
+import org.jetbrains.kotlin.config.LanguageVersion
+import java.io.PrintStream
+import java.net.URI
+import java.nio.file.Path
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.ForkJoinPool
+
+/**
+ * Single project input path constructor.
+ */
+fun createProcessingSettings(
+    inputPath: Path,
+    config: Config = Config.empty,
+    pathFilters: PathFilters? = null,
+    parallelCompilation: Boolean = false,
+    excludeDefaultRuleSets: Boolean = false,
+    pluginPaths: List<Path> = emptyList(),
+    classpath: List<String> = emptyList(),
+    languageVersion: LanguageVersion = LanguageVersion.LATEST_STABLE,
+    jvmTarget: JvmTarget = JvmTarget.DEFAULT,
+    executorService: ExecutorService = ForkJoinPool.commonPool(),
+    outPrinter: PrintStream = System.out,
+    errorPrinter: PrintStream = System.err,
+    autoCorrect: Boolean = false,
+    debug: Boolean = false,
+    configUris: Collection<URI> = emptyList()
+) = ProcessingSettings(
+    inputPaths = listOf(inputPath),
+    config = config,
+    pathFilters = pathFilters,
+    parallelCompilation = parallelCompilation,
+    excludeDefaultRuleSets = excludeDefaultRuleSets,
+    pluginPaths = pluginPaths,
+    classpath = classpath,
+    languageVersion = languageVersion,
+    jvmTarget = jvmTarget,
+    executorService = executorService,
+    outPrinter = outPrinter,
+    errorPrinter = errorPrinter,
+    autoCorrect = autoCorrect,
+    debug = debug,
+    configUris = configUris
+)


### PR DESCRIPTION
This is the third of a serie of PRs related with how we manage the output.

The main ideas:
- Always use `PrinterStream.println` instead of `println`
- Don't have a default `printerStream`. Because that is the same as use `println`.
- Reduce the noise in out tests. If we always use `PrinterStream` to print output we can use `NullPrinterStream` or other types of `PrinterStream` so we don't print to the stdout when we run tests. With this we can reduce the log size related with tests about 40%.