### PR TITLE
Fix false positives in UndocumentedPublicProperty

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Traversing.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Traversing.kt
@@ -2,6 +2,9 @@ package io.gitlab.arturbosch.detekt.rules
 
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
+import org.jetbrains.kotlin.psi.psiUtil.isPublic
 
 /**
  * Returns a list of all parents of type [T] before first occurrence of [S].
@@ -16,3 +19,14 @@ inline fun <reified T : KtElement, reified S : KtElement> KtElement.parentsOfTyp
             current = current.parent
         }
     }
+
+internal fun KtNamedDeclaration.isPublicInherited(): Boolean {
+    var classOrObject = containingClassOrObject
+    while (classOrObject != null) {
+        if (!classOrObject.isPublic) {
+            return false
+        }
+        classOrObject = classOrObject.containingClassOrObject
+    }
+    return true
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
@@ -40,10 +40,8 @@ class UndocumentedPublicProperty(config: Config = Config.empty) : Rule(config) {
     }
 
     override fun visitProperty(property: KtProperty) {
-        if (property.isPublicInherited()) {
-            if (!property.isLocal && property.docComment == null && property.shouldBeDocumented()) {
-                report(property)
-            }
+        if (property.isPublicInherited() && !property.isLocal && property.shouldBeDocumented()) {
+            report(property)
         }
         super.visitProperty(property)
     }
@@ -57,7 +55,9 @@ class UndocumentedPublicProperty(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun KtProperty.shouldBeDocumented() =
-        (isTopLevel || containingClass()?.isPublic == true) && isPublicNotOverridden()
+        docComment == null && isTopLevelOrInPublicClass() && isPublicNotOverridden()
+
+    private fun KtProperty.isTopLevelOrInPublicClass() = isTopLevel || containingClass()?.isPublic == true
 
     private fun report(property: KtNamedDeclaration) {
         report(

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -51,9 +51,25 @@ class UndocumentedPublicPropertySpec : Spek({
             val code = """
                 class Test {
                     /**
-                    *
+                    * Comment
                     */
                     val a = 1
+                }
+            """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it("does not report undocumented, public and overridden property in class") {
+            val code = """
+                interface I {
+                    /**
+                     * Comment
+                     */
+                    val a: Int
+                }
+                
+                class Test : I {
+                    override val a = 1
                 }
             """
             assertThat(subject.compileAndLint(code)).isEmpty()
@@ -115,6 +131,11 @@ class UndocumentedPublicPropertySpec : Spek({
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
+        it("does not report objects") {
+            val code = "object A {}"
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
         it("does not report undocumented public properties in a primary constructor for an internal class") {
             val code = "internal class Test(val a: Int)"
             assertThat(subject.compileAndLint(code)).isEmpty()
@@ -131,6 +152,118 @@ class UndocumentedPublicPropertySpec : Spek({
                 class Test(val a: Int, val b: Int, val c: Int, val d: Int)
             """
             assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        describe("public properties in nested classes") {
+
+            it("reports undocumented public properties in nested classes") {
+                val code = """
+                class Outer { 
+                    class Inner {
+                        val i = 0
+                        
+                        class InnerInner {
+                            val ii = 0
+                        }
+                    }
+                }
+            """
+                assertThat(subject.compileAndLint(code)).hasSize(2)
+            }
+
+            it("reports undocumented public properties in inner classes") {
+                val code = """
+                class Outer {
+                    inner class Inner {
+                        val i = 0
+                    }
+                }
+            """
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+
+            it("reports undocumented public properties inside objects") {
+                val code = """
+                object Outer {
+                    class Inner {
+                        val i = 0
+                    }
+                }
+            """
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+
+            it("does not report undocumented and non-public properties in nested classes") {
+                val code = """
+                internal class Outer {
+                    class Inner {
+                        val i = 0
+                    }
+                }
+            """
+                assertThat(subject.compileAndLint(code)).isEmpty()
+            }
+
+            it("does not report undocumented and non-public properties in inner classes") {
+                val code = """
+                internal class Outer {
+                    inner class Inner {
+                        val i = 0
+                    }
+                }
+            """
+                assertThat(subject.compileAndLint(code)).isEmpty()
+            }
+        }
+
+        describe("public properties in primary constructors inside nested classes") {
+
+            it("reports undocumented public properties in nested classes") {
+                val code = """
+                class Outer(val a: Int) {
+                    class Inner(val b: Int) {
+                        class InnerInner(val c: Int)
+                    }
+                }
+            """
+                assertThat(subject.compileAndLint(code)).hasSize(3)
+            }
+
+            it("reports undocumented public properties in inner classes") {
+                val code = """
+                class Outer(val a: Int) {
+                    inner class Inner(val b: Int)
+                }
+            """
+                assertThat(subject.compileAndLint(code)).hasSize(2)
+            }
+
+            it("reports undocumented public properties inside objects") {
+                val code = """
+                object Outer {
+                    class Inner(val a: Int)
+                }
+            """
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+
+            it("does not report undocumented and non-public properties in nested classes") {
+                val code = """
+                internal class Outer(val a: Int) {
+                    class Inner(val b: Int)
+                }
+            """
+                assertThat(subject.compileAndLint(code)).isEmpty()
+            }
+
+            it("does not report undocumented and non-public properties in inner classes") {
+                val code = """
+                internal class Outer(val a: Int) {
+                    inner class Inner(val b: Int)
+                }
+            """
+                assertThat(subject.compileAndLint(code)).isEmpty()
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -131,11 +131,6 @@ class UndocumentedPublicPropertySpec : Spek({
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
-        it("does not report objects") {
-            val code = "object A {}"
-            assertThat(subject.compileAndLint(code)).isEmpty()
-        }
-
         it("does not report undocumented public properties in a primary constructor for an internal class") {
             val code = "internal class Test(val a: Int)"
             assertThat(subject.compileAndLint(code)).isEmpty()


### PR DESCRIPTION
Properties in classes that are nested, non-public and undocumented are not flagged by this rule anymore.

Related #2580