### PR TITLE
Require CI to pass to run codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,3 @@
-codecov:
-  notify:
-    require_ci_to_pass: no
-    after_n_builds: 4
 coverage:
   status:
     # master branch only


### PR DESCRIPTION
This commit removes the 'require_ci_to_pass: no' declaration.
