### PR TITLE
Include statistics for our custom detekt tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -269,10 +269,11 @@ subprojects {
 
 // detekt self analysis section
 
-val analysisDir = files(projectDir)
+val analysisDir = file(projectDir)
 val baselineFile = file("$rootDir/config/detekt/baseline.xml")
-val formatConfigFile = files("$rootDir/config/detekt/format.yml")
-val configFiles = files("$rootDir/config/detekt/detekt.yml")
+val configFile = file("$rootDir/config/detekt/detekt.yml")
+val formatConfigFile = file("$rootDir/config/detekt/format.yml")
+val statisticsConfigFile = file("$rootDir/config/detekt/statistics.yml")
 
 val kotlinFiles = "**/*.kt"
 val kotlinScriptFiles = "**/*.kts"
@@ -326,11 +327,11 @@ val detektFormat by tasks.registering(Detekt::class) {
     buildUponDefaultConfig = true
     autoCorrect = true
     setSource(analysisDir)
+    config.setFrom(listOf(statisticsConfigFile, formatConfigFile))
     include(kotlinFiles)
     include(kotlinScriptFiles)
     exclude(resourceFiles)
     exclude(buildFiles)
-    config.setFrom(formatConfigFile)
     baseline.set(baselineFile)
     reports {
         xml.enabled = false
@@ -344,6 +345,7 @@ val detektAll by tasks.registering(Detekt::class) {
     parallel = true
     buildUponDefaultConfig = true
     setSource(analysisDir)
+    config.setFrom(listOf(statisticsConfigFile, configFile))
     include(kotlinFiles)
     include(kotlinScriptFiles)
     exclude(resourceFiles)
@@ -362,12 +364,12 @@ val detektProjectBaseline by tasks.registering(DetektCreateBaselineTask::class) 
     ignoreFailures.set(true)
     parallel.set(true)
     setSource(analysisDir)
+    config.setFrom(listOf(statisticsConfigFile, configFile))
     include(kotlinFiles)
     include(kotlinScriptFiles)
     exclude(resourceFiles)
     exclude(buildFiles)
     baseline.set(baselineFile)
-    config.setFrom(configFiles)
 }
 
 // release section

--- a/config/detekt/statistics.yml
+++ b/config/detekt/statistics.yml
@@ -1,0 +1,8 @@
+processors:
+  active: true
+  exclude: []
+
+console-reports:
+  active: true
+  exclude:
+    - 'FindingsReport'

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.core.DetektFacade
-import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.core.rules.visitFile
 import io.gitlab.arturbosch.detekt.test.createProcessingSettings
 import io.gitlab.arturbosch.detekt.test.loadRuleSet

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocaleSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocaleSpec.kt
@@ -10,7 +10,7 @@ import org.spekframework.spek2.style.specification.describe
 class ImplicitDefaultLocaleSpec : Spek({
     val subject by memoized { ImplicitDefaultLocale(Config.empty) }
 
-    val wrapper by memoized (
+    val wrapper by memoized(
         factory = { KtTestCompiler.createEnvironment() },
         destructor = { it.dispose() }
     )
@@ -52,7 +52,6 @@ class ImplicitDefaultLocaleSpec : Spek({
                 }"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
         }
-
 
         it("reports String.toLowerCase() call without explicit locale") {
             val code = """


### PR DESCRIPTION
Also `detektFormat` finds more issues with `detekt-formatting` than the Gradle task for each sub module ... I guess the bug reports are real :D 