### PR TITLE
Delete created temp file automatically on JVM exit

### DIFF
--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFormatSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFormatSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.cli.baseline
 
+import io.gitlab.arturbosch.detekt.test.createTempFileForTest
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
@@ -46,7 +47,7 @@ class BaselineFormatSpec : Spek({
                 Whitelist(setOf("1", "2", "3")))
 
             it("has a new line at the end of the written baseline file") {
-                val tempFile = Files.createTempFile("baseline1", ".xml")
+                val tempFile = createTempFileForTest("baseline1", ".xml")
 
                 val format = BaselineFormat()
                 format.write(savedBaseline, tempFile)
@@ -57,7 +58,7 @@ class BaselineFormatSpec : Spek({
             }
 
             it("asserts that the saved and loaded baseline files are equal") {
-                val tempFile = Files.createTempFile("baseline-saved", ".xml")
+                val tempFile = createTempFileForTest("baseline-saved", ".xml")
 
                 val format = BaselineFormat()
                 format.write(savedBaseline, tempFile)

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReportSpec.kt
@@ -13,6 +13,7 @@ import io.gitlab.arturbosch.detekt.core.processors.logicalLinesKey
 import io.gitlab.arturbosch.detekt.core.processors.sourceLinesKey
 import io.gitlab.arturbosch.detekt.core.whichDetekt
 import io.gitlab.arturbosch.detekt.test.TestDetektion
+import io.gitlab.arturbosch.detekt.test.createTempFileForTest
 import io.gitlab.arturbosch.detekt.test.resource
 import io.mockk.every
 import io.mockk.mockk
@@ -134,8 +135,7 @@ class HtmlOutputReportSpec : Spek({
             var result = htmlReport.render(createTestDetektionWithMultipleSmells())
             result = generatedRegex.replace(result, replacement)
 
-            val actual = Files.createTempFile("actual-report", ".html")
-            actual.toFile().deleteOnExit()
+            val actual = createTempFileForTest("actual-report", ".html")
             Files.write(actual, result.toByteArray())
 
             assertThat(actual).hasSameTextualContentAs(expected)
@@ -220,8 +220,7 @@ private fun createReportWithFindings(findings: Array<Pair<String, List<Finding>>
     val detektion = createHtmlDetektion(*findings)
     var result = htmlReport.render(detektion)
     result = generatedRegex.replace(result, replacement)
-    val reportPath = Files.createTempFile("report", ".html")
-    reportPath.toFile().deleteOnExit()
+    val reportPath = createTempFileForTest("report", ".html")
     Files.write(reportPath, result.toByteArray())
     return reportPath
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporterSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporterSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.cli.runners
 
-import io.gitlab.arturbosch.detekt.cli.CliArgs
 import io.gitlab.arturbosch.detekt.cli.createCliArgs
+import io.gitlab.arturbosch.detekt.test.createTempFileForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -12,7 +12,7 @@ class ConfigExporterSpec : Spek({
     describe("config exporter") {
 
         it("should export the given config") {
-            val tmpConfig = Files.createTempFile("ConfigPrinterSpec", ".yml")
+            val tmpConfig = createTempFileForTest("ConfigPrinterSpec", ".yml")
             val cliArgs = createCliArgs(
                 "--config", tmpConfig.toString()
             )

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.test.StringPrintStream
 import io.gitlab.arturbosch.detekt.cli.config.InvalidConfig
 import io.gitlab.arturbosch.detekt.cli.createCliArgs
 import io.gitlab.arturbosch.detekt.test.NullPrintStream
+import io.gitlab.arturbosch.detekt.test.createTempFileForTest
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
@@ -22,7 +23,7 @@ class RunnerSpec : Spek({
     describe("executes the runner with different maxIssues configurations") {
 
         it("should report one issue when maxIssues=2") {
-            val tmpReport = Files.createTempFile("RunnerSpec", ".txt")
+            val tmpReport = createTempFileForTest("RunnerSpec", ".txt")
             val cliArgs = createCliArgs(
                 "--input", inputPath.toString(),
                 "--report", "txt:$tmpReport",
@@ -77,7 +78,7 @@ class RunnerSpec : Spek({
         }
 
         it("should never throw on maxIssues=-1") {
-            val tmpReport = Files.createTempFile("RunnerSpec", ".txt")
+            val tmpReport = createTempFileForTest("RunnerSpec", ".txt")
             val cliArgs = createCliArgs(
                 "--input", inputPath.toString(),
                 "--report", "txt:$tmpReport",
@@ -92,7 +93,7 @@ class RunnerSpec : Spek({
         context("with additional baseline file") {
 
             it("should not throw on maxIssues=0 due to baseline blacklist") {
-                val tmpReport = Files.createTempFile("RunnerSpec", ".txt")
+                val tmpReport = createTempFileForTest("RunnerSpec", ".txt")
                 val cliArgs = createCliArgs(
                     "--input", inputPath.toString(),
                     "--report", "txt:$tmpReport",
@@ -110,7 +111,7 @@ class RunnerSpec : Spek({
     describe("executes the runner with create baseline") {
 
         it("should not throw on maxIssues=0") {
-            val tmpReport = Files.createTempFile("RunnerSpec", ".txt")
+            val tmpReport = createTempFileForTest("RunnerSpec", ".txt")
             val cliArgs = createCliArgs(
                 "--input", inputPath.toString(),
                 "--baseline", Paths.get(resource("configs/baseline-empty.xml")).toString(),

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.cli.runners
 
 import io.gitlab.arturbosch.detekt.cli.createCliArgs
 import io.gitlab.arturbosch.detekt.test.NullPrintStream
+import io.gitlab.arturbosch.detekt.test.createTempFileForTest
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -18,7 +19,7 @@ class SingleRuleRunnerSpec : Spek({
     describe("single rule runner") {
 
         it("should load and run custom rule") {
-            val tmp = Files.createTempFile("SingleRuleRunnerSpec", ".txt")
+            val tmp = createTempFileForTest("SingleRuleRunnerSpec", ".txt")
             val args = createCliArgs(
                 "--input", case.toString(),
                 "--report", "txt:$tmp",

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FileExtension.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FileExtension.kt
@@ -1,0 +1,15 @@
+package io.gitlab.arturbosch.detekt.test
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Creates an empty file in the default temporary-file directory, using
+ * the given [prefix] and [suffix] to generate its name.
+ * The resulting file in the returned path is automatically deleted on JVM exit.
+ */
+fun createTempFileForTest(prefix: String, suffix: String): Path {
+    val path = Files.createTempFile(prefix, suffix)
+    path.toFile().deleteOnExit()
+    return path
+}


### PR DESCRIPTION
This ensures that the temp directory is not polluted with unused files.

A helper function was created.
The created file in the returned path is automatically deleted on JVM exit.
