### PR TITLE
Generate the cli as a stand alone executable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -388,4 +388,5 @@ githubRelease {
         changelog.trim()
     }
     releaseAssets.setFrom(project(":detekt-cli").buildDir.resolve("libs/detekt-cli-${project.version}-all.jar"))
+    releaseAssets.setFrom(project(":detekt-cli").buildDir.resolve("run/detekt"))
 }

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -25,3 +25,23 @@ tasks.withType<Jar> {
         attributes(mapOf("DetektVersion" to detektVersion))
     }
 }
+
+// Implements https://github.com/brianm/really-executable-jars-maven-plugin maven plugin behaviour.
+// To check details how it works, see http://skife.org/java/unix/2011/06/20/really_executable_jars.html.
+// Extracted from https://github.com/pinterest/ktlint/blob/a86d1c76c44d0a1c1adc3f756f36d8b4cac15d32/ktlint/build.gradle#L40-L57
+tasks.register<DefaultTask>("shadowJarExecutable") {
+    description = "Creates self-executable file, that runs generated shadow jar"
+    group = "Distribution"
+
+    inputs.files(tasks.named("shadowJar"))
+    outputs.file("$buildDir/run/detekt")
+
+    doLast {
+        val execFile = outputs.files.singleFile
+        execFile.outputStream().use {
+            it.write("#!/bin/sh\n\nexec java -Xmx512m -jar \"\$0\" \"\$@\"\n\n".toByteArray())
+            it.write(inputs.files.singleFile.readBytes())
+        }
+        execFile.setExecutable(true, false)
+    }
+}


### PR DESCRIPTION
Fixes #2605

Now if we run `./gradlew shadowJarExecutable` we can execute detekt like this: `./detekt-cli/build/run/detek`. So, if we publish this file in each new release, we can help the users how to install/update detekt.

Problem: I think that this only work on UNIX. I didn't update the documentation for this reason. I don't know how many people uses windows CMD now a days... ktlint ignores this fact completely as you can check here: https://ktlint.github.io/ should we do it too? Or we can say somthing like:

Unix: `./detekt`
Windows: `java -jar detekt`

What do you think?