### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@ Visit [the project website](https://arturbosch.github.io/detekt/) for installati
 #### with the command-line interface
 
 ```shell script
-git clone https://github.com/arturbosch/detekt
-cd detekt
-./gradlew build shadowJar
-java -jar detekt-cli/build/libs/detekt-cli-[version]-all.jar --help
+```sh
+curl -sSLO https://github.com/arturbosch/detekt/releases/download/v[version]/detekt && chmod a+x detekt
+./detekt --help
 ```
+
+You can find [other ways to install detekt here](https://arturbosch.github.io/detekt/cli.html)
 
 #### with Gradle
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -109,3 +109,5 @@ description: "Meet detekt, a static code analysis tool for Kotlin."
 # needed for sitemap.xml file only
 url: http://github.com/arturbosch/detekt
 baseurl: /
+
+detekt_version: 1.7.4

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ buildscript {
 }
 
 plugins {
-    id("io.gitlab.arturbosch.detekt").version("[version]")
+    id("io.gitlab.arturbosch.detekt").version("{{ site.detekt_version }}")
 }
 
 repositories {
@@ -58,7 +58,7 @@ slim down the configuration file to only the changes from the default configurat
 
 ```kotlin
 detekt {
-    toolVersion = "[version]"
+    toolVersion = "{{ site.detekt_version }}"
     config = files("config/detekt/detekt.yml")
     buildUponDefaultConfig = true
 }
@@ -91,7 +91,7 @@ which can be easily added to the gradle configuration:
 
 ```gradle
 dependencies {
-    detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:[version]"
+    detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:{{ site.detekt_version }}"
 }
 ```
 

