### PR TITLE
InstanceOfCheckForException: do not report when catch blocks do not check for the subtype of an exception

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
@@ -1,12 +1,18 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class InstanceOfCheckForExceptionSpec : Spek({
     val subject by memoized { InstanceOfCheckForException() }
+
+    val wrapper by memoized(
+        factory = { KtTestCompiler.createEnvironment() },
+        destructor = { it.dispose() }
+    )
 
     describe("InstanceOfCheckForException rule") {
 
@@ -22,7 +28,7 @@ class InstanceOfCheckForExceptionSpec : Spek({
                     }
                 }
                 """
-            assertThat(subject.compileAndLint(code)).hasSize(2)
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(2)
         }
 
         it("has nested is and as checks") {
@@ -36,7 +42,7 @@ class InstanceOfCheckForExceptionSpec : Spek({
                     }
                 }
                 """
-            assertThat(subject.compileAndLint(code)).hasSize(2)
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(2)
         }
 
         it("has no instance of check") {
@@ -52,7 +58,22 @@ class InstanceOfCheckForExceptionSpec : Spek({
                     }
                 }
                 """
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+        }
+
+        it("has no checks for the subtype of an exception") {
+            val code = """
+                interface I
+                
+                fun foo() {
+                    try {
+                    } catch(e: Exception) {
+                        if (e is I || (e as I) != null) {
+                        }
+                    }
+                }
+                """
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
         }
     }
 })


### PR DESCRIPTION
Fixes #1927 