### PR TITLE
New Rule: UnnecessaryNotNullOperator

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -444,9 +444,9 @@ potential-bugs:
     active: true
   UnconditionalJumpStatementInLoop:
     active: false
-  UnnecessarySafeCall:
-    active: false
   UnnecessaryNotNullOperator:
+    active: false
+  UnnecessarySafeCall:
     active: false
   UnreachableCode:
     active: true

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -446,6 +446,8 @@ potential-bugs:
     active: false
   UnnecessarySafeCall:
     active: false
+  UnnecessaryNotNullOperator:
+    active: false
   UnreachableCode:
     active: true
   UnsafeCallOnNullableType:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.psi.KtUnaryExpression
 import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
- * Reports Unnecessary Not Null operator usage (!!) that can be removed by the user.
+ * Reports unnecessary not-null operator usage (!!) that can be removed by the user.
  *
  * <noncompliant>
  * val a = 1
@@ -28,7 +28,7 @@ class UnnecessaryNotNullOperator(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue("UnnecessaryNotNullOperator",
             Severity.Defect,
-            "Unnecessary Not Null unary operator (!!) detected.",
+            "Unnecessary not-null unary operator (!!) detected.",
             Debt.FIVE_MINS)
 
     override fun visitUnaryExpression(expression: KtUnaryExpression) {
@@ -38,7 +38,7 @@ class UnnecessaryNotNullOperator(config: Config = Config.empty) : Rule(config) {
         val compilerReports = bindingContext.diagnostics.forElement(expression.operationReference)
         if (compilerReports.any { it.factory == Errors.UNNECESSARY_NOT_NULL_ASSERTION }) {
             report(CodeSmell(issue, Entity.from(expression), "${expression.text} contains an unnecessary " +
-                    "not null (!!) operators"))
+                    "not-null (!!) operators"))
         }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
@@ -1,0 +1,44 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.diagnostics.Errors
+import org.jetbrains.kotlin.psi.KtUnaryExpression
+import org.jetbrains.kotlin.resolve.BindingContext
+
+/**
+ * Reports Unnecessary Not Null operator usage (!!) that can be removed by the user.
+ *
+ * <noncompliant>
+ * val a = 1
+ * val b = a!!
+ * </noncompliant>
+ *
+ * <compliant>
+ * val a = 1
+ * val b = a
+ * </compliant>
+ */
+class UnnecessaryNotNullOperator(config: Config = Config.empty) : Rule(config) {
+
+    override val issue: Issue = Issue("UnnecessaryNotNullOperator",
+            Severity.Defect,
+            "Unnecessary Not Null unary operator (!!) detected.",
+            Debt.FIVE_MINS)
+
+    override fun visitUnaryExpression(expression: KtUnaryExpression) {
+        super.visitUnaryExpression(expression)
+        if (bindingContext == BindingContext.EMPTY) return
+
+        val compilerReports = bindingContext.diagnostics.forElement(expression.operationReference)
+        if (compilerReports.any { it.factory == Errors.UNNECESSARY_NOT_NULL_ASSERTION }) {
+            report(CodeSmell(issue, Entity.from(expression), "${expression.text} contains an unnecessary " +
+                    "not null (!!) operators"))
+        }
+    }
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
@@ -21,6 +21,7 @@ import io.gitlab.arturbosch.detekt.rules.bugs.UnconditionalJumpStatementInLoop
 import io.gitlab.arturbosch.detekt.rules.bugs.UnreachableCode
 import io.gitlab.arturbosch.detekt.rules.bugs.UnsafeCallOnNullableType
 import io.gitlab.arturbosch.detekt.rules.bugs.UnnecessarySafeCall
+import io.gitlab.arturbosch.detekt.rules.bugs.UnnecessaryNotNullOperator
 import io.gitlab.arturbosch.detekt.rules.bugs.UnsafeCast
 import io.gitlab.arturbosch.detekt.rules.bugs.UselessPostfixExpression
 import io.gitlab.arturbosch.detekt.rules.bugs.WrongEqualsTypeParameter
@@ -40,23 +41,24 @@ class PotentialBugProvider : DefaultRuleSetProvider {
                 DuplicateCaseInWhenExpression(config),
                 EqualsAlwaysReturnsTrueOrFalse(config),
                 EqualsWithHashCodeExist(config),
-                HasPlatformType(config),
-                IteratorNotThrowingNoSuchElementException(config),
-                IteratorHasNextCallsNextMethod(config),
-                UselessPostfixExpression(config),
-                InvalidRange(config),
-                WrongEqualsTypeParameter(config),
                 ExplicitGarbageCollectionCall(config),
+                HasPlatformType(config),
+                ImplicitDefaultLocale(config),
+                InvalidRange(config),
+                IteratorHasNextCallsNextMethod(config),
+                IteratorNotThrowingNoSuchElementException(config),
                 LateinitUsage(config),
                 MapGetWithNotNullAssertionOperator(config),
                 MissingWhenCase(config),
                 RedundantElseInWhen(config),
                 UnconditionalJumpStatementInLoop(config),
+                UnnecessaryNotNullOperator(config),
                 UnnecessarySafeCall(config),
                 UnreachableCode(config),
                 UnsafeCallOnNullableType(config),
                 UnsafeCast(config),
-                ImplicitDefaultLocale(config)
+                UselessPostfixExpression(config),
+                WrongEqualsTypeParameter(config)
         ))
     }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperatorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperatorSpec.kt