--- a/docs/pages/extensions.md
+++ b/docs/pages/extensions.md
@@ -205,7 +205,7 @@ Take a look at our [sample project](https://github.com/arturbosch/detekt/tree/ma
 
 Mention your `jar` with the `--plugins` flag when calling the cli fatjar:
 ```
-java -jar detekt-cli-{{ site.detekt_version }}-all.jar --input ... --plugins /path/to/my/jar
+detekt --input ... --plugins /path/to/my/jar
 ```
 
 ##### Integrate your extension with the detekt gradle plugin 

--- a/docs/pages/extensions.md
+++ b/docs/pages/extensions.md
@@ -214,7 +214,7 @@ For example `detekt` itself provides a wrapper over [ktlint](https://github.com/
 custom `formatting` rule set.
 To enable it, we add the published dependency to `detekt` via the `detektPlugins` configuration:
 
-```kotlin
+```groovy
 dependencies {
     detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:{{ site.detekt_version }}"
 }

--- a/docs/pages/extensions.md
+++ b/docs/pages/extensions.md
@@ -205,7 +205,7 @@ Take a look at our [sample project](https://github.com/arturbosch/detekt/tree/ma
 
 Mention your `jar` with the `--plugins` flag when calling the cli fatjar:
 ```
-java -jar detekt-cli-[version]-all.jar --input ... --plugins /path/to/my/jar
+java -jar detekt-cli-{{ site.detekt_version }}-all.jar --input ... --plugins /path/to/my/jar
 ```
 
 ##### Integrate your extension with the detekt gradle plugin 
@@ -216,7 +216,7 @@ To enable it, we add the published dependency to `detekt` via the `detektPlugins
 
 ```kotlin
 dependencies {
-    detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:[version]"
+    detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:{{ site.detekt_version }}"
 }
 ```
 

--- a/docs/pages/gettingstarted/cli.md
+++ b/docs/pages/gettingstarted/cli.md
@@ -7,9 +7,31 @@ folder: gettingstarted
 summary:
 ---
 
-1. `cd detekt`
-2. `gradle build`
-3. `java -jar detekt-cli/build/libs/detekt-cli-[version]-all.jar [parameters]*`
+# Install the cli
+
+There are different ways to install the Command Line Interface (CLI):
+
+### MacOS, with [Homebrew](https://brew.sh/):
+```sh
+brew install detekt
+detekt [options]
+```
+
+### Unix, with the stand-alone executable:
+```sh
+curl -sSLO https://github.com/arturbosch/detekt/releases/download/v[version]/detekt && chmod a+x detekt
+./detekt [options]
+```
+You can add this file to your `PATH` so you can use it like `detekt [options]`.
+For example, like this: `mv detekt /var/local/bin`
+
+### Any OS:
+```sh
+curl -sSLO https://github.com/arturbosch/detekt/releases/download/v[version]/detekt-cli-[version].zip && unzip detekt-cli-[version].zip
+./bin/detekt [options]
+```
+
+# Use the cli
 
 detekt will exit with one of the following exit codes:
 

--- a/docs/pages/gettingstarted/cli.md
+++ b/docs/pages/gettingstarted/cli.md
@@ -67,7 +67,8 @@ Usage: detekt [options]
       override rule properties which includes turning off specific rules.
       Default: false
     --generate-config, -gc
-      Export default config to default-detekt-config.yml.
+      Export default config. Path can be specified with --config option
+      (default path: default-detekt-config.yml)
       Default: false
     --help, -h
       Shows the usage.
@@ -77,19 +78,21 @@ Usage: detekt [options]
     --input, -i
       Input paths to analyze. Multiple paths are separated by comma. If not
       specified the current working directory is used.
-    --language-version
-      EXPERIMENTAL: Compatibility mode for Kotlin language version X.Y, reports
-      errors for all language features that came out later.
-      Default: latest stable
-      Possible Values: [1.0, 1.1, 1.2, 1.3, 1.4]
     --jvm-target
       EXPERIMENTAL: Target version of the generated JVM bytecode that was
       generated during compilation and is now being used for type resolution
-      Default: 1.6
-      Possible Values: [1.6, 1.8, 9, 10, 11, 12]
+      (1.6, 1.8, 9, 10, 11 or 12)
+      Default: JVM_1_6
+      Possible Values: [JVM_1_6, JVM_1_8, JVM_9, JVM_10, JVM_11, JVM_12, JVM_13]
+    --language-version
+      EXPERIMENTAL: Compatibility mode for Kotlin language version X.Y,
+      reports errors for all language features that came out later (1.0, 1.1,
+      1.2, 1.3, 1.4)
+      Possible Values: [1.0, 1.1, 1.2, 1.3, 1.4]
     --parallel
-      Enables parallel compilation of source files. Should only be used if the
-      analyzing project has more than ~200 Kotlin files.
+      Enables parallel compilation and analysis of source files. Do some
+      benchmarks first before enabling this flag. Heuristics show performance
+      benefits starting from 2000 lines of Kotlin code.
       Default: false
     --plugins, -p
       Extra paths to plugin jars separated by ',' or ';'.
@@ -100,4 +103,5 @@ Usage: detekt [options]
       other e.g. '-r txt:reports/detekt.txt -r xml:reports/detekt.xml'
     --version
       Prints the detekt CLI version.
+      Default: false
 ```

--- a/docs/pages/gettingstarted/cli.md
+++ b/docs/pages/gettingstarted/cli.md
@@ -19,7 +19,7 @@ detekt [options]
 
 ### Unix, with the stand-alone executable:
 ```sh
-curl -sSLO https://github.com/arturbosch/detekt/releases/download/v[version]/detekt && chmod a+x detekt
+curl -sSLO https://github.com/arturbosch/detekt/releases/download/v{{ site.detekt_version }}/detekt && chmod a+x detekt
 ./detekt [options]
 ```
 You can add this file to your `PATH` so you can use it like `detekt [options]`.
@@ -27,7 +27,7 @@ For example, like this: `mv detekt /var/local/bin`
 
 ### Any OS:
 ```sh
-curl -sSLO https://github.com/arturbosch/detekt/releases/download/v[version]/detekt-cli-[version].zip && unzip detekt-cli-[version].zip
+curl -sSLO https://github.com/arturbosch/detekt/releases/download/v{{ site.detekt_version }}/detekt-cli-{{ site.detekt_version }}.zip && unzip detekt-cli-{{ site.detekt_version }}.zip
 ./bin/detekt [options]
 ```
 

--- a/docs/pages/gettingstarted/gradletask.md
+++ b/docs/pages/gettingstarted/gradletask.md
@@ -42,6 +42,6 @@ task detekt(type: JavaExec) {
 }
 
 dependencies {
-	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:[version]'
+	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:{{ site.detekt_version }}'
 }
 ```

--- a/docs/pages/gettingstarted/groovydsl.md
+++ b/docs/pages/gettingstarted/groovydsl.md
@@ -45,7 +45,7 @@ repositories {
 }
 
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "[version]"
+    id "io.gitlab.arturbosch.detekt" version "{{ site.detekt_version }}"
 }
 ```
 
@@ -61,13 +61,13 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:[version]'
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[version]"
+        classpath 'com.android.tools.build:gradle:{{ site.detekt_version }}'
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:{{ site.detekt_version }}"
     }
 
 }
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "[version]"
+    id "io.gitlab.arturbosch.detekt" version "{{ site.detekt_version }}"
 }
 
 apply plugin: 'io.gitlab.arturbosch.detekt'
