### PR TITLE
Move test factory outside the main code

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -193,11 +193,5 @@ class CliArgs : Args {
          * of the arguments should be used.
          */
         operator fun invoke(init: CliArgs.() -> Unit): CliArgs = CliArgs().apply(init)
-
-        /**
-         * Creates an instance of [CliArgs]. Verification if the settings are sound
-         * must be made by the caller.
-         */
-        fun parse(args: Array<String>): CliArgs = parseArguments(args)
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
@@ -6,7 +6,7 @@ import java.io.PrintStream
 
 @Suppress("detekt.SpreadOperator", "detekt.ThrowsCount")
 inline fun <reified T : Args> parseArguments(
-    args: Array<String>,
+    args: Array<out String>,
     outPrinter: PrintStream = System.out,
     errorPrinter: PrintStream = System.err,
     validateCli: T.(MessageCollector) -> Unit = {}

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/OutputFacadeSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/OutputFacadeSpec.kt
@@ -32,13 +32,11 @@ internal class OutputFacadeSpec : Spek({
     describe("Running the output facade") {
 
         describe("with multiple reports") {
-            val cliArgs = CliArgs.parse(
-                arrayOf(
-                    "--input", inputPath.toString(),
-                    "--report", "xml:$xmlOutputPath",
-                    "--report", "txt:$plainOutputPath",
-                    "--report", "html:$htmlOutputPath"
-                )
+            val cliArgs = createCliArgs(
+                "--input", inputPath.toString(),
+                "--report", "xml:$xmlOutputPath",
+                "--report", "txt:$plainOutputPath",
+                "--report", "html:$htmlOutputPath"
             )
 
             it("creates all output files") {

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/TestFactory.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/TestFactory.kt
@@ -67,3 +67,11 @@ fun createLocation(
 )
 
 fun createNotification() = ModificationNotification(Paths.get(resource("empty.txt")))
+
+/**
+ * Creates an instance of [CliArgs]. Verification if the settings are sound
+ * must be made by the caller.
+ */
+fun createCliArgs(vararg args: String): CliArgs {
+    return parseArguments(args)
+}

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporterSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporterSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.cli.runners
 
 import io.gitlab.arturbosch.detekt.cli.CliArgs
+import io.gitlab.arturbosch.detekt.cli.createCliArgs
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -12,9 +13,9 @@ class ConfigExporterSpec : Spek({
 
         it("should export the given config") {
             val tmpConfig = Files.createTempFile("ConfigPrinterSpec", ".yml")
-            val cliArgs = CliArgs.parse(arrayOf(
+            val cliArgs = createCliArgs(
                 "--config", tmpConfig.toString()
-            ))
+            )
 
             ConfigExporter(cliArgs).execute()
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.cli.runners
 
 import io.gitlab.arturbosch.detekt.cli.BuildFailure
-import io.gitlab.arturbosch.detekt.cli.CliArgs
 import io.gitlab.arturbosch.detekt.cli.config.InvalidConfig
+import io.gitlab.arturbosch.detekt.cli.createCliArgs
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
@@ -25,11 +25,11 @@ class RunnerSpec : Spek({
 
         it("should report one issue when maxIssues=2") {
             val tmpReport = Files.createTempFile("RunnerSpec", ".txt")
-            val cliArgs = CliArgs.parse(arrayOf(
+            val cliArgs = createCliArgs(
                 "--input", inputPath.toString(),
                 "--report", "txt:$tmpReport",
                 "--config-resource", "/configs/max-issues-2.yml"
-            ))
+            )
 
             Runner(cliArgs).execute()
 
@@ -37,19 +37,19 @@ class RunnerSpec : Spek({
         }
 
         it("should throw on maxIssues=0") {
-            val cliArgs = CliArgs.parse(arrayOf(
+            val cliArgs = createCliArgs(
                 "--input", inputPath.toString(),
                 "--config-resource", "/configs/max-issues-0.yml"
-            ))
+            )
 
             assertThatThrownBy { Runner(cliArgs).execute() }.isExactlyInstanceOf(BuildFailure::class.java)
         }
 
         it("should throw on invalid config property when validation=true") {
-            val cliArgs = CliArgs.parse(arrayOf(
+            val cliArgs = createCliArgs(
                 "--input", inputPath.toString(),
                 "--config-resource", "/configs/invalid-config.yml"
-            ))
+            )
 
             assertThatThrownBy { Runner(cliArgs).execute() }
                 .isExactlyInstanceOf(InvalidConfig::class.java)
@@ -57,10 +57,10 @@ class RunnerSpec : Spek({
         }
 
         it("should throw on invalid config properties when validation=true") {
-            val cliArgs = CliArgs.parse(arrayOf(
+            val cliArgs = createCliArgs(
                 "--input", inputPath.toString(),
                 "--config-resource", "/configs/invalid-configs.yml"
-            ))
+            )
 
             assertThatThrownBy { Runner(cliArgs).execute() }
                 .isExactlyInstanceOf(InvalidConfig::class.java)
@@ -68,21 +68,21 @@ class RunnerSpec : Spek({
         }
 
         it("should not throw on invalid config property when validation=false") {
-            val cliArgs = CliArgs.parse(arrayOf(
+            val cliArgs = createCliArgs(
                 "--input", inputPath.toString(),
                 "--config-resource", "/configs/invalid-config_no-validation.yml"
-            ))
+            )
 
             assertThatCode { Runner(cliArgs).execute() }.doesNotThrowAnyException()
         }
 
         it("should never throw on maxIssues=-1") {
             val tmpReport = Files.createTempFile("RunnerSpec", ".txt")
-            val cliArgs = CliArgs.parse(arrayOf(
+            val cliArgs = createCliArgs(
                 "--input", inputPath.toString(),
                 "--report", "txt:$tmpReport",
                 "--config-resource", "/configs/max-issues--1.yml"
-            ))
+            )
 
             Runner(cliArgs).execute()
 
@@ -93,12 +93,12 @@ class RunnerSpec : Spek({
 
             it("should not throw on maxIssues=0 due to baseline blacklist") {
                 val tmpReport = Files.createTempFile("RunnerSpec", ".txt")
-                val cliArgs = CliArgs.parse(arrayOf(
+                val cliArgs = createCliArgs(
                     "--input", inputPath.toString(),
                     "--report", "txt:$tmpReport",
                     "--config-resource", "/configs/max-issues-0.yml",
                     "--baseline", Paths.get(resource("configs/baseline-with-two-excludes.xml")).toString()
-                ))
+                )
 
                 Runner(cliArgs).execute()
 
@@ -111,13 +111,13 @@ class RunnerSpec : Spek({
 
         it("should not throw on maxIssues=0") {
             val tmpReport = Files.createTempFile("RunnerSpec", ".txt")
-            val cliArgs = CliArgs.parse(arrayOf(
+            val cliArgs = createCliArgs(
                 "--input", inputPath.toString(),
                 "--baseline", Paths.get(resource("configs/baseline-empty.xml")).toString(),
                 "--create-baseline",
                 "--report", "txt:$tmpReport",
                 "--config-resource", "/configs/max-issues-0.yml"
-            ))
+            )
 
             Runner(cliArgs).execute()
 
@@ -138,7 +138,7 @@ class RunnerSpec : Spek({
             val path: Path = Paths.get(resource("/cases/CleanPoko.kt"))
 
             beforeEachTest {
-                val args = CliArgs.parse(arrayOf("--input", path.toString()))
+                val args = createCliArgs("--input", path.toString())
 
                 Runner(args, outputPrinter, errorPrinter).execute()
 
@@ -161,9 +161,9 @@ class RunnerSpec : Spek({
         context("execute with strict config") {
 
             beforeEachTest {
-                val args = CliArgs.parse(
-                    arrayOf("--input", inputPath.toString(), "--config-resource", "/configs/max-issues-0.yml")
-                )
+                val args = createCliArgs(
+                    "--input", inputPath.toString(),
+                    "--config-resource", "/configs/max-issues-0.yml")
 
                 try {
                     Runner(args, outputPrinter, errorPrinter).execute()

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.cli.runners
 
-import io.gitlab.arturbosch.detekt.cli.CliArgs
+import io.gitlab.arturbosch.detekt.cli.createCliArgs
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -18,11 +18,11 @@ class SingleRuleRunnerSpec : Spek({
 
         it("should load and run custom rule") {
             val tmp = Files.createTempFile("SingleRuleRunnerSpec", ".txt")
-            val args = CliArgs.parse(arrayOf(
+            val args = createCliArgs(
                 "--input", case.toString(),
                 "--report", "txt:$tmp",
                 "--run-rule", "test:test"
-            ))
+            )
 
             SingleRuleRunner(args).execute()
 
@@ -30,19 +30,19 @@ class SingleRuleRunnerSpec : Spek({
         }
 
         it("should throw on non existing rule") {
-            val args = CliArgs.parse(arrayOf("--run-rule", "test:non_existing"))
+            val args = createCliArgs("--run-rule", "test:non_existing")
             assertThatThrownBy { SingleRuleRunner(args).execute() }
                 .isExactlyInstanceOf(IllegalArgumentException::class.java)
         }
 
         it("should throw on non existing rule set") {
-            val args = CliArgs.parse(arrayOf("--run-rule", "non_existing:test"))
+            val args = createCliArgs("--run-rule", "non_existing:test")
             assertThatThrownBy { SingleRuleRunner(args).execute() }
                 .isExactlyInstanceOf(IllegalArgumentException::class.java)
         }
 
         it("should throw on non existing run-rule") {
-            val args = CliArgs.parse(arrayOf())
+            val args = createCliArgs()
             assertThatThrownBy { SingleRuleRunner(args).execute() }
                 .isExactlyInstanceOf(IllegalStateException::class.java)
                 .withFailMessage("Unexpected empty 'runRule' argument.")


### PR DESCRIPTION
`CliArgs.parse` was a factory of CliArgs used only by the tests. So I moved it to the test classpath.