### PR TITLE
Cleanup Gradle Folders

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -24,17 +24,25 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v2
 
+      # Let's cleanup the gradle cache folders to make sure
+      # we don't accidentally cache stale files.
+    - name: Cleanup Gradle Folders
+      shell: bash
+      run: |
+        rm -rf ~/.gradle/caches/ && \
+        rm -rf ~/.gradle/wrapper/
+
 
     - name: Cache Gradle Caches
       uses: actions/cache@v1
       with:
         path: ~/.gradle/caches/
-        key: cache-gradle-${{ matrix.os }}-${{ matrix.jdk }}
+        key: cache-clean-gradle-${{ matrix.os }}-${{ matrix.jdk }}
     - name: Cache Gradle Wrapper
       uses: actions/cache@v1
       with:
         path: ~/.gradle/wrapper/
-        key: cache-wrapper-${{ matrix.os }}-${{ matrix.jdk }}
+        key: cache-clean-wrapper-${{ matrix.os }}-${{ matrix.jdk }}
 
 
     - name: Setup Java


### PR DESCRIPTION
After some investigation seems like the `macos` worker has several old versions of Gradle in the home (4.x, 5.x, ...). I'm adding a cleanup of the cache folders to make sure we don't cache/restore 3Gb of data.

Here a run with a proof: https://github.com/cortinico/detekt/actions/runs/65408267

The first run of this PR will be longer as I've invalidated the caches.
