### PR TITLE
Remove unnecesary symbolic link

### DIFF
--- a/detekt-gradle-plugin/.editorconfig
+++ b/detekt-gradle-plugin/.editorconfig
@@ -1,1 +1,0 @@
-../.editorconfig


### PR DESCRIPTION
editorconfig is inherited by default. We don't need to have sym links.