### PR TITLE
Single runner

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -61,7 +61,7 @@ fun buildRunner(
     return when {
         arguments.showVersion -> VersionPrinter(outputPrinter)
         arguments.generateConfig -> ConfigExporter(arguments)
-        arguments.runRule != null -> SingleRuleRunner(arguments)
+        arguments.runRule != null -> SingleRuleRunner(arguments, outputPrinter, errorPrinter)
         arguments.printAst -> AstPrinter(arguments, outputPrinter)
         else -> Runner(arguments, outputPrinter, errorPrinter)
     }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
@@ -15,8 +15,13 @@ import io.gitlab.arturbosch.detekt.core.DetektFacade
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.core.RuleSetLocator
 import io.gitlab.arturbosch.detekt.core.rules.createRuleSet
+import java.io.PrintStream
 
-class SingleRuleRunner(private val arguments: CliArgs) : Executable {
+class SingleRuleRunner(
+    private val arguments: CliArgs,
+    private val outPrinter: PrintStream,
+    private val errPrinter: PrintStream
+) : Executable {
 
     override fun execute() {
         val (ruleSet, rule: RuleId) = checkNotNull(
@@ -31,7 +36,9 @@ class SingleRuleRunner(private val arguments: CliArgs) : Executable {
                 parallelCompilation = parallel,
                 autoCorrect = autoCorrect,
                 excludeDefaultRuleSets = disableDefaultRuleSets,
-                pluginPaths = createPlugins())
+                pluginPaths = createPlugins(),
+                outPrinter = outPrinter,
+                errorPrinter = errPrinter)
         }.use { settings ->
             val realProvider = requireNotNull(
                 RuleSetLocator(settings).load().find { it.ruleSetId == ruleSet }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.cli.runners
 
 import io.gitlab.arturbosch.detekt.cli.createCliArgs
+import io.gitlab.arturbosch.detekt.test.NullPrintStream
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -24,26 +25,25 @@ class SingleRuleRunnerSpec : Spek({
                 "--run-rule", "test:test"
             )
 
-            SingleRuleRunner(args).execute()
+            SingleRuleRunner(args, NullPrintStream(), NullPrintStream()).execute()
 
             assertThat(Files.readAllLines(tmp)).hasSize(1)
         }
 
         it("should throw on non existing rule") {
             val args = createCliArgs("--run-rule", "test:non_existing")
-            assertThatThrownBy { SingleRuleRunner(args).execute() }
+            assertThatThrownBy { SingleRuleRunner(args, NullPrintStream(), NullPrintStream()).execute() }
                 .isExactlyInstanceOf(IllegalArgumentException::class.java)
         }
 
         it("should throw on non existing rule set") {
             val args = createCliArgs("--run-rule", "non_existing:test")
-            assertThatThrownBy { SingleRuleRunner(args).execute() }
-                .isExactlyInstanceOf(IllegalArgumentException::class.java)
+            assertThatThrownBy { SingleRuleRunner(args, NullPrintStream(), NullPrintStream()).execute() }
         }
 
         it("should throw on non existing run-rule") {
             val args = createCliArgs()
-            assertThatThrownBy { SingleRuleRunner(args).execute() }
+            assertThatThrownBy { SingleRuleRunner(args, NullPrintStream(), NullPrintStream()).execute() }
                 .isExactlyInstanceOf(IllegalStateException::class.java)
                 .withFailMessage("Unexpected empty 'runRule' argument.")
         }


### PR DESCRIPTION
blocked by #2485

This is the third of a serie of PRs related with how we manage the output.

The main ideas:
- Always use `PrinterStream.println` instead of `println`
- Don't have a default `printerStream`. Because that is the same as use `println`.
- Reduce the noise in out tests. If we always use `PrinterStream` to print output we can use `NullPrinterStream` or other types of `PrinterStream` so we don't print to the stdout when we run tests. With this we can reduce the log size related with tests about 40%.