### PR TITLE
Delete created temp dir automatically on JVM exit

### DIFF
--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFacadeSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFacadeSpec.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.cli.baseline
 
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.cli.createFinding
+import io.gitlab.arturbosch.detekt.test.createTempDirectoryForTest
 import io.gitlab.arturbosch.detekt.test.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
@@ -14,7 +15,7 @@ class BaselineFacadeSpec : Spek({
 
     describe("a baseline facade") {
 
-        val dir = Files.createTempDirectory("baseline_format")
+        val dir = createTempDirectoryForTest("baseline_format")
 
         it("creates a baseline file") {
             val fullPath = dir.resolve("baseline.xml")

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
 dependencies {
     implementation(kotlin("gradle-plugin"))
     implementation(kotlin("gradle-plugin-api"))
+
+    testImplementation(project(":detekt-test"))
 }
 
 gradlePlugin {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt
 
+import io.gitlab.arturbosch.detekt.test.createTempDirectoryForTest
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import java.io.File
@@ -15,7 +16,7 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
     val dryRun: Boolean = false
 ) {
 
-    private val rootDir: File = createTempDir(prefix = "applyPlugin")
+    private val rootDir: File = createTempDirectoryForTest(prefix = "applyPlugin").toFile()
     private val randomString = UUID.randomUUID().toString()
 
     private val settingsContent = """

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/SupportConfigValidationSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/SupportConfigValidationSpec.kt
@@ -5,16 +5,16 @@ import io.gitlab.arturbosch.detekt.cli.config.InvalidConfig
 import io.gitlab.arturbosch.detekt.cli.console.red
 import io.gitlab.arturbosch.detekt.cli.runners.Runner
 import io.gitlab.arturbosch.detekt.test.NullPrintStream
+import io.gitlab.arturbosch.detekt.test.createTempDirectoryForTest
 import org.assertj.core.api.Assertions.assertThatCode
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import java.nio.file.Files
 
 class SupportConfigValidationSpec : Spek({
 
     describe("support config validation") {
 
-        val testDir = Files.createTempDirectory("detekt-sample")
+        val testDir = createTempDirectoryForTest("detekt-sample")
 
         context("failing cases") {
             arrayOf(

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FileExtension.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FileExtension.kt
@@ -13,3 +13,14 @@ fun createTempFileForTest(prefix: String, suffix: String): Path {
     path.toFile().deleteOnExit()
     return path
 }
+
+/**
+ * Creates a new directory in the default temporary-file directory, using
+ * the given [prefix] to generate its name.
+ * The resulting directory in the returned path is automatically deleted on JVM exit.
+ */
+fun createTempDirectoryForTest(prefix: String): Path {
+    val dir = Files.createTempDirectory(prefix)
+    dir.toFile().deleteOnExit()
+    return dir
+}


### PR DESCRIPTION
This ensures that the temp directory is not polluted with unused files.

A helper function was created.
The created directory in the returned path is automatically deleted on JVM exit.
