### PR TITLE
Display actual and threshold values for several metric rules

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
@@ -80,7 +80,8 @@ class ComplexCondition(
                 report(ThresholdedCodeSmell(issue,
                         Entity.from(condition),
                         Metric("SIZE", count, threshold),
-                        "This condition is too complex."))
+                        "This condition is too complex ($count). " +
+                                "Defined complexity threshold for conditions is set to '$threshold'"))
             }
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -83,7 +83,8 @@ class ComplexMethod(
                     issue,
                     Entity.from(function.nameIdentifier!!),
                     Metric("MCC", complexity, threshold),
-                    "The function ${function.nameAsSafeName} appears to be too complex."
+                    "The function ${function.nameAsSafeName} appears to be too complex ($complexity). " +
+                            "Defined complexity threshold for methods is set to '$threshold'"
                 )
             )
         }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -50,7 +50,7 @@ class LongMethod(
                 report(ThresholdedCodeSmell(issue,
                         Entity.from(function.nameIdentifier!!),
                         Metric("SIZE", lines, threshold),
-                        "The function ${function.nameAsSafeName} is too long. " +
+                        "The function ${function.nameAsSafeName} is too long ($lines). " +
                                 "The maximum length is $threshold."))
             }
         }


### PR DESCRIPTION
Display actual values and threshold values for several metric rules.
The text is similar to [this one](https://github.com/arturbosch/detekt/blob/d7088791a6d2a075202570ce87f1bba8c0413c59/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt#L105).