### PR TITLE
Check jcenter repository present in Gradle plugin

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,8 +3,8 @@
 - Read [this article](https://chris.beams.io/posts/git-commit/) before writing commit messages
 - Use `gradle build -x dokka` to build the source but exclude documentation jar generating to save time.
 - `gradle detekt` should not report any errors
-- This repository follows the [Kotlin Coding Conventions](https://kotlinlang.org/docs/reference/coding-conventions.html) which are enforced by KtLint when running `gradle detekt`.
-- Make sure your IDE uses [KtLint](https://github.com/shyiko/ktlint) formatting rules as well as the settings in [.editorconfig](../.editorconfig)
+- This repository follows the [Kotlin Coding Conventions](https://kotlinlang.org/docs/reference/coding-conventions.html) which are enforced by ktlint when running `gradle detekt`.
+- Make sure your IDE uses [ktlint](https://github.com/pinterest/ktlint) formatting rules as well as the settings in [.editorconfig](../.editorconfig)
 - We use [Spek](https://github.com/spekframework/spek) for testing. Please use the `Spec.kt`-Suffix. For easier testing you might want to use the [Spek IntelliJ Plugin](https://plugins.jetbrains.com/plugin/10915-spek-framework).
 - Feel free to add your name to the contributors list at the end of the readme file when opening a pull request.
 - The code in `detekt-api` and any rule in `detekt-rules` must be documented. We generate documentation for our website based on these modules.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ See [bintray](https://bintray.com/arturbosch/code-analysis/detekt) for releases 
 
 ### Adding more rule sets
 
-detekt itself provides a wrapper over [KtLint](https://github.com/shyiko/ktlint) as a `formatting` rule set
+detekt itself provides a wrapper over [ktlint](https://github.com/pinterest/ktlint) as a `formatting` rule set
 which can be easily added to the Gradle configuration:
 
 ```kotlin
@@ -244,4 +244,4 @@ Integrations:
 #### Credits
 
 - [JetBrains](https://github.com/jetbrains/) - Creating IntelliJ + Kotlin
-- [PMD](https://github.com/pmd/pmd) & [Checkstyle](https://github.com/checkstyle/checkstyle) & [KtLint](https://github.com/shyiko/ktlint) - Ideas for threshold values and style rules
+- [PMD](https://github.com/pmd/pmd) & [Checkstyle](https://github.com/checkstyle/checkstyle) & [ktlint](https://github.com/pinterest/ktlint) - Ideas for threshold values and style rules

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Sebastian Schuberth](https://github.com/sschuberth) - Active on Issues, Windows support
 - [Olivier Lemasle](https://github.com/olivierlemasle) - NP-Bugfix, rules fixes, Gradle plugin improvement
 - [Marc Prengemann](https://github.com/winterDroid) - Support for custom output formats, prototyped Rule-Context-Issue separation
-- [Sebastiano Poggi](https://github.com/rock3r) - Enhanced milestone report script, Magic number fixes
+- [Sebastiano Poggi](https://github.com/rock3r) - Build tooling improvements, rules improvements and fixes, docs fixes, Gradle plugin improvements
 - [Ilya Tretyakov](https://github.com/jvilya) - Sonar runs should not auto correct formatting.
 - [Andrey T](https://github.com/mr-procrastinator) - Readme fix
 - [Ivan Balaksha](https://github.com/tagantroy) - Rules: UnsafeCast, SpreadOperator, UnsafeCallOnNullableType, LabeledExpression

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 
 /**
- * This rule set provides wrappers for rules implemented by KtLint - https://ktlint.github.io/.
+ * This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
  *
  * Note: Issues reported by this rule set can only be suppressed on file level (@file:Suppress("detekt.rule").
  * Note: The formatting rule set is not included in the detekt-cli or gradle plugin.

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -1,13 +1,12 @@
 package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import io.gitlab.arturbosch.detekt.internal.checkRequiredRepositoriesAreConfiguredOn
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.HasConvention
-import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.provider.Provider
@@ -16,7 +15,6 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import java.io.File
-import java.net.URI
 
 class DetektPlugin : Plugin<Project> {
 
@@ -43,21 +41,6 @@ class DetektPlugin : Plugin<Project> {
         registerGenerateConfigTask(project)
 
         registerIdeaTasks(project, extension)
-    }
-
-    private fun checkRequiredRepositoriesAreConfiguredOn(project: Project) {
-        val bintrayJcenterUri = URI.create(DefaultRepositoryHandler.BINTRAY_JCENTER_URL)
-
-        val missingJCenter = project.repositories.none {
-            it is MavenArtifactRepository && it.url == bintrayJcenterUri
-        }
-
-        if (missingJCenter) {
-            project.logger.error(
-                "The project ${project.path} doesn't have the jcenter() repository in its repositories list; " +
-                        "this is required for Detekt to work correctly. Please add jcenter() to the project's " +
-                        "repositories { } closure and try again.")
-        }
     }
 
     private fun registerDetektTasks(project: Project, extension: DetektExtension) {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/GradleProjectChecks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/GradleProjectChecks.kt
@@ -1,0 +1,22 @@
+package io.gitlab.arturbosch.detekt.internal
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler
+import java.net.URI
+
+internal fun checkRequiredRepositoriesAreConfiguredOn(project: Project) {
+    val bintrayJcenterUri = URI.create(DefaultRepositoryHandler.BINTRAY_JCENTER_URL)
+
+    val missingJCenter = project.repositories.none {
+        it is MavenArtifactRepository && it.url == bintrayJcenterUri
+    }
+
+    if (missingJCenter) {
+        project.logger.error(
+            "The project ${project.path} doesn't have the jcenter() repository in its repositories list; " +
+                    "this is required for Detekt to work correctly. Please add jcenter() to the project's " +
+                    "repositories { } closure and try again."
+        )
+    }
+}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/GradleProjectChecks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/GradleProjectChecks.kt
@@ -15,8 +15,8 @@ internal fun checkRequiredRepositoriesAreConfiguredOn(project: Project) {
 
         if (missingJCenter) {
             project.logger.error(
-                "The project ${project.path} doesn't have the jcenter() repository in its repositories list; " +
-                        "this is required for Detekt to work correctly. Please add jcenter() to the project's " +
+                "The project ${project.path} doesn't have the jcenter() repository in its repositories list. " +
+                        "This is required for Detekt to work correctly. Please add jcenter() to the project's " +
                         "repositories { } closure and try again."
             )
         }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/GradleProjectChecks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/GradleProjectChecks.kt
@@ -5,18 +5,20 @@ import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler
 import java.net.URI
 
+private val bintrayJCenterUri = URI.create(DefaultRepositoryHandler.BINTRAY_JCENTER_URL)
+
 internal fun checkRequiredRepositoriesAreConfiguredOn(project: Project) {
-    val bintrayJcenterUri = URI.create(DefaultRepositoryHandler.BINTRAY_JCENTER_URL)
+    project.afterEvaluate {
+        val missingJCenter = project.repositories.none {
+            it is MavenArtifactRepository && it.url == bintrayJCenterUri
+        }
 
-    val missingJCenter = project.repositories.none {
-        it is MavenArtifactRepository && it.url == bintrayJcenterUri
-    }
-
-    if (missingJCenter) {
-        project.logger.error(
-            "The project ${project.path} doesn't have the jcenter() repository in its repositories list; " +
-                    "this is required for Detekt to work correctly. Please add jcenter() to the project's " +
-                    "repositories { } closure and try again."
-        )
+        if (missingJCenter) {
+            project.logger.error(
+                "The project ${project.path} doesn't have the jcenter() repository in its repositories list; " +
+                        "this is required for Detekt to work correctly. Please add jcenter() to the project's " +
+                        "repositories { } closure and try again."
+            )
+        }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  *
  * Library updates can introduce naming clashes with your own classes which might result in compilation errors.
  *
- * **NOTE:** This rule is effectively overridden by the `NoWildcardImports` formatting rule (a wrapped KtLint rule).
+ * **NOTE:** This rule is effectively overridden by the `NoWildcardImports` formatting rule (a wrapped ktlint rule).
  * That rule will fail the check regardless of the whitelist configured here.
  * Therefore if whitelist is needed `NoWildcardImports` rule should be disabled.
  *

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ summary:
 
 ### Quick Start with Gradle
 
-Apply following configuration to your gradle build file and run `gradle detekt`:
+Apply the following configuration to your Gradle project build file:
 
 ```kotlin
 buildscript {
@@ -39,20 +39,30 @@ plugins {
     id("io.gitlab.arturbosch.detekt").version("[version]")
 }
 
-detekt {
-    toolVersion = "[version]"
-    source = files("src/main/kotlin")
-    config = files("path/to/config.yml")
+repositories {
+    jcenter()
 }
 ```
 
-If you want to change the default behaviour of detekt rules, first generate yourself a detekt configuration file and apply your changes:
+The format is very similar if you use the Gradle Groovy DSL. You can find what is the **latest version of detekt** in
+the [release notes](/detekt/changelog.html).
 
-`gradle detektGenerateConfig`
+Once you have set up detekt in your project, simply run `gradle detekt`.
 
-Then reference the config inside the defaultProfile-closure:
+To change the default behaviour of detekt rules, first generate yourself a detekt configuration file by running the
+`detektGenerateConfig` task and applying any changes to the generated file.
 
-`config = files("default-detekt-config.yml")`
+Don't forget to reference the newly generated config inside the `detekt { }` closure. Optionally, it is possible to
+slim down the configuration file to only the changes from the default configuration, by applying the
+`buildUponDefaultConfig` option:
+
+```kotlin
+detekt {
+    toolVersion = "[version]"
+    config = files("config/detekt/detekt.yml")
+    buildUponDefaultConfig = true
+}
+```
 
 To enable/disable detekt reports and to configure their output directories edit the `detekt { }` closure:
 ```kotlin
@@ -72,7 +82,7 @@ detekt {
         }
     }
 }
-``` 
+```
 
 ### Adding more rule sets
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,7 +76,7 @@ detekt {
 
 ### Adding more rule sets
 
-detekt itself provides a wrapper over [KtLint](https://github.com/shyiko/ktlint) as a `formatting` rule set
+detekt itself provides a wrapper over [ktlint](https://github.com/pinterest/ktlint) as a `formatting` rule set
 which can be easily added to the gradle configuration:
 
 ```gradle

--- a/docs/pages/documentation/formatting.md
+++ b/docs/pages/documentation/formatting.md
@@ -6,7 +6,7 @@ permalink: formatting.html
 toc: true
 folder: documentation
 ---
-This rule set provides wrappers for rules implemented by KtLint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
 
 Note: Issues reported by this rule set can only be suppressed on file level (@file:Suppress("detekt.rule").
 Note: The formatting rule set is not included in the detekt-cli or gradle plugin.

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -1606,7 +1606,7 @@ which classes are imported and helps prevent naming conflicts.
 
 Library updates can introduce naming clashes with your own classes which might result in compilation errors.
 
-**NOTE:** This rule is effectively overridden by the `NoWildcardImports` formatting rule (a wrapped KtLint rule).
+**NOTE:** This rule is effectively overridden by the `NoWildcardImports` formatting rule (a wrapped ktlint rule).
 That rule will fail the check regardless of the whitelist configured here.
 Therefore if whitelist is needed `NoWildcardImports` rule should be disabled.
 

--- a/docs/pages/extensions.md
+++ b/docs/pages/extensions.md
@@ -210,7 +210,7 @@ java -jar detekt-cli-[version]-all.jar --input ... --plugins /path/to/my/jar
 
 ##### Integrate your extension with the detekt gradle plugin 
 
-For example `detekt` itself provides a wrapper over [KtLint](https://github.com/shyiko/ktlint) as a 
+For example `detekt` itself provides a wrapper over [ktlint](https://github.com/pinterest/ktlint) as a 
 custom `formatting` rule set.
 To enable it, we add the published dependency to `detekt` via the `detektPlugins` configuration:
 


### PR DESCRIPTION
This PR fixes #2549 by adding a log when the user doesn't have `jcenter()` configured in their project, by emitting an error with a clear warning and resolution instructions.

I have run all the tests in the project and smoke tested the plugin locally.