### PR TITLE
Update Gradle plugin-publish to 0.11.0

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     `java-gradle-plugin`
-    id("com.gradle.plugin-publish") version "0.10.1"
+    id("com.gradle.plugin-publish") version "0.11.0"
 }
 
 dependencies {


### PR DESCRIPTION
There is a security update for the `plugin-publish` Gradle Plugin:
https://blog.gradle.org/plugin-portal-update after a vulnerability was discovered.

This is mandatory as previous version of the plugin will stop working.