### PR TITLE
Make the gradle plugin a sub project again

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -80,6 +80,13 @@ Following warning is expected until [Jekyll](https://github.com/jekyll/jekyll/is
 
 `warning: Using the last argument as keyword parameters is deprecated (Ruby 2.7.0)`
 
+### When working on the Gradle plugin ...
+
+- Make changes to the core modules (e.g. adding a new CLI flag)
+- Run `gradle publishToMavenLocal`
+- Make changes to the Gradle plugin and add tests
+- Verify with `gradle detekt`
+
 ### Release checklist
 
 - add changes in CHANGELOG.md -> `groovy github-milestone-report.groovy arturbosch detekt [milestone-number]`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,6 @@ plugins {
     id("io.gitlab.arturbosch.detekt")
     jacoco
     `maven-publish`
-    // Plugin versions for these plugins are defined in gradle.properties and applied in settings.gradle.kts
     id("com.jfrog.artifactory") apply false
     id("com.jfrog.bintray")
     id("org.jetbrains.dokka") apply false
@@ -26,30 +25,6 @@ plugins {
 buildScan {
     termsOfServiceUrl = "https://gradle.com/terms-of-service"
     termsOfServiceAgree = "yes"
-}
-
-tasks.wrapper {
-    val gradleVersion: String by project
-    this.gradleVersion = gradleVersion
-    distributionType = Wrapper.DistributionType.ALL
-    doLast {
-        /*
-         * Copy the properties file into the detekt-gradle-plugin project.
-         * This allows IDEs like IntelliJ to import the detekt-gradle-plugin as a standalone project.
-         */
-        copy {
-            from(propertiesFile)
-            into(file("${gradle.includedBuild("detekt-gradle-plugin").projectDir}/gradle/wrapper"))
-        }
-    }
-}
-
-tasks.check {
-    dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":check"))
-}
-
-tasks.withType<Detekt> {
-    dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":detekt"))
 }
 
 val detektVersion: String by project
