### PR TITLE
Add ignoreAnnotated option to LongParameterList

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -87,6 +87,7 @@ complexity:
     constructorThreshold: 7
     ignoreDefaultParameters: false
     ignoreDataClasses: true
+    ignoreAnnotated: ''
   MethodOverloading:
     active: false
     threshold: 6

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -4,4 +4,7 @@ dependencies {
     implementation(project(":detekt-api"))
 
     testImplementation(project(":detekt-test"))
+
+    // For @javax.inject.Inject usage in LongParameterListSpec.kt
+    testImplementation("javax.inject:javax.inject:1")
 }

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -4,7 +4,4 @@ dependencies {
     implementation(project(":detekt-api"))
 
     testImplementation(project(":detekt-test"))
-
-    // For @javax.inject.Inject usage in LongParameterListSpec.kt
-    testImplementation("javax.inject:javax.inject:1")
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -80,14 +80,14 @@ class LongParameterList(
 
     private fun validateConstructor(constructor: KtConstructor<*>) {
         val owner = constructor.getContainingClassOrObject()
-        if (owner is KtClass && owner.isDataClassOrIgnored) {
+        if (owner is KtClass && owner.isDataClassOrIgnored()) {
             return
         }
         
-        fun KtClassOrObject.isDataClassOrIgnored() = isIgnored || ignoreDataClasses && owner.isData()
-        }
         validateFunction(constructor, constructorThreshold)
     }
+
+    private fun KtClass.isDataClassOrIgnored() = isIgnored() || ignoreDataClasses && isData()
 
     private fun validateFunction(function: KtFunction, threshold: Int) {
         if (function.isOverride() || function.isIgnored() || function.containingKtFile.isIgnored()) return

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -83,7 +83,6 @@ class LongParameterList(
         if (owner is KtClass && owner.isDataClassOrIgnored()) {
             return
         }
-        
         validateFunction(constructor, constructorThreshold)
     }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -1,8 +1,23 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
-import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Metric
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.SplitPattern
+import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
 import io.gitlab.arturbosch.detekt.rules.isOverride
-import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtConstructor
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtParameterList
+import org.jetbrains.kotlin.psi.KtPrimaryConstructor
+import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 
 /**
@@ -88,9 +103,7 @@ class LongParameterList(
     }
 
     private fun validateFunction(function: KtFunction, threshold: Int) {
-        if (function.isOverride()) return
-        if (function.isIgnored()) return
-        if (function.containingKtFile.isIgnored()) return
+        if (function.isOverride() || function.isIgnored() || function.containingKtFile.isIgnored()) return
         val parameterList = function.valueParameterList
         val parameters = parameterList?.parameterCount()
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -80,12 +80,11 @@ class LongParameterList(
 
     private fun validateConstructor(constructor: KtConstructor<*>) {
         val owner = constructor.getContainingClassOrObject()
-        if (owner is KtClass) {
-            if (ignoreDataClasses && owner.isData()) {
-                return
-            } else if (owner.isIgnored()) {
-                return
-            }
+        if (owner is KtClass && owner.isDataClassOrIgnored) {
+            return
+        }
+        
+        fun KtClassOrObject.isDataClassOrIgnored() = isIgnored || ignoreDataClasses && owner.isData()
         }
         validateFunction(constructor, constructorThreshold)
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -10,9 +10,9 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SplitPattern
 import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
 import io.gitlab.arturbosch.detekt.rules.isOverride
+import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtConstructor
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameterList
@@ -72,19 +72,7 @@ class LongParameterList(
         validateConstructor(constructor)
     }
 
-    private fun KtFunction.isIgnored(): Boolean {
-        return annotationEntries.any {
-            ignoreAnnotated.contains(it.typeReference?.text)
-        }
-    }
-
-    private fun KtClass.isIgnored(): Boolean {
-        return annotationEntries.any {
-            ignoreAnnotated.contains(it.typeReference?.text)
-        }
-    }
-
-    private fun KtFile.isIgnored(): Boolean {
+    private fun KtAnnotated.isIgnored(): Boolean {
         return annotationEntries.any {
             ignoreAnnotated.contains(it.typeReference?.text)
         }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
  * @configuration constructorThreshold - number of constructor parameters required to trigger the rule (default: `7`)
  * @configuration ignoreDefaultParameters - ignore parameters that have a default value (default: `false`)
  * @configuration ignoreDataClasses - ignore long constructor parameters list for data classes (default: `true`)
- * @configuration ignoreAnnotated - ignore long parameters list for constructors or functions in the context of these comma-separated annotation class names (default: ``)
+ * @configuration ignoreAnnotated - ignore long parameters list for constructors or functions in the context of these comma-separated annotation class names (default: `''`)
  *
  * @active since v1.0.0
  */

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -78,7 +78,7 @@ class LongParameterListSpec : Spek({
         it("does not report long parameter list for functions if file is annotated with ignored annotation") {
             val config = TestConfig(mapOf(LongParameterList.IGNORE_ANNOTATED to "javax.annotation.Generated"))
             val rule = LongParameterList(config)
-            val code = "@file:javax.annotation.Generated class Data { fun foo(val a: Int, val b: Int, val c: Int, val d: Int, val e: Int, val f: Int, val g: Int) {} }"
+            val code = "@file:javax.annotation.Generated class Data { fun foo(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) {} }"
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
 
@@ -92,7 +92,7 @@ class LongParameterListSpec : Spek({
         it("does not report long parameter list for functions if class is annotated with ignored annotation") {
             val config = TestConfig(mapOf(LongParameterList.IGNORE_ANNOTATED to "javax.annotation.Generated"))
             val rule = LongParameterList(config)
-            val code = "@javax.annotation.Generated class Data { fun foo(val a: Int, val b: Int, val c: Int, val d: Int, val e: Int, val f: Int, val g: Int) {} }"
+            val code = "@javax.annotation.Generated class Data { fun foo(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) {} }"
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
 
@@ -106,7 +106,7 @@ class LongParameterListSpec : Spek({
         it("does not report long parameter list for functions if function is annotated with ignored annotation") {
             val config = TestConfig(mapOf(LongParameterList.IGNORE_ANNOTATED to "javax.inject.Inject"))
             val rule = LongParameterList(config)
-            val code = "class Data { @javax.inject.Inject fun foo(val a: Int, val b: Int, val c: Int, val d: Int, val e: Int, val f: Int, val g: Int) {} }"
+            val code = "class Data { @javax.inject.Inject fun foo(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) {} }"
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -97,16 +97,16 @@ class LongParameterListSpec : Spek({
         }
 
         it("does not report long parameter list for constructors if constructor is annotated with ignored annotation") {
-            val config = TestConfig(mapOf(LongParameterList.IGNORE_ANNOTATED to "javax.inject.Inject"))
+            val config = TestConfig(mapOf(LongParameterList.IGNORE_ANNOTATED to "kotlin.Deprecated"))
             val rule = LongParameterList(config)
-            val code = "class Data @javax.inject.Inject constructor(val a: Int, val b: Int, val c: Int, val d: Int, val e: Int, val f: Int, val g: Int)"
+            val code = "class Data @kotlin.Deprecated(message = \"\") constructor(val a: Int, val b: Int, val c: Int, val d: Int, val e: Int, val f: Int, val g: Int)"
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
 
         it("does not report long parameter list for functions if function is annotated with ignored annotation") {
-            val config = TestConfig(mapOf(LongParameterList.IGNORE_ANNOTATED to "javax.inject.Inject"))
+            val config = TestConfig(mapOf(LongParameterList.IGNORE_ANNOTATED to "kotlin.Deprecated"))
             val rule = LongParameterList(config)
-            val code = "class Data { @javax.inject.Inject fun foo(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) {} }"
+            val code = "class Data { @kotlin.Deprecated(message = \"\") fun foo(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) {} }"
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -67,5 +67,47 @@ class LongParameterListSpec : Spek({
             val code = "data class Data(val a: Int, val b: Int, val c: Int, val d: Int, val e: Int, val f: Int, val g: Int)"
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
+
+        it("does not report long parameter list for constructors if file is annotated with ignored annotation") {
+            val config = TestConfig(mapOf(LongParameterList.IGNORE_ANNOTATED to "javax.annotation.Generated"))
+            val rule = LongParameterList(config)
+            val code = "@file:javax.annotation.Generated class Data(val a: Int, val b: Int, val c: Int, val d: Int, val e: Int, val f: Int, val g: Int)"
+            assertThat(rule.compileAndLint(code)).isEmpty()
+        }
+
+        it("does not report long parameter list for functions if file is annotated with ignored annotation") {
+            val config = TestConfig(mapOf(LongParameterList.IGNORE_ANNOTATED to "javax.annotation.Generated"))
+            val rule = LongParameterList(config)
+            val code = "@file:javax.annotation.Generated class Data { fun foo(val a: Int, val b: Int, val c: Int, val d: Int, val e: Int, val f: Int, val g: Int) {} }"
+            assertThat(rule.compileAndLint(code)).isEmpty()
+        }
+
+        it("does not report long parameter list for constructors if class is annotated with ignored annotation") {
+            val config = TestConfig(mapOf(LongParameterList.IGNORE_ANNOTATED to "javax.annotation.Generated"))
+            val rule = LongParameterList(config)
+            val code = "@javax.annotation.Generated class Data(val a: Int, val b: Int, val c: Int, val d: Int, val e: Int, val f: Int, val g: Int)"
+            assertThat(rule.compileAndLint(code)).isEmpty()
+        }
+
+        it("does not report long parameter list for functions if class is annotated with ignored annotation") {
+            val config = TestConfig(mapOf(LongParameterList.IGNORE_ANNOTATED to "javax.annotation.Generated"))
+            val rule = LongParameterList(config)
+            val code = "@javax.annotation.Generated class Data { fun foo(val a: Int, val b: Int, val c: Int, val d: Int, val e: Int, val f: Int, val g: Int) {} }"
+            assertThat(rule.compileAndLint(code)).isEmpty()
+        }
+
+        it("does not report long parameter list for constructors if constructor is annotated with ignored annotation") {
+            val config = TestConfig(mapOf(LongParameterList.IGNORE_ANNOTATED to "javax.inject.Inject"))
+            val rule = LongParameterList(config)
+            val code = "class Data @javax.inject.Inject constructor(val a: Int, val b: Int, val c: Int, val d: Int, val e: Int, val f: Int, val g: Int)"
+            assertThat(rule.compileAndLint(code)).isEmpty()
+        }
+
+        it("does not report long parameter list for functions if function is annotated with ignored annotation") {
+            val config = TestConfig(mapOf(LongParameterList.IGNORE_ANNOTATED to "javax.inject.Inject"))
+            val rule = LongParameterList(config)
+            val code = "class Data { @javax.inject.Inject fun foo(val a: Int, val b: Int, val c: Int, val d: Int, val e: Int, val f: Int, val g: Int) {} }"
+            assertThat(rule.compileAndLint(code)).isEmpty()
+        }
     }
 })

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -240,6 +240,10 @@ Reports functions and constructors which have more parameters than a certain thr
 
    ignore long constructor parameters list for data classes
 
+* ``ignoreAnnotated`` (default: ``''``)
+
+   ignore long parameters list for constructors or functions in the context of these comma-separated annotation class names
+
 ### MethodOverloading
 
 This rule reports methods which are overloaded often.


### PR DESCRIPTION
Resolves #2563

This adds a new `ignoreAnnotated` option to `LongParameterList`, that allows for ignoring annotations within function/class/file scope.
