### PR TITLE
valueOrDefaultCommaSeparated throws a ClassCastException

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/DisabledAutoCorrectConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/DisabledAutoCorrectConfig.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Notification
 
 @Suppress("UNCHECKED_CAST")
-class DisabledAutoCorrectConfig(val wrapped: Config) : Config, ValidatableConfiguration {
+class DisabledAutoCorrectConfig(private val wrapped: Config) : Config, ValidatableConfiguration {
 
     override fun subConfig(key: String): Config = DisabledAutoCorrectConfig(wrapped.subConfig(key))
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules
 
-import io.gitlab.arturbosch.detekt.api.ConfigAware
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import io.gitlab.arturbosch.detekt.api.commaSeparatedPattern
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
@@ -37,7 +37,7 @@ fun KtClass.companionObject() = this.companionObjects.singleOrNull { it.isCompan
 
 inline fun <reified T : Any> Any.safeAs(): T? = this as? T
 
-internal fun ConfigAware.valueOrDefaultCommaSeparated(
+internal fun Config.valueOrDefaultCommaSeparated(
     key: String,
     default: List<String>,
     defaultString: String
@@ -45,6 +45,10 @@ internal fun ConfigAware.valueOrDefaultCommaSeparated(
     return try {
         valueOrDefault(key, default)
     } catch (_: IllegalStateException) {
+        valueOrDefault(key, defaultString)
+            .commaSeparatedPattern()
+            .toList()
+    } catch (_: ClassCastException) {
         valueOrDefault(key, defaultString)
             .commaSeparatedPattern()
             .toList()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/JunkSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/JunkSpec.kt
@@ -1,0 +1,51 @@
+package io.gitlab.arturbosch.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.internal.CompositeConfig
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class JunkSpec : Spek({
+
+    describe("valueOrDefaultCommaSeparated works with CompositeConfig") {
+
+        it("and empty String") {
+            val config = CompositeConfig(
+                TestConfig(mapOf("imports" to "")),
+                TestConfig(mapOf("imports" to emptyList<String>()))
+            )
+
+            assertThat(config.valueOrDefaultCommaSeparated("imports", emptyList(), "")).isEmpty()
+        }
+
+        it("and empty List") {
+            val config = CompositeConfig(
+                TestConfig(mapOf("imports" to emptyList<String>())),
+                TestConfig(mapOf("imports" to emptyList<String>()))
+            )
+
+            assertThat(config.valueOrDefaultCommaSeparated("imports", emptyList(), "")).isEmpty()
+        }
+
+        it("and String with values") {
+            val config = CompositeConfig(
+                TestConfig(mapOf("imports" to "java.utils.*,butterknife.*")),
+                TestConfig(mapOf("imports" to emptyList<String>()))
+            )
+
+            assertThat(config.valueOrDefaultCommaSeparated("imports", emptyList(), ""))
+                .containsExactly("java.utils.*", "butterknife.*")
+        }
+
+        it("and List with values") {
+            val config = CompositeConfig(
+                TestConfig(mapOf("imports" to listOf("java.utils.*", "butterknife.*"))),
+                TestConfig(mapOf("imports" to emptyList<String>()))
+            )
+
+            assertThat(config.valueOrDefaultCommaSeparated("imports", emptyList(), ""))
+                .containsExactly("java.utils.*", "butterknife.*")
+        }
+    }
+})

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-disabled-auto-correct-config/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api.internal/-disabled-auto-correct-config/index.md
@@ -12,10 +12,6 @@ title: DisabledAutoCorrectConfig - detekt-api
 
 | [&lt;init&gt;](-init-.html) | `DisabledAutoCorrectConfig(wrapped: `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html)`)` |
 
-### Properties
-
-| [wrapped](wrapped.html) | `val wrapped: `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html) |
-
 ### Functions
 
 | [subConfig](sub-config.html) | Tries to retrieve part of the configuration based on given key.`fun subConfig(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): `[`Config`](../../io.gitlab.arturbosch.detekt.api/-config/index.html) |


### PR DESCRIPTION
Fix #2561

Ok bear with me, this is complex. This is a bug added in #2474. The reason of that PR is described at #2463.

When `ForbiddenImport` executes the extension function `ConfigAware.valueOrDefaultCommaSeparated` the actual implementation that we are using is `DisabledAutoCorrectConfig`. But `DisabledAutoCorrectConfig` does nearly nothing here. It just delegate the work to `CompositeConfig`.

This is the code that is executed there:
https://github.com/arturbosch/detekt/blob/91fdc64fecb858045059bf544fa9bfb6017c8c1d/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/CompositeConfig.kt#L15-L16

The problem is that `lookFirst.valueOrNull(key)` returns a `String` but `T` is a `List<String>`. So we and with a function that should return a List<String> returning `""`. This is not flagged by the compiler because we are doing *a lot* of casting in this part of the code.

The type is checked in the line 46 after the function is called
https://github.com/arturbosch/detekt/blob/91fdc64fecb858045059bf544fa9bfb6017c8c1d/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt#L40-L52

and, of course, it crash with a `ClassCastException`.

For this reason it's safe to catch the `ClassCastException` too and try again as `String`. Does it have sense?

~Tests pending... I'm figuring out how to test this...~