### PR TITLE
Remove default print stream

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
@@ -7,8 +7,8 @@ import java.io.PrintStream
 @Suppress("detekt.SpreadOperator", "detekt.ThrowsCount")
 inline fun <reified T : Args> parseArguments(
     args: Array<out String>,
-    outPrinter: PrintStream = System.out,
-    errorPrinter: PrintStream = System.err,
+    outPrinter: PrintStream,
+    errorPrinter: PrintStream,
     validateCli: T.(MessageCollector) -> Unit = {}
 ): T {
     val cli = T::class.java.declaredConstructors

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -17,7 +17,7 @@ import kotlin.system.exitProcess
 @Suppress("TooGenericExceptionCaught")
 fun main(args: Array<String>) {
     try {
-        buildRunner(args).execute()
+        buildRunner(args, System.out, System.err).execute()
     } catch (_: HelpRequest) {
         // handled by JCommander, exit normally
     } catch (e: InvalidConfig) {
@@ -38,8 +38,8 @@ fun main(args: Array<String>) {
 
 fun buildRunner(
     args: Array<String>,
-    outputPrinter: PrintStream = System.out,
-    errorPrinter: PrintStream = System.err
+    outputPrinter: PrintStream,
+    errorPrinter: PrintStream
 ): Executable {
     val arguments = parseArguments<CliArgs>(
         args,

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -22,8 +22,8 @@ import java.io.PrintStream
 
 class Runner(
     private val arguments: CliArgs,
-    private val outputPrinter: PrintStream = System.out,
-    private val errorPrinter: PrintStream = System.err
+    private val outputPrinter: PrintStream,
+    private val errorPrinter: PrintStream
 ) : Executable {
 
     override fun execute() {

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -53,7 +53,7 @@ internal class CliArgsSpec : Spek({
 
         it("reports an error when using --create-baseline without a --baseline file") {
             assertThatExceptionOfType(HandledArgumentViolation::class.java)
-                .isThrownBy { buildRunner(arrayOf("--create-baseline")) }
+                .isThrownBy { buildRunner(arrayOf("--create-baseline"), NullPrintStream(), NullPrintStream()) }
         }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.cli
 
 import com.beust.jcommander.ParameterException
+import io.gitlab.arturbosch.detekt.test.NullPrintStream
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
@@ -16,13 +17,16 @@ internal class CliArgsSpec : Spek({
     describe("Parsing the input path") {
 
         it("the current working directory is used if parameter is not set") {
-            val cli = parseArguments<CliArgs>(emptyArray())
+            val cli = parseArguments<CliArgs>(emptyArray(), NullPrintStream(), NullPrintStream())
             assertThat(cli.inputPaths).hasSize(1)
             assertThat(cli.inputPaths.first()).isEqualTo(Paths.get(System.getProperty("user.dir")))
         }
 
         it("a single value is converted to a path") {
-            val cli = parseArguments<CliArgs>(arrayOf("--input", "$projectPath"))
+            val cli = parseArguments<CliArgs>(
+                arrayOf("--input", "$projectPath"),
+                NullPrintStream(),
+                NullPrintStream())
             assertThat(cli.inputPaths).hasSize(1)
             assertThat(cli.inputPaths.first().toAbsolutePath()).isEqualTo(projectPath)
         }
@@ -30,9 +34,10 @@ internal class CliArgsSpec : Spek({
         it("multiple input paths can be separated by comma") {
             val mainPath = projectPath.resolve("src/main").toAbsolutePath()
             val testPath = projectPath.resolve("src/test").toAbsolutePath()
-            val cli = parseArguments<CliArgs>(arrayOf(
-                "--input", "$mainPath,$testPath")
-            )
+            val cli = parseArguments<CliArgs>(
+                arrayOf("--input", "$mainPath,$testPath"),
+                NullPrintStream(),
+                NullPrintStream())
             assertThat(cli.inputPaths).hasSize(2)
             assertThat(cli.inputPaths.map(Path::toAbsolutePath)).containsExactlyInAnyOrder(mainPath, testPath)
         }
@@ -42,7 +47,7 @@ internal class CliArgsSpec : Spek({
             val params = arrayOf("--input", "$pathToNonExistentDirectory")
 
             assertThatExceptionOfType(ParameterException::class.java)
-                .isThrownBy { parseArguments<CliArgs>(params).inputPaths }
+                .isThrownBy { parseArguments<CliArgs>(params, NullPrintStream(), NullPrintStream()).inputPaths }
                 .withMessageContaining("does not exist")
         }
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
@@ -18,32 +18,26 @@ class MainSpec : Spek({
 
     describe("build runner") {
 
-        listOf(NullPrintStream(), null).forEach { printer ->
+        listOf(
+            arrayOf("--generate-config"),
+            arrayOf("--run-rule", "Rule"),
+            arrayOf("--print-ast"),
+            arrayOf("--version"),
+            emptyArray()
+        ).forEach { args ->
 
-            context("printer is [${if (printer == null) "default" else "provided"}]") {
+            val expectedRunnerClass = when {
+                args.contains("--version") -> VersionPrinter::class
+                args.contains("--generate-config") -> ConfigExporter::class
+                args.contains("--run-rule") -> SingleRuleRunner::class
+                args.contains("--print-ast") -> AstPrinter::class
+                else -> Runner::class
+            }
 
-                listOf(
-                    arrayOf("--generate-config"),
-                    arrayOf("--run-rule", "Rule"),
-                    arrayOf("--print-ast"),
-                    arrayOf("--version"),
-                    emptyArray()
-                ).forEach { args ->
+            it("returns [${expectedRunnerClass.simpleName}] when arguments are $args") {
+                val runner = buildRunner(args, NullPrintStream(), NullPrintStream())
 
-                    val expectedRunnerClass = when {
-                        args.contains("--version") -> VersionPrinter::class
-                        args.contains("--generate-config") -> ConfigExporter::class
-                        args.contains("--run-rule") -> SingleRuleRunner::class
-                        args.contains("--print-ast") -> AstPrinter::class
-                        else -> Runner::class
-                    }
-
-                    it("returns [${expectedRunnerClass.simpleName}] when arguments are $args") {
-                        val runner = if (printer == null) buildRunner(args) else buildRunner(args, printer, printer)
-
-                        assertThat(runner).isExactlyInstanceOf(expectedRunnerClass.java)
-                    }
-                }
+                assertThat(runner).isExactlyInstanceOf(expectedRunnerClass.java)
             }
         }
     }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/TestFactory.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/TestFactory.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.core.ModificationNotification
+import io.gitlab.arturbosch.detekt.test.NullPrintStream
 import io.gitlab.arturbosch.detekt.test.resource
 import org.jetbrains.kotlin.psi.KtElement
 import java.nio.file.Paths
@@ -73,5 +74,5 @@ fun createNotification() = ModificationNotification(Paths.get(resource("empty.tx
  * must be made by the caller.
  */
 fun createCliArgs(vararg args: String): CliArgs {
-    return parseArguments(args)
+    return parseArguments(args, NullPrintStream(), NullPrintStream())
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/ReportsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/ReportsSpec.kt
@@ -28,7 +28,7 @@ internal class ReportsSpec : Spek({
                 "--report", "$reportUnderTest:/tmp/path3",
                 "--report", "html:D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html"
             )
-            val cli = parseArguments<CliArgs>(args)
+            val cli = parseArguments<CliArgs>(args, NullPrintStream(), NullPrintStream())
 
             val reports = cli.reportPaths
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.cli.BuildFailure
 import io.gitlab.arturbosch.detekt.test.StringPrintStream
 import io.gitlab.arturbosch.detekt.cli.config.InvalidConfig
 import io.gitlab.arturbosch.detekt.cli.createCliArgs
+import io.gitlab.arturbosch.detekt.test.NullPrintStream
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
@@ -28,7 +29,7 @@ class RunnerSpec : Spek({
                 "--config-resource", "/configs/max-issues-2.yml"
             )
 
-            Runner(cliArgs).execute()
+            Runner(cliArgs, NullPrintStream(), NullPrintStream()).execute()
 
             assertThat(Files.readAllLines(tmpReport)).hasSize(1)
         }
@@ -39,7 +40,8 @@ class RunnerSpec : Spek({
                 "--config-resource", "/configs/max-issues-0.yml"
             )
 
-            assertThatThrownBy { Runner(cliArgs).execute() }.isExactlyInstanceOf(BuildFailure::class.java)
+            assertThatThrownBy { Runner(cliArgs, NullPrintStream(), NullPrintStream()).execute() }
+                .isExactlyInstanceOf(BuildFailure::class.java)
         }
 
         it("should throw on invalid config property when validation=true") {
@@ -48,7 +50,7 @@ class RunnerSpec : Spek({
                 "--config-resource", "/configs/invalid-config.yml"
             )
 
-            assertThatThrownBy { Runner(cliArgs).execute() }
+            assertThatThrownBy { Runner(cliArgs, NullPrintStream(), NullPrintStream()).execute() }
                 .isExactlyInstanceOf(InvalidConfig::class.java)
                 .hasMessageContaining("property")
         }
@@ -59,7 +61,7 @@ class RunnerSpec : Spek({
                 "--config-resource", "/configs/invalid-configs.yml"
             )
 
-            assertThatThrownBy { Runner(cliArgs).execute() }
+            assertThatThrownBy { Runner(cliArgs, NullPrintStream(), NullPrintStream()).execute() }
                 .isExactlyInstanceOf(InvalidConfig::class.java)
                 .hasMessageContaining("properties")
         }
@@ -70,7 +72,8 @@ class RunnerSpec : Spek({
                 "--config-resource", "/configs/invalid-config_no-validation.yml"
             )
 
-            assertThatCode { Runner(cliArgs).execute() }.doesNotThrowAnyException()
+            assertThatCode { Runner(cliArgs, NullPrintStream(), NullPrintStream()).execute() }
+                .doesNotThrowAnyException()
         }
 
         it("should never throw on maxIssues=-1") {
@@ -81,7 +84,7 @@ class RunnerSpec : Spek({
                 "--config-resource", "/configs/max-issues--1.yml"
             )
 
-            Runner(cliArgs).execute()
+            Runner(cliArgs, NullPrintStream(), NullPrintStream()).execute()
 
             assertThat(Files.readAllLines(tmpReport)).hasSize(1)
         }
@@ -97,7 +100,7 @@ class RunnerSpec : Spek({
                     "--baseline", Paths.get(resource("configs/baseline-with-two-excludes.xml")).toString()
                 )
 
-                Runner(cliArgs).execute()
+                Runner(cliArgs, NullPrintStream(), NullPrintStream()).execute()
 
                 assertThat(Files.readAllLines(tmpReport)).isEmpty()
             }
@@ -116,7 +119,7 @@ class RunnerSpec : Spek({
                 "--config-resource", "/configs/max-issues-0.yml"
             )
 
-            Runner(cliArgs).execute()
+            Runner(cliArgs, NullPrintStream(), NullPrintStream()).execute()
 
             assertThat(tmpReport).hasContent("")
         }

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/SupportConfigValidationSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/SupportConfigValidationSpec.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.cli.CliArgs
 import io.gitlab.arturbosch.detekt.cli.config.InvalidConfig
 import io.gitlab.arturbosch.detekt.cli.console.red
 import io.gitlab.arturbosch.detekt.cli.runners.Runner
+import io.gitlab.arturbosch.detekt.test.NullPrintStream
 import org.assertj.core.api.Assertions.assertThatCode
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -26,7 +27,7 @@ class SupportConfigValidationSpec : Spek({
                         configResource = config
                     }
 
-                    assertThatCode { Runner(args).execute() }
+                    assertThatCode { Runner(args, NullPrintStream(), NullPrintStream()).execute() }
                         .isInstanceOf(InvalidConfig::class.java)
                         .hasMessage("Run failed with 1 invalid config property.".red())
                 }
@@ -39,7 +40,7 @@ class SupportConfigValidationSpec : Spek({
                 configResource = "excluded-config.yml"
             }
 
-            assertThatCode { Runner(args).execute() }
+            assertThatCode { Runner(args, NullPrintStream(), NullPrintStream()).execute() }
                 .doesNotThrowAnyException()
         }
     }


### PR DESCRIPTION
This PR is part of a serie of PRs related with how we manage the output.

The main ideas:
- Always use `PrinterStream.println` instead of `println`
- Don't have a default `printerStream`. Because that is the same as use `println`.
- Reduce the noise in out tests. If we always use `PrinterStream` to print output we can use `NullPrinterStream` or other types of `PrinterStream` so we don't print to the stdout when we run tests. With this we can reduce the log size related with tests about 40%.