@@ -1,0 +1,61 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class UnnecessaryNotNullOperatorSpec : Spek({
+    val subject by memoized { UnnecessaryNotNullOperator() }
+
+    val wrapper by memoized(
+        factory = { KtTestCompiler.createEnvironment() },
+        destructor = { it.dispose() }
+    )
+
+    describe("check unnecessary not null operators") {
+
+        it("reports a simple not null operator usage") {
+            val code = """
+                val a = 1
+                val b = a!!
+                """
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasTextLocations(18 to 21)
+        }
+
+        it("reports a chained not null operator usage") {
+            val code = """
+                val a = 1
+                val b = a!!.plus(42)
+                """
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasTextLocations(18 to 21)
+        }
+
+        it("reports multiple chained not null operator usage") {
+            val code = """
+                val a = 1
+                val b = a!!.plus(42)!!
+                """
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(2)
+            assertThat(findings).hasTextLocations(18 to 21, 18 to 32)
+        }
+    }
+
+    describe("check valid not null operators usage") {
+
+        it("does not report a simple not null operator usage on nullable type") {
+            val code = """
+                val a : Int? = 1
+                val b = a!!
+                """
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).isEmpty()
+        }
+    }
+})

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -484,10 +484,6 @@ for (i in 1..2) {
 }
 ```
 
-### UnnecessarySafeCall
-
-Reports unnecessary safe call operators (`.?`) that can be removed by the user.
-
 **Severity**: Defect
 
 **Debt**: 5min
@@ -495,15 +491,11 @@ Reports unnecessary safe call operators (`.?`) that can be removed by the user.
 #### Noncompliant Code:
 
 ```kotlin
-val a: String = ""
-val b = someValue?.length
 ```
 
 #### Compliant Code:
 
 ```kotlin
-val a: String? = null
-val b = someValue?.length
 ```
 
 ### UnreachableCode

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -484,6 +484,10 @@ for (i in 1..2) {
 }
 ```
 
+### UnnecessaryNotNullOperator
+
+Reports unnecessary not-null operator usage (!!) that can be removed by the user.
+
 **Severity**: Defect
 
 **Debt**: 5min
@@ -491,11 +495,37 @@ for (i in 1..2) {
 #### Noncompliant Code:
 
 ```kotlin
+val a = 1
+val b = a!!
 ```
 
 #### Compliant Code:
 
 ```kotlin
+val a = 1
+val b = a
+```
+
+### UnnecessarySafeCall
+
+Reports unnecessary safe call operators (`.?`) that can be removed by the user.
+
+**Severity**: Defect
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+val a: String = ""
+val b = someValue?.length
+```
+
+#### Compliant Code:
+
+```kotlin
+val a: String? = null
+val b = someValue?.length
 ```
 
 ### UnreachableCode


### PR DESCRIPTION
As suggested in #2572, I'm adding a rule to detect unnecessary usages of the  not-null (`!!`) operator.
