### PR TITLE
Use more lintAndCompile

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocksMultiRuleSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocksMultiRuleSpec.kt
@@ -37,7 +37,7 @@ class EmptyBlocksMultiRuleSpec : Spek({
         }
 
         it("reports an empty kt file") {
-            assertThat(subject.lint("")).hasSize(1)
+            assertThat(subject.compileAndLint("")).hasSize(1)
         }
 
         it("reports no duplicated findings - issue #1605") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocksMultiRuleSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocksMultiRuleSpec.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.core.rules.visitFile
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.rules.providers.EmptyCodeProvider
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.compileForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import io.gitlab.arturbosch.detekt.test.yamlConfig
@@ -38,8 +37,7 @@ class EmptyBlocksMultiRuleSpec : Spek({
         }
 
         it("reports an empty kt file") {
-            val emptyFile = compileContentForTest("")
-            assertThat(subject.lint(emptyFile)).hasSize(1)
+            assertThat(subject.lint("")).hasSize(1)
         }
 
         it("reports no duplicated findings - issue #1605") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
@@ -45,32 +44,30 @@ class ThrowingExceptionInMainSpec : Spek({
         }
 
         it("does not report top level main functions with a wrong signature") {
-            val file = compileContentForTest("""
+            val code = """
                 private fun main(args: Array<String>) { throw IllegalArgumentException() }
                 private fun main() { throw IllegalArgumentException() }
                 fun mai() { throw IllegalArgumentException() }
                 fun main(args: String) { throw IllegalArgumentException() }
                 fun main(args: Array<String>, i: Int) { throw IllegalArgumentException() }"""
-            )
-            assertThat(subject.lint(file)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report top level main functions which throw no exception") {
-            val file = compileContentForTest("""
+            val code = """
                 fun main(args: Array<String>) { }
                 fun main() { }
                 fun mai() { }
                 fun main(args: String) { }"""
-            )
-            assertThat(subject.lint(file)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report top level main functions with expression body which throw no exception") {
-            val file = compileContentForTest("""
+            val code = """
                 fun main(args: Array<String>) = ""
                 fun main() = Unit
-            """)
-            assertThat(subject.lint(file)).isEmpty()
+            """
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report main functions with no @JvmStatic annotation inside a class") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
@@ -59,7 +59,7 @@ class ThrowingExceptionInMainSpec : Spek({
                 fun main() { }
                 fun mai() { }
                 fun main(args: String) { }"""
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report top level main functions with expression body which throw no exception") {
@@ -67,7 +67,7 @@ class ThrowingExceptionInMainSpec : Spek({
                 fun main(args: Array<String>) = ""
                 fun main() = Unit
             """
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report main functions with no @JvmStatic annotation inside a class") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -55,8 +55,8 @@ class ObjectPropertyNamingSpec : Spek({
                 object O {
                     ${PublicConst.positive}
                 }
-            """)
-            assertThat(subject.lint(code)).hasSourceLocation(3, 21)
+            """.trimIndent())
+            assertThat(subject.lint(code)).hasSourceLocation(2, 5)
         }
     }
 
@@ -115,8 +115,8 @@ class ObjectPropertyNamingSpec : Spek({
                         ${PublicConst.positive}
                     }
                 }
-            """)
-            assertThat(subject.lint(code)).hasSourceLocation(4, 25)
+            """.trimIndent())
+            assertThat(subject.lint(code)).hasSourceLocation(3, 9)
         }
     }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.spekframework.spek2.Spek
@@ -15,47 +14,47 @@ class ObjectPropertyNamingSpec : Spek({
         val subject by memoized { ObjectPropertyNaming() }
 
         it("should not detect public constants complying to the naming rules") {
-            val code = compileContentForTest("""
+            val code = """
                 object O {
                     ${PublicConst.negative}
                 }
-            """)
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should detect public constants not complying to the naming rules") {
-            val code = compileContentForTest("""
+            val code = """
                 object O {
                     ${PublicConst.positive}
                 }
-            """)
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("should not detect private constants complying to the naming rules") {
-            val code = compileContentForTest("""
+            val code = """
                 object O {
                     ${PrivateConst.negative}
                 }
-            """)
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should detect private constants not complying to the naming rules") {
-            val code = compileContentForTest("""
+            val code = """
                 object O {
                     ${PrivateConst.positive}
                 }
-            """)
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("should report constants not complying to the naming rules at the right position") {
-            val code = compileContentForTest("""
+            val code = """
                 object O {
                     ${PublicConst.positive}
                 }
-            """.trimIndent())
+            """
             assertThat(subject.lint(code)).hasSourceLocation(2, 5)
         }
     }
@@ -65,57 +64,57 @@ class ObjectPropertyNamingSpec : Spek({
         val subject by memoized { ObjectPropertyNaming() }
 
         it("should not detect public constants complying to the naming rules") {
-            val code = compileContentForTest("""
+            val code = """
                 class C {
                     companion object {
                         ${PublicConst.negative}
                     }
                 }
-            """)
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should detect public constants not complying to the naming rules") {
-            val code = compileContentForTest("""
+            val code = """
                 class C {
                     companion object {
                         ${PublicConst.positive}
                     }
                 }
-            """)
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("should not detect private constants complying to the naming rules") {
-            val code = compileContentForTest("""
+            val code = """
                 class C {
                     companion object {
                         ${PrivateConst.negative}
                     }
                 }
-            """)
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should detect private constants not complying to the naming rules") {
-            val code = compileContentForTest("""
+            val code = """
                 class C {
                     companion object {
                         ${PrivateConst.positive}
                     }
                 }
-            """)
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("should report constants not complying to the naming rules at the right position") {
-            val code = compileContentForTest("""
+            val code = """
                 class C {
                     companion object {
                         ${PublicConst.positive}
                     }
                 }
-            """.trimIndent())
+            """
             assertThat(subject.lint(code)).hasSourceLocation(3, 9)
         }
     }
@@ -125,38 +124,38 @@ class ObjectPropertyNamingSpec : Spek({
         val subject by memoized { ObjectPropertyNaming() }
 
         it("should not detect public variables complying to the naming rules") {
-            val code = compileContentForTest("""
+            val code = """
                 object O {
                     ${PublicVal.negative}
                 }
-            """)
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should detect public variables not complying to the naming rules") {
-            val code = compileContentForTest("""
+            val code = """
                 object O {
                     ${PublicVal.positive}
                 }
-            """)
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("should not detect private variables complying to the naming rules") {
-            val code = compileContentForTest("""
+            val code = """
                 object O {
                     ${PrivateVal.negative}
                 }
-            """)
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should detect private variables not complying to the naming rules") {
-            val code = compileContentForTest("""
+            val code = """
                 object O {
                     private val __NAME = "Artur"
                 }
-            """)
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
     }
@@ -170,22 +169,22 @@ class ObjectPropertyNamingSpec : Spek({
         val subject = ObjectPropertyNaming(config)
 
         it("should not detect constants in object with underscores") {
-            val code = compileContentForTest("""
+            val code = """
                 object O {
                     const val _NAME = "Artur"
                     const val _name = "Artur"
                 }
-            """)
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should not detect private properties in object") {
-            val code = compileContentForTest("""
+            val code = """
                 object O {
                     private val __NAME = "Artur"
                     private val _1234 = "Artur"
                 }
-            """)
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.lint
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -19,7 +18,7 @@ class ObjectPropertyNamingSpec : Spek({
                     ${PublicConst.negative}
                 }
             """
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("should detect public constants not complying to the naming rules") {
@@ -28,7 +27,7 @@ class ObjectPropertyNamingSpec : Spek({
                     ${PublicConst.positive}
                 }
             """
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("should not detect private constants complying to the naming rules") {
@@ -37,7 +36,7 @@ class ObjectPropertyNamingSpec : Spek({
                     ${PrivateConst.negative}
                 }
             """
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("should detect private constants not complying to the naming rules") {
@@ -46,7 +45,7 @@ class ObjectPropertyNamingSpec : Spek({
                     ${PrivateConst.positive}
                 }
             """
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("should report constants not complying to the naming rules at the right position") {
@@ -55,7 +54,7 @@ class ObjectPropertyNamingSpec : Spek({
                     ${PublicConst.positive}
                 }
             """
-            assertThat(subject.lint(code)).hasSourceLocation(2, 5)
+            assertThat(subject.compileAndLint(code)).hasSourceLocation(2, 5)
         }
     }
 
@@ -71,7 +70,7 @@ class ObjectPropertyNamingSpec : Spek({
                     }
                 }
             """
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("should detect public constants not complying to the naming rules") {
@@ -82,7 +81,7 @@ class ObjectPropertyNamingSpec : Spek({
                     }
                 }
             """
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("should not detect private constants complying to the naming rules") {
@@ -93,7 +92,7 @@ class ObjectPropertyNamingSpec : Spek({
                     }
                 }
             """
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("should detect private constants not complying to the naming rules") {
@@ -104,7 +103,7 @@ class ObjectPropertyNamingSpec : Spek({
                     }
                 }
             """
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("should report constants not complying to the naming rules at the right position") {
@@ -115,7 +114,7 @@ class ObjectPropertyNamingSpec : Spek({
                     }
                 }
             """
-            assertThat(subject.lint(code)).hasSourceLocation(3, 9)
+            assertThat(subject.compileAndLint(code)).hasSourceLocation(3, 9)
         }
     }
 
@@ -129,7 +128,7 @@ class ObjectPropertyNamingSpec : Spek({
                     ${PublicVal.negative}
                 }
             """
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("should detect public variables not complying to the naming rules") {
@@ -138,7 +137,7 @@ class ObjectPropertyNamingSpec : Spek({
                     ${PublicVal.positive}
                 }
             """
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("should not detect private variables complying to the naming rules") {
@@ -147,7 +146,7 @@ class ObjectPropertyNamingSpec : Spek({
                     ${PrivateVal.negative}
                 }
             """
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("should detect private variables not complying to the naming rules") {
@@ -156,7 +155,7 @@ class ObjectPropertyNamingSpec : Spek({
                     private val __NAME = "Artur"
                 }
             """
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }
 
@@ -175,7 +174,7 @@ class ObjectPropertyNamingSpec : Spek({
                     const val _name = "Artur"
                 }
             """
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("should not detect private properties in object") {
@@ -185,7 +184,7 @@ class ObjectPropertyNamingSpec : Spek({
                     private val _1234 = "Artur"
                 }
             """
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
-import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
@@ -13,21 +12,21 @@ class TopLevelPropertyNamingSpec : Spek({
     describe("constants on top level") {
 
         it("should not detect any constants not complying to the naming rules") {
-            val code = compileContentForTest("""
+            val code = """
                 const val MY_NAME_8 = "Artur"
                 const val MYNAME = "Artur"
-            """)
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should detect five constants not complying to the naming rules") {
-            val code = compileContentForTest("""
+            val code = """
                 const val MyNAME = "Artur"
                 const val name = "Artur"
                 const val nAme = "Artur"
                 private const val _nAme = "Artur"
                 const val serialVersionUID = 42L
-            """)
+            """
             assertThat(subject.lint(code)).hasSize(5)
         }
     }
@@ -35,7 +34,7 @@ class TopLevelPropertyNamingSpec : Spek({
     describe("variables on top level") {
 
         it("should not report any") {
-            val code = compileContentForTest("""
+            val code = """
                 val name = "Artur"
                 val nAme8 = "Artur"
                 private val _name = "Artur"
@@ -46,21 +45,21 @@ class TopLevelPropertyNamingSpec : Spek({
                 private val NAME = "Artur"
                 val s_d_d_1 = listOf("")
                 private val INTERNAL_VERSION = "1.0.0"
-            """)
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should report non private top level property using underscore") {
-            val code = compileContentForTest("""
+            val code = """
                 val _nAme = "Artur"
-            """)
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("should report private top level property using two underscores") {
-            val code = compileContentForTest("""
+            val code = """
                 private val __NAME = "Artur"
-            """)
+            """
             io.gitlab.arturbosch.detekt.test.assertThat(subject.lint(code)).hasSize(1)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -6,7 +6,6 @@ import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assert
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.spekframework.spek2.Spek
@@ -18,247 +17,247 @@ class MagicNumberSpec : Spek({
     describe("Magic Number rule") {
 
         context("a float of 1") {
-            val ktFile = compileContentForTest("val myFloat = 1.0f")
+            val code = "val myFloat = 1.0f"
 
             it("should not be reported by default") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should be reported when ignoredNumbers is empty") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
                 assertThat(findings).hasSourceLocation(1, 15)
             }
         }
 
         context("a const float of 1") {
-            val ktFile = compileContentForTest("const val MY_FLOAT = 1.0f")
+            val code = "const val MY_FLOAT = 1.0f"
 
             it("should not be reported by default") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should not be reported when ignoredNumbers is empty") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
                 assertThat(findings).isEmpty()
             }
         }
 
         context("an integer of 1") {
-            val ktFile = compileContentForTest("val myInt = 1")
+            val code = "val myInt = 1"
 
             it("should not be reported by default") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should be reported when ignoredNumbers is empty") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
                 assertThat(findings).hasSourceLocation(1, 13)
             }
         }
 
         context("a const integer of 1") {
-            val ktFile = compileContentForTest("const val MY_INT = 1")
+            val code = "const val MY_INT = 1"
 
             it("should not be reported by default") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should not be reported when ignoredNumbers is empty") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
                 assertThat(findings).isEmpty()
             }
         }
 
         context("a long of 1") {
-            val ktFile = compileContentForTest("val myLong = 1L")
+            val code = "val myLong = 1L"
 
             it("should not be reported by default") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should be reported when ignoredNumbers is empty") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
                 assertThat(findings).hasSourceLocation(1, 14)
             }
         }
 
         context("a long of -1") {
-            val ktFile = compileContentForTest("val myLong = -1L")
+            val code = "val myLong = -1L"
 
             it("should not be reported by default") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should be reported when ignoredNumbers is empty") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
                 assertThat(findings).hasSourceLocation(1, 15)
             }
         }
 
         context("a long of -2") {
-            val ktFile = compileContentForTest("val myLong = -2L")
+            val code = "val myLong = -2L"
 
             it("should be reported by default") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).hasSourceLocation(1, 15)
             }
 
             it("should be ignored when ignoredNumbers contains it verbatim") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("-2L")))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("-2L")))).lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should be ignored when ignoredNumbers contains it as floating point") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("-2f")))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("-2f")))).lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should not be ignored when ignoredNumbers contains 2 but not -2") {
                 val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("1", "2", "3", "-1", "0"))))
-                    .lint(ktFile)
+                    .lint(code)
                 assertThat(findings).hasSourceLocation(1, 15)
             }
 
             it("should not be ignored when ignoredNumbers contains 2 but not -2 config with string") {
                 val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to "1,2,3,-1,0")))
-                    .lint(ktFile)
+                    .lint(code)
                 assertThat(findings).hasSourceLocation(1, 15)
             }
         }
 
         context("a const long of 1") {
-            val ktFile = compileContentForTest("const val MY_LONG = 1L")
+            val code = "const val MY_LONG = 1L"
 
             it("should not be reported by default") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should not be reported when ignoredNumbers is empty") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
                 assertThat(findings).isEmpty()
             }
         }
 
         context("a double of 1") {
-            val ktFile = compileContentForTest("val myDouble = 1.0")
+            val code = "val myDouble = 1.0"
 
             it("should not be reported by default") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should be reported when ignoredNumbers is empty") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
                 assertThat(findings).hasSourceLocation(1, 16)
             }
         }
 
         context("a const double of 1") {
-            val ktFile = compileContentForTest("const val MY_DOUBLE = 1.0")
+            val code = "const val MY_DOUBLE = 1.0"
 
             it("should not be reported by default") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should not be reported when ignoredNumbers is empty") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
                 assertThat(findings).isEmpty()
             }
         }
 
         context("a hex of 1") {
-            val ktFile = compileContentForTest("val myHex = 0x1")
+            val code = "val myHex = 0x1"
 
             it("should not be reported by default") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should be reported when ignoredNumbers is empty") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
                 assertThat(findings).hasSourceLocation(1, 13)
             }
         }
 
         context("a const hex of 1") {
-            val ktFile = compileContentForTest("const val MY_HEX = 0x1")
+            val code = "const val MY_HEX = 0x1"
 
             it("should not be reported by default") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should not be reported when ignoredNumbers is empty") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
                 assertThat(findings).isEmpty()
             }
         }
 
         context("an integer of 300") {
-            val ktFile = compileContentForTest("val myInt = 300")
+            val code = "val myInt = 300"
 
             it("should not be reported when ignoredNumbers contains 300") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("300")))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("300")))).lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should not be reported when ignoredNumbers contains a floating point 300") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("300.0")))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("300.0")))).lint(code)
                 assertThat(findings).isEmpty()
             }
         }
 
         context("a binary literal") {
-            val ktFile = compileContentForTest("val myBinary = 0b01001")
+            val code = "val myBinary = 0b01001"
 
             it("should not be reported") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).hasSize(1)
             }
 
             it("should not be reported when ignoredNumbers contains a binary literal 0b01001") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("0b01001")))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("0b01001")))).lint(code)
                 assertThat(findings).isEmpty()
             }
         }
 
         context("an integer literal with underscores") {
-            val ktFile = compileContentForTest("val myInt = 100_000")
+            val code = "val myInt = 100_000"
 
             it("should be reported by default") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).hasSourceLocation(1, 13)
             }
 
             it("should not be reported when ignored verbatim") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("100_000")))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("100_000")))).lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should not be reported when ignored with different underscores") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("10_00_00")))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("10_00_00")))).lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should not be reported when ignored without underscores") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("100000")))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("100000")))).lint(code)
                 assertThat(findings).isEmpty()
             }
         }
 
         context("an if statement with magic numbers") {
-            val ktFile = compileContentForTest("val myInt = if (5 < 6) 7 else 8")
+            val code = "val myInt = if (5 < 6) 7 else 8"
 
             it("should be reported") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings)
                     .hasSourceLocations(
                         SourceLocation(1, 17),
@@ -270,7 +269,7 @@ class MagicNumberSpec : Spek({
         }
 
         context("a when statement with magic numbers") {
-            val ktFile = compileContentForTest("""
+            val code = """
             fun test(x: Int) {
                 when (x) {
                     5 -> return 5
@@ -278,10 +277,10 @@ class MagicNumberSpec : Spek({
                     3 -> return 3
                 }
             }
-        """.trimIndent())
+        """
 
             it("should be reported") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).hasSourceLocations(
                     SourceLocation(3, 9),
                     SourceLocation(3, 21),
@@ -294,50 +293,50 @@ class MagicNumberSpec : Spek({
         }
 
         context("a method containing variables with magic numbers") {
-            val ktFile = compileContentForTest("""
+            val code = """
             fun test(x: Int) {
                 val i = 5
             }
-        """)
+        """
 
             it("should be reported") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).hasSize(1)
             }
         }
 
         context("a boolean value") {
-            val ktFile = compileContentForTest("""
+            val code = """
             fun test() : Boolean {
                 return true;
             }
-        """)
+        """
 
             it("should not be reported") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).isEmpty()
             }
         }
 
         context("a non-numeric constant expression") {
-            val ktFile = compileContentForTest("val surprise = true")
+            val code = "val surprise = true"
 
             it("should not be reported") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).isEmpty()
             }
         }
 
         context("a float of 0.5") {
-            val ktFile = compileContentForTest("val test = 0.5f")
+            val code = "val test = 0.5f"
 
             it("should be reported by default") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).hasSourceLocation(1, 12)
             }
 
             it("should not be reported when ignoredNumbers contains it") {
-                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf(".5")))).lint(ktFile)
+                val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf(".5")))).lint(code)
                 assertThat(findings).isEmpty()
             }
         }
@@ -368,7 +367,7 @@ class MagicNumberSpec : Spek({
         }
 
         context("ignoring properties") {
-            val ktFile = compileContentForTest("""
+            val code = """
             @Magic(number = 69)
             class A {
                 val boringNumber = 42
@@ -383,7 +382,7 @@ class MagicNumberSpec : Spek({
                     const val anotherBoringConstant = 93872
                 }
             }
-        """.trimIndent())
+        """
 
             it("should report all without ignore flags") {
                 val config = TestConfig(
@@ -396,7 +395,7 @@ class MagicNumberSpec : Spek({
                         )
                 )
 
-                val findings = MagicNumber(config).lint(ktFile)
+                val findings = MagicNumber(config).lint(code)
                 assertThat(findings)
                     .hasSourceLocations(
                         SourceLocation(1, 17),
@@ -419,13 +418,13 @@ class MagicNumberSpec : Spek({
                         )
                 )
 
-                val findings = MagicNumber(config).lint(ktFile)
+                val findings = MagicNumber(config).lint(code)
                 assertThat(findings).isEmpty()
             }
         }
 
         context("magic numbers in companion object property assignments") {
-            val ktFile = compileContentForTest("""
+            val code = """
             class A {
 
                 companion object {
@@ -433,10 +432,10 @@ class MagicNumberSpec : Spek({
                     const val anotherBoringConstant = 93872
                 }
             }
-        """.trimIndent())
+        """
 
             it("should not report any issues by default") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).isEmpty()
             }
 
@@ -449,7 +448,7 @@ class MagicNumberSpec : Spek({
                         )
                 )
 
-                val findings = MagicNumber(config).lint(ktFile)
+                val findings = MagicNumber(config).lint(code)
                 assertThat(findings).isEmpty()
             }
 
@@ -462,7 +461,7 @@ class MagicNumberSpec : Spek({
                         )
                 )
 
-                val findings = MagicNumber(config).lint(ktFile)
+                val findings = MagicNumber(config).lint(code)
                 assertThat(findings).isEmpty()
             }
 
@@ -475,7 +474,7 @@ class MagicNumberSpec : Spek({
                         )
                 )
 
-                val findings = MagicNumber(config).lint(ktFile)
+                val findings = MagicNumber(config).lint(code)
                 assertThat(findings).isEmpty()
             }
 
@@ -488,7 +487,7 @@ class MagicNumberSpec : Spek({
                         )
                 )
 
-                val findings = MagicNumber(config).lint(ktFile)
+                val findings = MagicNumber(config).lint(code)
                 assertThat(findings).isEmpty()
             }
 
@@ -501,7 +500,7 @@ class MagicNumberSpec : Spek({
                         )
                 )
 
-                val findings = MagicNumber(config).lint(ktFile)
+                val findings = MagicNumber(config).lint(code)
                 assertThat(findings).hasSourceLocation(4, 35)
             }
 
@@ -514,7 +513,7 @@ class MagicNumberSpec : Spek({
                         )
                 )
 
-                val findings = MagicNumber(config).lint(ktFile)
+                val findings = MagicNumber(config).lint(code)
                 assertThat(findings)
                     .hasSourceLocations(
                         SourceLocation(4, 35),
@@ -524,24 +523,24 @@ class MagicNumberSpec : Spek({
         }
 
         context("a property without number") {
-            val ktFile = compileContentForTest("private var pair: Pair<String, Int>? = null")
+            val code = "private var pair: Pair<String, Int>? = null"
 
             it("should not lead to a crash #276") {
-                val findings = MagicNumber().lint(ktFile)
+                val findings = MagicNumber().lint(code)
                 assertThat(findings).isEmpty()
             }
         }
 
         context("ignoring named arguments") {
             context("in constructor invocation") {
-                fun code(numberString: String) = compileContentForTest("""
+                fun code(numberString: String) = """
                 data class Model(
                         val someVal: Int,
                         val other: String = "default"
                 )
 
                 var model = Model(someVal = $numberString)
-            """)
+            """
 
                 it("should not ignore int by default") {
                     assertThat(MagicNumber().lint(code("53"))).hasSize(1)
@@ -591,14 +590,14 @@ class MagicNumberSpec : Spek({
 
             context("Issue#659 - false-negative reporting on unnamed argument when ignore is true") {
 
-                fun code(numberString: String) = compileContentForTest("""
+                fun code(numberString: String) = """
                 data class Model(
                         val someVal: Int,
                         val other: String = "default"
                 )
 
                 var model = Model($numberString)
-            """)
+            """
 
                 it("should detect the argument") {
                     val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NAMED_ARGUMENT to "true")))
@@ -607,11 +606,11 @@ class MagicNumberSpec : Spek({
             }
 
             context("in function invocation") {
-                fun code(number: Number) = compileContentForTest("""
+                fun code(number: Number) = """
                 fun tested(someVal: Int, other: String = "default")
 
                 tested(someVal = $number)
-            """)
+            """
                 it("should ignore int by default") {
                     assertThat(MagicNumber().lint(code(53))).isEmpty()
                 }
@@ -629,33 +628,33 @@ class MagicNumberSpec : Spek({
                 }
             }
             context("in enum constructor argument") {
-                val ktFile = compileContentForTest("""
+                val code = """
                 enum class Bag(id: Int) {
                     SMALL(1),
                     EXTRA_LARGE(5)
                 }
-            """)
+            """
                 it("should be reported by default") {
-                    assertThat(MagicNumber().lint(ktFile)).hasSize(1)
+                    assertThat(MagicNumber().lint(code)).hasSize(1)
                 }
                 it("numbers when 'ignoreEnums' is set to true") {
                     val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_ENUMS to "true")))
-                    assertThat(rule.lint(ktFile)).isEmpty()
+                    assertThat(rule.lint(code)).isEmpty()
                 }
             }
             context("in enum constructor as named argument") {
-                val ktFile = compileContentForTest("""
+                val code = """
                 enum class Bag(id: Int) {
                     SMALL(id = 1),
                     EXTRA_LARGE(id = 5)
                 }
-            """)
+            """
                 it("should be reported by default") {
-                    assertThat(MagicNumber().lint(ktFile)).hasSize(1)
+                    assertThat(MagicNumber().lint(code)).hasSize(1)
                 }
                 it("numbers when 'ignoreEnums' is set to true") {
                     val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_ENUMS to "true")))
-                    assertThat(rule.lint(ktFile)).isEmpty()
+                    assertThat(rule.lint(code)).isEmpty()
                 }
             }
         }
@@ -680,12 +679,12 @@ class MagicNumberSpec : Spek({
         context("in-class declaration with default parameters") {
 
             it("reports no finding") {
-                val code = compileContentForTest("class SomeClassWithDefault(val defaultValue: Int = 10)")
+                val code = "class SomeClassWithDefault(val defaultValue: Int = 10)"
                 assertThat(MagicNumber().lint(code)).isEmpty()
             }
 
             it("reports no finding for an explicit declaration") {
-                val code = compileContentForTest("class SomeClassWithDefault constructor(val defaultValue: Int = 10)")
+                val code = "class SomeClassWithDefault constructor(val defaultValue: Int = 10)"
                 assertThat(MagicNumber().lint(code)).isEmpty()
             }
         }
@@ -693,10 +692,10 @@ class MagicNumberSpec : Spek({
         context("default parameters in secondary constructor") {
 
             it("reports no finding") {
-                val code = compileContentForTest("""
+                val code = """
                 class SomeClassWithDefault {
                     constructor(val defaultValue: Int = 10) { }
-                }""")
+                }"""
                 assertThat(MagicNumber().lint(code)).isEmpty()
             }
         }
@@ -704,7 +703,7 @@ class MagicNumberSpec : Spek({
         context("default parameters in function") {
 
             it("reports no finding") {
-                val code = compileContentForTest("fun f(p: Int = 100)")
+                val code = "fun f(p: Int = 100)"
                 assertThat(MagicNumber().lint(code)).isEmpty()
             }
         }
@@ -723,27 +722,27 @@ class MagicNumberSpec : Spek({
 
             magicNumberInRangeExpressions.forEach { codeWithMagicNumberInRange ->
                 it("'$codeWithMagicNumberInRange' reports a code smell by default") {
-                    val code = compileContentForTest(codeWithMagicNumberInRange)
+                    val code = codeWithMagicNumberInRange
                     assertThat(MagicNumber().lint(code)).hasSize(1)
                 }
                 it("'$codeWithMagicNumberInRange' reports a code smell if ranges are not ignored") {
-                    val code = compileContentForTest(codeWithMagicNumberInRange)
+                    val code = codeWithMagicNumberInRange
                     assertThat(MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_RANGES to "false"))).lint(code))
                             .hasSize(1)
                 }
                 it("'$codeWithMagicNumberInRange' reports no finding if ranges are ignored") {
-                    val code = compileContentForTest(codeWithMagicNumberInRange)
+                    val code = codeWithMagicNumberInRange
                     assertThat(MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_RANGES to "true"))).lint(code))
                             .isEmpty()
                 }
             }
 
             it("reports a finding for a parenthesized number if ranges are ignored") {
-                val code = compileContentForTest("val foo : Int = (127)")
+                val code = "val foo : Int = (127)"
                 assertThat(MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_RANGES to "true"))).lint(code)).hasSize(1)
             }
             it("reports a finding for an addition if ranges are ignored") {
-                val code = compileContentForTest("val foo : Int = 1 + 27")
+                val code = "val foo : Int = 1 + 27"
                 assertThat(MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_RANGES to "true"))).lint(code)).hasSize(1)
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -278,17 +278,17 @@ class MagicNumberSpec : Spek({
                     3 -> return 3
                 }
             }
-        """.trimMargin())
+        """.trimIndent())
 
             it("should be reported") {
                 val findings = MagicNumber().lint(ktFile)
                 assertThat(findings).hasSourceLocations(
+                    SourceLocation(3, 9),
                     SourceLocation(3, 21),
-                    SourceLocation(3, 33),
+                    SourceLocation(4, 9),
                     SourceLocation(4, 21),
-                    SourceLocation(4, 33),
-                    SourceLocation(5, 21),
-                    SourceLocation(5, 33)
+                    SourceLocation(5, 9),
+                    SourceLocation(5, 21)
                 )
             }
         }
@@ -383,7 +383,7 @@ class MagicNumberSpec : Spek({
                     const val anotherBoringConstant = 93872
                 }
             }
-        """.trimMargin())
+        """.trimIndent())
 
             it("should report all without ignore flags") {
                 val config = TestConfig(
@@ -399,12 +399,12 @@ class MagicNumberSpec : Spek({
                 val findings = MagicNumber(config).lint(ktFile)
                 assertThat(findings)
                     .hasSourceLocations(
-                        SourceLocation(1, 29),
-                        SourceLocation(3, 36),
-                        SourceLocation(4, 45),
-                        SourceLocation(7, 38),
-                        SourceLocation(11, 47),
-                        SourceLocation(12, 55)
+                        SourceLocation(1, 17),
+                        SourceLocation(3, 24),
+                        SourceLocation(4, 33),
+                        SourceLocation(7, 26),
+                        SourceLocation(11, 35),
+                        SourceLocation(12, 43)
                     )
             }
 
@@ -433,7 +433,7 @@ class MagicNumberSpec : Spek({
                     const val anotherBoringConstant = 93872
                 }
             }
-        """.trimMargin())
+        """.trimIndent())
 
             it("should not report any issues by default") {
                 val findings = MagicNumber().lint(ktFile)
@@ -502,7 +502,7 @@ class MagicNumberSpec : Spek({
                 )
 
                 val findings = MagicNumber(config).lint(ktFile)
-                assertThat(findings).hasSourceLocation(4, 47)
+                assertThat(findings).hasSourceLocation(4, 35)
             }
 
             it("should report property and constant when not ignoring properties, constants nor companion objects") {
@@ -517,8 +517,8 @@ class MagicNumberSpec : Spek({
                 val findings = MagicNumber(config).lint(ktFile)
                 assertThat(findings)
                     .hasSourceLocations(
-                        SourceLocation(4, 47),
-                        SourceLocation(5, 55)
+                        SourceLocation(4, 35),
+                        SourceLocation(5, 43)
                     )
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
@@ -13,18 +12,18 @@ class NewLineAtEndOfFileSpec : Spek({
     describe("NewLineAtEndOfFile rule") {
 
         it("should not flag a kt file containing new line at the end") {
-            val file = compileContentForTest("class Test\n")
-            assertThat(subject.lint(file)).isEmpty()
+            val code = "class Test\n\n" // we need double '\n' because .lint() applies .trimIndent() which removes one
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         it("should flag a kt file not containing new line at the end") {
-            val file = compileContentForTest("class Test")
-            assertThat(subject.lint(file)).hasSize(1)
+            val code = "class Test"
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("should not flag an empty kt file") {
-            val file = compileContentForTest("")
-            assertThat(subject.lint(file)).isEmpty()
+            val code = ""
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -13,17 +13,17 @@ class NewLineAtEndOfFileSpec : Spek({
 
         it("should not flag a kt file containing new line at the end") {
             val code = "class Test\n\n" // we need double '\n' because .lint() applies .trimIndent() which removes one
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("should flag a kt file not containing new line at the end") {
             val code = "class Test"
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("should not flag an empty kt file") {
             val code = ""
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -10,289 +9,285 @@ import org.spekframework.spek2.style.specification.describe
 class UnderscoresInNumericLiteralsSpec : Spek({
 
     describe("an Int of 1000") {
-        val ktFile = compileContentForTest("val myInt = 1000")
+        val code = "val myInt = 1000"
 
         it("should not be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isEmpty()
         }
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
-            ).lint(ktFile)
+            ).lint(code)
             assertThat(findings).isNotEmpty
         }
     }
 
     describe("an Int of 1_000_000") {
-        val ktFile = compileContentForTest("val myInt = 1_000_000")
+        val code = "val myInt = 1_000_000"
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a const Int of 1000000") {
-        val ktFile = compileContentForTest("const val myInt = 1000000")
+        val code = "const val myInt = 1000000"
 
         it("should be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isNotEmpty
         }
 
         it("should not be reported if acceptableDecimalLength is 8") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
-            ).lint(ktFile)
+            ).lint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a Float of 1000f") {
-        val ktFile = compileContentForTest("val myFloat = 1000f")
+        val code = "val myFloat = 1000f"
 
         it("should not be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isEmpty()
         }
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
-            ).lint(ktFile)
+            ).lint(code)
             assertThat(findings).isNotEmpty
         }
     }
 
     describe("a Float of -1000f") {
-        val ktFile = compileContentForTest("val myFloat = -1000f")
+        val code = "val myFloat = -1000f"
 
         it("should not be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isEmpty()
         }
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
-            ).lint(ktFile)
+            ).lint(code)
             assertThat(findings).isNotEmpty
         }
     }
 
     describe("a Float of -1_000f") {
-        val ktFile = compileContentForTest("const val myFloat = -1_000f")
+        val code = "const val myFloat = -1_000f"
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a Long of 1000000L") {
-        val ktFile = compileContentForTest("const val myLong = 1000000L")
+        val code = "const val myLong = 1000000L"
 
         it("should be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isNotEmpty
         }
 
         it("should not be reported if ignored acceptableDecimalLength is 8") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
-            ).lint(ktFile)
+            ).lint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a Double of 1_000_000.00_000_000") {
-        val ktFile = compileContentForTest("val myDouble = 1_000_000.00_000_000")
+        val code = "val myDouble = 1_000_000.00_000_000"
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a function with default Int parameter value 1000") {
-        val ktFile = compileContentForTest("fun testFunction(testParam: Int = 1000) {}")
+        val code = "fun testFunction(testParam: Int = 1000) {}"
 
         it("should not be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isEmpty()
         }
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
-            ).lint(ktFile)
+            ).lint(code)
             assertThat(findings).isNotEmpty
         }
     }
 
     describe("an annotation with numeric literals 0 and 10") {
-        val ktFile = compileContentForTest(
-                "fun setCustomDimension(@IntRange(from = 0, to = 10) index: Int, value: String?) {}"
-        )
-
+        val code = "fun setCustomDimension(@IntRange(from = 0, to = 10) index: Int, value: String?) {}"
+        
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("an annotation with numeric literals 0 and 1000000") {
-        val ktFile = compileContentForTest(
-                "fun setCustomDimension(@IntRange(from = 0, to = 1000000) index: Int, value: String?) {}"
-        )
+        val code = "fun setCustomDimension(@IntRange(from = 0, to = 1000000) index: Int, value: String?) {}"
 
         it("should be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isNotEmpty
         }
     }
 
     describe("an Int of 10_00_00") {
-        val ktFile = compileContentForTest("const val myInt = 10_00_00")
+        val code = "const val myInt = 10_00_00"
 
         it("should be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isNotEmpty
         }
 
         it("should still be reported even if acceptableDecimalLength is 7") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "7"))
-            ).lint(ktFile)
+            ).lint(code)
             assertThat(findings).isNotEmpty
         }
     }
 
     describe("a binary Int of 0b1011") {
-        val ktFile = compileContentForTest("const val myBinInt = 0b1011")
+        val code = "const val myBinInt = 0b1011"
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a hexadecimal Int of 0x1facdf") {
-        val ktFile = compileContentForTest("const val myHexInt = 0x1facdf")
+        val code = "const val myHexInt = 0x1facdf"
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a hexadecimal Int of 0xFFFFFF") {
-        val ktFile = compileContentForTest("const val myHexInt = 0xFFFFFF")
+        val code = "const val myHexInt = 0xFFFFFF"
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a property named serialVersionUID in an object that implements Serializable") {
-        val ktFile = compileContentForTest("""
+        val code = """
             object TestSerializable : Serializable {
                 private val serialVersionUID = 314159L
             }
-        """)
+        """
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a property named serialVersionUID in an object that does not implement Serializable") {
-        val ktFile = compileContentForTest("""
+        val code = """
             object TestSerializable {
                 private val serialVersionUID = 314159L
             }
-        """)
+        """
 
         it("should be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isNotEmpty
         }
     }
 
     describe("a property named serialVersionUID in an object that does not implement Serializable") {
-        val ktFile = compileContentForTest("""
+        val code = """
             object TestSerializable {
                 private val serialVersionUID = 314_159L
             }
-        """)
+        """
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("an Int of 10000") {
-        val ktFile = compileContentForTest("val myInt = 10000")
+        val code = "val myInt = 10000"
 
         it("should be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isNotEmpty
         }
 
         it("should not be reported if acceptableDecimalLength is 6") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "6"))
-            ).lint(ktFile)
+            ).lint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a Float of 30_000_000.1415926535897932385") {
-        val ktFile = compileContentForTest("val myFloat = 30_000_000.1415926535897932385f")
+        val code = "val myFloat = 30_000_000.1415926535897932385f"
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a Double of 3.1415926535897932385") {
-        val ktFile = compileContentForTest("val myDouble = 3.1415926535897932385")
+        val code = "val myDouble = 3.1415926535897932385"
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a Double of 3000.1415926535897932385") {
-        val ktFile = compileContentForTest("val myDouble = 3000.1415926535897932385")
+        val code = "val myDouble = 3000.1415926535897932385"
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
-            ).lint(ktFile)
+            ).lint(code)
             assertThat(findings).isNotEmpty
         }
     }
 
     describe("a Float of 1000000.31415926535f") {
-        val ktFile = compileContentForTest("val myFloat = 1000000.31415926535f")
+        val code = "val myFloat = 1000000.31415926535f"
 
         it("should be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(ktFile)
+            val findings = UnderscoresInNumericLiterals().lint(code)
             assertThat(findings).isNotEmpty
         }
 
         it("should not be reported if acceptableDecimalLength is 8") {
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
-            ).lint(ktFile)
+            ).lint(code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -13,10 +13,10 @@ class WildcardImportSpec : Spek({
 
         context("a kt file with wildcard imports") {
             val code = """
-                package test
+                package org
 
                 import io.gitlab.arturbosch.detekt.*
-                import test.test.detekt.*
+                import org.spekframework.*
 
                 class Test {
                 }
@@ -25,51 +25,52 @@ class WildcardImportSpec : Spek({
             it("should not report anything when the rule is turned off") {
                 val rule = WildcardImport(TestConfig(mapOf(Config.ACTIVE_KEY to "false")))
 
-                val findings = rule.lint(code)
+                val findings = rule.compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should report all wildcard imports") {
                 val rule = WildcardImport()
 
-                val findings = rule.lint(code)
+                val findings = rule.compileAndLint(code)
                 assertThat(findings).hasSize(2)
             }
 
             it("should not report excluded wildcard imports") {
-                val rule = WildcardImport(TestConfig(mapOf(WildcardImport.EXCLUDED_IMPORTS to "test.test.*")))
+                val rule = WildcardImport(TestConfig(mapOf(WildcardImport.EXCLUDED_IMPORTS to "org.spekframework.*")))
 
-                val findings = rule.lint(code)
+                val findings = rule.compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
 
             it("should not report excluded wildcard imports when multiple are excluded") {
-                val rule = WildcardImport(TestConfig(mapOf(WildcardImport.EXCLUDED_IMPORTS to "test.test.*, io.gitlab.arturbosch.detekt")))
+                val rule =
+                    WildcardImport(TestConfig(mapOf(WildcardImport.EXCLUDED_IMPORTS to "org.spekframework.*, io.gitlab.arturbosch.detekt")))
 
-                val findings = rule.lint(code)
+                val findings = rule.compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("ignores excludes that are not matching") {
                 val rule = WildcardImport(TestConfig(mapOf(WildcardImport.EXCLUDED_IMPORTS to "other.test.*")))
 
-                val findings = rule.lint(code)
+                val findings = rule.compileAndLint(code)
                 assertThat(findings).hasSize(2)
             }
         }
 
         context("a kt file with no wildcard imports") {
             val code = """
-            package test
+            package org
 
-            import test.Test
+            import org.spekframework.spek2.Spek
 
             class Test {
             }
         """
 
             it("should not report any issues") {
-                val findings = WildcardImport().lint(code)
+                val findings = WildcardImport().compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
@@ -23,40 +22,38 @@ class WildcardImportSpec : Spek({
                 }
             """
 
-            val file = compileContentForTest(code).text
-
             it("should not report anything when the rule is turned off") {
                 val rule = WildcardImport(TestConfig(mapOf(Config.ACTIVE_KEY to "false")))
 
-                val findings = rule.lint(file)
+                val findings = rule.lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should report all wildcard imports") {
                 val rule = WildcardImport()
 
-                val findings = rule.lint(file)
+                val findings = rule.lint(code)
                 assertThat(findings).hasSize(2)
             }
 
             it("should not report excluded wildcard imports") {
                 val rule = WildcardImport(TestConfig(mapOf(WildcardImport.EXCLUDED_IMPORTS to "test.test.*")))
 
-                val findings = rule.lint(file)
+                val findings = rule.lint(code)
                 assertThat(findings).hasSize(1)
             }
 
             it("should not report excluded wildcard imports when multiple are excluded") {
                 val rule = WildcardImport(TestConfig(mapOf(WildcardImport.EXCLUDED_IMPORTS to "test.test.*, io.gitlab.arturbosch.detekt")))
 
-                val findings = rule.lint(file)
+                val findings = rule.lint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("ignores excludes that are not matching") {
                 val rule = WildcardImport(TestConfig(mapOf(WildcardImport.EXCLUDED_IMPORTS to "other.test.*")))
 
-                val findings = rule.lint(file)
+                val findings = rule.lint(code)
                 assertThat(findings).hasSize(2)
             }
         }


### PR DESCRIPTION
Blocked by #2600 

`lintAndCompile()` only accepts a `String` as parameter. But we were using `compileContentForTest(String)` to generate a `KtFile` and using it to pass to `lint()`.

In this PR I eliminate a lot of not needed calls to `compileContentForTest` so it's easier to move drom `lint` to `lintAndCompile`. I just moved the easiests ones in this PR, I didn't want to make it even bigger.