### PR TITLE
Remove ignore:AppVeyor from codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,4 @@
 codecov:
-  ci:
-    - !appveyor
   notify:
     require_ci_to_pass: no
     after_n_builds: 4


### PR DESCRIPTION
Since this repo migrated to GitHub Actions away from TravisCI and AppVeyor, the mentioned declaration is unnecessary.