### PR TITLE
Fix console output indentation

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ComplexityReport.kt
@@ -13,7 +13,7 @@ class ComplexityReport : ConsoleReport() {
             with(StringBuilder()) {
                 append("Complexity Report:\n")
                 list.forEach {
-                    append(PREFIX)
+                    append("\t- ")
                     append(it)
                     append("\n")
                 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ProjectStatisticsReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ProjectStatisticsReport.kt
@@ -12,8 +12,7 @@ class ProjectStatisticsReport : ConsoleReport() {
         if (metrics.isEmpty()) return null
         return with(StringBuilder()) {
             append("Project Statistics:\n")
-            metrics.sortedBy { it.priority }
-                .reversed()
+            metrics.sortedBy { -it.priority }
                 .forEach {
                     append("\t- ")
                     append(it)

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ProjectStatisticsReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ProjectStatisticsReport.kt
@@ -11,10 +11,14 @@ class ProjectStatisticsReport : ConsoleReport() {
         val metrics = detektion.metrics
         if (metrics.isEmpty()) return null
         return with(StringBuilder()) {
-            append("Project Statistics:".format())
+            append("Project Statistics:\n")
             metrics.sortedBy { it.priority }
-                    .reversed()
-                    .forEach { append(it.toString().format(PREFIX)) }
+                .reversed()
+                .forEach {
+                    append("\t- ")
+                    append(it)
+                    append("\n")
+                }
             toString()
         }
     }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ReportFormatting.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ReportFormatting.kt
@@ -16,10 +16,11 @@ internal fun printFindings(findings: Map<String, List<Finding>>): String? {
                 .reduce { acc, d -> acc + d }
             debtList.add(debt)
             append("$key - $debt debt".format())
-            val issuesString = issues.joinToString("") {
-                it.compact().format("\t")
+            issues.forEach {
+                append("\t")
+                append(it.compact().yellow())
+                append("\n")
             }
-            append(issuesString.yellow())
         }
         val overallDebt = debtList.reduce { acc, d -> acc + d }
         append("Overall debt: $overallDebt".format("\n"))

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ReportFormatting.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/ReportFormatting.kt
@@ -3,10 +3,6 @@ package io.gitlab.arturbosch.detekt.cli.console
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Finding
 
-internal const val PREFIX = "\t- "
-
-internal fun Any.format(prefix: String = "", suffix: String = "\n") = "$prefix$this$suffix"
-
 internal fun printFindings(findings: Map<String, List<Finding>>): String? {
     return with(StringBuilder()) {
         val debtList = mutableListOf<Debt>()
@@ -15,7 +11,7 @@ internal fun printFindings(findings: Map<String, List<Finding>>): String? {
                 .map { it.issue.debt }
                 .reduce { acc, d -> acc + d }
             debtList.add(debt)
-            append("$key - $debt debt".format())
+            append("$key - $debt debt\n")
             issues.forEach {
                 append("\t")
                 append(it.compact().yellow())
@@ -23,7 +19,7 @@ internal fun printFindings(findings: Map<String, List<Finding>>): String? {
             }
         }
         val overallDebt = debtList.reduce { acc, d -> acc + d }
-        append("Overall debt: $overallDebt".format("\n"))
+        append("\nOverall debt: $overallDebt\n")
         toString()
     }
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ProjectStatisticsReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ProjectStatisticsReportSpec.kt
@@ -16,7 +16,7 @@ class ProjectStatisticsReportSpec : Spek({
             val expected = "Project Statistics:\n\t- M2: 2\n\t- M1: 1\n"
             val detektion = object : TestDetektion() {
                 override val metrics: Collection<ProjectMetric> = listOf(
-                        ProjectMetric("M1", 1), ProjectMetric("M2", 2))
+                    ProjectMetric("M1", 1, priority = 1), ProjectMetric("M2", 2, priority = 2))
             }
             assertThat(subject.render(detektion)).isEqualTo(expected)
         }


### PR DESCRIPTION
Fixes #2551

This PR changes this:
<img width="365" alt="Captura de pantalla 2020-03-29 a las 15 31 37" src="https://user-images.githubusercontent.com/721244/77850819-4fdbd080-71d5-11ea-8568-7ded32c43448.png">

to this:
<img width="315" alt="Captura de pantalla 2020-03-29 a las 15 52 21" src="https://user-images.githubusercontent.com/721244/77850822-536f5780-71d5-11ea-9311-7b532b10f9cd.png">

Any idea about how to test this? Because I don't really know why this code works and the other don't...

I tested this with zsh and bash.