### PR TITLE
Fix report for documented data classes property

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
@@ -47,10 +47,10 @@ class UndocumentedPublicProperty(config: Config = Config.empty) : Rule(config) {
     private fun KtParameter.isUndocumented(comment: String?) =
         comment == null || isNotReferenced(comment)
 
-    private fun KtParameter.isNotReferenced(comment: String) =
-        !comment.contains("[$nameAsSafeName]")
-                && !comment.contains("@property $nameAsSafeName")
-                && !comment.contains("@param $nameAsSafeName")
+    private fun KtParameter.isNotReferenced(comment: String): Boolean {
+        val name = nameAsSafeName
+        return !comment.contains("[$name]") && !comment.contains("@property $name") && !comment.contains("@param $name")
+    }
 
     private fun KtProperty.shouldBeDocumented() =
         (isTopLevel || containingClass()?.isPublic == true) && isPublicNotOverridden()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
@@ -45,7 +45,12 @@ class UndocumentedPublicProperty(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun KtParameter.isUndocumented(comment: String?) =
-        comment == null || !comment.contains("[$nameAsSafeName]") && !comment.contains("@$nameAsSafeName")
+        comment == null || isNotReferenced(comment)
+
+    private fun KtParameter.isNotReferenced(comment: String) =
+        !comment.contains("[$nameAsSafeName]")
+                && !comment.contains("@property $nameAsSafeName")
+                && !comment.contains("@param $nameAsSafeName")
 
     private fun KtProperty.shouldBeDocumented() =
         (isTopLevel || containingClass()?.isPublic == true) && isPublicNotOverridden()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -11,9 +11,7 @@ class UndocumentedPublicPropertySpec : Spek({
     describe("UndocumentedPublicProperty rule") {
 
         it("reports undocumented public property") {
-            val code = """
-                val a = 1
-            """
+            val code = "val a = 1"
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -125,10 +123,12 @@ class UndocumentedPublicPropertySpec : Spek({
         it("does not report documented public properties in a primary constructor") {
             val code = """
                 /**
-                * @a int1
-                * [b] int2 
+                * @property a int1
+                * [b] int2
+                * @property [c] int3
+                * @param d int4
                 */
-                class Test(val a: Int, val b: Int)
+                class Test(val a: Int, val b: Int, val c: Int, val d: Int)
             """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }


### PR DESCRIPTION
A documented property should not be reported as undocumented by the UndocumentedPublicProperty rule.

This closes #2529
