### PR TITLE
UseCheckOrError/UseRequire: fix false positive with a non-String argument

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtValueArgument.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtValueArgument.kt
@@ -1,0 +1,21 @@
+package io.gitlab.arturbosch.detekt.rules
+
+import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
+import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+
+fun KtValueArgument.isString(bindingContext: BindingContext): Boolean {
+    return if (bindingContext != BindingContext.EMPTY) {
+        val descriptor =
+            getArgumentExpression()?.getResolvedCall(bindingContext)?.resultingDescriptor as? ValueParameterDescriptor
+        val type = descriptor?.type
+        type != null && KotlinBuiltIns.isString(type)
+    } else {
+        true
+    }
+}
+
+fun List<KtValueArgument>.isEmptyOrSingleStringArgument(bindingContext: BindingContext): Boolean =
+    isEmpty() || singleOrNull()?.isString(bindingContext) == true

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtValueArgument.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtValueArgument.kt
@@ -2,18 +2,20 @@ package io.gitlab.arturbosch.detekt.rules
 
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 
 fun KtValueArgument.isString(bindingContext: BindingContext): Boolean {
+    val argumentExpression = getArgumentExpression()
     return if (bindingContext != BindingContext.EMPTY) {
         val descriptor =
-            getArgumentExpression()?.getResolvedCall(bindingContext)?.resultingDescriptor as? ValueParameterDescriptor
+            argumentExpression?.getResolvedCall(bindingContext)?.resultingDescriptor as? ValueParameterDescriptor
         val type = descriptor?.type
         type != null && KotlinBuiltIns.isString(type)
     } else {
-        true
+        argumentExpression is KtStringTemplateExpression
     }
 }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtValueArgument.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtValueArgument.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules
 
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
-import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -10,9 +9,7 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 fun KtValueArgument.isString(bindingContext: BindingContext): Boolean {
     val argumentExpression = getArgumentExpression()
     return if (bindingContext != BindingContext.EMPTY) {
-        val descriptor =
-            argumentExpression?.getResolvedCall(bindingContext)?.resultingDescriptor as? ValueParameterDescriptor
-        val type = descriptor?.type
+        val type = argumentExpression?.getResolvedCall(bindingContext)?.resultingDescriptor?.returnType
         type != null && KotlinBuiltIns.isString(type)
     } else {
         argumentExpression is KtStringTemplateExpression

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensions.kt
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtContainerNodeForControlStructureBody
 import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.KtThrowExpression
+import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 
 internal fun KtThrowExpression.isIllegalStateException() =
@@ -16,8 +17,8 @@ internal inline fun <reified T : Exception> KtThrowExpression.isExceptionOfType(
     return findDescendantOfType<KtCallExpression>()?.firstChild?.text == T::class.java.simpleName
 }
 
-internal val KtThrowExpression.argumentCount
-    get() = findDescendantOfType<KtCallExpression>()?.valueArgumentList?.children?.size ?: 0
+internal val KtThrowExpression.arguments: List<KtValueArgument>
+    get() = findDescendantOfType<KtCallExpression>()?.valueArguments.orEmpty()
 
 internal fun KtThrowExpression.isEnclosedByConditionalStatement(): Boolean {
     return parent is KtIfExpression || parent is KtContainerNodeForControlStructureBody

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
@@ -7,7 +7,8 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.rules.argumentCount
+import io.gitlab.arturbosch.detekt.rules.arguments
+import io.gitlab.arturbosch.detekt.rules.isEmptyOrSingleStringArgument
 import io.gitlab.arturbosch.detekt.rules.isIllegalStateException
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtFunctionLiteral
@@ -18,8 +19,8 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  * Prefer them instead of manually throwing an IllegalStateException.
  *
  * <noncompliant>
- * if (value == null) throw new IllegalStateException("value should not be null")
- * if (value < 0) throw new IllegalStateException("value is $value but should be at least 0")
+ * if (value == null) throw IllegalStateException("value should not be null")
+ * if (value < 0) throw IllegalStateException("value is $value but should be at least 0")
  * when(a) {
  *   1 -> doSomething()
  *   else -> throw IllegalStateException("Unexpected value")
@@ -27,7 +28,7 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  * </noncompliant>
  *
  * <compliant>
- * checkNotNull(value) {"value should not be null"}
+ * checkNotNull(value) { "value should not be null" }
  * check(value >= 0) { "value is $value but should be at least 0" }
  * when(a) {
  *   1 -> doSomething()
@@ -46,7 +47,8 @@ class UseCheckOrError(config: Config = Config.empty) : Rule(config) {
     override fun visitThrowExpression(expression: KtThrowExpression) {
         if (expression.isOnlyExpressionInLambda()) return
 
-        if (expression.isIllegalStateException() && expression.argumentCount < 2) {
+        if (expression.isIllegalStateException() &&
+            expression.arguments.isEmptyOrSingleStringArgument(bindingContext)) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequire.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequire.kt
@@ -7,7 +7,8 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.rules.argumentCount
+import io.gitlab.arturbosch.detekt.rules.arguments
+import io.gitlab.arturbosch.detekt.rules.isEmptyOrSingleStringArgument
 import io.gitlab.arturbosch.detekt.rules.isEnclosedByConditionalStatement
 import io.gitlab.arturbosch.detekt.rules.isIllegalArgumentException
 import org.jetbrains.kotlin.psi.KtBlockExpression
@@ -19,12 +20,12 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  * IllegalArgumentException.
  *
  * <noncompliant>
- * if (value == null) throw new IllegalArgumentException("value should not be null")
- * if (value < 0) throw new IllegalArgumentException("value is $value but should be at least 0")
+ * if (value == null) throw IllegalArgumentException("value should not be null")
+ * if (value < 0) throw IllegalArgumentException("value is $value but should be at least 0")
  * </noncompliant>
  *
  * <compliant>
- * requireNotNull(value) {"value should not be null"}
+ * requireNotNull(value) { "value should not be null" }
  * require(value >= 0) { "value is $value but should be at least 0" }
  * </compliant>
  */
@@ -42,7 +43,7 @@ class UseRequire(config: Config = Config.empty) : Rule(config) {
         if (expression.isOnlyExpressionInBlock()) return
 
         if (expression.isEnclosedByConditionalStatement() &&
-            expression.argumentCount < 2) {
+            expression.arguments.isEmptyOrSingleStringArgument(bindingContext)) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.KtTestCompiler
 import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.lint
 import org.spekframework.spek2.Spek
@@ -111,7 +112,7 @@ class UseCheckOrErrorSpec : Spek({
                     }
                 }
             """
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report if the exception thrown has a String literal argument and a non-String argument") {
@@ -123,7 +124,7 @@ class UseCheckOrErrorSpec : Spek({
                     }
                 }
             """
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report if the exception thrown has a non-String literal argument") {
@@ -135,7 +136,7 @@ class UseCheckOrErrorSpec : Spek({
                     }
                 }
             """
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         context("with binding context") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
@@ -90,13 +90,63 @@ class UseRequireSpec : Spek({
             assertThat(subject.lint(code)).isEmpty()
         }
 
-        it("does not report an issue if the exception thrown has a non-String argument") {
+        it("does not report if the exception thrown has a non-String argument") {
             val code = """
                 fun test(throwable: Throwable) {
                     if (throwable !is NumberFormatException) throw IllegalArgumentException(throwable)
                 }
-            """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+            """
+            assertThat(subject.lint(code)).isEmpty()
+        }
+
+        it("does not report if the exception thrown has a String literal argument and a non-String argument") {
+            val code = """
+                fun test(throwable: Throwable) {
+                    if (throwable !is NumberFormatException) throw IllegalArgumentException("a", throwable)
+                }
+            """
+            assertThat(subject.lint(code)).isEmpty()
+        }
+
+        it("does not report if the exception thrown has a non-String literal argument") {
+            val code = """
+                fun test(throwable: Throwable) {
+                    val s = ""
+                    if (throwable !is NumberFormatException) throw IllegalArgumentException(s)
+                }
+            """
+            assertThat(subject.lint(code)).isEmpty()
+        }
+
+        context("with binding context") {
+
+            it("does not report if the exception thrown has a non-String argument") {
+                val code = """
+                    fun test(throwable: Throwable) {
+                        if (throwable !is NumberFormatException) throw IllegalArgumentException(throwable)
+                    }
+                """
+                assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+            }
+
+            it("does not report if the exception thrown has a String literal argument and a non-String argument") {
+                val code = """
+                    fun test(throwable: Throwable) {
+                        if (throwable !is NumberFormatException) throw IllegalArgumentException("a", throwable)
+                    }
+                """
+                assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
+            }
+
+            it("reports if the exception thrown has a non-String literal argument") {
+                val code = """
+                    fun test(throwable: Throwable) {
+                        val s = ""
+                        if (throwable !is NumberFormatException) throw IllegalArgumentException(s)
+                    }
+                """
+                assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+            }
         }
 
         context("throw is not after a precondition") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.KtTestCompiler
 import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.lint
 import org.spekframework.spek2.Spek
@@ -96,7 +97,7 @@ class UseRequireSpec : Spek({
                     if (throwable !is NumberFormatException) throw IllegalArgumentException(throwable)
                 }
             """
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report if the exception thrown has a String literal argument and a non-String argument") {
@@ -105,7 +106,7 @@ class UseRequireSpec : Spek({
                     if (throwable !is NumberFormatException) throw IllegalArgumentException("a", throwable)
                 }
             """
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report if the exception thrown has a non-String literal argument") {
@@ -115,7 +116,7 @@ class UseRequireSpec : Spek({
                     if (throwable !is NumberFormatException) throw IllegalArgumentException(s)
                 }
             """
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         context("with binding context") {

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -1388,8 +1388,8 @@ Prefer them instead of manually throwing an IllegalStateException.
 #### Noncompliant Code:
 
 ```kotlin
-if (value == null) throw new IllegalStateException("value should not be null")
-if (value < 0) throw new IllegalStateException("value is $value but should be at least 0")
+if (value == null) throw IllegalStateException("value should not be null")
+if (value < 0) throw IllegalStateException("value is $value but should be at least 0")
 when(a) {
 1 -> doSomething()
 else -> throw IllegalStateException("Unexpected value")
@@ -1399,7 +1399,7 @@ else -> throw IllegalStateException("Unexpected value")
 #### Compliant Code:
 
 ```kotlin
-checkNotNull(value) {"value should not be null"}
+checkNotNull(value) { "value should not be null" }
 check(value >= 0) { "value is $value but should be at least 0" }
 when(a) {
 1 -> doSomething()
@@ -1480,14 +1480,14 @@ IllegalArgumentException.
 #### Noncompliant Code:
 
 ```kotlin
-if (value == null) throw new IllegalArgumentException("value should not be null")
-if (value < 0) throw new IllegalArgumentException("value is $value but should be at least 0")
+if (value == null) throw IllegalArgumentException("value should not be null")
+if (value < 0) throw IllegalArgumentException("value is $value but should be at least 0")
 ```
 
 #### Compliant Code:
 
 ```kotlin
-requireNotNull(value) {"value should not be null"}
+requireNotNull(value) { "value should not be null" }
 require(value >= 0) { "value is $value but should be at least 0" }
 ```
 


### PR DESCRIPTION
Fixes #2514 