### PR TITLE
Fix false positive in UndocumentedPublicClass

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Traversing.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Traversing.kt
@@ -2,6 +2,9 @@ package io.gitlab.arturbosch.detekt.rules
 
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
+import org.jetbrains.kotlin.psi.psiUtil.isPublic
 
 /**
  * Returns a list of all parents of type [T] before first occurrence of [S].
@@ -16,3 +19,14 @@ inline fun <reified T : KtElement, reified S : KtElement> KtElement.parentsOfTyp
             current = current.parent
         }
     }
+
+internal fun KtNamedDeclaration.isPublicInherited(): Boolean {
+    var classOrObject = containingClassOrObject
+    while (classOrObject != null) {
+        if (!classOrObject.isPublic) {
+            return false
+        }
+        classOrObject = classOrObject.containingClassOrObject
+    }
+    return true
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -60,12 +60,14 @@ class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun reportIfUndocumented(element: KtClassOrObject) {
-        if (element.isPublicInherited() && element.isPublicNotOverridden() &&
-            element.notEnumEntry() && element.docComment == null) {
+        if (isPublicAndPublicInherited(element) && element.notEnumEntry() && element.docComment == null) {
             report(CodeSmell(issue, Entity.from(element),
                     "${element.nameAsSafeName} is missing required documentation."))
         }
     }
+
+    private fun isPublicAndPublicInherited(element: KtClassOrObject) =
+        element.isPublicInherited() && element.isPublicNotOverridden()
 
     private fun KtObjectDeclaration.isCompanionWithoutName() =
             isCompanion() && nameAsSafeName.asString() == "Companion"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.isPublicInherited
 import io.gitlab.arturbosch.detekt.rules.isPublicNotOverridden
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
@@ -59,7 +60,8 @@ class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun reportIfUndocumented(element: KtClassOrObject) {
-        if (element.isPublicNotOverridden() && element.notEnumEntry() && element.docComment == null) {
+        if (element.isPublicInherited() && element.isPublicNotOverridden() &&
+            element.notEnumEntry() && element.docComment == null) {
             report(CodeSmell(issue, Entity.from(element),
                     "${element.nameAsSafeName} is missing required documentation."))
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -108,6 +108,34 @@ class UndocumentedPublicClassSpec : Spek({
             assertThat(subject.compileAndLint("object o")).hasSize(1)
         }
 
+        it("should not report non-public nested classes") {
+            val code = """
+            internal class Outer {
+                class Nested
+                inner class Inner
+            }
+        """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it("should not report non-public nested interfaces") {
+            val code = """
+            internal class Outer {
+                interface Inner
+            }
+        """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it("should not report non-public nested objects") {
+            val code = """
+            internal class Outer {
+                object Inner
+            }
+        """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
         it("should not report for documented public object") {
             val code = """
             /**
@@ -124,7 +152,6 @@ class UndocumentedPublicClassSpec : Spek({
                 }
             }
         """
-
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -137,7 +164,6 @@ class UndocumentedPublicClassSpec : Spek({
                 }
             }
         """
-
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -157,7 +183,6 @@ class UndocumentedPublicClassSpec : Spek({
                 CONSTANT
             }
         """
-
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }


### PR DESCRIPTION
Classes that are nested, non-public and undocumented are not flagged by this rule anymore.

Closes #2580
