### PR TITLE
Set failfast to false for pre-merge

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   gradle:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         jdk: [8, 11, 13]


### PR DESCRIPTION
Do not abort all the other jobs if one is failing.
This should provide insights to understand if a failure is related to a specific configuration of the matrix or is affecting all the builds.