@@ -78,7 +78,7 @@ apply plugin: 'io.gitlab.arturbosch.detekt'
 
 ```groovy
 detekt {
-    toolVersion = "[version]"                             // Version of the Detekt CLI that will be used. When unspecified the latest detekt version found will be used. Override to stay on the same version.
+    toolVersion = "{{ site.detekt_version }}"                                 // Version of the Detekt CLI that will be used. When unspecified the latest detekt version found will be used. Override to stay on the same version.
     input = files(                                        // The directories where detekt looks for source files. Defaults to `files("src/main/java", "src/main/kotlin")`.
         "src/main/kotlin",
         "gensrc/main/kotlin"

--- a/docs/pages/gettingstarted/kotlindsl.md
+++ b/docs/pages/gettingstarted/kotlindsl.md
@@ -31,12 +31,12 @@ repositories {
 }
 
 plugins {
-    id("io.gitlab.arturbosch.detekt").version("[version]")
+    id("io.gitlab.arturbosch.detekt").version("{{ site.detekt_version }}")
 }
 
 detekt {
-    toolVersion = "[version]"                             // Version of the Detekt CLI that will be used. When unspecified the latest detekt version found will be used. Override to stay on the same version.
-    input = files("src/main/java", "src/main/kotlin")    // The directories where detekt looks for source files. Defaults to `files("src/main/java", "src/main/kotlin")`.
+    toolVersion = "{{ site.detekt_version }}"                                 // Version of the Detekt CLI that will be used. When unspecified the latest detekt version found will be used. Override to stay on the same version.
+    input = files("src/main/java", "src/main/kotlin")     // The directories where detekt looks for source files. Defaults to `files("src/main/java", "src/main/kotlin")`.
     parallel = false                                      // Builds the AST in parallel. Rules are always executed in parallel. Can lead to speedups in larger projects. `false` by default.
     config = files("path/to/config.yml")                  // Define the detekt configuration(s) you want to use. Defaults to the default detekt configuration.
     buildUponDefaultConfig = false                        // Interpret config files as updates to the default config. `false` by default.

--- a/docs/pages/gettingstarted/mavenanttask.md
+++ b/docs/pages/gettingstarted/mavenanttask.md
@@ -47,7 +47,7 @@ summary:
                 <dependency>
                     <groupId>io.gitlab.arturbosch.detekt</groupId>
                     <artifactId>detekt-cli</artifactId>
-                    <version>[version]</version>
+                    <version>{{ site.detekt_version }}</version>
                 </dependency>
             </dependencies>
         </plugin>


### PR DESCRIPTION
This PR updates two things:

- Update how to install detekt. It turns out that [detekt it's already at homebrew](https://formulae.brew.sh/formula/detekt). You can see what they do to install and run detekt here: https://github.com/Homebrew/homebrew-core/blob/master/Formula/detekt.rb
- Instead of show [version] in our code samples show the current version of detekt so the snippets are easier to copy/paste.

This PR is not ready to merge for two reasons:
- In the documentation I refer to the stand-alone executable and the last version of detekt doesn't have it. So we should wait to the next release to merge this or upload the stand-alone executable to the current version. This should be kind of easy.
- How do we do to sync the `gradle.properties>detektVersion` with `docs/_config.yml>detekt_version`? Maybe we can create a mini script and change this from `CONTRIBUTING.md`
> Increment `detektVersion` in `gradle.properties`

to something like:
> `./scripts/changeVersion X.Y.Z`

And that script will update both values at once. Or if we want to keep it simple, just add a new point in the `CONTRIBUTING.md` pointing out that we should update that too.