@@ -119,8 +94,6 @@ subprojects {
     val projectJvmTarget = "1.8"
 
     tasks.withType<Detekt> {
-        exclude("resources/")
-        exclude("build/")
         jvmTarget = projectJvmTarget
     }
 

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -1,42 +1,14 @@
-import com.jfrog.bintray.gradle.BintrayExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
-import java.util.Date
-
-repositories {
-    jcenter()
-}
 
 plugins {
     `java-gradle-plugin`
-    `maven-publish`
     id("com.gradle.plugin-publish") version "0.10.1"
-    id("com.jfrog.bintray") version "1.8.4"
-    kotlin("jvm") version "1.3.70"
-    id("org.jetbrains.dokka") version "0.10.1"
-    id("com.github.ben-manes.versions") version "0.28.0"
-    id("io.gitlab.arturbosch.detekt") version "1.7.0"
 }
 
-group = "io.gitlab.arturbosch.detekt"
-version = "1.7.0"
-
-val spekVersion = "2.0.9"
-val junitPlatformVersion = "1.6.0"
-val assertjVersion = "3.15.0"
-val detektFormattingVersion = version
-
 dependencies {
-    implementation(kotlin("stdlib"))
     implementation(kotlin("gradle-plugin"))
     implementation(kotlin("gradle-plugin-api"))
-
-    testImplementation("org.assertj:assertj-core:$assertjVersion")
-    testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
-    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
-
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$detektFormattingVersion")
 }
 
 gradlePlugin {
@@ -74,23 +46,13 @@ pluginBundle {
     website = "https://arturbosch.github.io/detekt"
     vcsUrl = "https://github.com/arturbosch/detekt"
     description = "Static code analysis for Kotlin"
-    tags = listOf("kotlin", "detekt", "code-analysis", "badsmells", "codesmells")
+    tags = listOf("kotlin", "detekt", "code-analysis", "linter", "codesmells")
 
     (plugins) {
         "detektPlugin" {
             id = "io.gitlab.arturbosch.detekt"
             displayName = "Static code analysis for Kotlin"
         }
-    }
-}
-
-tasks.dokka {
-    outputFormat = "javadoc"
-    outputDirectory = "$buildDir/javadoc"
-    configuration {
-        // suppresses undocumented classes but not dokka warnings
-        // https://github.com/Kotlin/dokka/issues/229 && https://github.com/Kotlin/dokka/issues/319
-        reportUndocumented = false
     }
 }
 
@@ -116,96 +78,4 @@ sourceSets.main.get().java.srcDir("$buildDir/generated/src")
 
 tasks.compileKotlin {
     dependsOn(generateDefaultDetektVersionFile)
-}
-
-val sourcesJar by tasks.creating(Jar::class) {
-    dependsOn(tasks.classes)
-    archiveClassifier.set("sources")
-    from(sourceSets.main.get().allSource)
-}
-
-val javadocJar by tasks.creating(Jar::class) {
-    dependsOn(tasks.dokka)
-    archiveClassifier.set("javadoc")
-    from(buildDir.resolve("javadoc"))
-}
-
-artifacts {
-    archives(sourcesJar)
-    archives(javadocJar)
-}
-
-detekt {
-    buildUponDefaultConfig = true
-    config.setFrom(file("../config/detekt/detekt.yml"))
-}
-
-val bintrayUser: String? = findProperty("bintrayUser")?.toString() ?: System.getenv("BINTRAY_USER")
-val bintrayKey: String? = findProperty("bintrayKey")?.toString() ?: System.getenv("BINTRAY_API_KEY")
-val detektPublication = "DetektPublication"
-
-publishing {
-    publications.create<MavenPublication>(detektPublication) {
-        from(components["java"])
-        artifact(sourcesJar)
-        artifact(javadocJar)
-        groupId = rootProject.group as? String
-        artifactId = rootProject.name
-        version = rootProject.version as? String
-        pom {
-            description.set("Static code analysis for Kotlin")
-            name.set("detekt")
-            url.set("https://github.com/arturbosch/detekt")
-            licenses {
-                license {
-                    name.set("The Apache Software License, Version 2.0")
-                    url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                    distribution.set("repo")
-                }
-            }
-            developers {
-                developer {
-                    id.set("Artur Bosch")
-                    name.set("Artur Bosch")
-                    email.set("arturbosch@gmx.de")
-                }
-            }
-            scm {
-                url.set("https://github.com/arturbosch/detekt")
-            }
-        }
-    }
-}
-
-bintray {
-    user = bintrayUser
-    key = bintrayKey
-    val mavenCentralUser = System.getenv("MAVEN_CENTRAL_USER") ?: ""
-    val mavenCentralPassword = System.getenv("MAVEN_CENTRAL_PW") ?: ""
-
-    setPublications(detektPublication)
-
-    pkg(delegateClosureOf<BintrayExtension.PackageConfig> {
-        repo = "code-analysis"
-        name = "detekt"
-        userOrg = "arturbosch"
-        setLicenses("Apache-2.0")
-        vcsUrl = "https://github.com/arturbosch/detekt"
-
-        version(delegateClosureOf<BintrayExtension.VersionConfig> {
-            name = project.version as? String
-            released = Date().toString()
-
-            gpg(delegateClosureOf<BintrayExtension.GpgConfig> {
-                sign = true
-            })
-
-            mavenCentralSync(delegateClosureOf<BintrayExtension.MavenCentralSyncConfig> {
-                sync = true
-                user = mavenCentralUser
-                password = mavenCentralPassword
-                close = "1"
-            })
-        })
-    })
 }

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -1,5 +1,0 @@
-// DO NOT DELETE - REQUIRED FOR PROPER INTELLIJ GRADLE INTEGRATION
-
-// If this file is removed it is not possible to run a task in the included build  directly from the Gradle Tool Window
-// in IntelliJ, and this error will  be shown:
-// Project directory '...\detekt\detekt-gradle-plugin' is not part of the build defined by settings file '...\detekt\settings.gradle.kts'. If this is an unrelated build, it must have its own settings file.

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -179,6 +179,7 @@ open class Detekt : SourceTask(), VerificationTask {
         group = LifecycleBasePlugin.VERIFICATION_GROUP
     }
 
+    @Suppress("DEPRECATION")
     @TaskAction
     fun check() {
         val arguments = mutableListOf(

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 detektVersion=1.7.0
+detektAnalysisVersion=1.7.0
 
 # Project dependencies
 assertjVersion=3.15.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,11 @@ pluginManagement {
     val sonarQubeVersion: String by settings
     val detektAnalysisVersion: String by settings
 
+    repositories {
+        maven { setUrl("https://plugins.gradle.org/m2/") }
+        mavenLocal() // used to publish and test local gradle plugin changes
+    }
+
     plugins {
         id("io.gitlab.arturbosch.detekt") version detektAnalysisVersion
         id("com.jfrog.artifactory") version artifactoryVersion

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,10 +7,9 @@ include(
     "detekt-test",
     "detekt-sample-extensions",
     "detekt-generator",
-    "detekt-formatting"
+    "detekt-formatting",
+    "detekt-gradle-plugin"
 )
-
-includeBuild("detekt-gradle-plugin")
 
 pluginManagement {
 
@@ -21,8 +20,10 @@ pluginManagement {
     val kotlinVersion: String by settings
     val shadowVersion: String by settings
     val sonarQubeVersion: String by settings
+    val detektAnalysisVersion: String by settings
 
     plugins {
+        id("io.gitlab.arturbosch.detekt") version detektAnalysisVersion
         id("com.jfrog.artifactory") version artifactoryVersion
         id("com.jfrog.bintray") version bintrayVersion
         id("org.jetbrains.dokka") version dokkaVersion


### PR DESCRIPTION
With the current setup adding a new feature like in #2492 is cumbersome.
Until a new cli version is published this feature cannot be merged or it will fail the build.
Our current approach is good for having the newest gradle plugin changes in a `gradle detekt` run. However it slows down build time and development time.
Fast feedback can still be provided with the new `pluginManagement` closure:
```gradle
pluginManagement {
    repositories {
        maven { setUrl("https://plugins.gradle.org/m2/") }
        mavenLocal() // used to publish and test local gradle plugin changes
    }
...
}
```
All it needs is to run `publishToMavenLocal`.

I propose to change it back to a sub project. To verify newest changes we could move to following commands in our CI:
```shell script
gradle build -x detekt
gradle publishToMavenLocal
gradle detekt
```

This PR leads to:
- faster build file evaluate, no need to wait for the composite build file evaluation
- cleaner build files, less duplications
- more up-to-date tasks
- faster builds, clean build is ~30 seconds faster