### PR TITLE
Validate Wrapper only on push to master

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,11 @@
 name: Validate Gradle Wrapper
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   validation:


### PR DESCRIPTION
Updating the `Validate Gradle Wrapper` action to make sure it runs only once for a pull request.

The list of active checks is already long and this action was fired twice.